### PR TITLE
Ember data compat shim

### DIFF
--- a/packages/compat/src/compat-adapters/ember-data.ts
+++ b/packages/compat/src/compat-adapters/ember-data.ts
@@ -1,0 +1,47 @@
+import V1Addon from "../v1-addon";
+import { join } from 'path';
+import { Memoize } from "typescript-memoize";
+import cloneDeep from 'lodash/cloneDeep';
+import { AddonMeta } from "@embroider/core";
+
+export default class EmberData extends V1Addon {
+  // ember-data customizes the addon tree, but we don't want to run that one
+  // because it breaks when we try to eliminate absolute self-imports. We'll
+  // take the stock behavior instead.
+  customizes(...names: string[]) {
+    return super.customizes(...names.filter(n => n !== 'treeForAddon'));
+  }
+
+  // ember-data needs its dynamically generated version module.
+  @Memoize()
+  get v2Trees() {
+    let version = require(join(this.root, 'lib/version'));
+    let trees = super.v2Trees;
+    trees.push(version());
+    return trees;
+  }
+
+  // this is enough to make sure we drop the debug code in prod. This only
+  // matters when the app is running with staticAddonTrees=false, otherwise this
+  // kind of optimization is automatic.
+  get packageMeta(): AddonMeta {
+    let meta = super.packageMeta;
+    if (isProductionEnv() && !isInstrumentedBuild()) {
+      meta = cloneDeep(meta);
+      if (meta['implicit-modules']) {
+        meta['implicit-modules'] = meta['implicit-modules'].filter(name => !name.startsWith('./-debug/'));
+      }
+    }
+    return meta;
+  }
+}
+
+function isProductionEnv() {
+  let isProd = /production/.test(process.env.EMBER_ENV!);
+  let isTest = process.env.EMBER_CLI_TEST_COMMAND;
+  return isProd && !isTest;
+}
+
+function isInstrumentedBuild() {
+  return process.argv.includes('--instrument');
+}

--- a/packages/compat/src/rewrite-package-json.ts
+++ b/packages/compat/src/rewrite-package-json.ts
@@ -13,7 +13,7 @@ export default class RewritePackageJSON extends Plugin {
     });
   }
 
-  private cachedLast: AddonMeta | undefined;
+  private cachedLast: { 'ember-addon': AddonMeta } | undefined;
 
   get lastPackageJSON() {
     if (!this.cachedLast) {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -274,7 +274,7 @@ export default class V1Addon implements V1Package {
 
   // this is split out so that compatability shims can override it to add more
   // things to the package metadata.
-  protected get packageMeta() {
+  protected get packageMeta(): AddonMeta {
     let built = this.build();
     return mergeWithAppend(
       {},


### PR DESCRIPTION
- Disable the custom rollup build
- But keep the dynamically generated version module
- And keep the dropping of `-debug` in prod

A thing about the debug stripping here is that it's only relevant when the app is running with `staticAddonTrees: false`. When you flip that flag on, the debug code would necessarily get dropped as long as you aren't using it.