### PR TITLE
use resolve-package-path

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -51,6 +51,7 @@
     "lodash": "^4.17.10",
     "pkg-up": "^2.0.0",
     "resolve": "^1.8.1",
+    "resolve-package-path": "^1.2.2",
     "semver": "^5.5.0",
     "symlink-or-copy": "^1.2.0",
     "typescript-memoize": "^1.0.0-alpha.3",

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -17,6 +17,7 @@ import AddToTree from './add-to-tree';
 import DummyPackage from './dummy-package';
 import { TransformOptions } from '@babel/core';
 import { isEmbroiderMacrosPlugin } from '@embroider/macros';
+import resolvePackagePath from 'resolve-package-path';
 
 // This controls and types the interface between our new world and the classic
 // v1 app instance.
@@ -57,7 +58,7 @@ export default class V1App implements V1Package {
 
   @Memoize()
   private get emberCLILocation() {
-    return dirname(resolve.sync('ember-cli/package.json', { basedir: this.root }));
+    return dirname(resolvePackagePath('ember-cli', this.root));
   }
 
   private requireFromEmberCLI(specifier: string) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.10",
     "pkg-up": "^2.0.0",
     "resolve": "^1.8.1",
+    "resolve-package-path": "^1.2.2",
     "strip-bom": "^3.0.0",
     "typescript-memoize": "^1.0.0-alpha.3",
     "walk-sync": "^1.1.3"

--- a/packages/core/src/package-cache.ts
+++ b/packages/core/src/package-cache.ts
@@ -1,15 +1,15 @@
 import Package from './package';
 import { realpathSync } from 'fs';
 import { getOrCreate } from './get-or-create';
-import resolve from 'resolve';
-import { join, dirname } from 'path';
+import resolvePackagePath from 'resolve-package-path';
+import { dirname } from 'path';
 import { sync as pkgUpSync }  from 'pkg-up';
 
 export default class PackageCache {
   resolve(packageName: string, fromPackage: Package): Package {
     let cache = getOrCreate(this.resolutionCache, fromPackage, () => new Map());
     return getOrCreate(cache, packageName, () => {
-      let root = dirname(resolve.sync(join(packageName, 'package.json'), { basedir: this.basedir(fromPackage) }));
+      let root = dirname(resolvePackagePath(packageName, this.basedir(fromPackage)));
       return this.getAddon(root);
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8888,6 +8888,14 @@ resolve-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
   integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
 
+resolve-package-path@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-1.2.2.tgz#0c6f7cfeffdd96215c97a0082eadd6dc98a1de57"
+  integrity sha512-Rva99mD09iKulXPC7JnH3CAtdD3n5pZtTHtyhqknXcPKyu+bVkYUvUV0qxaO/+STvY8/JQsZdlmcBEgbPdFU4w==
+  dependencies:
+    path-root "^0.1.1"
+    resolve "^1.10.0"
+
 resolve-path@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"


### PR DESCRIPTION
* allows all ember related algorithms to be the same
* ensures all ember usages can share the same FS cache


- [x] add typings to resolve-package-path

```js
src/v1-app.ts:19:32 - error TS7016: Could not find a declaration file for module 'resolve-package-path'. '/Users/spenner/src/embroider-build/embroider/node_modules/resolve-package-path/index.js' implicitly has an 'any' type.
  Try `npm install @types/resolve-package-path` if it exists or add a new declaration (.d.ts) file containing `declare module 'resolve-package-path';`

19 import resolvePackagePath from 'resolve-package-path';
                                  ~~~~~~~~~~~~~~~~~~~~~~
```

```js
../core/src/package-cache.ts:4:32 - error TS7016: Could not find a declaration file for module 'resolve-package-path'. '/Users/spenner/src/embroider-build/embroider/node_modules/resolve-package-path/index.js' implicitly has an 'any' type.
  Try `npm install @types/resolve-package-path` if it exists or add a new declaration (.d.ts) file containing `declare module 'resolve-package-path';`

4 import resolvePackagePath from 'resolve-package-path';
```
- [x] investigate other TS error (@ef4 i think this is unrelated to my change, may be pre-existing?)

```
../core/src/basic-package.d.ts:3:22 - error TS2415: Class 'BasicPackage' incorrectly extends base class 'Package'.
  Types have separate declarations of a private property 'dependencyKeys'.

3 export default class BasicPackage extends Package {
                       ~~~~~~~~~~~~
```