### PR TITLE
[Failing Test] Adding test for addon pod component

### DIFF
--- a/test-packages/macro-sample-addon/addon/components/classic-component.js
+++ b/test-packages/macro-sample-addon/addon/components/classic-component.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import layout from '../templates/components/classic-component';
+
+export default Component.extend({
+  layout
+});

--- a/test-packages/macro-sample-addon/addon/components/pod-component/component.js
+++ b/test-packages/macro-sample-addon/addon/components/pod-component/component.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import layout from './template';
+
+export default Component.extend({
+  layout
+});

--- a/test-packages/macro-sample-addon/addon/components/pod-component/template.hbs
+++ b/test-packages/macro-sample-addon/addon/components/pod-component/template.hbs
@@ -1,0 +1,1 @@
+<div data-test-pod-component>Pod Component</div>

--- a/test-packages/macro-sample-addon/addon/templates/components/classic-component.hbs
+++ b/test-packages/macro-sample-addon/addon/templates/components/classic-component.hbs
@@ -1,0 +1,1 @@
+<div data-test-classic-component>Classic Component</div>

--- a/test-packages/macro-sample-addon/app/components/classic-component.js
+++ b/test-packages/macro-sample-addon/app/components/classic-component.js
@@ -1,0 +1,1 @@
+export { default } from 'macro-sample-addon/components/classic-component';

--- a/test-packages/macro-sample-addon/app/components/pod-component/component.js
+++ b/test-packages/macro-sample-addon/app/components/pod-component/component.js
@@ -1,0 +1,1 @@
+export { default } from 'macro-sample-addon/components/pod-component/component';

--- a/test-packages/macro-tests/app/templates/application.hbs
+++ b/test-packages/macro-tests/app/templates/application.hbs
@@ -1,2 +1,5 @@
 <div data-test-mode >{{this.mode}}</div>
 <div data-test-count >{{macroGetOwnConfig "count"}}</div>
+
+{{classic-component}}
+{{pod-component}}

--- a/test-packages/macro-tests/tests/acceptance/basic-test.js
+++ b/test-packages/macro-tests/tests/acceptance/basic-test.js
@@ -16,4 +16,18 @@ module('Acceptance | smoke tests', function(hooks) {
     assert.equal(currentURL(), '/');
     assert.equal(this.element.querySelector('[data-test-count]').textContent.trim(), '42');
   });
+
+  test('Addon classic component renders', async function(assert) {
+    await visit('/');
+    assert.equal(currentURL(), '/');
+
+    assert.dom('[data-test-classic-component]').isVisible({count: 1});
+  });
+
+  test('Addon pod component renders', async function(assert) {
+    await visit('/');
+    assert.equal(currentURL(), '/');
+
+    assert.dom('[data-test-pod-component]').isVisible({count: 1});
+  });
 });


### PR DESCRIPTION
An addon with a pod component throws a build error.

Includes a failing test.

Passes:
```
cd test-packages/macro-tests && CLASSIC=true yarn test
```

Fails
```
cd test-packages/macro-tests && yarn test
```

Failure
`Module not found: Error: Can't resolve './template' in '/private/var/folders/59/6y4_b2y15ys0bk910x5rfgg00000gn/T/embroider-DP1uY8/test-packages/macro-sample-addon/components/pod-component'`
