### PR TITLE
Simplify test code

### DIFF
--- a/test-packages/macro-sample-addon.test.js
+++ b/test-packages/macro-sample-addon.test.js
@@ -1,13 +1,18 @@
 const execa = require('execa');
 
-const TESTS = [
-  ['macro-addon', 'test', { cwd: `${__dirname}/macro-sample-addon` }],
-  ['macro-addon-classic', 'test', { cwd: `${__dirname}/macro-sample-addon`, env: { CLASSIC: 'true' } }],
-];
+test('macro-addon', async () => {
+  jest.setTimeout(60000);
 
-for (let [testName, command, options] of TESTS) {
-  test(testName, async () => {
-    jest.setTimeout(60000);
-    await execa('yarn', [command], options);
+  await execa('yarn', ['test'], {
+    cwd: `${__dirname}/macro-sample-addon`,
   });
-}
+});
+
+test('macro-addon-classic', async () => {
+  jest.setTimeout(60000);
+
+  await execa('yarn', ['test'], {
+    cwd: `${__dirname}/macro-sample-addon`,
+    env: { CLASSIC: 'true' },
+  });
+});

--- a/test-packages/macro-sample-addon.test.js
+++ b/test-packages/macro-sample-addon.test.js
@@ -8,11 +8,6 @@ const TESTS = [
 for (let [testName, command, options] of TESTS) {
   test(testName, async () => {
     jest.setTimeout(60000);
-
-    try {
-      await execa('yarn', [command], options);
-    } catch (error) {
-      throw error;
-    }
+    await execa('yarn', [command], options);
   });
 }

--- a/test-packages/macro-tests.test.js
+++ b/test-packages/macro-tests.test.js
@@ -1,13 +1,18 @@
 const execa = require('execa');
 
-const TESTS = [
-  ['macro-classic', 'test', { cwd: `${__dirname}/macro-tests`, env: { CLASSIC: 'true' } }],
-  ['macro', 'test', { cwd: `${__dirname}/macro-tests` }],
-];
+test('macro', async () => {
+  jest.setTimeout(60000);
 
-for (let [testName, command, options] of TESTS) {
-  test(testName, async () => {
-    jest.setTimeout(60000);
-    await execa('yarn', [command], options);
+  await execa('yarn', ['test'], {
+    cwd: `${__dirname}/macro-tests`,
   });
-}
+});
+
+test('macro-classic', async () => {
+  jest.setTimeout(60000);
+
+  await execa('yarn', ['test'], {
+    cwd: `${__dirname}/macro-tests`,
+    env: { CLASSIC: 'true' },
+  });
+});

--- a/test-packages/macro-tests.test.js
+++ b/test-packages/macro-tests.test.js
@@ -8,11 +8,6 @@ const TESTS = [
 for (let [testName, command, options] of TESTS) {
   test(testName, async () => {
     jest.setTimeout(60000);
-
-    try {
-      await execa('yarn', [command], options);
-    } catch (error) {
-      throw error;
-    }
+    await execa('yarn', [command], options);
   });
 }

--- a/test-packages/node.test.js
+++ b/test-packages/node.test.js
@@ -7,11 +7,7 @@ const TESTS = [
 for (let [testName, command, options] of TESTS) {
   test(testName, async () => {
     jest.setTimeout(60000);
-
-    try {
-      await execa('yarn', [command], options);
-    } catch (error) {
-      throw error;
-    }
+    await execa('yarn', [command], options);
   });
 }
+

--- a/test-packages/node.test.js
+++ b/test-packages/node.test.js
@@ -1,13 +1,11 @@
 const execa = require('execa');
 
-const TESTS = [
-  ['node', 'node-test', { cwd: `${__dirname}/..`, env: { JOBS: '1' } }],
-];
+test('node', async () => {
+  jest.setTimeout(60000);
 
-for (let [testName, command, options] of TESTS) {
-  test(testName, async () => {
-    jest.setTimeout(60000);
-    await execa('yarn', [command], options);
+  await execa('yarn', ['node-test'], {
+    cwd: `${__dirname}/..`,
+    env: { JOBS: '1' },
   });
-}
+});
 

--- a/test-packages/static-app.test.js
+++ b/test-packages/static-app.test.js
@@ -1,13 +1,18 @@
 const execa = require('execa');
 
-const TESTS = [
-  ['static-app', 'test', { cwd: `${__dirname}/static-app` }],
-  ['static-app-classic', 'test', { cwd: `${__dirname}/static-app`, env: { CLASSIC: 'true' } }],
-];
+test('static-app', async () => {
+  jest.setTimeout(60000);
 
-for (let [testName, command, options] of TESTS) {
-  test(testName, async () => {
-    jest.setTimeout(60000);
-    await execa('yarn', [command], options);
+  await execa('yarn', ['test'], {
+    cwd: `${__dirname}/static-app`,
   });
-}
+});
+
+test('static-app-classic', async () => {
+  jest.setTimeout(60000);
+
+  await execa('yarn', ['test'], {
+    cwd: `${__dirname}/static-app`,
+    env: { CLASSIC: 'true' },
+  });
+});

--- a/test-packages/static-app.test.js
+++ b/test-packages/static-app.test.js
@@ -8,11 +8,6 @@ const TESTS = [
 for (let [testName, command, options] of TESTS) {
   test(testName, async () => {
     jest.setTimeout(60000);
-
-    try {
-      await execa('yarn', [command], options);
-    } catch (error) {
-      throw error;
-    }
+    await execa('yarn', [command], options);
   });
 }


### PR DESCRIPTION
The `TESTS` array was still from an iteration when I had all tests in one file, which did not parallelize as expected though. Removing the array makes the tests a little more straight forward to understand without making them much more verbose.