### PR TITLE
Update `typescript` to v3.2.4

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -32,7 +32,7 @@
     "fixturify-project": "^1.8.0",
     "qunit": "^2.8.0",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.6"
+    "typescript": "~3.2.0"
   },
   "dependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "@types/strip-bom": "^3.0.0",
     "qunit": "^2.8.0",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.6"
+    "typescript": "~3.2.0"
   },
   "dependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -471,7 +471,7 @@ export class AppBuilder<TreeNames> {
     let assets: Asset[] = [];
     for (let pkg of this.adapter.activeAddonDescendants) {
       if (pkg.meta['public-assets']) {
-        for (let [filename, appRelativeURL] of Object.entries(pkg.meta['public-assets'])) {
+        for (let [filename, appRelativeURL] of Object.entries(pkg.meta['public-assets'] || {})) {
           assets.push({
             kind: 'on-disk',
             sourcePath: join(pkg.root, filename),

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -25,7 +25,7 @@
     "@types/resolve": "^0.0.8",
     "qunit": "^2.8.0",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.6"
+    "typescript": "~3.2.0"
   },
   "dependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^10.5.2",
     "@types/webpack": "^4.4.17",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.6"
+    "typescript": "~3.2.0"
   },
   "dependencies": {
     "babel-core": "^6.26.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10998,10 +10998,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@^3.1.6:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
-  integrity sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
+typescript@~3.2.0:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
There was only a single issue around `Object.entries()` usage, everything else seems to work fine.

