### PR TITLE
Add ESLint with TypeScript and Prettier integration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,26 @@
+/packages/**/*.js
+/packages/**/*.d.ts
+/test-packages/support/**/*.js
+/test-packages/**/*.d.ts
+
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/test-packages/*/dist/
+/test-packages/*/tmp/
+
+# dependencies
+bower_components/
+node_modules/
+
+# misc
+coverage/
+!.*
+
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try
+

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
+    ecmaVersion: 2017,
+    sourceType: 'module',
+  },
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
+    '@typescript-eslint/indent': ['error', 2],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,4 +8,7 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module',
   },
+  plugins: ['@typescript-eslint'],
+  rules: {
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,10 +9,7 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['prettier', '@typescript-eslint'],
-  extends: [
-    'prettier',
-    'prettier/@typescript-eslint',
-  ],
+  extends: ['prettier', 'prettier/@typescript-eslint'],
   rules: {
     'prettier/prettier': 'error',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,8 +8,12 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint'],
+  plugins: ['prettier', '@typescript-eslint'],
+  extends: [
+    'prettier',
+    'prettier/@typescript-eslint',
+  ],
   rules: {
-    '@typescript-eslint/indent': ['error', 2],
+    'prettier/prettier': 'error',
   },
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+  printWidth: 120,
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "execa": "^1.0.0",
-    "jest": "^24.5.0"
+    "jest": "^24.5.0",
+    "tslint": "^5.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
     "@typescript-eslint/eslint-plugin": "^1.5.0",
     "@typescript-eslint/parser": "^1.5.0",
     "eslint": "^5.15.3",
+    "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-prettier": "^3.0.1",
     "execa": "^1.0.0",
     "jest": "^24.5.0",
+    "prettier": "1.16.4",
     "tslint": "^5.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
   ],
   "scripts": {
     "compile": "tsc",
-    "lint": "tslint --project .",
+    "lint": "eslint . --ext=js,ts --cache && tslint --project .",
     "clean": "git clean -x -f",
     "node-test": "qunit packages/*/tests",
     "test": "jest"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "^1.5.0",
+    "eslint": "^5.15.3",
     "execa": "^1.0.0",
     "jest": "^24.5.0",
     "tslint": "^5.11.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^1.5.0",
     "@typescript-eslint/parser": "^1.5.0",
     "eslint": "^5.15.3",
     "execa": "^1.0.0",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -31,7 +31,6 @@
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "fixturify-project": "^1.8.0",
     "qunit": "^2.8.0",
-    "tslint": "^5.11.0",
     "typescript": "~3.2.0"
   },
   "dependencies": {

--- a/packages/compat/src/add-to-tree.ts
+++ b/packages/compat/src/add-to-tree.ts
@@ -10,5 +10,5 @@ export default class AddToTree extends Funnel {
   async build() {
     await super.build();
     await this.hook(this.outputPath);
-   }
+  }
 }

--- a/packages/compat/src/add-to-tree.ts
+++ b/packages/compat/src/add-to-tree.ts
@@ -1,10 +1,10 @@
-import { Tree } from "broccoli-plugin";
-import Funnel from "broccoli-funnel";
+import { Tree } from 'broccoli-plugin';
+import Funnel from 'broccoli-funnel';
 
 export default class AddToTree extends Funnel {
   constructor(combinedVendor: Tree, private hook: (outputPath: string) => Promise<void> | void) {
     super(combinedVendor, {
-      annotation: '@embroider/compat/synthvendor'
+      annotation: '@embroider/compat/synthvendor',
     });
   }
   async build() {

--- a/packages/compat/src/addon-dependency-rules/ember-basic-dropdown.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-basic-dropdown.ts
@@ -1,26 +1,20 @@
-import { PackageRules } from "..";
+import { PackageRules } from '..';
 
 let rules: PackageRules = {
   package: 'ember-basic-dropdown',
   addonModules: {
     'components/basic-dropdown.js': {
-      dependsOnComponents: [
-        '{{basic-dropdown/trigger}}',
-        '{{basic-dropdown/content}}',
-      ]
+      dependsOnComponents: ['{{basic-dropdown/trigger}}', '{{basic-dropdown/content}}'],
     },
   },
   components: {
     '{{basic-dropdown}}': {
       layout: {
-        addonPath: "templates/components/basic-dropdown.hbs"
+        addonPath: 'templates/components/basic-dropdown.hbs',
       },
-      acceptsComponentArguments: [
-        'triggerComponent',
-        'contentComponent',
-      ]
-    }
-  }
+      acceptsComponentArguments: ['triggerComponent', 'contentComponent'],
+    },
+  },
 };
 
-export default [ rules ];
+export default [rules];

--- a/packages/compat/src/addon-dependency-rules/ember-power-select-typeahead.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-power-select-typeahead.ts
@@ -1,21 +1,19 @@
-import { PackageRules } from "..";
+import { PackageRules } from '..';
 
 let rules: PackageRules = {
-  package: "ember-power-select-typeahead",
+  package: 'ember-power-select-typeahead',
   addonModules: {
-    "./components/power-select-typeahead.js": {
-      dependsOnComponents: [
-        "{{power-select-typeahead/trigger}}",
-      ],
+    './components/power-select-typeahead.js': {
+      dependsOnComponents: ['{{power-select-typeahead/trigger}}'],
     },
-    "./components/power-select-multiple.js": {
-      dependsOnComponents: ["{{power-select-multiple/trigger}}"],
+    './components/power-select-multiple.js': {
+      dependsOnComponents: ['{{power-select-multiple/trigger}}'],
     },
   },
   components: {
-    "{{power-select-typeahead}}": {
+    '{{power-select-typeahead}}': {
       layout: {
-        addonPath: "templates/components/power-select-typeahead.hbs"
+        addonPath: 'templates/components/power-select-typeahead.hbs',
       },
       acceptsComponentArguments: [
         'afterOptionsComponent',

--- a/packages/compat/src/addon-dependency-rules/ember-power-select.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-power-select.ts
@@ -1,26 +1,26 @@
-import { PackageRules } from "..";
+import { PackageRules } from '..';
 
 let rules: PackageRules = {
-  package: "ember-power-select",
+  package: 'ember-power-select',
   addonModules: {
-    "./components/power-select.js": {
+    './components/power-select.js': {
       dependsOnComponents: [
-        "{{power-select/before-options}}",
-        "{{power-select/options}}",
-        "{{power-select/power-select-group}}",
-        "{{power-select/trigger}}",
-        "{{power-select/search-message}}",
-        "{{power-select/placeholder}}",
+        '{{power-select/before-options}}',
+        '{{power-select/options}}',
+        '{{power-select/power-select-group}}',
+        '{{power-select/trigger}}',
+        '{{power-select/search-message}}',
+        '{{power-select/placeholder}}',
       ],
     },
-    "./components/power-select-multiple.js": {
-      dependsOnComponents: ["{{power-select-multiple/trigger}}"],
+    './components/power-select-multiple.js': {
+      dependsOnComponents: ['{{power-select-multiple/trigger}}'],
     },
   },
   components: {
-    "{{power-select}}": {
+    '{{power-select}}': {
       layout: {
-        addonPath: "templates/components/power-select.hbs"
+        addonPath: 'templates/components/power-select.hbs',
       },
       acceptsComponentArguments: [
         'afterOptionsComponent',
@@ -32,9 +32,9 @@ let rules: PackageRules = {
         'triggerComponent',
       ],
     },
-    "{{power-select-multiple}}": {
+    '{{power-select-multiple}}': {
       layout: {
-        addonPath: "templates/components/power-select-multiple.hbs"
+        addonPath: 'templates/components/power-select-multiple.hbs',
       },
       acceptsComponentArguments: [
         'afterOptionsComponent',
@@ -47,32 +47,24 @@ let rules: PackageRules = {
         'triggerComponent',
       ],
     },
-    "{{power-select/trigger}}": {
+    '{{power-select/trigger}}': {
       layout: {
-        addonPath: "templates/components/power-select/trigger.hbs"
+        addonPath: 'templates/components/power-select/trigger.hbs',
       },
-      acceptsComponentArguments: [
-        'selectedItemComponent',
-        'placeholderComponent',
-      ]
+      acceptsComponentArguments: ['selectedItemComponent', 'placeholderComponent'],
     },
-    "{{power-select/options}}": {
+    '{{power-select/options}}': {
       layout: {
-        addonPath: "templates/components/power-select/options.hbs"
+        addonPath: 'templates/components/power-select/options.hbs',
       },
-      acceptsComponentArguments: [
-        'groupComponent',
-        'optionsComponent',
-      ]
+      acceptsComponentArguments: ['groupComponent', 'optionsComponent'],
     },
-    "{{power-select-multiple/trigger}}": {
+    '{{power-select-multiple/trigger}}': {
       layout: {
-        addonPath: "templates/components/power-select-multiple/trigger.hbs"
+        addonPath: 'templates/components/power-select-multiple/trigger.hbs',
       },
-      acceptsComponentArguments: [
-        'selectedItemComponent',
-      ]
-    }
+      acceptsComponentArguments: ['selectedItemComponent'],
+    },
   },
 };
 

--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -1,12 +1,12 @@
-import V1InstanceCache from "./v1-instance-cache";
+import V1InstanceCache from './v1-instance-cache';
 import { Package } from '@embroider/core';
-import SmooshPackageJSON from "./smoosh-package-json";
-import broccoliMergeTrees from "broccoli-merge-trees";
-import { Tree } from "broccoli-plugin";
-import OneShot from "./one-shot";
+import SmooshPackageJSON from './smoosh-package-json';
+import broccoliMergeTrees from 'broccoli-merge-trees';
+import { Tree } from 'broccoli-plugin';
+import OneShot from './one-shot';
 import Funnel from 'broccoli-funnel';
 import { UnwatchedDir } from 'broccoli-source';
-import EmptyPackageTree from "./empty-package-tree";
+import EmptyPackageTree from './empty-package-tree';
 
 export default function cachedBuildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): Tree {
   let tree = buildCompatAddon(originalPackage, v1Cache);
@@ -51,6 +51,6 @@ function buildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): T
 
 function withoutNodeModules(root: string): Tree {
   return new Funnel(new UnwatchedDir(root), {
-    exclude: ['node_modules']
+    exclude: ['node_modules'],
   });
 }

--- a/packages/compat/src/compat-adapters/active-model-adapter.ts
+++ b/packages/compat/src/compat-adapters/active-model-adapter.ts
@@ -1,5 +1,5 @@
-import V1Addon from "../v1-addon";
-import { addPeerDependency } from "../compat-utils";
+import V1Addon from '../v1-addon';
+import { addPeerDependency } from '../compat-utils';
 
 export default class extends V1Addon {
   get packageJSON() {

--- a/packages/compat/src/compat-adapters/ember-cli-clipboard.ts
+++ b/packages/compat/src/compat-adapters/ember-cli-clipboard.ts
@@ -1,5 +1,5 @@
-import V1Addon from "../v1-addon";
-import { Memoize } from "typescript-memoize";
+import V1Addon from '../v1-addon';
+import { Memoize } from 'typescript-memoize';
 import Funnel from 'broccoli-funnel';
 
 export default class EmberCLIClipboard extends V1Addon {
@@ -11,7 +11,7 @@ export default class EmberCLIClipboard extends V1Addon {
       // a fastboot guard, including a package.json file. The presence a file
       // named "package.json" that isn't actually valid JSON makes packagers
       // like Webpack barf.
-      exclude: ['vendor/clipboard/package.json']
+      exclude: ['vendor/clipboard/package.json'],
     });
   }
 }

--- a/packages/compat/src/compat-adapters/ember-cli-deprecation-workflow.ts
+++ b/packages/compat/src/compat-adapters/ember-cli-deprecation-workflow.ts
@@ -1,8 +1,8 @@
-import V1Addon from "../v1-addon";
+import V1Addon from '../v1-addon';
 import { join, dirname } from 'path';
 import { UnwatchedDir } from 'broccoli-source';
 import resolve from 'resolve';
-import { Memoize } from "typescript-memoize";
+import { Memoize } from 'typescript-memoize';
 import Funnel from 'broccoli-funnel';
 
 export default class extends V1Addon {
@@ -15,9 +15,11 @@ export default class extends V1Addon {
     // its own app.import, and (2) even if you fix that,
     // ember-debug-handlers-polyfill itself has a bug that makes it not work as
     // a second-level addon.
-    let polyfillDir = dirname(resolve.sync('ember-debug-handlers-polyfill/package.json', { basedir: this.addonInstance.root }));
+    let polyfillDir = dirname(
+      resolve.sync('ember-debug-handlers-polyfill/package.json', { basedir: this.addonInstance.root })
+    );
     let tree = new Funnel(new UnwatchedDir(join(polyfillDir, 'vendor')), {
-      destDir: 'vendor'
+      destDir: 'vendor',
     });
     let trees = super.v2Trees;
     trees.push(tree);

--- a/packages/compat/src/compat-adapters/ember-cli-mirage.ts
+++ b/packages/compat/src/compat-adapters/ember-cli-mirage.ts
@@ -1,5 +1,5 @@
-import V1Addon from "../v1-addon";
-import Funnel from "broccoli-funnel";
+import V1Addon from '../v1-addon';
+import Funnel from 'broccoli-funnel';
 
 export default class extends V1Addon {
   get packageMeta() {
@@ -18,7 +18,7 @@ export default class extends V1Addon {
       return tree;
     }
     return new Funnel(tree, {
-      include: ['package.json']
+      include: ['package.json'],
     });
   }
 }

--- a/packages/compat/src/compat-adapters/ember-composable-helpers.ts
+++ b/packages/compat/src/compat-adapters/ember-composable-helpers.ts
@@ -1,11 +1,11 @@
-import V1Addon from "../v1-addon";
+import V1Addon from '../v1-addon';
 import { join } from 'path';
-import { Tree } from "broccoli-plugin";
-import { readdirSync, writeFileSync, readFileSync } from "fs";
-import { pathExistsSync, removeSync } from "fs-extra";
-import Funnel from "broccoli-funnel";
+import { Tree } from 'broccoli-plugin';
+import { readdirSync, writeFileSync, readFileSync } from 'fs';
+import { pathExistsSync, removeSync } from 'fs-extra';
+import Funnel from 'broccoli-funnel';
 import { transform } from '@babel/core';
-import { stripBadReexportsPlugin } from "../compat-utils";
+import { stripBadReexportsPlugin } from '../compat-utils';
 
 export default class extends V1Addon {
   get v2Tree(): Tree {
@@ -32,9 +32,7 @@ class MatchHelpers extends Funnel {
       }
     }
     let src = readFileSync(join(this.inputPaths[0], 'index.js'), 'utf8');
-    let plugins = [
-      stripBadReexportsPlugin({ resolveBase: this.outputPath })
-    ];
+    let plugins = [stripBadReexportsPlugin({ resolveBase: this.outputPath })];
     writeFileSync(join(this.outputPath, 'index.js'), transform(src, { plugins })!.code);
   }
 }

--- a/packages/compat/src/compat-adapters/ember-data.ts
+++ b/packages/compat/src/compat-adapters/ember-data.ts
@@ -1,8 +1,8 @@
-import V1Addon from "../v1-addon";
+import V1Addon from '../v1-addon';
 import { join } from 'path';
-import { Memoize } from "typescript-memoize";
+import { Memoize } from 'typescript-memoize';
 import cloneDeep from 'lodash/cloneDeep';
-import { AddonMeta } from "@embroider/core";
+import { AddonMeta } from '@embroider/core';
 
 export default class EmberData extends V1Addon {
   // ember-data customizes the addon tree, but we don't want to run that one

--- a/packages/compat/src/compat-adapters/ember-decorators.ts
+++ b/packages/compat/src/compat-adapters/ember-decorators.ts
@@ -1,5 +1,5 @@
-import V1Addon from "../v1-addon";
-import { addPeerDependency } from "../compat-utils";
+import V1Addon from '../v1-addon';
+import { addPeerDependency } from '../compat-utils';
 
 export default class extends V1Addon {
   get packageJSON() {

--- a/packages/compat/src/compat-adapters/ember-percy.ts
+++ b/packages/compat/src/compat-adapters/ember-percy.ts
@@ -1,5 +1,5 @@
-import V1Addon from "../v1-addon";
-import { forceIncludeModule } from "../compat-utils";
+import V1Addon from '../v1-addon';
+import { forceIncludeModule } from '../compat-utils';
 
 export default class extends V1Addon {
   get packageMeta() {

--- a/packages/compat/src/compat-adapters/ember-test-selectors.ts
+++ b/packages/compat/src/compat-adapters/ember-test-selectors.ts
@@ -1,5 +1,5 @@
-import V1Addon from "../v1-addon";
-import { forceIncludeModule } from "../compat-utils";
+import V1Addon from '../v1-addon';
+import { forceIncludeModule } from '../compat-utils';
 
 export default class extends V1Addon {
   get packageMeta() {

--- a/packages/compat/src/compat-adapters/ember-window-mock.ts
+++ b/packages/compat/src/compat-adapters/ember-window-mock.ts
@@ -1,5 +1,5 @@
-import V1Addon from "../v1-addon";
-import { todo } from "@embroider/core/src/messages";
+import V1Addon from '../v1-addon';
+import { todo } from '@embroider/core/src/messages';
 
 export default class extends V1Addon {
   /*

--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -1,21 +1,14 @@
-import { Tree } from "broccoli-plugin";
+import { Tree } from 'broccoli-plugin';
 import { join } from 'path';
-import {
-  emptyDirSync,
-  ensureSymlinkSync,
-  ensureDirSync,
-  realpathSync,
-  mkdtempSync,
-  copySync,
-} from 'fs-extra';
+import { emptyDirSync, ensureSymlinkSync, ensureDirSync, realpathSync, mkdtempSync, copySync } from 'fs-extra';
 import { Stage, Package, PackageCache, WaitForTrees } from '@embroider/core';
-import V1InstanceCache from "./v1-instance-cache";
+import V1InstanceCache from './v1-instance-cache';
 import { tmpdir } from 'os';
-import { MovedPackageCache } from "./moved-package-cache";
-import { Memoize } from "typescript-memoize";
+import { MovedPackageCache } from './moved-package-cache';
+import { Memoize } from 'typescript-memoize';
 import buildCompatAddon from './build-compat-addon';
 import Options, { optionsWithDefaults } from './options';
-import V1App from "./v1-app";
+import V1App from './v1-app';
 
 export default class CompatAddons implements Stage {
   private didBuild = false;
@@ -36,15 +29,19 @@ export default class CompatAddons implements Stage {
     this.packageCache = v1Cache.packageCache.moveAddons(v1Cache.app.root, this.destDir);
     let movedAddons = [...this.packageCache.moved.keys()].map(oldPkg => buildCompatAddon(oldPkg, v1Cache));
     let { synthVendor, synthStyles } = this.getSyntheticPackages(v1Cache.app, movedAddons);
-    this.tree = new WaitForTrees({ movedAddons, synthVendor, synthStyles }, '@embroider/compat/addons', this.build.bind(this));
+    this.tree = new WaitForTrees(
+      { movedAddons, synthVendor, synthStyles },
+      '@embroider/compat/addons',
+      this.build.bind(this)
+    );
     this.inputPath = v1Cache.app.root;
   }
 
-  async ready(): Promise<{ outputPath: string, packageCache: PackageCache }>{
+  async ready(): Promise<{ outputPath: string; packageCache: PackageCache }> {
     await this.deferReady.promise;
     return {
       outputPath: this.packageCache.appDestDir,
-      packageCache: this.packageCache
+      packageCache: this.packageCache,
     };
   }
 
@@ -56,7 +53,15 @@ export default class CompatAddons implements Stage {
     return this.packageCache.app;
   }
 
-  private async build({ movedAddons, synthVendor, synthStyles }: { movedAddons: string[], synthVendor: string, synthStyles: string }) {
+  private async build({
+    movedAddons,
+    synthVendor,
+    synthStyles,
+  }: {
+    movedAddons: string[];
+    synthVendor: string;
+    synthStyles: string;
+  }) {
     if (this.didBuild) {
       // TODO: we can selectively allow some addons to rebuild, equivalent to
       // the old isDevelopingAddon. This should be based off Package#mayRebuild.
@@ -71,16 +76,20 @@ export default class CompatAddons implements Stage {
     });
     this.linkNonCopiedDeps(this.app, this.appDestDir);
     await this.packageCache.updatePreexistingResolvableSymlinks();
-    copySync(synthVendor, join(this.appDestDir, 'node_modules', '@embroider', 'synthesized-vendor'), { dereference: true });
-    copySync(synthStyles, join(this.appDestDir, 'node_modules', '@embroider', 'synthesized-styles'), { dereference: true });
+    copySync(synthVendor, join(this.appDestDir, 'node_modules', '@embroider', 'synthesized-vendor'), {
+      dereference: true,
+    });
+    copySync(synthStyles, join(this.appDestDir, 'node_modules', '@embroider', 'synthesized-styles'), {
+      dereference: true,
+    });
     this.didBuild = true;
     this.deferReady.resolve();
   }
 
-  private getSyntheticPackages(v1App: V1App, movedAddons: Tree[]): { synthVendor: Tree, synthStyles: Tree } {
+  private getSyntheticPackages(v1App: V1App, movedAddons: Tree[]): { synthVendor: Tree; synthStyles: Tree } {
     let index = 0;
     let upgradedAddonTrees = [];
-    for (let [ oldPkg ] of this.packageCache.moved.entries()) {
+    for (let [oldPkg] of this.packageCache.moved.entries()) {
       if (!oldPkg.isV2) {
         upgradedAddonTrees.push(movedAddons[index]);
       }
@@ -88,14 +97,14 @@ export default class CompatAddons implements Stage {
     }
     return {
       synthVendor: v1App.synthesizeVendorPackage(upgradedAddonTrees),
-      synthStyles: v1App.synthesizeStylesPackage(upgradedAddonTrees)
+      synthStyles: v1App.synthesizeStylesPackage(upgradedAddonTrees),
     };
   }
 
   @Memoize()
   private get deferReady() {
     let resolve: Function;
-    let promise: Promise<void> = new Promise(r => resolve =r);
+    let promise: Promise<void> = new Promise(r => (resolve = r));
     return { resolve: resolve!, promise };
   }
 

--- a/packages/compat/src/compat-utils.ts
+++ b/packages/compat/src/compat-utils.ts
@@ -4,7 +4,7 @@ import resolve from 'resolve';
 import { resolve as pathResolve } from 'path';
 import { PluginItem } from '@babel/core';
 
-export function addPeerDependency(packageJSON: any, packageName: string, version='*') {
+export function addPeerDependency(packageJSON: any, packageName: string, version = '*') {
   let pkg = cloneDeep(packageJSON);
   if (!pkg.peerDependencies) {
     pkg.peerDependencies = {};
@@ -35,8 +35,8 @@ export function forceIncludeTestModule(meta: AddonMeta, localPath: string) {
 // Unfortunately needed because some popular addons have bogus unused reexports.
 //
 // Append the output of this function to the `plugins` array in a babel config.
-export function stripBadReexportsPlugin(opts: { filenamePattern?: RegExp, resolveBase?: string } = {}): PluginItem {
-  return [stripBadReexportsTransform, { filenamePattern: opts.filenamePattern, resolveBase: opts.resolveBase } ];
+export function stripBadReexportsPlugin(opts: { filenamePattern?: RegExp; resolveBase?: string } = {}): PluginItem {
+  return [stripBadReexportsTransform, { filenamePattern: opts.filenamePattern, resolveBase: opts.resolveBase }];
 }
 
 function stripBadReexportsTransform() {
@@ -50,12 +50,12 @@ function stripBadReexportsTransform() {
         ) {
           try {
             resolve.sync(path.node.source.value, { basedir: state.opts.resolveBase });
-          } catch(err) {
+          } catch (err) {
             path.remove();
           }
         }
-      }
-    }
+      },
+    },
   };
 }
 (stripBadReexportsTransform as any).baseDir = function() {

--- a/packages/compat/src/dependency-analyzer.ts
+++ b/packages/compat/src/dependency-analyzer.ts
@@ -6,7 +6,7 @@ import { packageName as absolutePackageName, Package } from '@embroider/core';
 export default class DependencyAnalyzer extends Plugin {
   constructor(private importParsers: ImportParser[], private pkg: Package) {
     super(importParsers, {
-      annotation: '@embroider/core/dependency-analyzer'
+      annotation: '@embroider/core/dependency-analyzer',
     });
   }
 

--- a/packages/compat/src/dependency-rules.ts
+++ b/packages/compat/src/dependency-rules.ts
@@ -33,7 +33,7 @@ export interface ActivePackageRules extends PackageRules {
 }
 
 export interface ComponentRules {
- // This declares that our component yields other components that are safe to
+  // This declares that our component yields other components that are safe to
   // invoke with the {{component}} helper.
   //
   // The array corresponds to your yielded positional arguments. Any value that

--- a/packages/compat/src/dependency-rules.ts
+++ b/packages/compat/src/dependency-rules.ts
@@ -1,6 +1,6 @@
-import { Package } from "@embroider/core";
-import { satisfies } from "semver";
-import CompatResolver from "./resolver";
+import { Package } from '@embroider/core';
+import { satisfies } from 'semver';
+import CompatResolver from './resolver';
 
 export interface PackageRules {
   // This whole set of rules will only apply when the given addon package
@@ -48,7 +48,7 @@ export interface ComponentRules {
   //    If you do: {{yield (hash x=(component "x") y=(component "y")) }}
   //    Then say: yieldsSafeComponents: [{x: true, y: true}]
   //
-  yieldsSafeComponents?: (boolean | { [name: string]: boolean } )[];
+  yieldsSafeComponents?: (boolean | { [name: string]: boolean })[];
 
   // This declares that our component accepts arguments that will be invoked
   // with the {{component}} helper. This silences warnings in the places where
@@ -87,12 +87,14 @@ export interface ModuleRules {
 }
 
 // The bare "string" short form implies that `becomes` is the same as `name`.
-export type ArgumentMapping = string | {
-  // the name of the argument you accept
-  name: string;
-  // the name its consumed as in your template
-  becomes: string;
-};
+export type ArgumentMapping =
+  | string
+  | {
+      // the name of the argument you accept
+      name: string;
+      // the name its consumed as in your template
+      becomes: string;
+    };
 
 // A component snippet is a string containing valid HBS that is a single
 // component invocation. We use it to refer to compoanents in a way that doesn't
@@ -109,7 +111,7 @@ export type ArgumentMapping = string | {
 type ComponentSnippet = string;
 
 export interface PreprocessedComponentRule {
-  yieldsSafeComponents: Required<ComponentRules>["yieldsSafeComponents"];
+  yieldsSafeComponents: Required<ComponentRules>['yieldsSafeComponents'];
   argumentsAreComponents: string[];
   safeInteriorPaths: string[];
 }
@@ -161,13 +163,13 @@ export function activePackageRules(packageRules: PackageRules[], activePackages:
   }
   let output = [];
   for (let [rule, roots] of rootsPerRule) {
-    output.push(Object.assign({ roots }, rule ));
+    output.push(Object.assign({ roots }, rule));
   }
   return output;
 }
 
 export function expandModuleRules(absPath: string, moduleRules: ModuleRules, resolver: CompatResolver) {
-  let output: { absPath: string, target: string, runtimeName?: string }[] = [];
+  let output: { absPath: string; target: string; runtimeName?: string }[] = [];
   if (moduleRules.dependsOnModules) {
     for (let target of moduleRules.dependsOnModules) {
       output.push({ absPath, target });
@@ -177,7 +179,7 @@ export function expandModuleRules(absPath: string, moduleRules: ModuleRules, res
     for (let snippet of moduleRules.dependsOnComponents) {
       let found = resolver.resolveComponentSnippet(snippet, moduleRules);
       for (let { absPath: target, runtimeName } of found.modules) {
-        output.push({ absPath, target, runtimeName  });
+        output.push({ absPath, target, runtimeName });
       }
     }
   }

--- a/packages/compat/src/dummy-package.ts
+++ b/packages/compat/src/dummy-package.ts
@@ -1,6 +1,6 @@
-import { Package, PackageCache } from "@embroider/core";
-import { Memoize } from "typescript-memoize";
-import cloneDeep  from "lodash/cloneDeep";
+import { Package, PackageCache } from '@embroider/core';
+import { Memoize } from 'typescript-memoize';
+import cloneDeep from 'lodash/cloneDeep';
 
 export default class DummyPackage extends Package {
   constructor(root: string, private owningAddon: Package, packageCache: PackageCache) {

--- a/packages/compat/src/empty-package-tree.ts
+++ b/packages/compat/src/empty-package-tree.ts
@@ -1,6 +1,6 @@
-import Plugin from "broccoli-plugin";
-import { writeJSONSync } from "fs-extra";
-import { join } from "path";
+import Plugin from 'broccoli-plugin';
+import { writeJSONSync } from 'fs-extra';
+import { join } from 'path';
 
 export default class extends Plugin {
   private built = false;

--- a/packages/compat/src/import-parser.ts
+++ b/packages/compat/src/import-parser.ts
@@ -66,20 +66,20 @@ export default class ImportParser extends Plugin {
       let outputPath = join(this.outputPath, relativePath);
 
       switch (operation) {
-      case 'unlink':
-        if (this.extensions.includes(extname(relativePath))) {
-          this.removeImports(relativePath);
-        }
-        unlinkSync(outputPath);
-        break;
-      case 'rmdir' :
-        rmdirSync(outputPath);
-        break;
-      case 'mkdir' :
-        mkdirSync(outputPath);
-        break;
-      case 'create':
-      case 'change':
+        case 'unlink':
+          if (this.extensions.includes(extname(relativePath))) {
+            this.removeImports(relativePath);
+          }
+          unlinkSync(outputPath);
+          break;
+        case 'rmdir' :
+          rmdirSync(outputPath);
+          break;
+        case 'mkdir' :
+          mkdirSync(outputPath);
+          break;
+        case 'create':
+        case 'change':
         {
           let absoluteInputPath  = join(this.inputPaths[0], relativePath);
           if (this.extensions.includes(extname(relativePath))) {

--- a/packages/compat/src/import-parser.ts
+++ b/packages/compat/src/import-parser.ts
@@ -1,13 +1,6 @@
 import Plugin, { Tree } from 'broccoli-plugin';
-import walkSync from  'walk-sync';
-import {
-  unlinkSync,
-  rmdirSync,
-  mkdirSync,
-  readFileSync,
-  existsSync,
-  mkdirpSync
-} from 'fs-extra';
+import walkSync from 'walk-sync';
+import { unlinkSync, rmdirSync, mkdirSync, readFileSync, existsSync, mkdirpSync } from 'fs-extra';
 import FSTree from 'fs-tree-diff';
 import makeDebug from 'debug';
 import { Pipeline, File } from 'babel-core';
@@ -37,15 +30,15 @@ export default class ImportParser extends Plugin {
   constructor(inputTree: Tree, private extensions = ['.js', '.hbs']) {
     super([inputTree], {
       annotation: 'embroider:core:import-parser',
-      persistentOutput: true
+      persistentOutput: true,
     });
     this.parserOptions = this.buildParserOptions();
   }
 
-  get imports() : Import[] {
+  get imports(): Import[] {
     if (!this.modules) {
       this.modules = flatten([...this.paths.values()]);
-      debug("imports %s", new PrintableImports(this.modules));
+      debug('imports %s', new PrintableImports(this.modules));
     }
     return this.modules;
   }
@@ -72,16 +65,15 @@ export default class ImportParser extends Plugin {
           }
           unlinkSync(outputPath);
           break;
-        case 'rmdir' :
+        case 'rmdir':
           rmdirSync(outputPath);
           break;
-        case 'mkdir' :
+        case 'mkdir':
           mkdirSync(outputPath);
           break;
         case 'create':
-        case 'change':
-        {
-          let absoluteInputPath  = join(this.inputPaths[0], relativePath);
+        case 'change': {
+          let absoluteInputPath = join(this.inputPaths[0], relativePath);
           if (this.extensions.includes(extname(relativePath))) {
             this.updateImports(relativePath, absoluteInputPath);
           }
@@ -92,9 +84,9 @@ export default class ImportParser extends Plugin {
   }
 
   private getPatchset() {
-    let input = walkSync.entries(this.inputPaths[0], { globs: [ '**/*' ] });
-    let previous  = this.previousTree;
-    let next = this.previousTree = FSTree.fromEntries(input);
+    let input = walkSync.entries(this.inputPaths[0], { globs: ['**/*'] });
+    let previous = this.previousTree;
+    let next = (this.previousTree = FSTree.fromEntries(input));
     return previous.calculatePatch(next);
   }
 
@@ -102,7 +94,7 @@ export default class ImportParser extends Plugin {
     debug(`removing imports for ${relativePath}`);
     let imports = this.paths.get(relativePath);
     if (imports) {
-      if (imports.length > 0){
+      if (imports.length > 0) {
         this.modules = null; // invalidates cache
       }
       this.paths.delete(relativePath);
@@ -119,7 +111,7 @@ export default class ImportParser extends Plugin {
     }
   }
 
-  private parseImports(relativePath: string, source: string) : Import[] {
+  private parseImports(relativePath: string, source: string): Import[] {
     if (extname(relativePath) === '.hbs') {
       // there are no hbs templates yet that have imports. When ember introduces
       // them, this will need to parse them and discover the imports.
@@ -129,7 +121,7 @@ export default class ImportParser extends Plugin {
     let ast;
     try {
       ast = parse(source, this.parserOptions);
-    } catch(err){
+    } catch (err) {
       if (err.name !== 'SyntaxError') {
         throw err;
       }
@@ -137,8 +129,8 @@ export default class ImportParser extends Plugin {
       // normal babel processing, which will generate a nice error for it.
       debug('Ignoring an unparseable file');
     }
-    let imports : Import[] = [];
-    if (!ast){
+    let imports: Import[] = [];
+    if (!ast) {
       return imports;
     }
 
@@ -156,18 +148,18 @@ export default class ImportParser extends Plugin {
 
     // No need to recurse here, because we only deal with top-level static import declarations
     for (let node of ast.program.body) {
-      let specifier : string | undefined;
-      if (node.type === 'ImportDeclaration'){
+      let specifier: string | undefined;
+      if (node.type === 'ImportDeclaration') {
         specifier = node.source.value;
       }
-      if (node.type === 'ExportNamedDeclaration' && node.source){
+      if (node.type === 'ExportNamedDeclaration' && node.source) {
         specifier = node.source.value;
       }
       if (specifier) {
         imports.push({
           isDynamic: false,
           specifier,
-          path: relativePath
+          path: relativePath,
         });
       }
     }
@@ -194,10 +186,10 @@ function copy(sourcePath: string, destPath: string) {
 }
 
 const skipKeys: { [key: string]: boolean } = {
-  'loc': true,
-  'type': true,
-  'start': true,
-  'end': true
+  loc: true,
+  type: true,
+  start: true,
+  end: true,
 };
 
 function forEachNode(node: any, visit: (node: any) => void) {

--- a/packages/compat/src/moved-package-cache.ts
+++ b/packages/compat/src/moved-package-cache.ts
@@ -1,12 +1,7 @@
 import { join, dirname, resolve } from 'path';
-import {
-  ensureSymlinkSync,
-  readdir,
-  readlink,
-  realpath,
-} from 'fs-extra';
-import { Memoize } from "typescript-memoize";
-import { PackageCache, Package, getOrCreate } from "@embroider/core";
+import { ensureSymlinkSync, readdir, readlink, realpath } from 'fs-extra';
+import { Memoize } from 'typescript-memoize';
+import { PackageCache, Package, getOrCreate } from '@embroider/core';
 import { MacrosConfig } from '@embroider/macros';
 
 export class MovablePackageCache extends PackageCache {
@@ -29,8 +24,8 @@ export class MovedPackageCache extends PackageCache {
   readonly moved: Map<Package, Package> = new Map();
 
   constructor(
-    rootCache: PackageCache["rootCache"],
-    resolutionCache: PackageCache["resolutionCache"],
+    rootCache: PackageCache['rootCache'],
+    resolutionCache: PackageCache['resolutionCache'],
     private destDir: string,
     movedSet: MovedSet,
     origApp: Package
@@ -90,18 +85,20 @@ export class MovedPackageCache extends PackageCache {
   // given path, going up a maximum of `depth` levels.
   async updatePreexistingResolvableSymlinks(): Promise<void> {
     let roots = this.originalRoots();
-    await Promise.all([...this.candidateDirs()].map(async path => {
-      let links = await symlinksInDir(path);
-      for (let { source, target } of links) {
-        let realTarget = await realpath(resolve(dirname(source), target));
-        let pkg = roots.get(realTarget);
-        if (pkg) {
-          // we found a symlink that points at a package that was copied.
-          // Replicate it in the new structure pointing at the new package.
-          ensureSymlinkSync(pkg.root, this.localPath(source));
+    await Promise.all(
+      [...this.candidateDirs()].map(async path => {
+        let links = await symlinksInDir(path);
+        for (let { source, target } of links) {
+          let realTarget = await realpath(resolve(dirname(source), target));
+          let pkg = roots.get(realTarget);
+          if (pkg) {
+            // we found a symlink that points at a package that was copied.
+            // Replicate it in the new structure pointing at the new package.
+            ensureSymlinkSync(pkg.root, this.localPath(source));
+          }
         }
-      }
-    }));
+      })
+    );
   }
 
   // places that might have symlinks we need to mimic
@@ -110,7 +107,7 @@ export class MovedPackageCache extends PackageCache {
     for (let pkg of this.moved.keys()) {
       let segments = pathSegments(pkg.root);
       for (let i = segments.length - 1; i >= this.commonSegmentCount; i--) {
-        if (segments[i-1] !== 'node_modules') {
+        if (segments[i - 1] !== 'node_modules') {
           let candidate = '/' + join(...segments.slice(0, i), 'node_modules');
           if (candidates.has(candidate)) {
             break;
@@ -131,7 +128,7 @@ export class MovedPackageCache extends PackageCache {
   }
 }
 
-async function symlinksInDir(path: string): Promise<{ source: string, target: string }[]> {
+async function symlinksInDir(path: string): Promise<{ source: string; target: string }[]> {
   let names;
   try {
     names = await readdir(path);
@@ -141,18 +138,20 @@ async function symlinksInDir(path: string): Promise<{ source: string, target: st
     }
     return [];
   }
-  let results = await Promise.all(names.map(async name => {
-    let source = join(path, name);
-    try {
-      let target = await readlink(source);
-      return { source, target };
-    } catch (err) {
-      if (err.code !== 'EINVAL') {
-        throw err;
+  let results = await Promise.all(
+    names.map(async name => {
+      let source = join(path, name);
+      try {
+        let target = await readlink(source);
+        return { source, target };
+      } catch (err) {
+        if (err.code !== 'EINVAL') {
+          throw err;
+        }
       }
-    }
-  }));
-  return results.filter(Boolean) as { source: string, target: string }[];
+    })
+  );
+  return results.filter(Boolean) as { source: string; target: string }[];
 }
 
 function pathSegments(filename: string) {
@@ -244,7 +243,7 @@ function packageProxy(pkg: Package, getMovedPackage: (pkg: Package) => Package) 
         return pkg.findDescendants.bind(p);
       }
       return (pkg as any)[prop];
-    }
+    },
   });
   return p;
 }

--- a/packages/compat/src/multi-funnel.ts
+++ b/packages/compat/src/multi-funnel.ts
@@ -13,7 +13,7 @@ interface MultiOptions extends Options {
 }
 
 export default class MultiFunnel extends Funnel {
-  private srcDirs!: MultiOptions["srcDirs"];
+  private srcDirs!: MultiOptions['srcDirs'];
   constructor(inputTree: Tree, options: MultiOptions) {
     super(inputTree, options);
   }

--- a/packages/compat/src/one-shot.ts
+++ b/packages/compat/src/one-shot.ts
@@ -1,6 +1,6 @@
-import Plugin, { Tree } from "broccoli-plugin";
+import Plugin, { Tree } from 'broccoli-plugin';
 import { Builder } from 'broccoli';
-import { copySync } from "fs-extra";
+import { copySync } from 'fs-extra';
 
 // Wraps a broccoli tree such that it (and everything it depends on) will only
 // build a single time.
@@ -11,7 +11,7 @@ export default class OneShot extends Plugin {
   constructor(originalTree: Tree) {
     // from broccoli's perspective, we don't depend on any input trees!
     super([], {
-      persistentOutput: true
+      persistentOutput: true,
     });
     this.builder = new Builder(originalTree);
   }

--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -1,18 +1,13 @@
-import { V1AddonConstructor } from "./v1-addon";
-import { Tree } from "broccoli-plugin";
-import {
-  Options as CoreOptions,
-  optionsWithDefaults as
-  coreWithDefaults
-} from '@embroider/core';
-import { PackageRules } from "./dependency-rules";
+import { V1AddonConstructor } from './v1-addon';
+import { Tree } from 'broccoli-plugin';
+import { Options as CoreOptions, optionsWithDefaults as coreWithDefaults } from '@embroider/core';
+import { PackageRules } from './dependency-rules';
 
 // These options control how hard we will try to achieve compatibility with v1
 // addons. The defaults are conservative and try to maximize compatibility, at
 // the cost of slower or bigger builds. As you eliminate sources of legacy
 // behavior you can benefit from the more aggressive modes.
 export default interface Options extends CoreOptions {
-
   // Controls whether your addon's "addon" trees should be resolved statically
   // at build time.
   //

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -23,7 +23,7 @@ export function makeResolverTransform(resolver: Resolver) {
             if (node.blockParams.length > 0) {
               scopeStack.pop();
             }
-          }
+          },
         },
         BlockStatement(node: any) {
           if (node.path.type !== 'PathExpression') {
@@ -41,14 +41,25 @@ export function makeResolverTransform(resolver: Resolver) {
           let hasArgs = true;
           let resolution = resolver.resolveMustache(node.path.original, hasArgs, env.moduleName);
           if (resolution) {
-            if (resolution.type === 'component' && node.program.blockParams.length > 0 && resolution.yieldsComponents.length > 0) {
+            if (
+              resolution.type === 'component' &&
+              node.program.blockParams.length > 0 &&
+              resolution.yieldsComponents.length > 0
+            ) {
               scopeStack.yieldingComponents(resolution.yieldsComponents);
             }
             if (resolution.type === 'component') {
               for (let name of resolution.argumentsAreComponents) {
                 let pair = node.hash.pairs.find((pair: any) => pair.key === name);
                 if (pair) {
-                  handleImpliedComponentHelper(node.path.original, name, pair.value, resolver, env.moduleName, scopeStack);
+                  handleImpliedComponentHelper(
+                    node.path.original,
+                    name,
+                    pair.value,
+                    resolver,
+                    env.moduleName,
+                    scopeStack
+                  );
                 }
               }
             }
@@ -84,7 +95,14 @@ export function makeResolverTransform(resolver: Resolver) {
             for (let name of resolution.argumentsAreComponents) {
               let pair = node.hash.pairs.find((pair: any) => pair.key === name);
               if (pair) {
-                handleImpliedComponentHelper(node.path.original, name, pair.value, resolver, env.moduleName, scopeStack);
+                handleImpliedComponentHelper(
+                  node.path.original,
+                  name,
+                  pair.value,
+                  resolver,
+                  env.moduleName,
+                  scopeStack
+                );
               }
             }
           }
@@ -113,16 +131,16 @@ export function makeResolverTransform(resolver: Resolver) {
             if (node.blockParams.length > 0) {
               scopeStack.pop();
             }
-          }
-        }
-      }
+          },
+        },
+      },
     };
   };
 }
 
 type ScopeEntry =
-{ type: 'blockParams', blockParams: string[] } |
-{ type: 'safeComponentMarker', safeComponentMarker: Required<ComponentRules>["yieldsSafeComponents"] };
+  | { type: 'blockParams'; blockParams: string[] }
+  | { type: 'safeComponentMarker'; safeComponentMarker: Required<ComponentRules>['yieldsSafeComponents'] };
 
 class ScopeStack {
   private stack: ScopeEntry[] = [];
@@ -145,8 +163,8 @@ class ScopeStack {
   // right before we enter a block, we might determine that some of the values
   // that will be yielded as marked (by a rule) as safe to be used with the
   // {{component}} helper.
-  yieldingComponents(safeComponentMarker: Required<ComponentRules>["yieldsSafeComponents"]) {
-    this.stack.unshift({ type: 'safeComponentMarker', safeComponentMarker});
+  yieldingComponents(safeComponentMarker: Required<ComponentRules>['yieldsSafeComponents']) {
+    this.stack.unshift({ type: 'safeComponentMarker', safeComponentMarker });
   }
 
   inScope(name: string) {
@@ -168,7 +186,7 @@ class ScopeStack {
     }
     for (let i = 0; i < this.stack.length - 1; i++) {
       let here = this.stack[i];
-      let next = this.stack[i+1];
+      let next = this.stack[i + 1];
       if (here.type === 'blockParams' && next.type === 'safeComponentMarker') {
         let positionalIndex = here.blockParams.indexOf(parts[0]);
         if (positionalIndex === -1) {
@@ -188,7 +206,14 @@ class ScopeStack {
   }
 }
 
-function handleImpliedComponentHelper(componentName: string, argumentName: string, param: any, resolver: Resolver, moduleName: string, scopeStack: ScopeStack) {
+function handleImpliedComponentHelper(
+  componentName: string,
+  argumentName: string,
+  param: any,
+  resolver: Resolver,
+  moduleName: string,
+  scopeStack: ScopeStack
+) {
   if (handleComponentHelper(param, resolver, moduleName, scopeStack)) {
     return;
   }
@@ -198,7 +223,9 @@ function handleImpliedComponentHelper(componentName: string, argumentName: strin
     param.hash.pairs.length === 0 &&
     param.params.length === 0 &&
     handleComponentHelper(param.path, resolver, moduleName, scopeStack)
-  ) { return; }
+  ) {
+    return;
+  }
 
   if (
     param.type === 'MustacheStatement' &&

--- a/packages/compat/src/rewrite-addon-test-support.ts
+++ b/packages/compat/src/rewrite-addon-test-support.ts
@@ -39,24 +39,28 @@ import { AddonMeta, packageName } from '@embroider/core';
 
 type GetMeta = () => AddonMeta;
 
-export default function rewriteAddonTestSupport(tree: Tree, ownName: string): { tree: Tree, getMeta: GetMeta } {
+export default function rewriteAddonTestSupport(tree: Tree, ownName: string): { tree: Tree; getMeta: GetMeta } {
   let renamed: { [name: string]: string } = {};
-  let goodParts = new Snitch(tree, {
-    allowedPaths: new RegExp(`^${ownName}/`),
-    foundBadPaths: (badPaths: string[]) => {
-      for (let badPath of badPaths) {
-        let name = packageName(badPath)!;
-        renamed[name] = `${ownName}/${name}`;
-      }
+  let goodParts = new Snitch(
+    tree,
+    {
+      allowedPaths: new RegExp(`^${ownName}/`),
+      foundBadPaths: (badPaths: string[]) => {
+        for (let badPath of badPaths) {
+          let name = packageName(badPath)!;
+          renamed[name] = `${ownName}/${name}`;
+        }
+      },
+    },
+    {
+      srcDir: ownName,
     }
-  }, {
-    srcDir: ownName
-  });
+  );
   let badParts = new Funnel(tree, {
-    exclude: [`${ownName}/**`]
+    exclude: [`${ownName}/**`],
   });
   return {
     tree: mergeTrees([goodParts, badParts]),
-    getMeta: () => ({ 'renamed-modules' : renamed, version: 2 })
+    getMeta: () => ({ 'renamed-modules': renamed, version: 2 }),
   };
 }

--- a/packages/compat/src/rewrite-package-json.ts
+++ b/packages/compat/src/rewrite-package-json.ts
@@ -9,7 +9,7 @@ type GetMeta = () => AddonMeta;
 export default class RewritePackageJSON extends Plugin {
   constructor(inputTree: Tree, private analyzer: DependencyAnalyzer, private getMeta: GetMeta) {
     super([inputTree, analyzer], {
-      annotation: 'embroider:core:rewrite-package-json'
+      annotation: 'embroider:core:rewrite-package-json',
     });
   }
 

--- a/packages/compat/src/smoosh-package-json.ts
+++ b/packages/compat/src/smoosh-package-json.ts
@@ -6,7 +6,7 @@ import { mergeWithUniq } from './merges';
 export default class SmooshPackageJSON extends Plugin {
   constructor(inputTrees: Tree[]) {
     super(inputTrees, {
-      annotation: 'embroider:core:smoosh-package-json'
+      annotation: 'embroider:core:smoosh-package-json',
     });
   }
 

--- a/packages/compat/src/snitch.ts
+++ b/packages/compat/src/snitch.ts
@@ -15,11 +15,7 @@ export default class Snitch extends Funnel {
   private foundBadPaths: Function;
   private mustCheck = true;
 
-  constructor(
-    inputTree: Tree,
-    snitchOptions: { allowedPaths: RegExp, foundBadPaths: Function },
-    funnelOptions: any
-  ) {
+  constructor(inputTree: Tree, snitchOptions: { allowedPaths: RegExp; foundBadPaths: Function }, funnelOptions: any) {
     super(inputTree, funnelOptions);
     this.allowedPaths = snitchOptions.allowedPaths;
     this.foundBadPaths = snitchOptions.foundBadPaths;
@@ -28,12 +24,11 @@ export default class Snitch extends Funnel {
   build() {
     if (this.mustCheck) {
       let badPaths: string[] = [];
-      walkSync(this.inputPaths[0], { directories: false })
-        .map(filename => {
-          if (!this.allowedPaths.test(filename)) {
-            badPaths.push(filename);
-          }
-        });
+      walkSync(this.inputPaths[0], { directories: false }).map(filename => {
+        if (!this.allowedPaths.test(filename)) {
+          badPaths.push(filename);
+        }
+      });
       if (badPaths.length > 0) {
         this.foundBadPaths(badPaths);
       }

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -1,7 +1,7 @@
-import V1Package from "./v1-package";
+import V1Package from './v1-package';
 import { Memoize } from 'typescript-memoize';
 import { dirname } from 'path';
-import { sync as pkgUpSync }  from 'pkg-up';
+import { sync as pkgUpSync } from 'pkg-up';
 import { join } from 'path';
 import { existsSync, pathExistsSync } from 'fs-extra';
 import resolvePackagePath from 'resolve-package-path';
@@ -12,21 +12,21 @@ import RewritePackageJSON from './rewrite-package-json';
 import { todo, unsupported } from '@embroider/core/src/messages';
 import MultiFunnel from './multi-funnel';
 import ImportParser from './import-parser';
-import { Tree } from "broccoli-plugin";
+import { Tree } from 'broccoli-plugin';
 import mergeTrees from 'broccoli-merge-trees';
 import semver from 'semver';
 import Snitch from './snitch';
-import rewriteAddonTestSupport from "./rewrite-addon-test-support";
+import rewriteAddonTestSupport from './rewrite-addon-test-support';
 import { mergeWithAppend } from './merges';
-import { Package, PackageCache, AddonMeta, TemplateCompiler } from "@embroider/core";
-import Options from "./options";
+import { Package, PackageCache, AddonMeta, TemplateCompiler } from '@embroider/core';
+import Options from './options';
 import walkSync from 'walk-sync';
-import AddToTree from "./add-to-tree";
+import AddToTree from './add-to-tree';
 import { Options as HTMLBarsOptions } from 'ember-cli-htmlbars';
-import resolve from "resolve";
-import { isEmbroiderMacrosPlugin } from "@embroider/macros";
-import { TransformOptions, PluginItem } from "@babel/core";
-import cloneDeep from "lodash/cloneDeep";
+import resolve from 'resolve';
+import { isEmbroiderMacrosPlugin } from '@embroider/macros';
+import { TransformOptions, PluginItem } from '@babel/core';
+import cloneDeep from 'lodash/cloneDeep';
 
 const stockTreeNames = Object.freeze([
   'addon',
@@ -42,16 +42,16 @@ const stockTreeNames = Object.freeze([
 ]);
 
 const dynamicTreeHooks = Object.freeze([
-  "treeFor",
-  "treeForAddon",
-  "treeForAddonTemplates",
-  "treeForAddonTestSupport",
-  "treeForApp",
-  "treeForPublic",
-  "treeForStyles",
-  "treeForTemplates",
-  "treeForTestSupport",
-  "treeForVendor",
+  'treeFor',
+  'treeForAddon',
+  'treeForAddonTemplates',
+  'treeForAddonTestSupport',
+  'treeForApp',
+  'treeForPublic',
+  'treeForStyles',
+  'treeForTemplates',
+  'treeForTestSupport',
+  'treeForVendor',
 ]);
 
 const appPublicationDir = '_app_';
@@ -71,7 +71,11 @@ let locatePreprocessRegistry: (addonInstance: any) => any;
 // This controls and types the interface between our new world and the classic
 // v1 addon instance.
 export default class V1Addon implements V1Package {
-  constructor(protected addonInstance: any, private packageCache: PackageCache, protected addonOptions: Required<Options>) {
+  constructor(
+    protected addonInstance: any,
+    private packageCache: PackageCache,
+    protected addonOptions: Required<Options>
+  ) {
     this.updateBabelConfig();
     if (addonInstance.registry) {
       this.updateRegistry(addonInstance.registry);
@@ -127,7 +131,7 @@ export default class V1Addon implements V1Package {
           // anything at all.
           return tree;
         }
-      }
+      },
     });
   }
 
@@ -182,14 +186,17 @@ export default class V1Addon implements V1Package {
     return this.addonInstance.treePaths && existsSync(join(this.root, this.addonInstance.treePaths[treeName]));
   }
 
-  hasAnyTrees() : boolean {
+  hasAnyTrees(): boolean {
     return Boolean(stockTreeNames.find(name => this.hasStockTree(name))) || this.customizes(...dynamicTreeHooks);
   }
 
   protected stockTree(treeName: string, funnelOpts?: FunnelOptions) {
-    let opts = Object.assign({
-      srcDir: this.addonInstance.treePaths[treeName]
-    }, funnelOpts);
+    let opts = Object.assign(
+      {
+        srcDir: this.addonInstance.treePaths[treeName],
+      },
+      funnelOpts
+    );
     return new Funnel(this.rootTree, opts);
   }
 
@@ -210,16 +217,16 @@ export default class V1Addon implements V1Package {
   // every kind of tree through every kind of transpiler, and they could freely
   // mix JS, CSS, and HBS. Unfortunately, some existing transpiler plugins like
   // ember-cli-sass will blow up if they don't find some files.
-  private transpile(tree: Tree, { includeCSS } = { includeCSS: false}) {
+  private transpile(tree: Tree, { includeCSS } = { includeCSS: false }) {
     if (includeCSS) {
       tree = this.addonInstance.compileStyles(tree);
     }
     tree = this.addonInstance.preprocessJs(tree, '/', this.moduleName, {
-      registry : this.addonInstance.registry
+      registry: this.addonInstance.registry,
     });
     if (this.addonInstance.registry.load('template').length > 0) {
       tree = locatePreprocessRegistry(this.addonInstance).preprocessTemplates(tree, {
-        registry: this.addonInstance.registry
+        registry: this.addonInstance.registry,
       });
     }
     return tree;
@@ -248,7 +255,7 @@ export default class V1Addon implements V1Package {
       compileModules: false,
       disablePresetEnv: true,
       disableDebugTooling: true,
-      disableEmberModulesAPIPolyfill: true
+      disableEmberModulesAPIPolyfill: true,
     });
 
     if (version && semver.satisfies(version, '^5')) {
@@ -266,9 +273,12 @@ export default class V1Addon implements V1Package {
       babelConfig.plugins.push(this.templateCompiler.inlineTransformsBabelPlugin());
     }
 
-    babelConfig.plugins.push([require.resolve('@embroider/core/src/babel-plugin-adjust-imports'), {
-      ownName: this.name
-    } ]);
+    babelConfig.plugins.push([
+      require.resolve('@embroider/core/src/babel-plugin-adjust-imports'),
+      {
+        ownName: this.name,
+      },
+    ]);
   }
 
   get v2Tree() {
@@ -279,11 +289,7 @@ export default class V1Addon implements V1Package {
   // things to the package metadata.
   protected get packageMeta(): AddonMeta {
     let built = this.build();
-    return mergeWithAppend(
-      {},
-      built.staticMeta,
-      ...built.dynamicMeta.map(d => d())
-    );
+    return mergeWithAppend({}, built.staticMeta, ...built.dynamicMeta.map(d => d()));
   }
 
   @Memoize()
@@ -295,7 +301,7 @@ export default class V1Addon implements V1Package {
     // DependencyAnalyzer will respect tweaks made by Compat Adapters.
     let pkg = new TweakedPackage(this.packageCache.getAddon(this.root), this.packageJSON, this.packageCache);
 
-    let analyzer = new DependencyAnalyzer(importParsers, pkg );
+    let analyzer = new DependencyAnalyzer(importParsers, pkg);
     let packageJSONRewriter = new RewritePackageJSON(this.rootTree, analyzer, () => this.packageMeta);
     trees.push(packageJSONRewriter);
     return trees;
@@ -306,7 +312,9 @@ export default class V1Addon implements V1Package {
     try {
       if (neuterPreprocessors) {
         original = this.addonInstance.preprocessJs;
-        this.addonInstance.preprocessJs = function(tree: Tree){ return tree; };
+        this.addonInstance.preprocessJs = function(tree: Tree) {
+          return tree;
+        };
       }
       return this.addonInstance._treeFor(name);
     } finally {
@@ -316,22 +324,26 @@ export default class V1Addon implements V1Package {
     }
   }
 
-  protected treeForAddon(): Tree|undefined {
+  protected treeForAddon(): Tree | undefined {
     if (this.customizes('treeForAddon', 'treeForAddonTemplates')) {
       let tree = this.invokeOriginalTreeFor('addon', { neuterPreprocessors: true });
       if (tree) {
-        return this.transpile(new MultiFunnel(tree, {
-          srcDirs: [this.moduleName, `modules/${this.moduleName}`]
-        }));
+        return this.transpile(
+          new MultiFunnel(tree, {
+            srcDirs: [this.moduleName, `modules/${this.moduleName}`],
+          })
+        );
       }
     } else if (this.hasStockTree('addon')) {
-      return this.transpile(this.stockTree('addon', {
-        exclude: ['styles/**']
-      }));
+      return this.transpile(
+        this.stockTree('addon', {
+          exclude: ['styles/**'],
+        })
+      );
     }
   }
 
-  protected addonStylesTree(): Tree|undefined {
+  protected addonStylesTree(): Tree | undefined {
     if (this.customizes('treeForAddonStyles')) {
       todo(`${this.name} may have customized the addon style tree`);
     } else if (this.hasStockTree('addon-styles')) {
@@ -339,7 +351,7 @@ export default class V1Addon implements V1Package {
     }
   }
 
-  protected treeForTestSupport(): Tree|undefined {
+  protected treeForTestSupport(): Tree | undefined {
     if (this.customizes('treeForTestSupport')) {
       todo(`${this.name} has customized the test support tree`);
     } else if (this.hasStockTree('test-support')) {
@@ -348,7 +360,7 @@ export default class V1Addon implements V1Package {
       // the consuming app, not our own package. That is some of what is lame
       // about app trees and why they will go away once everyone is all MU.
       return new Funnel(this.stockTree('test-support'), {
-        destDir: `${appPublicationDir}/tests`
+        destDir: `${appPublicationDir}/tests`,
       });
     }
   }
@@ -360,7 +372,9 @@ export default class V1Addon implements V1Package {
       built.importParsers.push(addonParser);
       built.trees.push(addonTree);
       if (!this.addonOptions.staticAddonTrees) {
-        built.dynamicMeta.push(() => ({ 'implicit-modules': addonParser.filenames.map(f => `./${f.replace(/.js$/i, '')}`)}));
+        built.dynamicMeta.push(() => ({
+          'implicit-modules': addonParser.filenames.map(f => `./${f.replace(/.js$/i, '')}`),
+        }));
       }
     }
   }
@@ -385,12 +399,12 @@ export default class V1Addon implements V1Package {
       if (tree) {
         tree = new Funnel(tree, {
           srcDir: 'app/styles',
-          destDir: '_app_styles_'
+          destDir: '_app_styles_',
         });
       }
     } else if (this.hasStockTree('styles')) {
       tree = this.stockTree('styles', {
-        destDir: '_app_styles_'
+        destDir: '_app_styles_',
       });
     }
     if (tree) {
@@ -408,16 +422,20 @@ export default class V1Addon implements V1Package {
       addonTestSupportTree = this.transpile(tree);
       built.dynamicMeta.push(getMeta);
     } else if (this.hasStockTree('addon-test-support')) {
-      addonTestSupportTree = this.transpile(this.stockTree('addon-test-support', {
-        destDir: 'test-support'
-      }));
+      addonTestSupportTree = this.transpile(
+        this.stockTree('addon-test-support', {
+          destDir: 'test-support',
+        })
+      );
     }
     if (addonTestSupportTree) {
       let testSupportParser = this.parseImports(addonTestSupportTree);
       built.importParsers.push(testSupportParser);
       built.trees.push(addonTestSupportTree);
       if (!this.addonOptions.staticAddonTestSupportTrees) {
-        built.dynamicMeta.push(() => ({ 'implicit-test-modules': testSupportParser.filenames.map(f => `./${f.replace(/.js$/i, '')}`)}));
+        built.dynamicMeta.push(() => ({
+          'implicit-test-modules': testSupportParser.filenames.map(f => `./${f.replace(/.js$/i, '')}`),
+        }));
       }
     }
   }
@@ -455,13 +473,13 @@ export default class V1Addon implements V1Package {
       let original = this.invokeOriginalTreeFor('app');
       if (original) {
         appTree = new Funnel(original, {
-          destDir: appPublicationDir
+          destDir: appPublicationDir,
         });
       }
     } else if (this.hasStockTree('app')) {
       appTree = this.stockTree('app', {
         exclude: ['styles/**'],
-        destDir: appPublicationDir
+        destDir: appPublicationDir,
       });
     }
 
@@ -499,19 +517,24 @@ export default class V1Addon implements V1Package {
     if (this.customizes('treeForPublic')) {
       let original = this.invokeOriginalTreeFor('public');
       if (original) {
-        publicTree = new Snitch(this.invokeOriginalTreeFor('public'), {
-          // The normal behavior is to namespace your public files under your
-          // own name. But addons can flaunt that, and that goes beyond what
-          // the v2 format is allowed to do.
-          allowedPaths: new RegExp(`^${this.name}/`),
-          foundBadPaths: (badPaths: string[]) => `${this.name} treeForPublic contains unsupported paths: ${badPaths.join(', ')}`
-        }, {
-          destDir: 'public'
-        });
+        publicTree = new Snitch(
+          this.invokeOriginalTreeFor('public'),
+          {
+            // The normal behavior is to namespace your public files under your
+            // own name. But addons can flaunt that, and that goes beyond what
+            // the v2 format is allowed to do.
+            allowedPaths: new RegExp(`^${this.name}/`),
+            foundBadPaths: (badPaths: string[]) =>
+              `${this.name} treeForPublic contains unsupported paths: ${badPaths.join(', ')}`,
+          },
+          {
+            destDir: 'public',
+          }
+        );
       }
     } else if (this.hasStockTree('public')) {
       publicTree = this.stockTree('public', {
-        destDir: 'public'
+        destDir: 'public',
       });
     }
     if (publicTree) {
@@ -538,26 +561,26 @@ export default class V1Addon implements V1Package {
       if (tree) {
         built.trees.push(
           new Funnel(tree, {
-            destDir: 'vendor'
+            destDir: 'vendor',
           })
         );
       }
     } else if (this.hasStockTree('vendor')) {
       built.trees.push(
         this.stockTree('vendor', {
-          destDir: 'vendor'
+          destDir: 'vendor',
         })
       );
     }
   }
 
   @Memoize()
-  private build() : IntermediateBuild {
+  private build(): IntermediateBuild {
     let built = new IntermediateBuild();
 
-    if (this.moduleName !== this.name ) {
+    if (this.moduleName !== this.name) {
       built.staticMeta['renamed-modules'] = {
-        [this.moduleName]: this.name
+        [this.moduleName]: this.name,
       };
     }
 
@@ -579,7 +602,7 @@ export default class V1Addon implements V1Package {
 }
 
 export interface V1AddonConstructor {
-  new(addonInstance: any, packageCache: PackageCache, options: Required<Options>): V1Addon;
+  new (addonInstance: any, packageCache: PackageCache, options: Required<Options>): V1Addon;
 }
 
 class TweakedPackage extends Package {

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -313,35 +313,35 @@ export default class V1App implements V1Package {
       // internal implementation detail, and respecting outputPaths here is
       // unnecessary complexity. The corresponding code that adjusts the HTML
       // <link> is in updateHTML in app.ts.
-     outputPaths: { app: `/assets/${this.name}.css` },
-     registry: this.app.registry,
-     minifyCSS: this.app.options.minifyCSS.options,
-   };
+      outputPaths: { app: `/assets/${this.name}.css` },
+      registry: this.app.registry,
+      minifyCSS: this.app.options.minifyCSS.options,
+    };
 
-   let styles = this.preprocessors.preprocessCss(
-     this.combinedStyles(addonTrees),
-     '.',
-     '/assets',
-     options
-   );
+    let styles = this.preprocessors.preprocessCss(
+      this.combinedStyles(addonTrees),
+      '.',
+      '/assets',
+      options
+    );
 
-   return new AddToTree(styles, outputPath => {
-    let addonMeta: AddonMeta = {
-      version: 2,
-      'public-assets': {
+    return new AddToTree(styles, outputPath => {
+      let addonMeta: AddonMeta = {
+        version: 2,
+        'public-assets': {
+        }
+      };
+      for (let file of readdirSync(join(outputPath, 'assets'))) {
+        addonMeta['public-assets']![`./assets/${file}`] = `/assets/${file}`;
       }
-    };
-    for (let file of readdirSync(join(outputPath, 'assets'))) {
-      addonMeta['public-assets']![`./assets/${file}`] = `/assets/${file}`;
-    }
-    let meta = {
-      name: '@embroider/synthesized-styles',
-      version: '0.0.0',
-      keywords: 'ember-addon',
-      'ember-addon': addonMeta
-    };
-    writeJSONSync(join(outputPath, 'package.json'), meta, { spaces: 2 });
-   });
+      let meta = {
+        name: '@embroider/synthesized-styles',
+        version: '0.0.0',
+        keywords: 'ember-addon',
+        'ember-addon': addonMeta
+      };
+      writeJSONSync(join(outputPath, 'package.json'), meta, { spaces: 2 });
+    });
   }
 
   // this is taken nearly verbatim from ember-cli.

--- a/packages/compat/src/v1-config.ts
+++ b/packages/compat/src/v1-config.ts
@@ -1,6 +1,6 @@
-import Plugin, { Tree } from "broccoli-plugin";
+import Plugin, { Tree } from 'broccoli-plugin';
 import { join } from 'path';
-import { readFileSync, outputFileSync } from "fs-extra";
+import { readFileSync, outputFileSync } from 'fs-extra';
 import { EmberENV } from '@embroider/core';
 
 export interface ConfigContents {
@@ -30,7 +30,7 @@ export class WriteV1Config extends Plugin {
   private lastContents: string | undefined;
   constructor(private inputTree: V1Config, private storeConfigInMeta: boolean, private appName: string) {
     super([inputTree], {
-      persistentOutput: true
+      persistentOutput: true,
     });
   }
   build() {

--- a/packages/compat/src/v1-config.ts
+++ b/packages/compat/src/v1-config.ts
@@ -13,7 +13,7 @@ export interface ConfigContents {
 export class V1Config extends Plugin {
   private lastConfig: ConfigContents | undefined;
   constructor(configTree: Tree, private env: string) {
-  super([configTree], {});
+    super([configTree], {});
   }
   build() {
     this.lastConfig = JSON.parse(readFileSync(join(this.inputPaths[0], 'environments', `${this.env}.json`), 'utf8'));

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -57,7 +57,7 @@ export default class V1InstanceCache {
     let v1Addon = new Klass(addonInstance, this.packageCache, this.options);
     let pkgs = this.addons.get(v1Addon.root);
     if (!pkgs) {
-      this.addons.set(v1Addon.root, pkgs = []);
+      this.addons.set(v1Addon.root, (pkgs = []));
     }
     pkgs.push(v1Addon);
     (addonInstance.addons as any[]).forEach(a => this.addAddon(a));

--- a/packages/compat/tests/helpers.ts
+++ b/packages/compat/tests/helpers.ts
@@ -113,23 +113,23 @@ export class Project extends FixturifyProject {
 
   writeSync(root?: string) {
     super.writeSync(root);
-    let stack: { project: Project, root: string }[] = [{ project: this, root: root || this.root } ];
+    let stack: { project: Project; root: string }[] = [{ project: this, root: root || this.root }];
     while (stack.length > 0) {
       let { project, root } = stack.shift()!;
       for (let [name, target] of project.packageLinks) {
         ensureSymlinkSync(target, join(root, project.name, 'node_modules', name), 'dir');
       }
       for (let dep of project.dependencies()) {
-        stack.push({ project: dep as Project, root: join(root, project.name, 'node_modules')});
+        stack.push({ project: dep as Project, root: join(root, project.name, 'node_modules') });
       }
       for (let dep of project.devDependencies()) {
-        stack.push({ project: dep as Project, root: join(root, project.name, 'node_modules')});
+        stack.push({ project: dep as Project, root: join(root, project.name, 'node_modules') });
       }
     }
   }
 
-  toJSON(): Project["files"];
-  toJSON(key: string): Project["files"] | string;
+  toJSON(): Project['files'];
+  toJSON(key: string): Project['files'] | string;
   toJSON(key?: string) {
     let result = key ? super.toJSON(key) : super.toJSON();
     if (!key && this.packageLinks.size > 0) {
@@ -149,16 +149,16 @@ export function emberProject(emberAppOptions: any = {}, embroiderOptions: Option
   app.files = {
     'ember-cli-build.js': cliBuildFile(emberAppOptions, embroiderOptions),
     config: {
-      'environment.js': environmentFile(name)
+      'environment.js': environmentFile(name),
     },
     app: {
       'index.html': indexFile(name),
       styles: {
-        'app.css': ''
+        'app.css': '',
       },
       'app.js': appJSFile(),
-      'resolver.js': `export { default } from 'ember-resolver';`
-    }
+      'resolver.js': `export { default } from 'ember-resolver';`,
+    },
   };
   app.linkPackage('ember-cli');
   app.linkPackage('loader.js');
@@ -172,16 +172,15 @@ export function emberProject(emberAppOptions: any = {}, embroiderOptions: Option
   return app;
 }
 
-export function addAddon(app: Project, name: string, indexContent = "") {
+export function addAddon(app: Project, name: string, indexContent = '') {
   let addon = app.addDependency(name);
   addon.files = {
     'index.js': addonIndexFile(indexContent),
     addon: {
       templates: {
-        components: {
-        }
-      }
-    }
+        components: {},
+      },
+    },
   };
   addon.linkPackage('ember-cli-htmlbars');
   addon.linkPackage('ember-cli-babel');

--- a/packages/compat/tests/resolver-test.ts
+++ b/packages/compat/tests/resolver-test.ts
@@ -42,7 +42,7 @@ QUnit.module('compat-resolver', function(hooks) {
   throwOnWarnings(hooks);
 
   hooks.beforeEach(function(assert) {
-    assertWarning =function(pattern: RegExp, fn: () => void) {
+    assertWarning = function(pattern: RegExp, fn: () => void) {
       assert.ok(expectWarning(pattern, fn), `expected to get a warning matching ${pattern}`);
     };
   });
@@ -63,118 +63,98 @@ QUnit.module('compat-resolver', function(hooks) {
   test('emits no components when staticComponents is off', function(assert) {
     let findDependencies = configure({ staticComponents: false });
     givenFile('components/hello-world.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{hello-world}} <HelloWorld />`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}} <HelloWorld />`), []);
   });
 
   test('bare dasherized component, js only', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{hello-world}}`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}}`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+    ]);
   });
 
   test('bare dasherized component, hbs only', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('templates/components/hello-world.hbs');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{hello-world}}`),
-      [
-        {
-          "path": "./components/hello-world.hbs",
-          "runtimeName": "the-app/templates/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}}`), [
+      {
+        path: './components/hello-world.hbs',
+        runtimeName: 'the-app/templates/components/hello-world',
+      },
+    ]);
   });
 
   test('bare dasherized component, js and hbs', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
     givenFile('templates/components/hello-world.hbs');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{hello-world}}`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }, {
-          "path": "./components/hello-world.hbs",
-          "runtimeName": "the-app/templates/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}}`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+      {
+        path: './components/hello-world.hbs',
+        runtimeName: 'the-app/templates/components/hello-world',
+      },
+    ]);
   });
 
   test('coalesces repeated components', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{hello-world}}{{hello-world}}`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}}{{hello-world}}`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+    ]);
   });
 
   test('tolerates non path mustaches', function(assert) {
     let findDependencies = configure({ staticComponents: false, staticHelpers: true });
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `<Thing @foo={{1}} />`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `<Thing @foo={{1}} />`), []);
   });
 
   test('block form curly component', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{#hello-world}} {{/hello-world}}`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{#hello-world}} {{/hello-world}}`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+    ]);
   });
 
   test('block form angle component', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `<HelloWorld></HelloWorld>`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `<HelloWorld></HelloWorld>`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+    ]);
   });
 
   test('curly contextual component', function(assert) {
     let findDependencies = configure({ staticComponents: true, staticHelpers: true });
     givenFile('components/hello-world.js');
     assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{#hello-world as |h|}} {{h.title flavor="chocolate"}} {{/hello-world}}`),
+      findDependencies(
+        'templates/application.hbs',
+        `{{#hello-world as |h|}} {{h.title flavor="chocolate"}} {{/hello-world}}`
+      ),
       [
         {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
+          path: '../components/hello-world.js',
+          runtimeName: 'the-app/components/hello-world',
+        },
       ]
     );
   });
@@ -183,12 +163,15 @@ QUnit.module('compat-resolver', function(hooks) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
     assert.deepEqual(
-      findDependencies('templates/application.hbs', `<HelloWorld as |H|> <H.title @flavor="chocolate" /> </HelloWorld>`),
+      findDependencies(
+        'templates/application.hbs',
+        `<HelloWorld as |H|> <H.title @flavor="chocolate" /> </HelloWorld>`
+      ),
       [
         {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
+          path: '../components/hello-world.js',
+          runtimeName: 'the-app/components/hello-world',
+        },
       ]
     );
   });
@@ -197,12 +180,15 @@ QUnit.module('compat-resolver', function(hooks) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
     assert.deepEqual(
-      findDependencies('templates/application.hbs', `<HelloWorld as |h|> <h.title @flavor="chocolate" /> </HelloWorld>`),
+      findDependencies(
+        'templates/application.hbs',
+        `<HelloWorld as |h|> <h.title @flavor="chocolate" /> </HelloWorld>`
+      ),
       [
         {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
+          path: '../components/hello-world.js',
+          runtimeName: 'the-app/components/hello-world',
+        },
       ]
     );
   });
@@ -211,93 +197,85 @@ QUnit.module('compat-resolver', function(hooks) {
     let findDependencies = configure({
       staticComponents: true,
       staticHelpers: true,
-      packageRules: [{
-        package: 'the-test-package',
-        components: {
-          '{{this-one}}': { safeToIgnore: true }
-        }
-      }]
+      packageRules: [
+        {
+          package: 'the-test-package',
+          components: {
+            '{{this-one}}': { safeToIgnore: true },
+          },
+        },
+      ],
     });
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{this-one x=true}}`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{this-one x=true}}`), []);
   });
 
   test('optional component missing in mustache block', function(assert) {
     let findDependencies = configure({
       staticComponents: true,
       staticHelpers: true,
-      packageRules: [{
-        package: 'the-test-package',
-        components: {
-          '{{this-one}}': { safeToIgnore: true }
-        }
-      }]
+      packageRules: [
+        {
+          package: 'the-test-package',
+          components: {
+            '{{this-one}}': { safeToIgnore: true },
+          },
+        },
+      ],
     });
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{#this-one}} {{/this-one}}`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{#this-one}} {{/this-one}}`), []);
   });
 
   test('optional component missing in mustache', function(assert) {
     let findDependencies = configure({
       staticComponents: true,
       staticHelpers: true,
-      packageRules: [{
-        package: 'the-test-package',
-        components: {
-          '{{this-one}}': { safeToIgnore: true }
-        }
-      }]
+      packageRules: [
+        {
+          package: 'the-test-package',
+          components: {
+            '{{this-one}}': { safeToIgnore: true },
+          },
+        },
+      ],
     });
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{this-one x=true}}`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{this-one x=true}}`), []);
   });
 
   test('optional component declared as element missing in mustache block', function(assert) {
     let findDependencies = configure({
       staticComponents: true,
       staticHelpers: true,
-      packageRules: [{
-        package: 'the-test-package',
-        components: {
-          '<ThisOne />': { safeToIgnore: true }
-        }
-      }]
+      packageRules: [
+        {
+          package: 'the-test-package',
+          components: {
+            '<ThisOne />': { safeToIgnore: true },
+          },
+        },
+      ],
     });
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{#this-one}} {{/this-one}}`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{#this-one}} {{/this-one}}`), []);
   });
 
   test('optional component missing in element', function(assert) {
     let findDependencies = configure({
       staticComponents: true,
       staticHelpers: true,
-      packageRules: [{
-        package: 'the-test-package',
-        components: {
-          '{{this-one}}': { safeToIgnore: true }
-        }
-      }]
+      packageRules: [
+        {
+          package: 'the-test-package',
+          components: {
+            '{{this-one}}': { safeToIgnore: true },
+          },
+        },
+      ],
     });
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `<ThisOne/>`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `<ThisOne/>`), []);
   });
 
   test('mustache missing, no args', function(assert) {
     let findDependencies = configure({ staticComponents: true, staticHelpers: true });
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{hello-world}}`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}}`), []);
   });
 
   test('mustache missing, with args', function(assert) {
@@ -310,48 +288,39 @@ QUnit.module('compat-resolver', function(hooks) {
   test('string literal passed to component helper in content position', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{component "hello-world"}}`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{component "hello-world"}}`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+    ]);
   });
 
   test('string literal passed to component helper with block', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{#component "hello-world"}} {{/component}}`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{#component "hello-world"}} {{/component}}`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+    ]);
   });
 
   test('string literal passed to component helper in helper position', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
     givenFile('components/my-thing.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{my-thing header=(component "hello-world") }}`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        },
-        {
-          "path": "../components/my-thing.js",
-          "runtimeName": "the-app/components/my-thing"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{my-thing header=(component "hello-world") }}`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+      {
+        path: '../components/my-thing.js',
+        runtimeName: 'the-app/components/my-thing',
+      },
+    ]);
   });
 
   test('string literal passed to component helper fails to resolve', function(assert) {
@@ -383,18 +352,16 @@ QUnit.module('compat-resolver', function(hooks) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');
     givenFile('templates/components/hello-world.hbs');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `<HelloWorld />`),
-      [
-        {
-          "path": "../components/hello-world.js",
-          "runtimeName": "the-app/components/hello-world"
-        }, {
-          "path": "./components/hello-world.hbs",
-          "runtimeName": "the-app/templates/components/hello-world"
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `<HelloWorld />`), [
+      {
+        path: '../components/hello-world.js',
+        runtimeName: 'the-app/components/hello-world',
+      },
+      {
+        path: './components/hello-world.hbs',
+        runtimeName: 'the-app/templates/components/hello-world',
+      },
+    ]);
   });
 
   test('angle component missing', function(assert) {
@@ -413,7 +380,7 @@ QUnit.module('compat-resolver', function(hooks) {
         {
           runtimeName: 'the-app/helpers/array',
           path: '../helpers/array.js',
-        }
+        },
       ]
     );
   });
@@ -444,57 +411,45 @@ QUnit.module('compat-resolver', function(hooks) {
   test('helper as component argument', function(assert) {
     let findDependencies = configure({ staticHelpers: true });
     givenFile('helpers/array.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{my-component value=(array 1 2 3) }}`),
-      [
-        {
-          runtimeName: 'the-app/helpers/array',
-          path: '../helpers/array.js',
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{my-component value=(array 1 2 3) }}`), [
+      {
+        runtimeName: 'the-app/helpers/array',
+        path: '../helpers/array.js',
+      },
+    ]);
   });
 
   test('helper as html attribute', function(assert) {
     let findDependencies = configure({ staticHelpers: true });
     givenFile('helpers/capitalize.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `<div data-foo={{capitalize name}}></div>`),
-      [
-        {
-          runtimeName: 'the-app/helpers/capitalize',
-          path: '../helpers/capitalize.js',
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `<div data-foo={{capitalize name}}></div>`), [
+      {
+        runtimeName: 'the-app/helpers/capitalize',
+        path: '../helpers/capitalize.js',
+      },
+    ]);
   });
 
   test('helper in bare mustache, no args', function(assert) {
     let findDependencies = configure({ staticHelpers: true });
     givenFile('helpers/capitalize.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{capitalize}}`),
-      [
-        {
-          runtimeName: 'the-app/helpers/capitalize',
-          path: '../helpers/capitalize.js',
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{capitalize}}`), [
+      {
+        runtimeName: 'the-app/helpers/capitalize',
+        path: '../helpers/capitalize.js',
+      },
+    ]);
   });
 
   test('helper in bare mustache, with args', function(assert) {
     let findDependencies = configure({ staticHelpers: true });
     givenFile('helpers/capitalize.js');
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{capitalize name}}`),
-      [
-        {
-          runtimeName: 'the-app/helpers/capitalize',
-          path: '../helpers/capitalize.js',
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{capitalize name}}`), [
+      {
+        runtimeName: 'the-app/helpers/capitalize',
+        path: '../helpers/capitalize.js',
+      },
+    ]);
   });
 
   test('local binding takes precedence over helper in bare mustache', function(assert) {
@@ -528,12 +483,15 @@ QUnit.module('compat-resolver', function(hooks) {
     let findDependencies = configure({ staticHelpers: true });
     givenFile('helpers/capitalize.js');
     assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{#each things as |capitalize|}} {{capitalize}} {{/each}} {{capitalize}}`),
+      findDependencies(
+        'templates/application.hbs',
+        `{{#each things as |capitalize|}} {{capitalize}} {{/each}} {{capitalize}}`
+      ),
       [
         {
           runtimeName: 'the-app/helpers/capitalize',
           path: '../helpers/capitalize.js',
-        }
+        },
       ]
     );
   });
@@ -541,12 +499,15 @@ QUnit.module('compat-resolver', function(hooks) {
   test('ignores builtins', function(assert) {
     let findDependencies = configure({ staticHelpers: true, staticComponents: true });
     assert.deepEqual(
-      findDependencies('templates/application.hbs', `
+      findDependencies(
+        'templates/application.hbs',
+        `
         {{outlet "foo"}}
         {{yield bar}}
         {{#with (hash submit=(action doit)) as |thing| }}
         {{/with}}
-      `),
+      `
+      ),
       []
     );
   });
@@ -558,18 +519,21 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            yieldsSafeComponents: [true]
-          }
-        }
-      }
+            yieldsSafeComponents: [true],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
-    findDependencies('templates/application.hbs', `
+    findDependencies(
+      'templates/application.hbs',
+      `
       {{#form-builder as |field| }}
         {{component field}}
       {{/form-builder}}
-    `);
+    `
+    );
   });
 
   test('respects yieldsSafeComponents rule on element, position 0', function(assert) {
@@ -579,18 +543,21 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            yieldsSafeComponents: [true]
-          }
-        }
-      }
+            yieldsSafeComponents: [true],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
-    findDependencies('templates/application.hbs', `
+    findDependencies(
+      'templates/application.hbs',
+      `
       <FormBuilder as |field| >
         {{component field}}
       </FormBuilder>
-    `);
+    `
+    );
   });
 
   test('respects yieldsSafeComponents rule, position 1', function() {
@@ -599,24 +566,30 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            yieldsSafeComponents: [false, true]
-          }
-        }
-      }
+            yieldsSafeComponents: [false, true],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
-    findDependencies('templates/application.hbs', `
+    findDependencies(
+      'templates/application.hbs',
+      `
       {{#form-builder as |other field| }}
         {{component field}}
       {{/form-builder}}
-    `);
+    `
+    );
     assertWarning(/ignoring dynamic component other/, () => {
-      findDependencies('templates/application.hbs', `
+      findDependencies(
+        'templates/application.hbs',
+        `
         {{#form-builder as |other field| }}
           {{component other}}
         {{/form-builder}}
-      `);
+      `
+      );
     });
   });
 
@@ -626,24 +599,30 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            yieldsSafeComponents: [{ field: true }]
-          }
-        }
-      }
+            yieldsSafeComponents: [{ field: true }],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
-    findDependencies('templates/application.hbs', `
+    findDependencies(
+      'templates/application.hbs',
+      `
       {{#form-builder as |f| }}
         {{component f.field}}
       {{/form-builder}}
-    `);
+    `
+    );
     assertWarning(/ignoring dynamic component f.other/, () => {
-      findDependencies('templates/application.hbs', `
+      findDependencies(
+        'templates/application.hbs',
+        `
         {{#form-builder as |f| }}
           {{component f.other}}
         {{/form-builder}}
-      `);
+      `
+      );
     });
   });
 
@@ -653,24 +632,30 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            yieldsSafeComponents: [false, { field: true }]
-          }
-        }
-      }
+            yieldsSafeComponents: [false, { field: true }],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
-    findDependencies('templates/application.hbs', `
+    findDependencies(
+      'templates/application.hbs',
+      `
       {{#form-builder as |x f| }}
         {{component f.field}}
       {{/form-builder}}
-    `);
+    `
+    );
     assertWarning(/ignoring dynamic component f.other/, () => {
-      findDependencies('templates/application.hbs', `
+      findDependencies(
+        'templates/application.hbs',
+        `
         {{#form-builder as |x f| }}
           {{component f.other}}
         {{/form-builder}}
-    `);
+    `
+      );
     });
   });
 
@@ -680,28 +665,25 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
     givenFile('templates/components/fancy-title.hbs');
 
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{form-builder title="fancy-title"}}`),
-      [
-        {
-          runtimeName: 'the-app/templates/components/fancy-title',
-          path: './components/fancy-title.hbs',
-        },
-        {
-          runtimeName: 'the-app/templates/components/form-builder',
-          path: './components/form-builder.hbs',
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{form-builder title="fancy-title"}}`), [
+      {
+        runtimeName: 'the-app/templates/components/fancy-title',
+        path: './components/fancy-title.hbs',
+      },
+      {
+        runtimeName: 'the-app/templates/components/form-builder',
+        path: './components/form-builder.hbs',
+      },
+    ]);
   });
 
   test('acceptsComponentArguments on mustache block with valid literal', function(assert) {
@@ -710,10 +692,10 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
@@ -729,7 +711,7 @@ QUnit.module('compat-resolver', function(hooks) {
         {
           runtimeName: 'the-app/templates/components/form-builder',
           path: './components/form-builder.hbs',
-        }
+        },
       ]
     );
   });
@@ -740,28 +722,25 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['@title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['@title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
     givenFile('templates/components/fancy-title.hbs');
 
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `{{form-builder title="fancy-title"}}`),
-      [
-        {
-          runtimeName: 'the-app/templates/components/fancy-title',
-          path: './components/fancy-title.hbs',
-        },
-        {
-          runtimeName: 'the-app/templates/components/form-builder',
-          path: './components/form-builder.hbs',
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{form-builder title="fancy-title"}}`), [
+      {
+        runtimeName: 'the-app/templates/components/fancy-title',
+        path: './components/fancy-title.hbs',
+      },
+      {
+        runtimeName: 'the-app/templates/components/form-builder',
+        path: './components/form-builder.hbs',
+      },
+    ]);
   });
 
   test('acceptsComponentArguments on mustache with component subexpression', function(assert) {
@@ -770,10 +749,10 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
@@ -789,7 +768,7 @@ QUnit.module('compat-resolver', function(hooks) {
         {
           runtimeName: 'the-app/templates/components/form-builder',
           path: './components/form-builder.hbs',
-        }
+        },
       ]
     );
   });
@@ -800,10 +779,10 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
@@ -819,7 +798,7 @@ QUnit.module('compat-resolver', function(hooks) {
         {
           runtimeName: 'the-app/templates/components/form-builder',
           path: './components/form-builder.hbs',
-        }
+        },
       ]
     );
   });
@@ -830,10 +809,10 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
@@ -849,28 +828,25 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
     givenFile('templates/components/fancy-title.hbs');
 
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `<FormBuilder @title={{"fancy-title"}} />`),
-      [
-        {
-          runtimeName: 'the-app/templates/components/fancy-title',
-          path: './components/fancy-title.hbs',
-        },
-        {
-          runtimeName: 'the-app/templates/components/form-builder',
-          path: './components/form-builder.hbs',
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `<FormBuilder @title={{"fancy-title"}} />`), [
+      {
+        runtimeName: 'the-app/templates/components/fancy-title',
+        path: './components/fancy-title.hbs',
+      },
+      {
+        runtimeName: 'the-app/templates/components/form-builder',
+        path: './components/form-builder.hbs',
+      },
+    ]);
   });
 
   test('acceptsComponentArguments on element with valid attribute', function(assert) {
@@ -879,28 +855,25 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
     givenFile('templates/components/fancy-title.hbs');
 
-    assert.deepEqual(
-      findDependencies('templates/application.hbs', `<FormBuilder @title="fancy-title" />`),
-      [
-        {
-          runtimeName: 'the-app/templates/components/fancy-title',
-          path: './components/fancy-title.hbs',
-        },
-        {
-          runtimeName: 'the-app/templates/components/form-builder',
-          path: './components/form-builder.hbs',
-        }
-      ]
-    );
+    assert.deepEqual(findDependencies('templates/application.hbs', `<FormBuilder @title="fancy-title" />`), [
+      {
+        runtimeName: 'the-app/templates/components/fancy-title',
+        path: './components/fancy-title.hbs',
+      },
+      {
+        runtimeName: 'the-app/templates/components/form-builder',
+        path: './components/form-builder.hbs',
+      },
+    ]);
   });
 
   test('acceptsComponentArguments interior usage of path generates no warning', function(assert) {
@@ -909,17 +882,14 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
 
-    assert.deepEqual(
-      findDependencies('templates/components/form-builder.hbs', `{{component title}}`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/components/form-builder.hbs', `{{component title}}`), []);
   });
 
   test('acceptsComponentArguments interior usage of this.path generates no warning', function(assert) {
@@ -928,17 +898,14 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: [{ name: 'title', becomes: 'this.title' }]
-          }
-        }
-      }
+            acceptsComponentArguments: [{ name: 'title', becomes: 'this.title' }],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
 
-    assert.deepEqual(
-      findDependencies('templates/components/form-builder.hbs', `{{component this.title}}`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/components/form-builder.hbs', `{{component this.title}}`), []);
   });
 
   test('acceptsComponentArguments interior usage of @path generates no warning', function(assert) {
@@ -947,17 +914,14 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            acceptsComponentArguments: ['@title']
-          }
-        }
-      }
+            acceptsComponentArguments: ['@title'],
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
 
-    assert.deepEqual(
-      findDependencies('templates/components/form-builder.hbs', `{{component @title}}`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/components/form-builder.hbs', `{{component @title}}`), []);
   });
 
   test('safeToIgnore a missing component', function(assert) {
@@ -966,17 +930,14 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            safeToIgnore: true
-          }
-        }
-      }
+            safeToIgnore: true,
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
 
-    assert.deepEqual(
-      findDependencies('templates/components/x.hbs', `<FormBuilder />`),
-      []
-    );
+    assert.deepEqual(findDependencies('templates/components/x.hbs', `<FormBuilder />`), []);
   });
 
   test('safeToIgnore a present component', function(assert) {
@@ -985,20 +946,18 @@ QUnit.module('compat-resolver', function(hooks) {
         package: 'the-test-package',
         components: {
           '<FormBuilder />': {
-            safeToIgnore: true
-          }
-        }
-      }
+            safeToIgnore: true,
+          },
+        },
+      },
     ];
     let findDependencies = configure({ staticComponents: true, packageRules });
     givenFile('templates/components/form-builder.hbs');
-    assert.deepEqual(
-      findDependencies('templates/components/x.hbs', `<FormBuilder />`),
-      [{
+    assert.deepEqual(findDependencies('templates/components/x.hbs', `<FormBuilder />`), [
+      {
         path: './form-builder.hbs',
         runtimeName: 'the-app/templates/components/form-builder',
-      }]
-    );
+      },
+    ]);
   });
-
 });

--- a/packages/compat/tests/stage1-test.ts
+++ b/packages/compat/tests/stage1-test.ts
@@ -1,8 +1,4 @@
-import {
-  emberProject,
-  addAddon,
-  Project
-} from './helpers';
+import { emberProject, addAddon, Project } from './helpers';
 import 'qunit';
 import { emberApp } from '@embroider/test-support';
 import CompatAddons from '../src/compat-addons';
@@ -11,7 +7,6 @@ import { installFileAssertions } from './file-assertions';
 
 QUnit.module('stage1 build', function() {
   QUnit.module('max compatibility', function(origHooks) {
-
     let { hooks, test } = installFileAssertions(origHooks);
     let builder: Builder;
     let app: Project;
@@ -43,21 +38,21 @@ QUnit.module('stage1 build', function() {
               // call expression form:
               extra: hbs("<div class={{embroider-sample-transforms-target}}>Extra</div>")
             });
-          `
+          `,
         },
         templates: {
           components: {
             'hello-world.hbs': `
               <div class={{embroider-sample-transforms-target}}>hello world</div>
               <span>{{macroDependencySatisfies "ember-source" ">3"}}</span>
-            `
-          }
-        }
+            `,
+          },
+        },
       };
       addon.files.app = {
         components: {
           'hello-world.js': `export { default } from 'my-addon/components/hello-world'`,
-        }
+        },
       };
 
       // Our addon will use @embroider/sample-transforms as examples of custom
@@ -87,14 +82,15 @@ QUnit.module('stage1 build', function() {
       let assertMeta = assert.file('node_modules/my-addon/package.json').json('ember-addon');
       assertMeta.get('app-js').equals('_app_', 'should have app-js metadata');
       assertMeta.get('externals').includes('@ember/component', 'should detect external modules');
-      assertMeta.get('implicit-modules').includes(
-        './components/hello-world',
-        'staticAddonTrees is off so we should include the component implicitly'
-      );
-      assertMeta.get('implicit-modules').includes(
-        './templates/components/hello-world.hbs',
-        'staticAddonTrees is off so we should include the template implicitly'
-      );
+      assertMeta
+        .get('implicit-modules')
+        .includes('./components/hello-world', 'staticAddonTrees is off so we should include the component implicitly');
+      assertMeta
+        .get('implicit-modules')
+        .includes(
+          './templates/components/hello-world.hbs',
+          'staticAddonTrees is off so we should include the template implicitly'
+        );
       assertMeta.get('version').equals(2);
     });
 
@@ -104,14 +100,8 @@ QUnit.module('stage1 build', function() {
         `import layout from '../templates/components/hello-world.hbs'`,
         `template imports have explicit .hbs extension added`
       );
-      assertFile.matches(
-        `getOwnConfig()`,
-        `JS macros have not run yet`
-      );
-      assertFile.matches(
-        `embroider-sample-transforms-result`,
-        `custom babel plugins have run`
-      );
+      assertFile.matches(`getOwnConfig()`, `JS macros have not run yet`);
+      assertFile.matches(`embroider-sample-transforms-result`, `custom babel plugins have run`);
     });
 
     test('component template in addon tree', function(assert) {
@@ -142,5 +132,4 @@ QUnit.module('stage1 build', function() {
       );
     });
   });
-
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,6 @@
     "@types/resolve": "^0.0.8",
     "@types/strip-bom": "^3.0.0",
     "qunit": "^2.8.0",
-    "tslint": "^5.11.0",
     "typescript": "~3.2.0"
   },
   "dependencies": {

--- a/packages/core/src/app-differ.ts
+++ b/packages/core/src/app-differ.ts
@@ -1,8 +1,8 @@
-import Package from "./package";
-import MultiTreeDiff, { InputTree } from "./multi-tree-diff";
+import Package from './package';
+import MultiTreeDiff, { InputTree } from './multi-tree-diff';
 import walkSync from 'walk-sync';
 import { join } from 'path';
-import { mkdirpSync, unlinkSync, rmdirSync, removeSync, copySync } from "fs-extra";
+import { mkdirpSync, unlinkSync, rmdirSync, removeSync, copySync } from 'fs-extra';
 import { debug } from './messages';
 import assertNever from 'assert-never';
 
@@ -14,25 +14,28 @@ export default class AppDiffer {
 
   constructor(private outputPath: string, ownAppJSDir: string, activeAddonDescendants: Package[]) {
     let trees = activeAddonDescendants
-      .map((addon): InputTree | undefined => {
-        let dir = addon.meta['app-js'];
-        if (dir) {
-          let definitelyDir = join(addon.root, dir);
-          this.sourceDirs.push(definitelyDir);
-          return {
-            mayChange: addon.mayRebuild,
-            walk() {
-              return walkSync.entries(definitelyDir);
-            }
-          };
+      .map(
+        (addon): InputTree | undefined => {
+          let dir = addon.meta['app-js'];
+          if (dir) {
+            let definitelyDir = join(addon.root, dir);
+            this.sourceDirs.push(definitelyDir);
+            return {
+              mayChange: addon.mayRebuild,
+              walk() {
+                return walkSync.entries(definitelyDir);
+              },
+            };
+          }
         }
-      }).filter(Boolean) as InputTree[];
+      )
+      .filter(Boolean) as InputTree[];
 
     trees.push({
       mayChange: true,
       walk() {
         return walkSync.entries(ownAppJSDir);
-      }
+      },
     });
     this.sourceDirs.push(ownAppJSDir);
     this.differ = new MultiTreeDiff(trees);
@@ -56,7 +59,7 @@ export default class AppDiffer {
           break;
         case 'change':
           removeSync(outputPath);
-          // deliberate fallthrough
+        // deliberate fallthrough
         case 'create':
           copySync(join(this.sourceDirs[sources.get(relativePath)!], relativePath), outputPath, { dereference: true });
           this.files.add(relativePath);

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -264,7 +264,7 @@ export class AppBuilder<TreeNames> {
       {},
       ...this.adapter.activeAddonDescendants.map(dep => dep.meta["renamed-modules"])
     );
-      let adjustOptions: AdjustImportsOptions = {
+    let adjustOptions: AdjustImportsOptions = {
       ownName: this.app.name,
       basedir: this.root,
       rename,

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -3,7 +3,7 @@ import { OutputPaths } from './wait-for-trees';
 import { compile } from './js-handlebars';
 import Package from './package';
 import resolve from 'resolve';
-import { Memoize } from "typescript-memoize";
+import { Memoize } from 'typescript-memoize';
 import { writeFileSync, ensureDirSync, copySync, unlinkSync, statSync } from 'fs-extra';
 import { join, dirname, relative } from 'path';
 import { todo, unsupported, debug, warn } from './messages';
@@ -22,7 +22,7 @@ import PortableBabelConfig from './portable-babel-config';
 import { TemplateCompilerPlugins } from '.';
 import TemplateCompiler from './template-compiler';
 import { Resolver } from './resolver';
-import { Options as AdjustImportsOptions }  from './babel-plugin-adjust-imports';
+import { Options as AdjustImportsOptions } from './babel-plugin-adjust-imports';
 
 export type EmberENV = unknown;
 
@@ -37,7 +37,6 @@ export type EmberENV = unknown;
       because they opt into new authoring standards.
 */
 export interface AppAdapter<TreeNames> {
-
   // the set of addon packages that are active.
   readonly activeAddonDescendants: Package[];
 
@@ -88,7 +87,7 @@ export interface AppAdapter<TreeNames> {
 
   // lets you add imports to javascript modules. We need this to implement
   // things like our addon compatibility rules for static components.
-  extraImports(): { absPath: string, target: string, runtimeName?: string }[];
+  extraImports(): { absPath: string; target: string; runtimeName?: string }[];
 
   // The environment settings used to control Ember itself. In a classic app,
   // this comes from the EmberENV property returned by config/environment.js.
@@ -132,7 +131,7 @@ class BuiltEmberAsset {
 
 class ConcatenatedAsset {
   kind: 'concatenated-asset' = 'concatenated-asset';
-  constructor(public relativePath: string, public sources: (OnDiskAsset | InMemoryAsset)[]){}
+  constructor(public relativePath: string, public sources: (OnDiskAsset | InMemoryAsset)[]) {}
   get sourcemapPath() {
     return this.relativePath.replace(/\.js$/, '') + '.map';
   }
@@ -152,7 +151,7 @@ class AppFiles {
     let helpers: string[] = [];
     let otherAppFiles: string[] = [];
     for (let relativePath of relativePaths) {
-      if (relativePath.startsWith("tests/") && relativePath.endsWith('-test.js')) {
+      if (relativePath.startsWith('tests/') && relativePath.endsWith('-test.js')) {
         tests.push(relativePath);
         continue;
       }
@@ -187,9 +186,9 @@ export class AppBuilder<TreeNames> {
 
   private scriptPriority(pkg: Package) {
     switch (pkg.name) {
-      case "loader.js":
+      case 'loader.js':
         return 0;
-      case "ember-source":
+      case 'ember-source':
         return 10;
       default:
         return 1000;
@@ -197,16 +196,18 @@ export class AppBuilder<TreeNames> {
   }
 
   private impliedAssets(type: keyof ImplicitAssetPaths, emberENV?: EmberENV): (OnDiskAsset | InMemoryAsset)[] {
-    let result: (OnDiskAsset | InMemoryAsset)[] = this.impliedAddonAssets(type).map((sourcePath: string): OnDiskAsset => {
-      let stats = statSync(sourcePath);
-      return {
-        kind: 'on-disk',
-        relativePath: relative(this.root, sourcePath),
-        sourcePath,
-        mtime: stats.mtimeMs,
-        size: stats.size,
-      };
-    });
+    let result: (OnDiskAsset | InMemoryAsset)[] = this.impliedAddonAssets(type).map(
+      (sourcePath: string): OnDiskAsset => {
+        let stats = statSync(sourcePath);
+        return {
+          kind: 'on-disk',
+          relativePath: relative(this.root, sourcePath),
+          sourcePath,
+          mtime: stats.mtimeMs,
+          size: stats.size,
+        };
+      }
+    );
     if (type === 'implicit-scripts') {
       result.unshift({
         kind: 'in-memory',
@@ -219,10 +220,7 @@ export class AppBuilder<TreeNames> {
 
   private impliedAddonAssets(type: keyof ImplicitAssetPaths): string[] {
     let result = [];
-    for (let addon of sortBy(
-      this.adapter.activeAddonDescendants,
-      this.scriptPriority.bind(this)
-    )) {
+    for (let addon of sortBy(this.adapter.activeAddonDescendants, this.scriptPriority.bind(this))) {
       let implicitScripts = addon.meta[type];
       if (implicitScripts) {
         for (let mod of implicitScripts) {
@@ -245,14 +243,17 @@ export class AppBuilder<TreeNames> {
     babel.plugins.push(MacrosConfig.shared().babelPluginConfig());
 
     // this is our built-in support for the inline hbs macro
-    babel.plugins.push([join(__dirname, 'babel-plugin-inline-hbs.js'), {
-      templateCompiler: {
-        _parallelBabel: {
-          requireFile: join(this.root, '_template_compiler_.js')
-        }
+    babel.plugins.push([
+      join(__dirname, 'babel-plugin-inline-hbs.js'),
+      {
+        templateCompiler: {
+          _parallelBabel: {
+            requireFile: join(this.root, '_template_compiler_.js'),
+          },
+        },
+        stage: 3,
       },
-      stage: 3
-    }]);
+    ]);
 
     babel.plugins.push(this.adjustImportsPlugin());
 
@@ -260,10 +261,7 @@ export class AppBuilder<TreeNames> {
   }
 
   private adjustImportsPlugin(): PluginItem {
-    let rename = Object.assign(
-      {},
-      ...this.adapter.activeAddonDescendants.map(dep => dep.meta["renamed-modules"])
-    );
+    let rename = Object.assign({}, ...this.adapter.activeAddonDescendants.map(dep => dep.meta['renamed-modules']));
     let adjustOptions: AdjustImportsOptions = {
       ownName: this.app.name,
       basedir: this.root,
@@ -282,7 +280,12 @@ export class AppBuilder<TreeNames> {
     return appJS;
   }
 
-  private insertEmberApp(asset: ParsedEmberAsset, appFiles: AppFiles, prepared: Map<string, InternalAsset>, emberENV: EmberENV) {
+  private insertEmberApp(
+    asset: ParsedEmberAsset,
+    appFiles: AppFiles,
+    prepared: Map<string, InternalAsset>,
+    emberENV: EmberENV
+  ) {
     let html = asset.html;
 
     // our tests entrypoint already includes a correct module dependency on the
@@ -294,14 +297,14 @@ export class AppBuilder<TreeNames> {
 
     html.insertStyleLink(html.styles, `assets/${this.app.name}.css`);
 
-    let implicitScripts = this.impliedAssets("implicit-scripts", emberENV);
+    let implicitScripts = this.impliedAssets('implicit-scripts', emberENV);
     if (implicitScripts.length > 0) {
       let vendorJS = new ConcatenatedAsset('assets/vendor.js', implicitScripts);
       prepared.set(vendorJS.relativePath, vendorJS);
       html.insertScriptTag(html.implicitScripts, vendorJS.relativePath);
     }
 
-    let implicitStyles = this.impliedAssets("implicit-styles");
+    let implicitStyles = this.impliedAssets('implicit-styles');
     if (implicitStyles.length > 0) {
       let vendorCSS = new ConcatenatedAsset('assets/vendor.css', implicitStyles);
       prepared.set(vendorCSS.relativePath, vendorCSS);
@@ -316,14 +319,14 @@ export class AppBuilder<TreeNames> {
       }
       html.insertScriptTag(html.testJavascript, testJS.relativePath, { type: 'module' });
 
-      let implicitTestScripts = this.impliedAssets("implicit-test-scripts");
+      let implicitTestScripts = this.impliedAssets('implicit-test-scripts');
       if (implicitTestScripts.length > 0) {
         let testSupportJS = new ConcatenatedAsset('assets/test-support.js', implicitTestScripts);
         prepared.set(testSupportJS.relativePath, testSupportJS);
         html.insertScriptTag(html.implicitTestScripts, testSupportJS.relativePath);
       }
 
-      let implicitTestStyles = this.impliedAssets("implicit-test-styles");
+      let implicitTestStyles = this.impliedAssets('implicit-test-styles');
       if (implicitTestStyles.length > 0) {
         let testSupportCSS = new ConcatenatedAsset('assets/test-support.css', implicitTestStyles);
         prepared.set(testSupportCSS.relativePath, testSupportCSS);
@@ -372,7 +375,7 @@ export class AppBuilder<TreeNames> {
     if (!prior) {
       return false;
     }
-    switch(asset.kind) {
+    switch (asset.kind) {
       case 'on-disk':
         return prior.kind === 'on-disk' && prior.size === asset.size && prior.mtime === asset.mtime;
       case 'in-memory':
@@ -380,12 +383,14 @@ export class AppBuilder<TreeNames> {
       case 'built-ember':
         return prior.kind === 'built-ember' && prior.source === asset.source;
       case 'concatenated-asset':
-        return prior.kind === 'concatenated-asset' &&
+        return (
+          prior.kind === 'concatenated-asset' &&
           prior.sources.length === asset.sources.length &&
           prior.sources.every((priorFile, index) => {
             let newFile = asset.sources[index];
             return this.assetIsValid(newFile, priorFile);
-          });
+          })
+        );
     }
     assertNever(asset);
   }
@@ -399,13 +404,13 @@ export class AppBuilder<TreeNames> {
   private updateInMemoryAsset(asset: InMemoryAsset) {
     let destination = join(this.root, asset.relativePath);
     ensureDirSync(dirname(destination));
-    writeFileSync(destination, asset.source, "utf8");
+    writeFileSync(destination, asset.source, 'utf8');
   }
 
   private updateBuiltEmberAsset(asset: BuiltEmberAsset) {
     let destination = join(this.root, asset.relativePath);
     ensureDirSync(dirname(destination));
-    writeFileSync(destination, asset.source, "utf8");
+    writeFileSync(destination, asset.source, 'utf8');
   }
 
   private async updateConcatenatedAsset(asset: ConcatenatedAsset) {
@@ -480,7 +485,7 @@ export class AppBuilder<TreeNames> {
             sourcePath: join(pkg.root, filename),
             relativePath: appRelativeURL,
             mtime: 0,
-            size: 0
+            size: 0,
           });
         }
       }
@@ -514,18 +519,14 @@ export class AppBuilder<TreeNames> {
       version: 2,
       externals,
       assets: assetPaths,
-      "template-compiler": "_template_compiler_.js",
-      "babel-config": "_babel_config_.js",
-      "root-url": this.adapter.rootURL(),
+      'template-compiler': '_template_compiler_.js',
+      'babel-config': '_babel_config_.js',
+      'root-url': this.adapter.rootURL(),
     };
 
     let pkg = cloneDeep(this.app.packageJSON);
-    pkg["ember-addon"] = Object.assign({}, pkg["ember-addon"], meta);
-    writeFileSync(
-      join(this.root, "package.json"),
-      JSON.stringify(pkg, null, 2),
-      "utf8"
-    );
+    pkg['ember-addon'] = Object.assign({}, pkg['ember-addon'], meta);
+    writeFileSync(join(this.root, 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
   }
 
   private combineExternals() {
@@ -555,7 +556,6 @@ export class AppBuilder<TreeNames> {
   }
 
   private addTemplateCompiler(config: EmberENV) {
-
     let plugins = this.adapter.htmlbarsPlugins();
     if (!plugins.ast) {
       plugins.ast = [];
@@ -571,22 +571,14 @@ export class AppBuilder<TreeNames> {
       EmberENV: config,
     }).serialize(this.root);
 
-    writeFileSync(
-      join(this.root, "_template_compiler_.js"),
-      source,
-      "utf8"
-    );
+    writeFileSync(join(this.root, '_template_compiler_.js'), source, 'utf8');
   }
 
   private addBabelConfig() {
     if (!this.babelConfig.isParallelSafe) {
       warn('Your build is slower because some babel plugins are non-serializable');
     }
-    writeFileSync(
-      join(this.root, "_babel_config_.js"),
-      this.babelConfig.serialize(),
-      "utf8"
-    );
+    writeFileSync(join(this.root, '_babel_config_.js'), this.babelConfig.serialize(), 'utf8');
   }
 
   private javascriptEntrypoint(name: string, appFiles: AppFiles): InternalAsset {
@@ -596,22 +588,24 @@ export class AppBuilder<TreeNames> {
     if (!this.options.staticComponents) {
       requiredAppFiles.push(appFiles.components);
     }
-    if(!this.options.staticHelpers) {
+    if (!this.options.staticHelpers) {
       requiredAppFiles.push(appFiles.helpers);
     }
 
-    let lazyModules = flatten(requiredAppFiles).map(relativePath => {
-      let noJS = relativePath.replace(/\.js$/, "");
-      let noHBS = noJS.replace(/\.hbs$/, "");
-      return {
-        runtime: `${modulePrefix}/${noHBS}`,
-        buildtime: `../${noJS}`,
-      };
-    }).filter(Boolean) as { runtime: string, buildtime: string }[];
+    let lazyModules = flatten(requiredAppFiles)
+      .map(relativePath => {
+        let noJS = relativePath.replace(/\.js$/, '');
+        let noHBS = noJS.replace(/\.hbs$/, '');
+        return {
+          runtime: `${modulePrefix}/${noHBS}`,
+          buildtime: `../${noJS}`,
+        };
+      })
+      .filter(Boolean) as { runtime: string; buildtime: string }[];
 
     // for the src tree, we can limit ourselves to only known resolvable
     // collections
-    todo("app src tree");
+    todo('app src tree');
 
     // this is a backward-compatibility feature: addons can force inclusion of
     // modules.
@@ -636,9 +630,11 @@ export class AppBuilder<TreeNames> {
 
   private testJSEntrypoint(appFiles: AppFiles, prepared: Map<string, InternalAsset>): InternalAsset {
     const myName = 'assets/test.js';
-    let testModules = appFiles.tests.map(relativePath => {
-      return `../${relativePath}`;
-    }).filter(Boolean) as string[];
+    let testModules = appFiles.tests
+      .map(relativePath => {
+        return `../${relativePath}`;
+      })
+      .filter(Boolean) as string[];
 
     // tests necessarily also include the app. This is where we account for
     // that. The classic solution was to always include the app's separate
@@ -647,7 +643,7 @@ export class AppBuilder<TreeNames> {
     // module dependency.
     testModules.unshift('./' + relative(dirname(myName), this.appJSAsset(appFiles, prepared).relativePath));
 
-    let lazyModules: { runtime: string, buildtime: string }[] = [];
+    let lazyModules: { runtime: string; buildtime: string }[] = [];
     // this is a backward-compatibility feature: addons can force inclusion of
     // test support modules.
     this.gatherImplicitModules('implicit-test-modules', lazyModules);
@@ -655,27 +651,27 @@ export class AppBuilder<TreeNames> {
     let source = entryTemplate({
       lazyModules,
       eagerModules: testModules,
-      testSuffix: true
+      testSuffix: true,
     });
 
     return {
       kind: 'in-memory',
       source,
-      relativePath: myName
+      relativePath: myName,
     };
   }
 
-  private gatherImplicitModules(section: "implicit-modules" | "implicit-test-modules", lazyModules: { runtime: string, buildtime: string }[]) {
+  private gatherImplicitModules(
+    section: 'implicit-modules' | 'implicit-test-modules',
+    lazyModules: { runtime: string; buildtime: string }[]
+  ) {
     for (let addon of this.adapter.activeAddonDescendants) {
       let implicitModules = addon.meta[section];
       if (implicitModules) {
         for (let name of implicitModules) {
           lazyModules.push({
             runtime: join(addon.name, name),
-            buildtime: relative(
-              join(this.root, "assets"),
-              join(addon.root, name)
-            ),
+            buildtime: relative(join(this.root, 'assets'), join(addon.root, name)),
           });
         }
       }
@@ -752,7 +748,7 @@ function stringOrBufferEqual(a: string | Buffer, b: string | Buffer): boolean {
     return a === b;
   }
   if (a instanceof Buffer && b instanceof Buffer) {
-    return Buffer.compare(a,b) === 0;
+    return Buffer.compare(a, b) === 0;
   }
   return false;
 }

--- a/packages/core/src/asset.ts
+++ b/packages/core/src/asset.ts
@@ -1,11 +1,11 @@
-import { JSDOM } from "jsdom";
-import { EmberHTML } from "./ember-html";
+import { JSDOM } from 'jsdom';
+import { EmberHTML } from './ember-html';
 
 export interface ImplicitAssetPaths {
-  "implicit-scripts": string[];
-  "implicit-test-scripts": string[];
-  "implicit-styles": string[];
-  "implicit-test-styles": string[];
+  'implicit-scripts': string[];
+  'implicit-test-scripts': string[];
+  'implicit-styles': string[];
+  'implicit-test-styles': string[];
 }
 
 interface BaseAsset {
@@ -14,7 +14,7 @@ interface BaseAsset {
 }
 
 export interface OnDiskAsset extends BaseAsset {
-  kind: "on-disk";
+  kind: 'on-disk';
 
   // absolute path to where we will find it
   sourcePath: string;
@@ -23,7 +23,7 @@ export interface OnDiskAsset extends BaseAsset {
 }
 
 export interface InMemoryAsset extends BaseAsset {
-  kind: "in-memory";
+  kind: 'in-memory';
 
   // the actual bits
   source: string | Buffer;
@@ -31,7 +31,7 @@ export interface InMemoryAsset extends BaseAsset {
 
 // This represents an HTML entrypoint to the Ember app
 export interface EmberAsset extends BaseAsset {
-  kind: "ember";
+  kind: 'ember';
 
   // absolute path to where we will find the html file
   sourcePath: string;

--- a/packages/core/src/babel-plugin-inline-hbs.ts
+++ b/packages/core/src/babel-plugin-inline-hbs.ts
@@ -7,11 +7,11 @@ import {
   ExpressionStatement,
   stringLiteral,
   File,
-} from "@babel/types";
-import { NodePath } from "@babel/traverse";
-import { join } from "path";
+} from '@babel/types';
+import { NodePath } from '@babel/traverse';
+import { join } from 'path';
 import TemplateCompiler from './template-compiler';
-import { identifier, callExpression, memberExpression } from "@babel/types";
+import { identifier, callExpression, memberExpression } from '@babel/types';
 import { parse } from '@babel/core';
 
 // These are the known names that people are using to import the `hbs` macro
@@ -34,7 +34,7 @@ interface State {
     code: string;
     opts: {
       filename: string;
-    }
+    };
   };
 }
 
@@ -46,7 +46,7 @@ export default function inlineHBSTransform() {
           if (state.opts.stage === 3) {
             pruneImports(path);
           }
-        }
+        },
       },
       TaggedTemplateExpression(path: NodePath<TaggedTemplateExpression>, state: State) {
         for (let modulePath of modulePaths) {
@@ -61,13 +61,13 @@ export default function inlineHBSTransform() {
             handleCalled(path, state);
           }
         }
-      }
-    }
+      },
+    },
   };
 }
 
 inlineHBSTransform._parallelBabel = {
-  requireFile: __filename
+  requireFile: __filename,
 };
 
 inlineHBSTransform.baseDir = function() {
@@ -76,7 +76,7 @@ inlineHBSTransform.baseDir = function() {
 
 function handleTagged(path: NodePath<TaggedTemplateExpression>, state: State) {
   if (path.node.quasi.expressions.length) {
-    throw path.buildCodeFrameError("placeholders inside a tagged template string are not supported");
+    throw path.buildCodeFrameError('placeholders inside a tagged template string are not supported');
   }
   let template = path.node.quasi.quasis.map(quasi => quasi.value.cooked).join('');
   if (state.opts.stage === 1) {
@@ -91,11 +91,11 @@ function handleTagged(path: NodePath<TaggedTemplateExpression>, state: State) {
 
 function handleCalled(path: NodePath<CallExpression>, state: State) {
   if (path.node.arguments.length !== 1) {
-    throw path.buildCodeFrameError("hbs accepts exactly one argument");
+    throw path.buildCodeFrameError('hbs accepts exactly one argument');
   }
   let arg = path.node.arguments[0];
   if (!isStringLiteral(arg)) {
-    throw path.buildCodeFrameError("hbs accepts only a string literal argument");
+    throw path.buildCodeFrameError('hbs accepts only a string literal argument');
   }
   let template = arg.value;
   if (state.opts.stage === 1) {

--- a/packages/core/src/build-stage.ts
+++ b/packages/core/src/build-stage.ts
@@ -1,8 +1,8 @@
-import WaitForTrees, { OutputPaths } from "./wait-for-trees";
-import PackageCache from "./package-cache";
-import Stage from "./stage";
-import { Tree } from "broccoli-plugin";
-import { Memoize } from "typescript-memoize";
+import WaitForTrees, { OutputPaths } from './wait-for-trees';
+import PackageCache from './package-cache';
+import Stage from './stage';
+import { Tree } from 'broccoli-plugin';
+import { Memoize } from 'typescript-memoize';
 
 // This is a utility class for defining new Stages. It aids in handling the
 // boilerplate required to split your functionality between the
@@ -16,12 +16,16 @@ export default class BuildStage<NamedTrees> implements Stage {
     private prevStage: Stage,
     private inTrees: NamedTrees,
     private annotation: string,
-    private instantiate: (root: string, appSrcDir: string, packageCache: PackageCache) => Promise<BuilderInstance<NamedTrees>>
+    private instantiate: (
+      root: string,
+      appSrcDir: string,
+      packageCache: PackageCache
+    ) => Promise<BuilderInstance<NamedTrees>>
   ) {}
 
   @Memoize()
   get tree(): Tree {
-    return new WaitForTrees(this.augment(this.inTrees), this.annotation, async (treePaths) => {
+    return new WaitForTrees(this.augment(this.inTrees), this.annotation, async treePaths => {
       if (!this.active) {
         let { outputPath, packageCache } = await this.prevStage.ready();
         if (!packageCache) {
@@ -41,22 +45,22 @@ export default class BuildStage<NamedTrees> implements Stage {
     return this.prevStage.inputPath;
   }
 
-  async ready(): Promise<{ outputPath: string, packageCache: PackageCache }>{
+  async ready(): Promise<{ outputPath: string; packageCache: PackageCache }> {
     await this.deferReady.promise;
     return {
       outputPath: this.outputPath!,
-      packageCache: this.packageCache!
+      packageCache: this.packageCache!,
     };
   }
 
   @Memoize()
   private get deferReady() {
     let resolve: Function;
-    let promise: Promise<void> = new Promise(r => resolve =r);
+    let promise: Promise<void> = new Promise(r => (resolve = r));
     return { resolve: resolve!, promise };
   }
 
-  private augment(inTrees: NamedTrees) : NamedTrees & ExtraTree {
+  private augment(inTrees: NamedTrees): NamedTrees & ExtraTree {
     return Object.assign({ __prevStageTree: this.prevStage.tree }, inTrees);
   }
 

--- a/packages/core/src/ember-html.ts
+++ b/packages/core/src/ember-html.ts
@@ -1,7 +1,7 @@
-import { JSDOM } from "jsdom";
-import { readFileSync } from "fs";
-import { EmberAsset } from "./asset";
-import { relative, dirname } from "path";
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'fs';
+import { EmberAsset } from './asset';
+import { relative, dirname } from 'path';
 
 export interface EmberHTML {
   // each of the Nodes in here points at where we should insert the
@@ -61,19 +61,31 @@ export class PreparedEmberHTML {
   implicitTestStyles: NodeRange;
 
   constructor(private asset: EmberAsset) {
-    this.dom = new JSDOM(readFileSync(asset.sourcePath, "utf8"));
+    this.dom = new JSDOM(readFileSync(asset.sourcePath, 'utf8'));
     let html = asset.prepare(this.dom);
     this.javascript = new NodeRange(html.javascript);
     this.styles = new NodeRange(html.styles);
     this.implicitScripts = new NodeRange(html.implicitScripts);
     this.implicitStyles = new NodeRange(html.implicitStyles);
     this.testJavascript = html.testJavascript ? new NodeRange(html.testJavascript) : immediatelyAfter(html.javascript);
-    this.implicitTestScripts = html.implicitTestScripts ? new NodeRange(html.implicitTestScripts) : immediatelyAfter(html.implicitScripts);
-    this.implicitTestStyles = html.implicitTestStyles ? new NodeRange(html.implicitTestStyles) : immediatelyAfter(html.implicitStyles);
+    this.implicitTestScripts = html.implicitTestScripts
+      ? new NodeRange(html.implicitTestScripts)
+      : immediatelyAfter(html.implicitScripts);
+    this.implicitTestStyles = html.implicitTestStyles
+      ? new NodeRange(html.implicitTestStyles)
+      : immediatelyAfter(html.implicitStyles);
   }
 
   private allRanges(): NodeRange[] {
-    return [this.javascript, this.styles, this.implicitScripts, this.implicitStyles, this.implicitTestScripts, this.implicitTestStyles, this.testJavascript];
+    return [
+      this.javascript,
+      this.styles,
+      this.implicitScripts,
+      this.implicitStyles,
+      this.implicitTestScripts,
+      this.implicitTestStyles,
+      this.testJavascript,
+    ];
   }
 
   clear() {
@@ -90,7 +102,7 @@ export class PreparedEmberHTML {
     if (opts && opts.type) {
       newTag.type = opts.type;
     }
-    location.insert(this.dom.window.document.createTextNode("\n"));
+    location.insert(this.dom.window.document.createTextNode('\n'));
     location.insert(newTag);
   }
 
@@ -100,7 +112,7 @@ export class PreparedEmberHTML {
     let newTag = this.dom.window.document.createElement('link');
     newTag.rel = 'stylesheet';
     newTag.href = relativeTo(this.asset.relativePath, relativeHref);
-    location.insert(this.dom.window.document.createTextNode("\n"));
+    location.insert(this.dom.window.document.createTextNode('\n'));
     location.insert(newTag);
   }
 }
@@ -110,8 +122,5 @@ function relativeTo(documentPath: string, otherPath: string) {
 }
 
 export function insertNewline(at: Node) {
-  at.parentElement!.insertBefore(
-    at.ownerDocument!.createTextNode("\n"),
-    at
-  );
+  at.parentElement!.insertBefore(at.ownerDocument!.createTextNode('\n'), at);
 }

--- a/packages/core/src/get-or-create.ts
+++ b/packages/core/src/get-or-create.ts
@@ -1,9 +1,9 @@
-interface AbstractMap<K,V> {
+interface AbstractMap<K, V> {
   get(key: K): V | undefined;
   set(key: K, value: V): void;
 }
 
-export function getOrCreate<K,V>(map: AbstractMap<K, V>, key: K, construct: (key: K) => V): V {
+export function getOrCreate<K, V>(map: AbstractMap<K, V>, key: K, construct: (key: K) => V): V {
   let result = map.get(key);
   if (!result) {
     result = construct(key);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,11 +15,4 @@ export { default as BuildStage } from './build-stage';
 export { getOrCreate } from './get-or-create';
 export { compile as jsHandlebarsCompile } from './js-handlebars';
 export { AppAdapter, AppBuilder, EmberENV } from './app';
-export {
-  todo,
-  unsupported,
-  warn,
-  debug,
-  expectWarning,
-  throwOnWarnings,
-} from "./messages";
+export { todo, unsupported, warn, debug, expectWarning, throwOnWarnings } from './messages';

--- a/packages/core/src/measure-concat.ts
+++ b/packages/core/src/measure-concat.ts
@@ -1,6 +1,6 @@
-import SourceMapConcat from "fast-sourcemap-concat";
-import { join } from "path";
-import { statSync } from "fs";
+import SourceMapConcat from 'fast-sourcemap-concat';
+import { join } from 'path';
+import { statSync } from 'fs';
 import filesize from 'filesize';
 
 export default class MeasureConcat {
@@ -16,7 +16,12 @@ export default class MeasureConcat {
   }
   async end() {
     console.log(`Concatenated ${this.name}:`);
-    console.log(Object.entries(this.stats).sort((a,b) => b[1] - a[1]).map(([name, bytes]) => `  ${name}: ${filesize(bytes)}`).join("\n"));
+    console.log(
+      Object.entries(this.stats)
+        .sort((a, b) => b[1] - a[1])
+        .map(([name, bytes]) => `  ${name}: ${filesize(bytes)}`)
+        .join('\n')
+    );
     return await this.concat.end();
   }
 }

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -7,9 +7,9 @@ export interface AppMeta {
   version: 2;
   assets: filename[];
   externals?: string[];
-  "template-compiler": filename;
-  "babel-config": filename;
-  "root-url": string;
+  'template-compiler': filename;
+  'babel-config': filename;
+  'root-url': string;
 }
 
 // This describes the ember-specific parts of package.json of a v2-formatted
@@ -20,13 +20,13 @@ export interface AddonMeta {
   'public-assets'?: {
     [filename: string]: appRelativeURL;
   };
-  "implicit-scripts"?: filename[];
-  "implicit-test-scripts"?: filename[];
-  "implicit-styles"?: filename[];
-  "implicit-test-styles"?: filename[];
-  "implicit-modules"?: string[];
-  "implicit-test-modules"?: string[];
-  "renamed-modules"?: { [fromName: string]: string };
-  "app-js"?: filename;
-  "auto-upgraded"?: true;
+  'implicit-scripts'?: filename[];
+  'implicit-test-scripts'?: filename[];
+  'implicit-styles'?: filename[];
+  'implicit-test-styles'?: filename[];
+  'implicit-modules'?: string[];
+  'implicit-test-modules'?: string[];
+  'renamed-modules'?: { [fromName: string]: string };
+  'app-js'?: filename;
+  'auto-upgraded'?: true;
 }

--- a/packages/core/src/multi-tree-diff.ts
+++ b/packages/core/src/multi-tree-diff.ts
@@ -13,11 +13,9 @@ export default class MultiTreeDiff {
   private prevCombined: FSTree = new FSTree();
   private owners: WeakMap<Entry, number> = new WeakMap();
 
-  constructor(
-    private inTrees: InputTree[]
-  ) {}
+  constructor(private inTrees: InputTree[]) {}
 
-  update(): { ops: Operation[], sources: Sources } {
+  update(): { ops: Operation[]; sources: Sources } {
     let combinedEntries: Entry[] = [];
     let sources: Map<string, number> = new Map();
 
@@ -64,6 +62,6 @@ function compareByRelativePath(entryA: Entry, entryB: Entry) {
 
 function isEqual(owners: WeakMap<Entry, number>) {
   return function(a: Entry, b: Entry) {
-    return FSTree.defaultIsEqual(a,b) && owners.get(a) === owners.get(b);
+    return FSTree.defaultIsEqual(a, b) && owners.get(a) === owners.get(b);
   };
 }

--- a/packages/core/src/package-cache.ts
+++ b/packages/core/src/package-cache.ts
@@ -3,7 +3,7 @@ import { realpathSync } from 'fs';
 import { getOrCreate } from './get-or-create';
 import resolvePackagePath from 'resolve-package-path';
 import { dirname } from 'path';
-import { sync as pkgUpSync }  from 'pkg-up';
+import { sync as pkgUpSync } from 'pkg-up';
 
 export default class PackageCache {
   resolve(packageName: string, fromPackage: Package): Package {
@@ -53,7 +53,7 @@ export default class PackageCache {
     // first we look through our cached packages for any that are rooted right
     // at or above the file.
     for (let length = segments.length - 1; length >= 0; length--) {
-      if (segments[length-1] === 'node_modules') {
+      if (segments[length - 1] === 'node_modules') {
         // once we hit a node_modules, we're leaving the package we were in, so
         // any higher caches don't apply to us
         break;
@@ -80,11 +80,10 @@ export default class PackageCache {
     if (p) {
       return p;
     }
-    p =  new PackageCache();
-    shared.set(identifier,p);
+    p = new PackageCache();
+    shared.set(identifier, p);
     return p;
   }
-
 }
 
 const shared: Map<string, PackageCache> = new Map();

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -1,5 +1,5 @@
 import { Memoize } from 'typescript-memoize';
-import { readFileSync } from "fs";
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import get from 'lodash/get';
 import { AddonMeta } from './metadata';
@@ -8,14 +8,12 @@ import PackageCache from './package-cache';
 import flatMap from 'lodash/flatMap';
 
 export default class Package {
-  private dependencyKeys: ("dependencies" | "devDependencies" | "peerDependencies")[];
+  private dependencyKeys: ('dependencies' | 'devDependencies' | 'peerDependencies')[];
 
-  constructor(
-    readonly root: string,
-    mayUseDevDeps: boolean,
-    protected packageCache: PackageCache
-  ) {
-    this.dependencyKeys = mayUseDevDeps ? ['dependencies', 'devDependencies', 'peerDependencies'] : ['dependencies', 'peerDependencies'];
+  constructor(readonly root: string, mayUseDevDeps: boolean, protected packageCache: PackageCache) {
+    this.dependencyKeys = mayUseDevDeps
+      ? ['dependencies', 'devDependencies', 'peerDependencies']
+      : ['dependencies', 'peerDependencies'];
   }
 
   get name(): string {
@@ -33,12 +31,12 @@ export default class Package {
 
   get meta(): AddonMeta {
     if (!this.isV2) {
-      throw new Error("Not a v2-formatted Ember package");
+      throw new Error('Not a v2-formatted Ember package');
     }
-    return this.packageJSON["ember-addon"] as AddonMeta;
+    return this.packageJSON['ember-addon'] as AddonMeta;
   }
 
-  get isEmberPackage() : boolean {
+  get isEmberPackage(): boolean {
     let keywords = this.packageJSON.keywords;
     return keywords && (keywords as string[]).includes('ember-addon');
   }
@@ -54,10 +52,12 @@ export default class Package {
 
   findDescendants(filter?: (pkg: Package) => boolean): Package[] {
     let pkgs = new Set();
-    let queue : Package[] = [this];
+    let queue: Package[] = [this];
     while (true) {
       let pkg = queue.shift();
-      if (!pkg) { break; }
+      if (!pkg) {
+        break;
+      }
       if (!pkgs.has(pkg)) {
         pkgs.add(pkg);
         let nextLevel;
@@ -87,5 +87,5 @@ export default class Package {
 }
 
 export interface PackageConstructor {
-  new(root: string, mayUseDevDeps: boolean, packageCache: PackageCache): Package;
+  new (root: string, mayUseDevDeps: boolean, packageCache: PackageCache): Package;
 }

--- a/packages/core/src/packager.ts
+++ b/packages/core/src/packager.ts
@@ -1,4 +1,4 @@
-import PackageCache from "./package-cache";
+import PackageCache from './package-cache';
 
 export interface Packager<Options> {
   new (
@@ -7,23 +7,19 @@ export interface Packager<Options> {
     // what makes a Packager a cleanly separable stage that needs only a small
     // amount of ember-specific knowledge.
     inputPath: string,
-
     // where the packager should write the packaged app.
     outputPath: string,
-
     // if possible, the packager should direct its console output through this
     // hook.
     consoleWrite: (message: string) => void,
-
     // the packager is free to take advantage of this shared PackageCache
     // instance as an optimization, since it might want to know things that have
     // already been discovered by the earlier build stages.
     packageCache: PackageCache,
-
     // A packager can have whatever custom options type it wants here. If the
     // packager is based on a third-party tool, this is where that tool's
     // configuration can go.
-    options?: Options,
+    options?: Options
   ): PackagerInstance;
 
   // a description for this packager that aids debugging & profiling

--- a/packages/core/src/portable-babel-config.ts
+++ b/packages/core/src/portable-babel-config.ts
@@ -1,4 +1,4 @@
-import { PortablePluginConfig, ResolveOptions } from "./portable-plugin-config";
+import { PortablePluginConfig, ResolveOptions } from './portable-plugin-config';
 import { TransformOptions } from '@babel/core';
 
 export default class PortableBabelConfig extends PortablePluginConfig {
@@ -7,17 +7,14 @@ export default class PortableBabelConfig extends PortablePluginConfig {
   }
 
   protected makePortable(value: any, accessPath: string[] = []) {
-    if (
-      accessPath.length === 2 &&
-      (accessPath[0] === 'plugins' || accessPath[0] === 'presets')
-    ) {
+    if (accessPath.length === 2 && (accessPath[0] === 'plugins' || accessPath[0] === 'presets')) {
       if (typeof value === 'string') {
         return this.resolveBabelPlugin(value);
       }
       if (Array.isArray(value) && typeof value[0] === 'string') {
         let result = [this.resolveBabelPlugin(value[0])];
         if (value.length > 1) {
-          result.push(this.makePortable(value[1], accessPath.concat("1")));
+          result.push(this.makePortable(value[1], accessPath.concat('1')));
         }
         if (value.length > 2) {
           result.push(value[2]);

--- a/packages/core/src/portable-plugin-config.ts
+++ b/packages/core/src/portable-plugin-config.ts
@@ -12,24 +12,20 @@ module.exports = {
   config: PortablePluginConfig.load({{{json-stringify portable 2}}}),
   isParallelSafe: {{ isParallelSafe }},
 };
-`) as (params: {
-  portable: any,
-  here: string,
-  isParallelSafe: boolean,
-}) => string;
+`) as (params: { portable: any; here: string; isParallelSafe: boolean }) => string;
 
-export type ResolveOptions  = { basedir: string } | { resolve: (name: string) => any };
+export type ResolveOptions = { basedir: string } | { resolve: (name: string) => any };
 
 interface GlobalPlaceholder {
   embroiderPlaceholder: true;
-  type: "global";
+  type: 'global';
   nonce: number;
   index: number;
 }
 
 interface BroccoliParallelPlaceholder {
   embroiderPlaceholder: true;
-  type: "broccoli-parallel";
+  type: 'broccoli-parallel';
   requireFile: string;
   useMethod: string | undefined;
   buildUsing: string | undefined;
@@ -38,7 +34,7 @@ interface BroccoliParallelPlaceholder {
 
 interface HTMLBarsParallelPlaceholder {
   embroiderPlaceholder: true;
-  type: "htmlbars-parallel";
+  type: 'htmlbars-parallel';
   requireFile: string;
   buildUsing: string;
   params: any;
@@ -93,8 +89,10 @@ export class PortablePluginConfig {
     switch (typeof value) {
       case 'string':
       case 'number':
-      case 'boolean': return value;
-      case 'object': return mapValues(value, (propertyValue, key) => this.makePortable(propertyValue, accessPath.concat(key)));
+      case 'boolean':
+        return value;
+      case 'object':
+        return mapValues(value, (propertyValue, key) => this.makePortable(propertyValue, accessPath.concat(key)));
     }
 
     return this.globalPlaceholder(value);
@@ -108,7 +106,7 @@ export class PortablePluginConfig {
       embroiderPlaceholder: true,
       type: 'global',
       nonce,
-      index
+      index,
     };
   }
 
@@ -140,10 +138,9 @@ export class PortablePluginConfig {
 }
 
 function setupGlobals() {
-  let G = global as any as { [protocol]: { globalValues: any[], nonce: number }  };
+  let G = (global as any) as { [protocol]: { globalValues: any[]; nonce: number } };
   if (!G[protocol]) {
     G[protocol] = { globalValues: [], nonce: Math.floor(Math.random() * Math.pow(2, 32)) };
-
   }
   return G[protocol];
 }
@@ -154,7 +151,8 @@ function maybeBroccoli(object: any): BroccoliParallelPlaceholder | undefined {
   const type = typeof object;
   const hasProperties = type === 'function' || (type === 'object' && object !== null);
 
-  if (hasProperties &&
+  if (
+    hasProperties &&
     object._parallelBabel !== null &&
     typeof object._parallelBabel === 'object' &&
     typeof object._parallelBabel.requireFile === 'string'
@@ -175,7 +173,9 @@ function buildBroccoli(parallelApiInfo: BroccoliParallelPlaceholder) {
 
   if (parallelApiInfo.useMethod) {
     if (requiredStuff[parallelApiInfo.useMethod] === undefined) {
-      throw new Error("method '" + parallelApiInfo.useMethod + "' does not exist in file " + parallelApiInfo.requireFile);
+      throw new Error(
+        "method '" + parallelApiInfo.useMethod + "' does not exist in file " + parallelApiInfo.requireFile
+      );
     }
     return requiredStuff[parallelApiInfo.useMethod];
   }
@@ -195,7 +195,8 @@ function maybeHTMLBars(object: any): HTMLBarsParallelPlaceholder | undefined {
   const type = typeof object;
   const hasProperties = type === 'function' || (type === 'object' && object !== null);
 
-  if (hasProperties &&
+  if (
+    hasProperties &&
     object.parallelBabel !== null &&
     typeof object.parallelBabel === 'object' &&
     typeof object.parallelBabel.requireFile === 'string'

--- a/packages/core/src/prebuilt-addons.ts
+++ b/packages/core/src/prebuilt-addons.ts
@@ -1,9 +1,9 @@
-import Stage from "./stage";
+import Stage from './stage';
 import { realpathSync } from 'fs-extra';
-import Package from "./package";
-import PackageCache from "./package-cache";
-import { UnwatchedDir } from "broccoli-source";
-import { Tree } from "broccoli-plugin";
+import Package from './package';
+import PackageCache from './package-cache';
+import { UnwatchedDir } from 'broccoli-source';
+import { Tree } from 'broccoli-plugin';
 
 export default class PrebuiltAddons implements Stage {
   private packageCache: PackageCache;
@@ -18,10 +18,10 @@ export default class PrebuiltAddons implements Stage {
     this.tree = new UnwatchedDir(this.inputPath);
   }
 
-  async ready(): Promise<{ packageCache: PackageCache, outputPath: string }> {
+  async ready(): Promise<{ packageCache: PackageCache; outputPath: string }> {
     return {
       packageCache: this.packageCache,
-      outputPath: this.appDestDir
+      outputPath: this.appDestDir,
     };
   }
 }

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -1,4 +1,4 @@
-import TemplateCompiler from "./template-compiler";
+import TemplateCompiler from './template-compiler';
 
 export interface ResolvedDep {
   runtimeName: string;

--- a/packages/core/src/stage.ts
+++ b/packages/core/src/stage.ts
@@ -1,5 +1,5 @@
-import { Tree } from "broccoli-plugin";
-import PackageCache from "./package-cache";
+import { Tree } from 'broccoli-plugin';
+import PackageCache from './package-cache';
 
 // A build Stage is _kinda_ like a Broccoli transform, and it interoperates with
 // Broccoli, but it takes a different approach to how stages combine.

--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -1,6 +1,6 @@
 import stripBom from 'strip-bom';
 import { Resolver, ResolvedDep } from './resolver';
-import { PortablePluginConfig, ResolveOptions } from "./portable-plugin-config";
+import { PortablePluginConfig, ResolveOptions } from './portable-plugin-config';
 import { readFileSync } from 'fs';
 import { Tree } from 'broccoli-plugin';
 import Filter from 'broccoli-persistent-filter';
@@ -33,8 +33,8 @@ interface GlimmerSyntax {
   print(ast: AST): string;
   defaultOptions(options: PreprocessOptions): PreprocessOptions;
   registerPlugin(type: string, plugin: unknown): void;
-  precompile(templateContents: string, options: { contents: string, moduleName: string }): string;
-  _Ember: { FEATURES: any, ENV: any };
+  precompile(templateContents: string, options: { contents: string; moduleName: string }): string;
+  _Ember: { FEATURES: any; ENV: any };
   cacheKey: string;
 }
 
@@ -74,7 +74,9 @@ function loadGlimmerSyntax(templateCompilerPath: string): GlimmerSyntax {
         registerPlugin: obj['ember-template-compiler/lib/system/compile-options'].registerPlugin,
         precompile: theExports.precompile,
         _Ember: theExports._Ember,
-        cacheKey: createHash('md5').update(source).digest('hex'),
+        cacheKey: createHash('md5')
+          .update(source)
+          .digest('hex'),
       };
     }
   }
@@ -96,11 +98,7 @@ class PortableTemplateCompiler extends PortablePluginConfig {
   const templateCompiler = new TemplateCompiler(PortablePluginConfig.load({{{json-stringify portable 2}}}));
   templateCompiler.isParallelSafe = {{ isParallelSafe }};
   module.exports = templateCompiler;
-  `) as (params: {
-    portable: any,
-    here: string,
-    isParallelSafe: boolean,
-  }) => string;
+  `) as (params: { portable: any; here: string; isParallelSafe: boolean }) => string;
 
   constructor(config: SetupCompilerParams, resolveOptions: ResolveOptions) {
     super(config, resolveOptions);
@@ -114,7 +112,11 @@ class PortableTemplateCompiler extends PortablePluginConfig {
   }
 
   serialize() {
-    return PortableTemplateCompiler.template({ here: this.here, portable: this.portable, isParallelSafe: this.isParallelSafe });
+    return PortableTemplateCompiler.template({
+      here: this.here,
+      portable: this.portable,
+      isParallelSafe: this.isParallelSafe,
+    });
   }
 }
 
@@ -152,21 +154,23 @@ export default class TemplateCompiler {
       this.userPluginsCount++;
     }
     initializeEmberENV(syntax, this.params.EmberENV);
-    let cacheKey = createHash('md5').update(stringify({
-      // todo: get resolver reflected in cacheKey
-      syntax: syntax.cacheKey,
-    })).digest('hex');
+    let cacheKey = createHash('md5')
+      .update(
+        stringify({
+          // todo: get resolver reflected in cacheKey
+          syntax: syntax.cacheKey,
+        })
+      )
+      .digest('hex');
     return { syntax, cacheKey };
   }
 
   // Compiles to the wire format plus dependency list.
-  precompile(moduleName: string, contents: string): { compiled: string, dependencies: ResolvedDep[] } {
-    let compiled = this.syntax.precompile(
-      stripBom(contents), {
-        contents,
-        moduleName
-      }
-    );
+  precompile(moduleName: string, contents: string): { compiled: string; dependencies: ResolvedDep[] } {
+    let compiled = this.syntax.precompile(stripBom(contents), {
+      contents,
+      moduleName,
+    });
     let dependencies: ResolvedDep[];
     if (this.params.resolver) {
       dependencies = this.params.resolver.dependenciesOf(moduleName);
@@ -186,7 +190,7 @@ export default class TemplateCompiler {
       lines.push(`window.define('${runtimeName}', function(){ return a${counter++}});`);
     }
     lines.push(`export default Ember.HTMLBars.template(${compiled});`);
-    return lines.join("\n");
+    return lines.join('\n');
   }
 
   // Applies all custom AST transforms and emits the results still as
@@ -247,7 +251,6 @@ export default class TemplateCompiler {
     }
     return false;
   }
-
 }
 
 class TemplateCompileTree extends Filter {
@@ -258,7 +261,7 @@ class TemplateCompileTree extends Filter {
       extensions: ['hbs', 'handlebars'],
       // in stage3 we are changing the file extensions from hbs to js. In
       // stage1, we are just keeping hbs.
-      targetExtension: stage === 3 ? 'js' : undefined
+      targetExtension: stage === 3 ? 'js' : undefined,
     });
   }
 
@@ -297,7 +300,9 @@ function registerPlugins(syntax: GlimmerSyntax, plugins: Plugins) {
 }
 
 function initializeEmberENV(syntax: GlimmerSyntax, EmberENV: any) {
-  if (!EmberENV) { return; }
+  if (!EmberENV) {
+    return;
+  }
 
   let props;
 
@@ -311,7 +316,9 @@ function initializeEmberENV(syntax: GlimmerSyntax, EmberENV: any) {
   if (EmberENV) {
     props = Object.keys(EmberENV);
     props.forEach(prop => {
-      if (prop === 'FEATURES') { return; }
+      if (prop === 'FEATURES') {
+        return;
+      }
       syntax._Ember.ENV[prop] = EmberENV[prop];
     });
   }

--- a/packages/core/src/to-broccoli-plugin.ts
+++ b/packages/core/src/to-broccoli-plugin.ts
@@ -1,10 +1,10 @@
-import Plugin from "broccoli-plugin";
-import { Packager, PackagerInstance } from "./packager";
-import Stage from "./stage";
-import PackageCache from "./package-cache";
+import Plugin from 'broccoli-plugin';
+import { Packager, PackagerInstance } from './packager';
+import Stage from './stage';
+import PackageCache from './package-cache';
 
 interface BroccoliPackager<Options> {
-  new(stage: Stage, options?: Options): Plugin;
+  new (stage: Stage, options?: Options): Plugin;
 }
 
 export default function toBroccoliPlugin<Options>(packagerClass: Packager<Options>): BroccoliPackager<Options> {
@@ -14,7 +14,7 @@ export default function toBroccoliPlugin<Options>(packagerClass: Packager<Option
       super([stage.tree], {
         persistentOutput: true,
         needsCache: false,
-        annotation: packagerClass.annotation
+        annotation: packagerClass.annotation,
       });
     }
 
@@ -35,9 +35,9 @@ export default function toBroccoliPlugin<Options>(packagerClass: Packager<Option
         this.packager = new packagerClass(
           outputPath,
           this.outputPath,
-          (msg) => console.log(msg),
+          msg => console.log(msg),
           packageCache,
-          this.options,
+          this.options
         );
       }
       return this.packager.build();

--- a/packages/core/src/wait-for-trees.ts
+++ b/packages/core/src/wait-for-trees.ts
@@ -25,8 +25,8 @@ export default class WaitForTrees<NamedTrees> extends BroccoliPlugin {
   constructor(
     private trees: NamedTrees,
     annotation: string,
-    private buildHook: (trees: OutputPaths<NamedTrees>) => Promise<void>,
-  ){
+    private buildHook: (trees: OutputPaths<NamedTrees>) => Promise<void>
+  ) {
     super(flatTrees(trees), {
       persistentOutput: true,
       needsCache: false,
@@ -41,24 +41,22 @@ export default class WaitForTrees<NamedTrees> extends BroccoliPlugin {
       if (entry.single) {
         result[entry.name] = this.inputPaths[inputPathCounter++];
       } else if (entry.multi) {
-        result[entry.name] = this.inputPaths.slice(inputPathCounter, inputPathCounter += entry.multi.length);
+        result[entry.name] = this.inputPaths.slice(inputPathCounter, (inputPathCounter += entry.multi.length));
       }
     }
-    return this.buildHook(result as unknown as OutputPaths<NamedTrees>);
+    return this.buildHook((result as unknown) as OutputPaths<NamedTrees>);
   }
 }
 
 export type OutputPaths<NamedTrees> = {
-  [P in keyof NamedTrees]: NamedTrees[P] extends Tree ? string :
-    NamedTrees[P] extends Tree[] ? string[]
-      : never;
+  [P in keyof NamedTrees]: NamedTrees[P] extends Tree ? string : NamedTrees[P] extends Tree[] ? string[] : never
 };
 
 function isTree(x: any): x is Tree {
   return x && typeof x.__broccoliGetInfo__ === 'function';
 }
 
-function * findTrees<NamedTrees>(trees: NamedTrees): IterableIterator<{ name: string, single?: Tree, multi?: Tree[] }> {
+function* findTrees<NamedTrees>(trees: NamedTrees): IterableIterator<{ name: string; single?: Tree; multi?: Tree[] }> {
   for (let [name, value] of Object.entries(trees)) {
     if (Array.isArray(value)) {
       yield { name, multi: value.filter(isTree) };

--- a/packages/core/src/wait-for-trees.ts
+++ b/packages/core/src/wait-for-trees.ts
@@ -50,8 +50,8 @@ export default class WaitForTrees<NamedTrees> extends BroccoliPlugin {
 
 export type OutputPaths<NamedTrees> = {
   [P in keyof NamedTrees]: NamedTrees[P] extends Tree ? string :
-                           NamedTrees[P] extends Tree[] ? string[]
-                           : never;
+    NamedTrees[P] extends Tree[] ? string[]
+      : never;
 };
 
 function isTree(x: any): x is Tree {

--- a/packages/core/tests/inline-hbs-test.ts
+++ b/packages/core/tests/inline-hbs-test.ts
@@ -55,23 +55,21 @@ function stage3Tests(transform: (code: string) => string) {
 }
 
 QUnit.module('inline-hbs', function() {
-  QUnit.module('stage1', function () {
+  QUnit.module('stage1', function() {
     allBabelVersions({
       babelConfig() {
         let templateCompiler = new TemplateCompiler({
           compilerPath: emberTemplateCompilerPath(),
           EmberENV: {},
           plugins: {
-            ast: [sampleTransform]
+            ast: [sampleTransform],
           },
         });
         return {
-          plugins: [
-            [join(__dirname, '../src/babel-plugin-inline-hbs.js'), { templateCompiler, stage: 1 }]
-          ]
+          plugins: [[join(__dirname, '../src/babel-plugin-inline-hbs.js'), { templateCompiler, stage: 1 }]],
         };
       },
-      createTests: stage1Tests
+      createTests: stage1Tests,
     });
   });
 
@@ -82,16 +80,14 @@ QUnit.module('inline-hbs', function() {
           compilerPath: emberTemplateCompilerPath(),
           EmberENV: {},
           plugins: {
-            ast: []
+            ast: [],
           },
         });
         return {
-          plugins: [
-            [join(__dirname, '../src/babel-plugin-inline-hbs.js'), { templateCompiler, stage: 3 }]
-          ]
+          plugins: [[join(__dirname, '../src/babel-plugin-inline-hbs.js'), { templateCompiler, stage: 3 }]],
         };
       },
-      createTests: stage3Tests
+      createTests: stage3Tests,
     });
   });
 
@@ -102,24 +98,25 @@ QUnit.module('inline-hbs', function() {
           compilerPath: emberTemplateCompilerPath(),
           EmberENV: {},
           plugins: {
-            ast: []
+            ast: [],
           },
         });
         return {
-          plugins: [
-            [join(__dirname, '../src/babel-plugin-inline-hbs.js'), { templateCompiler, stage: 3 }]
-          ],
+          plugins: [[join(__dirname, '../src/babel-plugin-inline-hbs.js'), { templateCompiler, stage: 3 }]],
           presets: [
-            [require.resolve(major === 6 ? 'babel-preset-env' : '@babel/preset-env'), {
-              modules: false,
-              targets: {
-                ie: '11.0.0'
-              }
-            }]
-          ]
+            [
+              require.resolve(major === 6 ? 'babel-preset-env' : '@babel/preset-env'),
+              {
+                modules: false,
+                targets: {
+                  ie: '11.0.0',
+                },
+              },
+            ],
+          ],
         };
       },
-      createTests: stage3Tests
+      createTests: stage3Tests,
     });
   });
 });

--- a/packages/core/tests/multi-tree-diff-test.ts
+++ b/packages/core/tests/multi-tree-diff-test.ts
@@ -12,7 +12,7 @@ QUnit.module('tracked-merge-dirs', function() {
     let b = new MockTree({ beta: ['x'] });
     let c = new MockTree(['charlie']);
 
-    let t = new MultiTreeDiff([a,b,c]);
+    let t = new MultiTreeDiff([a, b, c]);
     let { ops, sources } = t.update();
 
     assert.deepEqual(fileOps(ops), [
@@ -34,14 +34,10 @@ QUnit.module('tracked-merge-dirs', function() {
     let a = new MockTree(['alpha', 'tomster']);
     let c = new MockTree(['charlie', 'alpha']);
 
-    let t = new MultiTreeDiff([a,c]);
+    let t = new MultiTreeDiff([a, c]);
     let { ops, sources } = t.update();
 
-    assert.deepEqual(fileOps(ops), [
-      ['create', 'alpha'],
-      ['create', 'charlie'],
-      ['create', 'tomster'],
-    ]);
+    assert.deepEqual(fileOps(ops), [['create', 'alpha'], ['create', 'charlie'], ['create', 'tomster']]);
 
     assert.equal(sources.get('alpha'), 1);
     assert.equal(sources.get('charlie'), 1);
@@ -53,7 +49,7 @@ QUnit.module('tracked-merge-dirs', function() {
     let b = new MockTree({ beta: ['x'] });
     let c = new MockTree(['charlie']);
 
-    let t = new MultiTreeDiff([a,b,c]);
+    let t = new MultiTreeDiff([a, b, c]);
     t.update();
     let { ops } = t.update();
     assert.deepEqual(fileOps(ops), []);
@@ -64,13 +60,11 @@ QUnit.module('tracked-merge-dirs', function() {
     let b = new MockTree({ beta: ['x'] });
     let c = new MockTree(['charlie']);
 
-    let t = new MultiTreeDiff([a,b,c]);
+    let t = new MultiTreeDiff([a, b, c]);
     t.update();
     dirty(a.entries[0]);
     let { ops, sources } = t.update();
-    assert.deepEqual(fileOps(ops), [
-      ['change', 'alpha']
-    ]);
+    assert.deepEqual(fileOps(ops), [['change', 'alpha']]);
     assert.equal(sources.get('alpha'), 0);
   });
 
@@ -78,7 +72,7 @@ QUnit.module('tracked-merge-dirs', function() {
     let a = new MockTree(['alpha', 'tomster']);
     let c = new MockTree(['charlie', 'alpha']);
 
-    let t = new MultiTreeDiff([a,c]);
+    let t = new MultiTreeDiff([a, c]);
 
     let result = t.update();
     assert.equal(result.sources.get('alpha'), 1);
@@ -86,9 +80,7 @@ QUnit.module('tracked-merge-dirs', function() {
     c.entries.splice(0, 1);
 
     result = t.update();
-    assert.deepEqual(fileOps(result.ops), [
-      ['change', 'alpha'],
-    ]);
+    assert.deepEqual(fileOps(result.ops), [['change', 'alpha']]);
     assert.equal(result.sources.get('alpha'), 0);
   });
 
@@ -96,7 +88,7 @@ QUnit.module('tracked-merge-dirs', function() {
     let a = new MockTree(['alpha', 'tomster']);
     let b = new MockTree(['charlie']);
 
-    let t = new MultiTreeDiff([a,b]);
+    let t = new MultiTreeDiff([a, b]);
 
     let result = t.update();
     assert.equal(result.sources.get('alpha'), 0);
@@ -106,13 +98,11 @@ QUnit.module('tracked-merge-dirs', function() {
       mode: 33188,
       size: 1000,
       mtime: Date.now(),
-      isDirectory: () => false
+      isDirectory: () => false,
     });
 
     result = t.update();
-    assert.deepEqual(fileOps(result.ops), [
-      ['change', 'alpha'],
-    ]);
+    assert.deepEqual(fileOps(result.ops), [['change', 'alpha']]);
     assert.equal(result.sources.get('alpha'), 1);
   });
 
@@ -120,7 +110,7 @@ QUnit.module('tracked-merge-dirs', function() {
     let a = new MockTree(['alpha']);
     let b = new MockTree(['alpha']);
 
-    let t = new MultiTreeDiff([a,b]);
+    let t = new MultiTreeDiff([a, b]);
     t.update();
     dirty(a.entries[0]);
     let { ops } = t.update();
@@ -136,17 +126,16 @@ QUnit.module('tracked-merge-dirs', function() {
     let { ops } = t.update();
     assert.deepEqual(fileOps(ops), []);
   });
-
 });
 
 class MockTree {
   entries: Entry[];
 
-  constructor(structure: any){
+  constructor(structure: any) {
     this.entries = [...MockTree.walk([], structure)];
   }
 
-  static * walk(breadcrumbs: string[], structure: any): IterableIterator<Entry> {
+  static *walk(breadcrumbs: string[], structure: any): IterableIterator<Entry> {
     if (Array.isArray(structure)) {
       let expanded: any = {};
       for (let name of structure) {
@@ -164,16 +153,16 @@ class MockTree {
           mode: 33188,
           size: 1000,
           mtime: Date.now(),
-          isDirectory: () => true
+          isDirectory: () => true,
         };
-        yield * this.walk([...breadcrumbs, name], value);
+        yield* this.walk([...breadcrumbs, name], value);
       } else {
         yield {
           relativePath: join(...breadcrumbs, name),
           mode: 33188,
           size: 1000,
           mtime: Date.now(),
-          isDirectory: () => false
+          isDirectory: () => false,
         };
       }
     }
@@ -188,7 +177,7 @@ class MockTree {
 
 function dirty(entry: Entry) {
   if (entry.mtime) {
-    entry.mtime = (+entry.mtime) + 1000;
+    entry.mtime = +entry.mtime + 1000;
   }
 }
 

--- a/packages/core/tests/portable-plugin-config-test.ts
+++ b/packages/core/tests/portable-plugin-config-test.ts
@@ -18,7 +18,7 @@ function resolvableNames(...names: string[]) {
       let e = new Error(`stub resolver failure for ${name}`);
       (e as any).code = 'MODULE_NOT_FOUND';
       throw e;
-    }
+    },
   };
 }
 
@@ -38,88 +38,122 @@ function run(config: PortableBabelConfig): any {
 
 QUnit.module('portable-plugin-config', function() {
   test('absolute path', function(assert) {
-    let config = new PortableBabelConfig({
-      plugins: ['/path/to/some/plugin.js']
-    }, resolvableNames());
+    let config = new PortableBabelConfig(
+      {
+        plugins: ['/path/to/some/plugin.js'],
+      },
+      resolvableNames()
+    );
     assert.deepEqual(runParallelSafe(config).plugins, ['/path/to/some/plugin.js']);
   });
 
   test('local path', function(assert) {
-    let config = new PortableBabelConfig({
-      plugins: ['./path/to/some/plugin.js']
-    }, resolvableNames());
+    let config = new PortableBabelConfig(
+      {
+        plugins: ['./path/to/some/plugin.js'],
+      },
+      resolvableNames()
+    );
     assert.deepEqual(runParallelSafe(config).plugins, ['/notional-base-dir/path/to/some/plugin.js']);
   });
 
   test('package name', function(assert) {
-    let config = new PortableBabelConfig({
-      plugins: ['my-package']
-    }, resolvableNames('my-package'));
+    let config = new PortableBabelConfig(
+      {
+        plugins: ['my-package'],
+      },
+      resolvableNames('my-package')
+    );
     assert.deepEqual(runParallelSafe(config).plugins, ['/notional-base-dir/node_modules/my-package/index.js']);
   });
 
   test('package name shorthand', function(assert) {
-    let config = new PortableBabelConfig({
-      plugins: ['my-package']
-    }, resolvableNames('babel-plugin-my-package'));
-    assert.deepEqual(runParallelSafe(config).plugins, ['/notional-base-dir/node_modules/babel-plugin-my-package/index.js']);
+    let config = new PortableBabelConfig(
+      {
+        plugins: ['my-package'],
+      },
+      resolvableNames('babel-plugin-my-package')
+    );
+    assert.deepEqual(runParallelSafe(config).plugins, [
+      '/notional-base-dir/node_modules/babel-plugin-my-package/index.js',
+    ]);
   });
 
   test('namespaced package name', function(assert) {
-    let config = new PortableBabelConfig({
-      plugins: ['@me/my-package']
-    }, resolvableNames('@me/my-package'));
+    let config = new PortableBabelConfig(
+      {
+        plugins: ['@me/my-package'],
+      },
+      resolvableNames('@me/my-package')
+    );
     assert.deepEqual(runParallelSafe(config).plugins, ['/notional-base-dir/node_modules/@me/my-package/index.js']);
   });
 
   test('namespaced package name shorthand', function(assert) {
-    let config = new PortableBabelConfig({
-      plugins: ['@me/my-package']
-    }, resolvableNames('@me/babel-plugin-my-package'));
-    assert.deepEqual(runParallelSafe(config).plugins, ['/notional-base-dir/node_modules/@me/babel-plugin-my-package/index.js']);
+    let config = new PortableBabelConfig(
+      {
+        plugins: ['@me/my-package'],
+      },
+      resolvableNames('@me/babel-plugin-my-package')
+    );
+    assert.deepEqual(runParallelSafe(config).plugins, [
+      '/notional-base-dir/node_modules/@me/babel-plugin-my-package/index.js',
+    ]);
   });
 
   test('resolves name with json-safe config', function(assert) {
-    let config = new PortableBabelConfig({
-      plugins: [['my-package', { theOptions: 'cool' }]]
-    }, resolvableNames('babel-plugin-my-package'));
+    let config = new PortableBabelConfig(
+      {
+        plugins: [['my-package', { theOptions: 'cool' }]],
+      },
+      resolvableNames('babel-plugin-my-package')
+    );
     assert.deepEqual(runParallelSafe(config).plugins, [
-      ['/notional-base-dir/node_modules/babel-plugin-my-package/index.js', { theOptions: 'cool' }]
+      ['/notional-base-dir/node_modules/babel-plugin-my-package/index.js', { theOptions: 'cool' }],
     ]);
   });
 
   test('resolves name with arbitrary config', function(assert) {
-    let options = { precompile() { return 'cool'; } };
-    let config = new PortableBabelConfig({
-      plugins: [['my-package', options]]
-    }, resolvableNames('babel-plugin-my-package'));
+    let options = {
+      precompile() {
+        return 'cool';
+      },
+    };
+    let config = new PortableBabelConfig(
+      {
+        plugins: [['my-package', options]],
+      },
+      resolvableNames('babel-plugin-my-package')
+    );
     assert.ok(!config.isParallelSafe);
     assert.deepEqual(run(config).plugins, [
-      ['/notional-base-dir/node_modules/babel-plugin-my-package/index.js', options]
+      ['/notional-base-dir/node_modules/babel-plugin-my-package/index.js', options],
     ]);
   });
 
   test('passes through bare function', function(assert) {
     let func = function() {};
-    let config = new PortableBabelConfig({
-      plugins: [func]
-    }, resolvableNames());
+    let config = new PortableBabelConfig(
+      {
+        plugins: [func],
+      },
+      resolvableNames()
+    );
     assert.ok(!config.isParallelSafe);
-    assert.deepEqual(run(config).plugins, [
-      func
-    ]);
+    assert.deepEqual(run(config).plugins, [func]);
   });
 
   test('passes through function with args', function(assert) {
     let func = function() {};
     let args = { theArgs: 'here' };
-    let config = new PortableBabelConfig({
-      plugins: [[func, args]]
-    }, resolvableNames());
+    let config = new PortableBabelConfig(
+      {
+        plugins: [[func, args]],
+      },
+      resolvableNames()
+    );
     assert.ok(!config.isParallelSafe);
-    assert.deepEqual(run(config).plugins, [
-      [func, args]
-    ]);
+    assert.deepEqual(run(config).plugins, [[func, args]]);
   });
 
   test('respects _parallelBabel api with buildUsing on PluginTarget', function(assert) {
@@ -127,12 +161,15 @@ QUnit.module('portable-plugin-config', function() {
       requireFile: __filename,
       buildUsing: 'exampleFunction',
       params: {
-        theParams: 'are here'
-      }
+        theParams: 'are here',
+      },
     };
-    let config = new PortableBabelConfig({
-      plugins: [exampleFunction]
-    }, resolvableNames());
+    let config = new PortableBabelConfig(
+      {
+        plugins: [exampleFunction],
+      },
+      resolvableNames()
+    );
     assert.ok(config.isParallelSafe);
     let output = runParallelSafe(config);
     assert.equal(output.plugins[0], 'this is the example function with theParams=are here');
@@ -141,11 +178,14 @@ QUnit.module('portable-plugin-config', function() {
   test('respects _parallelBabel api with useMethod on PluginTarget', function(assert) {
     (exampleFunction as any)._parallelBabel = {
       requireFile: __filename,
-      useMethod: 'exampleFunction'
+      useMethod: 'exampleFunction',
     };
-    let config = new PortableBabelConfig({
-      plugins: [exampleFunction]
-    }, resolvableNames());
+    let config = new PortableBabelConfig(
+      {
+        plugins: [exampleFunction],
+      },
+      resolvableNames()
+    );
     assert.ok(config.isParallelSafe);
     let output = runParallelSafe(config);
     assert.equal(output.plugins[0](), 'this is the example function with no params');
@@ -155,9 +195,12 @@ QUnit.module('portable-plugin-config', function() {
     (exampleFunction as any)._parallelBabel = {
       requireFile: __filename,
     };
-    let config = new PortableBabelConfig({
-      plugins: [exampleFunction]
-    }, resolvableNames());
+    let config = new PortableBabelConfig(
+      {
+        plugins: [exampleFunction],
+      },
+      resolvableNames()
+    );
     assert.ok(config.isParallelSafe);
     let output = runParallelSafe(config);
     assert.equal(output.plugins[0].exampleFunction(), 'this is the example function with no params');
@@ -168,16 +211,21 @@ QUnit.module('portable-plugin-config', function() {
     precompile._parallelBabel = {
       requireFile: __filename,
       buildUsing: 'exampleFunction',
-      params: { theParams: 'reconstituted precompile' }
+      params: { theParams: 'reconstituted precompile' },
     };
 
-    let config = new PortableBabelConfig({
-      plugins: [['my-plugin', { precompile }]]
-    }, resolvableNames('my-plugin'));
+    let config = new PortableBabelConfig(
+      {
+        plugins: [['my-plugin', { precompile }]],
+      },
+      resolvableNames('my-plugin')
+    );
     assert.ok(config.isParallelSafe);
     let output = runParallelSafe(config);
     assert.equal(output.plugins[0][0], '/notional-base-dir/node_modules/my-plugin/index.js');
-    assert.deepEqual(output.plugins[0][1], { precompile: 'this is the example function with theParams=reconstituted precompile' });
+    assert.deepEqual(output.plugins[0][1], {
+      precompile: 'this is the example function with theParams=reconstituted precompile',
+    });
   });
 });
 

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -24,7 +24,6 @@
     "@types/qunit": "^2.5.3",
     "@types/resolve": "^0.0.8",
     "qunit": "^2.8.0",
-    "tslint": "^5.11.0",
     "typescript": "~3.2.0"
   },
   "dependencies": {

--- a/packages/macros/src/babel/dependency-satisfies.ts
+++ b/packages/macros/src/babel/dependency-satisfies.ts
@@ -12,10 +12,16 @@ export default function dependencySatisfies(path: NodePath<CallExpression>, stat
   }
   let [packageName, range] = path.node.arguments;
   if (packageName.type !== 'StringLiteral') {
-    throw error(assertArray(path.get('arguments'))[0], `the first argument to dependencySatisfies must be a string literal`);
+    throw error(
+      assertArray(path.get('arguments'))[0],
+      `the first argument to dependencySatisfies must be a string literal`
+    );
   }
   if (range.type !== 'StringLiteral') {
-    throw error(assertArray(path.get('arguments'))[1], `the second argument to dependencySatisfies must be a string literal`);
+    throw error(
+      assertArray(path.get('arguments'))[1],
+      `the second argument to dependencySatisfies must be a string literal`
+    );
   }
   let sourceFileName = sourceFile(path, state);
   try {

--- a/packages/macros/src/babel/evaluate-json.ts
+++ b/packages/macros/src/babel/evaluate-json.ts
@@ -1,7 +1,7 @@
 import { NodePath } from '@babel/traverse';
 import { BoundVisitor } from './visitor';
 
-function evaluateKey(path: NodePath, visitor: BoundVisitor): { confident: boolean, value: any } {
+function evaluateKey(path: NodePath, visitor: BoundVisitor): { confident: boolean; value: any } {
   let first = evaluateJSON(path, visitor);
   if (first.confident) {
     return first;
@@ -12,7 +12,7 @@ function evaluateKey(path: NodePath, visitor: BoundVisitor): { confident: boolea
   return { confident: false, value: undefined };
 }
 
-export default function evaluateJSON(path: NodePath, visitor: BoundVisitor): { confident: boolean, value: any } {
+export default function evaluateJSON(path: NodePath, visitor: BoundVisitor): { confident: boolean; value: any } {
   if (path.isMemberExpression()) {
     let property = evaluateKey(assertNotArray(path.get('property')), visitor);
     if (property.confident) {
@@ -40,9 +40,12 @@ export default function evaluateJSON(path: NodePath, visitor: BoundVisitor): { c
   }
 
   if (path.isObjectExpression()) {
-    let props = assertArray(path.get('properties')).map(p => [ evaluateJSON(assertNotArray(p.get('key')), visitor), evaluateJSON(assertNotArray(p.get('value')), visitor) ]);
+    let props = assertArray(path.get('properties')).map(p => [
+      evaluateJSON(assertNotArray(p.get('key')), visitor),
+      evaluateJSON(assertNotArray(p.get('value')), visitor),
+    ]);
     let result: any = {};
-    for (let [k,v] of props) {
+    for (let [k, v] of props) {
       if (!k.confident || !v.confident) {
         return { confident: false, value: undefined };
       }

--- a/packages/macros/src/babel/get-config.ts
+++ b/packages/macros/src/babel/get-config.ts
@@ -6,7 +6,12 @@ import { PackageCache, Package } from '@embroider/core';
 import error from './error';
 import { assertArray } from './evaluate-json';
 
-export default function getConfig(path: NodePath<CallExpression>, state: State, packageCache: PackageCache, own: boolean) {
+export default function getConfig(
+  path: NodePath<CallExpression>,
+  state: State,
+  packageCache: PackageCache,
+  own: boolean
+) {
   let packageName: string | undefined;
   if (own) {
     if (path.node.arguments.length !== 0) {

--- a/packages/macros/src/babel/macro-if.ts
+++ b/packages/macros/src/babel/macro-if.ts
@@ -26,7 +26,7 @@ export default function macroIf(path: NodePath<CallExpression>, state: State, vi
   }
 
   state.removed.push(path.get('callee'));
-  let [kept, dropped] = predicate.value ? [consequent, alternate] : [ alternate, consequent];
+  let [kept, dropped] = predicate.value ? [consequent, alternate] : [alternate, consequent];
   if (kept) {
     let body = kept.get('body');
     if (body.type === 'BlockStatement') {

--- a/packages/macros/src/babel/macros-babel-plugin.ts
+++ b/packages/macros/src/babel/macros-babel-plugin.ts
@@ -21,7 +21,7 @@ export default function main() {
         state.pendingTasks.forEach(task => task());
         pruneRemovedImports(state);
         pruneMacroImports(path);
-      }
+      },
     },
     CallExpression(path: NodePath<CallExpression>, state: State) {
       let callee = path.get('callee');
@@ -51,7 +51,7 @@ export default function main() {
       if (path.referencesImport('@embroider/macros', 'macroIf')) {
         throw error(path, `You can only use macroIf as a function call`);
       }
-    }
+    },
   };
   return { visitor };
 }

--- a/packages/macros/src/babel/state.ts
+++ b/packages/macros/src/babel/state.ts
@@ -5,8 +5,8 @@ export default interface State {
   pendingTasks: (() => void)[];
   opts: {
     userConfigs: {
-      [pkgRoot: string]: unknown
-    },
+      [pkgRoot: string]: unknown;
+    };
     // we set this when we're running inside classic ember-cli, because in that
     // case we don't have finer-grained info available about where the files
     // we're processing are globally located. When running in embroider, we

--- a/packages/macros/src/babel/visitor.ts
+++ b/packages/macros/src/babel/visitor.ts
@@ -14,6 +14,6 @@ export function bindState(visitor: Visitor, state: State): BoundVisitor {
   return {
     CallExpression(node: NodePath<CallExpression>) {
       return visitor.CallExpression(node, state);
-    }
+    },
   };
 }

--- a/packages/macros/src/ember-addon-main.ts
+++ b/packages/macros/src/ember-addon-main.ts
@@ -7,8 +7,7 @@ export = {
   included(this: any, parent: any) {
     this._super.included.apply(this, arguments);
     let parentOptions = (parent.options = parent.options || {});
-    let ownOptions = (parentOptions['@embroider/macros'] =
-      parentOptions['@embroider/macros'] || {});
+    let ownOptions = (parentOptions['@embroider/macros'] = parentOptions['@embroider/macros'] || {});
 
     // if parent is an addon it has root. If it's an app it has project.root.
     let source = parent.root || parent.project.root;
@@ -28,9 +27,8 @@ export = {
     babelPlugins.unshift(MacrosConfig.shared().babelPluginConfig(source));
   },
 
-  setupPreprocessorRegistry(type: "parent" | "self", registry: any) {
+  setupPreprocessorRegistry(type: 'parent' | 'self', registry: any) {
     if (type === 'parent') {
-
       // the htmlbars-ast-plugins are split into two parts because order is
       // important. Weirdly, they appear to run in the reverse order that you
       // register them here.
@@ -42,9 +40,9 @@ export = {
           plugin,
           baseDir() {
             return join(__dirname, '..');
-          }
+          },
         });
       });
     }
-  }
+  },
 };

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -2,15 +2,10 @@ import { MacrosConfig } from '..';
 import literal from './literal';
 import getConfig from './get-config';
 import dependencySatisfies from './dependency-satisfies';
-import {
-  macroIfBlock,
-  macroIfExpression,
-  maybeAttrs,
-} from './macro-if';
+import { macroIfBlock, macroIfExpression, maybeAttrs } from './macro-if';
 
 export function makeFirstTransform(config: MacrosConfig, baseDir?: string) {
-  function embroiderFirstMacrosTransform(env: { syntax: { builders: any }, meta: { moduleName: string } }) {
-
+  function embroiderFirstMacrosTransform(env: { syntax: { builders: any }; meta: { moduleName: string } }) {
     let scopeStack: string[][] = [];
 
     return {
@@ -27,7 +22,7 @@ export function makeFirstTransform(config: MacrosConfig, baseDir?: string) {
             if (node.blockParams.length > 0) {
               scopeStack.pop();
             }
-          }
+          },
         },
         SubExpression(node: any) {
           if (node.path.type !== 'PathExpression') {
@@ -54,16 +49,22 @@ export function makeFirstTransform(config: MacrosConfig, baseDir?: string) {
             return;
           }
           if (node.path.original === 'macroGetOwnConfig') {
-            return env.syntax.builders.mustache(literal(getConfig(node, config, baseDir, env.meta.moduleName, true), env.syntax.builders));
+            return env.syntax.builders.mustache(
+              literal(getConfig(node, config, baseDir, env.meta.moduleName, true), env.syntax.builders)
+            );
           }
           if (node.path.original === 'macroGetConfig') {
-            return env.syntax.builders.mustache(literal(getConfig(node, config, baseDir, env.meta.moduleName, false), env.syntax.builders));
+            return env.syntax.builders.mustache(
+              literal(getConfig(node, config, baseDir, env.meta.moduleName, false), env.syntax.builders)
+            );
           }
           if (node.path.original === 'macroDependencySatisfies') {
-            return env.syntax.builders.mustache(literal(dependencySatisfies(node, config, baseDir, env.meta.moduleName), env.syntax.builders));
+            return env.syntax.builders.mustache(
+              literal(dependencySatisfies(node, config, baseDir, env.meta.moduleName), env.syntax.builders)
+            );
           }
-        }
-      }
+        },
+      },
     };
   }
   (embroiderFirstMacrosTransform as any).embroiderMacrosASTMarker = true;
@@ -72,7 +73,6 @@ export function makeFirstTransform(config: MacrosConfig, baseDir?: string) {
 
 export function makeSecondTransform() {
   function embroiderSecondMacrosTransform(env: { syntax: { builders: any } }) {
-
     let scopeStack: string[][] = [];
 
     return {
@@ -89,7 +89,7 @@ export function makeSecondTransform() {
             if (node.blockParams.length > 0) {
               scopeStack.pop();
             }
-          }
+          },
         },
         BlockStatement(node: any) {
           if (node.path.type !== 'PathExpression') {
@@ -138,8 +138,8 @@ export function makeSecondTransform() {
           if (node.path.original === 'macroIf') {
             return env.syntax.builders.mustache(macroIfExpression(node, env.syntax.builders));
           }
-        }
-      }
+        },
+      },
     };
   }
   (embroiderSecondMacrosTransform as any).embroiderMacrosASTMarker = true;

--- a/packages/macros/src/glimmer/dependency-satisfies.ts
+++ b/packages/macros/src/glimmer/dependency-satisfies.ts
@@ -11,7 +11,6 @@ export default function dependencySatisfies(
   baseDir: string | undefined,
   moduleName: string
 ) {
-
   if (node.params.length !== 2) {
     throw new Error(`macroDependencySatisfies requires two arguments, you passed ${node.params.length}`);
   }

--- a/packages/macros/src/glimmer/literal.ts
+++ b/packages/macros/src/glimmer/literal.ts
@@ -18,7 +18,11 @@ export default function literal(value: any, builders: any): any {
     return builders.sexpr('array', value.map(element => literal(element, builders)));
   }
   if (typeof value === 'object') {
-    return builders.sexpr('hash', undefined, builders.hash(Object.entries(value).map(([k,v]) => builders.pair(k,literal(v, builders)))));
+    return builders.sexpr(
+      'hash',
+      undefined,
+      builders.hash(Object.entries(value).map(([k, v]) => builders.pair(k, literal(v, builders))))
+    );
   }
 
   throw new Error(`don't know how to emit a literal form of value ${value}`);

--- a/packages/macros/src/glimmer/macro-if.ts
+++ b/packages/macros/src/glimmer/macro-if.ts
@@ -1,4 +1,3 @@
-
 export function macroIfBlock(node: any) {
   if (node.params.length !== 1) {
     throw new Error(`macroIf (block form) requires one arguments, you passed ${node.params.length}`);
@@ -35,7 +34,6 @@ export function macroIfExpression(node: any, builders: any) {
   } else {
     return node.params[2] || builders.undefined();
   }
-
 }
 
 export function maybeAttrs(elementNode: any, node: any, builders: any) {
@@ -58,17 +56,16 @@ export function maybeAttrs(elementNode: any, node: any, builders: any) {
 
   if (result.value) {
     for (let bareAttr of bareAttrs) {
-      elementNode.attributes.push(builders.attr(bareAttr.original, builders.text("")));
+      elementNode.attributes.push(builders.attr(bareAttr.original, builders.text('')));
     }
 
     for (let attr of node.hash.pairs) {
       elementNode.attributes.push(builders.attr(attr.key, builders.mustache(attr.value)));
     }
   }
-
 }
 
-function evaluate(node: any): { confident: true, value: any } | { confident: false } {
+function evaluate(node: any): { confident: true; value: any } | { confident: false } {
   switch (node.type) {
     case 'StringLiteral':
     case 'NumberLiteral':

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -23,26 +23,25 @@ export function getOwnConfig<T>(): T {
 class Oops extends Error {
   params: any[];
   constructor(...params: any[]) {
-    super(`this method is really implemented at compile time via a babel plugin. If you're seeing this exception, something went wrong`);
+    super(
+      `this method is really implemented at compile time via a babel plugin. If you're seeing this exception, something went wrong`
+    );
     this.params = params;
   }
 }
 
 // Entrypoint for managing the macro config within Node.
-export { default as MacrosConfig, Merger } from "./macros-config";
+export { default as MacrosConfig, Merger } from './macros-config';
 
 // Utility for detecting our babel and AST plugins.
-import { PluginItem } from "@babel/core";
+import { PluginItem } from '@babel/core';
 export function isEmbroiderMacrosPlugin(item: PluginItem) {
   return (
-    Array.isArray(item) &&
-    item.length > 1 &&
-    item[1] &&
-    typeof item[1] === 'object' &&
-    (item[1] as any).embroiderMacrosConfigMarker
-  ) || (
-    item &&
-    typeof item === 'function' &&
-    (item as any).embroiderMacrosASTMarker
+    (Array.isArray(item) &&
+      item.length > 1 &&
+      item[1] &&
+      typeof item[1] === 'object' &&
+      (item[1] as any).embroiderMacrosConfigMarker) ||
+    (item && typeof item === 'function' && (item as any).embroiderMacrosASTMarker)
   );
 }

--- a/packages/macros/tests/dependency-satisfies-test.ts
+++ b/packages/macros/tests/dependency-satisfies-test.ts
@@ -3,7 +3,7 @@ import { allBabelVersions, runDefault } from './helpers';
 const { test } = QUnit;
 
 QUnit.module(`dependencySatisfies`, function() {
-  allBabelVersions(function (transform: (code: string) => string) {
+  allBabelVersions(function(transform: (code: string) => string) {
     test('is satisfied', function(assert) {
       let code = transform(`
       import { dependencySatisfies } from '@embroider/macros';

--- a/packages/macros/tests/get-config-test.ts
+++ b/packages/macros/tests/get-config-test.ts
@@ -4,7 +4,7 @@ import { MacrosConfig } from '..';
 const { test } = QUnit;
 
 QUnit.module(`getConfig`, function() {
-  allBabelVersions(function (transform: (code: string) => string, config: MacrosConfig) {
+  allBabelVersions(function(transform: (code: string) => string, config: MacrosConfig) {
     config.setOwnConfig(__filename, { beverage: 'coffee' });
     config.setConfig(__filename, '@babel/core', [1, 2, 3]);
 
@@ -25,7 +25,7 @@ QUnit.module(`getConfig`, function() {
         return getConfig('@babel/core');
       }
       `);
-      assert.deepEqual(runDefault(code), [1,2,3]);
+      assert.deepEqual(runDefault(code), [1, 2, 3]);
     });
 
     test(`returns undefined when there's no config but the package exists`, function(assert) {
@@ -57,6 +57,5 @@ QUnit.module(`getConfig`, function() {
       `);
       assert.ok(!/dependencySatisfies/.test(code), `dependencySatisfies should not be in the output: ${code}`);
     });
-
   });
 });

--- a/packages/macros/tests/helpers.ts
+++ b/packages/macros/tests/helpers.ts
@@ -15,12 +15,12 @@ export function allBabelVersions(createTests: (transform: (code: string) => stri
         return {
           filename: join(__dirname, 'sample.js'),
           presets: [],
-          plugins: [config.babelPluginConfig()]
+          plugins: [config.babelPluginConfig()],
         };
       },
       createTests(transform: (code: string) => string) {
         createTests(transform, config);
-      }
+      },
     });
   });
 
@@ -31,19 +31,22 @@ export function allBabelVersions(createTests: (transform: (code: string) => stri
         return {
           filename: join(__dirname, 'sample.js'),
           presets: [
-            [require.resolve(major === 6 ? 'babel-preset-env' : '@babel/preset-env'), {
-              modules: false,
-              targets: {
-                ie: '11.0.0'
-              }
-            }]
+            [
+              require.resolve(major === 6 ? 'babel-preset-env' : '@babel/preset-env'),
+              {
+                modules: false,
+                targets: {
+                  ie: '11.0.0',
+                },
+              },
+            ],
           ],
-          plugins: [config.babelPluginConfig()]
+          plugins: [config.babelPluginConfig()],
         };
       },
       createTests(transform: (code: string) => string) {
         createTests(transform, config);
-      }
+      },
     });
   });
 }

--- a/packages/macros/tests/macro-if-test.ts
+++ b/packages/macros/tests/macro-if-test.ts
@@ -5,7 +5,7 @@ const { test } = QUnit;
 
 QUnit.module('macroIf', function() {
   allBabelVersions(function createTests(transform: (code: string) => string, config: MacrosConfig) {
-    config.setConfig(__filename, 'qunit', { items: [ { approved: true, other: null, size: 2.3 } ]});
+    config.setConfig(__filename, 'qunit', { items: [{ approved: true, other: null, size: 2.3 }] });
 
     test('select consequent, drop alternate', function(assert) {
       let code = transform(`
@@ -143,7 +143,7 @@ QUnit.module('macroIf', function() {
           return macroIf(other, () => a, () => b);
         }
         `);
-      },/the first argument to macroIf must be statically known/);
+      }, /the first argument to macroIf must be statically known/);
     });
 
     test('leaves unrelated unused imports alone', function(assert) {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -16,7 +16,6 @@
     "@types/mini-css-extract-plugin": "^0.2.0",
     "@types/node": "^10.5.2",
     "@types/webpack": "^4.4.17",
-    "tslint": "^5.11.0",
     "typescript": "~3.2.0"
   },
   "dependencies": {

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -9,15 +9,24 @@
   getting script vs module context correct).
 */
 
-import { PackagerInstance, AppMeta, Packager, PackageCache } from "@embroider/core";
+import { PackagerInstance, AppMeta, Packager, PackageCache } from '@embroider/core';
 import webpack, { Configuration } from 'webpack';
-import { readFileSync, writeFileSync, copySync, realpathSync, ensureDirSync, Stats, statSync, readJsonSync } from 'fs-extra';
+import {
+  readFileSync,
+  writeFileSync,
+  copySync,
+  realpathSync,
+  ensureDirSync,
+  Stats,
+  statSync,
+  readJsonSync,
+} from 'fs-extra';
 import { join, dirname, relative, resolve } from 'path';
 import { JSDOM } from 'jsdom';
 import isEqual from 'lodash/isEqual';
 import mergeWith from 'lodash/mergeWith';
 import partition from 'lodash/partition';
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import Placeholder from './html-placeholder';
 import makeDebug from 'debug';
 import { format } from 'util';
@@ -37,7 +46,7 @@ class HTMLEntrypoint {
   scripts: string[] = [];
   styles: string[] = [];
 
-  constructor(private pathToVanillaApp: string, public filename: string){
+  constructor(private pathToVanillaApp: string, public filename: string) {
     this.dir = dirname(this.filename);
     this.dom = new JSDOM(readFileSync(join(this.pathToVanillaApp, this.filename), 'utf8'));
 
@@ -127,10 +136,12 @@ interface AppInfo {
 
 // AppInfos are equal if they result in the same webpack config.
 function equalAppInfo(left: AppInfo, right: AppInfo): boolean {
-  return isEqual(left.externals, right.externals) &&
+  return (
+    isEqual(left.externals, right.externals) &&
     isEqual(left.babel, right.babel) &&
     left.entrypoints.length === right.entrypoints.length &&
-    left.entrypoints.every((e, index) => isEqual(e.modules, right.entrypoints[index].modules));
+    left.entrypoints.every((e, index) => isEqual(e.modules, right.entrypoints[index].modules))
+  );
 }
 
 interface Options {
@@ -142,7 +153,7 @@ interface Options {
 // just exporting our class directly, we export a const constructor of the
 // correct type.
 const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
-  static annotation = "@embroider/webpack";
+  static annotation = '@embroider/webpack';
 
   pathToVanillaApp: string;
   private extraConfig: Configuration | undefined;
@@ -210,9 +221,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
       mode: this.mode,
       context: this.pathToVanillaApp,
       entry,
-      plugins: [
-        new MiniCssExtractPlugin()
-      ],
+      plugins: [new MiniCssExtractPlugin()],
       module: {
         rules: [
           {
@@ -220,25 +229,25 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
             use: [
               {
                 loader: join(__dirname, './webpack-hbs-loader'),
-                options: { templateCompiler }
-              }
-            ]
+                options: { templateCompiler },
+              },
+            ],
           },
           {
             test: this.shouldTranspileFile.bind(this),
             use: [
-              (process.env.JOBS === '1' || !babel.isParallelSafe)? null : 'thread-loader',
+              process.env.JOBS === '1' || !babel.isParallelSafe ? null : 'thread-loader',
               {
                 loader: 'babel-loader', // todo use babel.version to ensure the correct loader
-                options: Object.assign({}, babel.config)
-              }
-            ].filter(Boolean)
+                options: Object.assign({}, babel.config),
+              },
+            ].filter(Boolean),
           },
           {
             test: isCSS,
-            use: this.makeCSSRule()
+            use: this.makeCSSRule(),
           },
-        ]
+        ],
       },
       output: {
         path: join(this.outputPath, 'assets'),
@@ -247,8 +256,8 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
       },
       optimization: {
         splitChunks: {
-          chunks: 'all'
-        }
+          chunks: 'all',
+        },
       },
       externals: amdExternals,
       resolveLoader: {
@@ -259,9 +268,9 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
           'thread-loader': require.resolve('thread-loader'),
           'babel-loader': require.resolve('babel-loader'),
           'css-loader': require.resolve('css-loader'),
-          'style-loader': require.resolve('style-loader')
-        }
-      }
+          'style-loader': require.resolve('style-loader'),
+        },
+      },
     };
   }
 
@@ -274,7 +283,9 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     let owner = this.packageCache.ownerOfFile(filename);
 
     // Not owned by any NPM package? Weird, leave it alone.
-    if (!owner) { return false; }
+    if (!owner) {
+      return false;
+    }
 
     // Owned by our app, so use babel
     if (owner.root === this.pathToVanillaApp) {
@@ -285,8 +296,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     // lot of them won't appreciate running through our AMD plugin, for example.
     // If you want to transpile some of them, you should make a different rule
     // from your own extension to the webpack config.
-    return owner.packageJSON.keywords &&
-      owner.packageJSON.keywords.includes('ember-addon');
+    return owner.packageJSON.keywords && owner.packageJSON.keywords.includes('ember-addon');
   }
 
   private lastAppInfo: AppInfo | undefined;
@@ -300,7 +310,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     debug(`configuring webpack`);
     let config = mergeWith({}, this.configureWebpack(appInfo), this.extraConfig, appendArrays);
     this.lastAppInfo = appInfo;
-    return this.lastWebpack = webpack(config);
+    return (this.lastWebpack = webpack(config));
   }
 
   private async writeScript(script: string, written: Set<string>) {
@@ -323,7 +333,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
       let content;
       try {
         content = readJsonSync(join(this.pathToVanillaApp, appRelativeSourceMapURL));
-      } catch(err) {
+      } catch (err) {
         // the script refers to a sourcemap that doesn't exist, so we just leave
         // the map out.
       }
@@ -375,7 +385,11 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
               bundles.set(script, [await this.writeScript(script, written)]);
             } catch (err) {
               if (err.code === 'ENOENT' && err.path === join(this.pathToVanillaApp, script)) {
-                this.consoleWrite(`warning: in ${entrypoint.filename} <script src="${script}"> does not exist on disk. If this is intentional, use a data-embroider-ignore attribute.`);
+                this.consoleWrite(
+                  `warning: in ${
+                    entrypoint.filename
+                  } <script src="${script}"> does not exist on disk. If this is intentional, use a data-embroider-ignore attribute.`
+                );
               } else {
                 throw err;
               }
@@ -456,9 +470,9 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
         options: {
           url: true,
           import: true,
-          modules: true
-        }
-      }
+          modules: true,
+        },
+      },
     ];
   }
 
@@ -486,7 +500,6 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     }
     return errors[0];
   }
-
 };
 
 function appendArrays(objValue: any, srcValue: any) {

--- a/packages/webpack/src/html-placeholder.ts
+++ b/packages/webpack/src/html-placeholder.ts
@@ -68,10 +68,7 @@ export default class Placeholder {
   }
 
   insertNewline() {
-    this.end.parentElement.insertBefore(
-      this.end.ownerDocument.createTextNode("\n"),
-      this.end
-    );
+    this.end.parentElement.insertBefore(this.end.ownerDocument.createTextNode('\n'), this.end);
   }
 }
 

--- a/packages/webpack/src/webpack-hbs-loader.ts
+++ b/packages/webpack/src/webpack-hbs-loader.ts
@@ -5,7 +5,7 @@ export default function hbsLoader(this: loader.LoaderContext, templateContent: s
   let { templateCompiler } = getOptions(this);
   try {
     return templateCompiler(this.resourcePath, templateContent);
-  } catch(error) {
+  } catch (error) {
     error.type = 'Template Compiler Error';
     error.file = this.resourcePath;
     throw error;

--- a/test-packages/node.test.js
+++ b/test-packages/node.test.js
@@ -8,4 +8,3 @@ test('node', async () => {
     env: { JOBS: '1' },
   });
 });
-

--- a/test-packages/support/index.ts
+++ b/test-packages/support/index.ts
@@ -28,13 +28,13 @@ class MockCLI {
 
 export function emberApp(dir: string, userOpts: any = {}): any {
   let cli = new MockCLI();
-  let project = new Project(dir, readJSONSync(join(dir, 'package.json',)), cli.ui, cli);
+  let project = new Project(dir, readJSONSync(join(dir, 'package.json')), cli.ui, cli);
   return new EmberApp({ project }, userOpts);
 }
 
 export function runDefault(code: string): any {
   let cjsCode = transform7(code, {
-    plugins: ['@babel/plugin-transform-modules-commonjs']
+    plugins: ['@babel/plugin-transform-modules-commonjs'],
   })!.code!;
   let exports = {};
   eval(cjsCode);
@@ -44,15 +44,14 @@ export function runDefault(code: string): any {
 export function allBabelVersions(params: {
   babelConfig(major: 6): Options6;
   babelConfig(major: 7): Options7;
-  createTests(transform: (code: string) => string): void
+  createTests(transform: (code: string) => string): void;
 }) {
-
   QUnit.module('babel6', function() {
     let options6: Options6 = params.babelConfig(6);
     if (!options6.filename) {
       options6.filename = 'sample.js';
     }
-    params.createTests(function(code: string){
+    params.createTests(function(code: string) {
       return transform6(code, options6).code!;
     });
   });

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,6 @@
   "rules": {
     "curly": false,
     "no-var-keyword": true,
-    "indent": [true, "spaces"],
     "label-position": true,
     "no-consecutive-blank-lines": [
       true

--- a/tslint.json
+++ b/tslint.json
@@ -1,20 +1,14 @@
 {
   "rules": {
-    "curly": false,
     "no-var-keyword": true,
     "label-position": true,
-    "no-consecutive-blank-lines": [
-      true
-    ],
     "no-angle-bracket-type-assertion": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-variable": true,
     "no-inferrable-types": [true],
     "no-implicit-dependencies": true,
-    "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "semicolon": [true, "always"],
     "triple-equals": [true, "allow-null-check"],
     "class-name": true,
     "no-require-imports": true

--- a/types/babel-core/index.d.ts
+++ b/types/babel-core/index.d.ts
@@ -1,5 +1,4 @@
 declare module 'babel-core' {
-
   // BEGIN our custom extensions, so we can use these private-ish APIs
   export class Pipeline {}
   export class File {
@@ -20,11 +19,11 @@ declare module 'babel-core' {
   export type Node = t.Node;
   export import template = require('babel-template');
   export const version: string;
-  import traverse, { Visitor, NodePath } from "babel-traverse";
+  import traverse, { Visitor, NodePath } from 'babel-traverse';
   export { traverse, Visitor };
-  import { BabylonOptions } from "babylon";
+  import { BabylonOptions } from 'babylon';
   export { BabylonOptions };
-  import { GeneratorOptions } from "babel-generator";
+  import { GeneratorOptions } from 'babel-generator';
   export { GeneratorOptions };
 
   // A babel plugin is a simple function which must return an object matching
@@ -44,7 +43,11 @@ declare module 'babel-core' {
   export function transform(code: string, opts?: TransformOptions): BabelFileResult;
 
   /** Asynchronously transforms the entire contents of a file. */
-  export function transformFile(filename: string, opts: TransformOptions, callback: (err: any, result: BabelFileResult) => void): void;
+  export function transformFile(
+    filename: string,
+    opts: TransformOptions,
+    callback: (err: any, result: BabelFileResult) => void
+  ): void;
 
   /** Synchronous version of `babel.transformFile`. Returns the transformed contents of the `filename`. */
   export function transformFileSync(filename: string, opts?: TransformOptions): BabelFileResult;
@@ -71,17 +74,17 @@ declare module 'babel-core' {
     comments?: boolean;
 
     /**
-       * Do not include superfluous whitespace characters and line terminators. When set to `"auto"`, `compact` is set to
-       * `true` on input sizes of >100KB.
-       */
-    compact?: boolean | "auto";
+     * Do not include superfluous whitespace characters and line terminators. When set to `"auto"`, `compact` is set to
+     * `true` on input sizes of >100KB.
+     */
+    compact?: boolean | 'auto';
 
     /**
-       * This is an object of keys that represent different environments. For example, you may have:
-       * `{ env: { production: { / * specific options * / } } }`
-       * which will use those options when the enviroment variable `BABEL_ENV` is set to `"production"`.
-       * If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"`.
-       */
+     * This is an object of keys that represent different environments. For example, you may have:
+     * `{ env: { production: { / * specific options * / } } }`
+     * which will use those options when the enviroment variable `BABEL_ENV` is set to `"production"`.
+     * If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"`.
+     */
     env?: object;
 
     /** A path to an .babelrc file to extend. */
@@ -97,9 +100,9 @@ declare module 'babel-core' {
     generatorOpts?: GeneratorOptions;
 
     /**
-       * Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`.
-       * If falsy value is returned then the generated module id is used.
-       */
+     * Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`.
+     * If falsy value is returned then the generated module id is used.
+     */
     getModuleId?(moduleName: string): string;
 
     /** Enable/disable ANSI syntax highlighting of code frames. Default: `true`. */
@@ -118,18 +121,18 @@ declare module 'babel-core' {
     moduleId?: string;
 
     /**
-       * If truthy, insert an explicit id for modules. By default, all modules are anonymous.
-       * (Not available for `common` modules).
-       */
+     * If truthy, insert an explicit id for modules. By default, all modules are anonymous.
+     * (Not available for `common` modules).
+     */
     moduleIds?: boolean;
 
     /** Optional prefix for the AMD module formatter that will be prepend to the filename on module definitions. */
     moduleRoot?: string;
 
     /**
-       * A glob, regex, or mixed array of both, matching paths to only compile. Can also be an array of arrays containing
-       * paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim.
-       */
+     * A glob, regex, or mixed array of both, matching paths to only compile. Can also be an array of arrays containing
+     * paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim.
+     */
     only?: string | RegExp | Array<string | RegExp>;
 
     /** Babylon parser options. */
@@ -148,20 +151,20 @@ declare module 'babel-core' {
     resolveModuleSource?(source: string, filename: string): string;
 
     /**
-       * An optional callback that controls whether a comment should be output or not. Called as
-       * `shouldPrintComment(commentContents)`. **NOTE**: This overrides the `comments` option when used.
-       */
+     * An optional callback that controls whether a comment should be output or not. Called as
+     * `shouldPrintComment(commentContents)`. **NOTE**: This overrides the `comments` option when used.
+     */
     shouldPrintComment?(comment: string): boolean;
 
     /** Set `sources[0]` on returned source map. */
     sourceFileName?: string;
 
     /**
-       * If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a `sourceMappingURL`
-       * directive is added to the bottom of the returned code. If set to `"both"` then a map property is returned as well
-       * as a source map comment appended.
-       */
-    sourceMaps?: boolean | "inline" | "both";
+     * If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a `sourceMappingURL`
+     * directive is added to the bottom of the returned code. If set to `"both"` then a map property is returned as well
+     * as a source map comment appended.
+     */
+    sourceMaps?: boolean | 'inline' | 'both';
 
     /** Set `file` on returned source map. */
     sourceMapTarget?: string;
@@ -170,20 +173,24 @@ declare module 'babel-core' {
     sourceRoot?: string;
 
     /** Indicate the mode the code should be parsed in. Can be either “script” or “module”. Default: "module" */
-    sourceType?: "script" | "module";
+    sourceType?: 'script' | 'module';
 
     /**
-       * An optional callback that can be used to wrap visitor methods.
-       * NOTE: This is useful for things like introspection, and not really needed for implementing anything.
-       */
-    wrapPluginVisitorMethod?(pluginAlias: string, visitorType: 'enter' | 'exit', callback: (path: NodePath, state: any) => void): (path: NodePath, state: any) => void ;
+     * An optional callback that can be used to wrap visitor methods.
+     * NOTE: This is useful for things like introspection, and not really needed for implementing anything.
+     */
+    wrapPluginVisitorMethod?(
+      pluginAlias: string,
+      visitorType: 'enter' | 'exit',
+      callback: (path: NodePath, state: any) => void
+    ): (path: NodePath, state: any) => void;
   }
 
   export interface BabelFileModulesMetadata {
     imports: object[];
     exports: {
-      exported: object[],
-      specifiers: object[]
+      exported: object[];
+      specifiers: object[];
     };
   }
 

--- a/types/babel-core/index.d.ts
+++ b/types/babel-core/index.d.ts
@@ -32,12 +32,12 @@ declare module 'babel-core' {
   // The list of allowed plugin keys is here:
   // https://github.com/babel/babel/blob/4e50b2d9d9c376cee7a2cbf56553fe5b982ea53c/packages/babel-core/src/config/option-manager.js#L71
   export interface PluginObj<S = {}> {
-      name?: string;
-      manipulateOptions?(opts: any, parserOpts: any): void;
-      pre?(this: S, state: any): void;
-      visitor: Visitor<S>;
-      post?(this: S, state: any): void;
-      inherits?: any;
+    name?: string;
+    manipulateOptions?(opts: any, parserOpts: any): void;
+    pre?(this: S, state: any): void;
+    visitor: Visitor<S>;
+    post?(this: S, state: any): void;
+    inherits?: any;
   }
 
   /** Transforms the passed in `code`. Returning an object with the generated code, source map, and AST. */
@@ -52,157 +52,157 @@ declare module 'babel-core' {
   export function transformFromAst(ast: Node, code?: string, opts?: TransformOptions): BabelFileResult;
 
   export interface TransformOptions {
-      /** Include the AST in the returned object. Default: `true`. */
-      ast?: boolean;
+    /** Include the AST in the returned object. Default: `true`. */
+    ast?: boolean;
 
-      /** Attach a comment after all non-user injected code. */
-      auxiliaryCommentAfter?: string;
+    /** Attach a comment after all non-user injected code. */
+    auxiliaryCommentAfter?: string;
 
-      /** Attach a comment before all non-user injected code. */
-      auxiliaryCommentBefore?: string;
+    /** Attach a comment before all non-user injected code. */
+    auxiliaryCommentBefore?: string;
 
-      /** Specify whether or not to use `.babelrc` and `.babelignore` files. Default: `true`. */
-      babelrc?: boolean;
+    /** Specify whether or not to use `.babelrc` and `.babelignore` files. Default: `true`. */
+    babelrc?: boolean;
 
-      /** Enable code generation. Default: `true`. */
-      code?: boolean;
+    /** Enable code generation. Default: `true`. */
+    code?: boolean;
 
-      /** write comments to generated output. Default: `true`. */
-      comments?: boolean;
+    /** write comments to generated output. Default: `true`. */
+    comments?: boolean;
 
-      /**
+    /**
        * Do not include superfluous whitespace characters and line terminators. When set to `"auto"`, `compact` is set to
        * `true` on input sizes of >100KB.
        */
-      compact?: boolean | "auto";
+    compact?: boolean | "auto";
 
-      /**
+    /**
        * This is an object of keys that represent different environments. For example, you may have:
        * `{ env: { production: { / * specific options * / } } }`
        * which will use those options when the enviroment variable `BABEL_ENV` is set to `"production"`.
        * If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"`.
        */
-      env?: object;
+    env?: object;
 
-      /** A path to an .babelrc file to extend. */
-      extends?: string;
+    /** A path to an .babelrc file to extend. */
+    extends?: string;
 
-      /** Filename to use when reading from stdin - this will be used in source-maps, errors etc. Default: "unknown". */
-      filename?: string;
+    /** Filename to use when reading from stdin - this will be used in source-maps, errors etc. Default: "unknown". */
+    filename?: string;
 
-      /** Filename relative to `sourceRoot`. */
-      filenameRelative?: string;
+    /** Filename relative to `sourceRoot`. */
+    filenameRelative?: string;
 
-      /** An object containing the options to be passed down to the babel code generator, babel-generator. Default: `{}` */
-      generatorOpts?: GeneratorOptions;
+    /** An object containing the options to be passed down to the babel code generator, babel-generator. Default: `{}` */
+    generatorOpts?: GeneratorOptions;
 
-      /**
+    /**
        * Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`.
        * If falsy value is returned then the generated module id is used.
        */
-      getModuleId?(moduleName: string): string;
+    getModuleId?(moduleName: string): string;
 
-      /** Enable/disable ANSI syntax highlighting of code frames. Default: `true`. */
-      highlightCode?: boolean;
+    /** Enable/disable ANSI syntax highlighting of code frames. Default: `true`. */
+    highlightCode?: boolean;
 
-      /** list of glob paths to **not** compile. Opposite to the `only` option. */
-      ignore?: string[];
+    /** list of glob paths to **not** compile. Opposite to the `only` option. */
+    ignore?: string[];
 
-      /** A source map object that the output source map will be based on. */
-      inputSourceMap?: object;
+    /** A source map object that the output source map will be based on. */
+    inputSourceMap?: object;
 
-      /** Should the output be minified. Default: `false` */
-      minified?: boolean;
+    /** Should the output be minified. Default: `false` */
+    minified?: boolean;
 
-      /** Specify a custom name for module ids. */
-      moduleId?: string;
+    /** Specify a custom name for module ids. */
+    moduleId?: string;
 
-      /**
+    /**
        * If truthy, insert an explicit id for modules. By default, all modules are anonymous.
        * (Not available for `common` modules).
        */
-      moduleIds?: boolean;
+    moduleIds?: boolean;
 
-      /** Optional prefix for the AMD module formatter that will be prepend to the filename on module definitions. */
-      moduleRoot?: string;
+    /** Optional prefix for the AMD module formatter that will be prepend to the filename on module definitions. */
+    moduleRoot?: string;
 
-      /**
+    /**
        * A glob, regex, or mixed array of both, matching paths to only compile. Can also be an array of arrays containing
        * paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim.
        */
-      only?: string | RegExp | Array<string | RegExp>;
+    only?: string | RegExp | Array<string | RegExp>;
 
-      /** Babylon parser options. */
-      parserOpts?: BabylonOptions;
+    /** Babylon parser options. */
+    parserOpts?: BabylonOptions;
 
-      /** List of plugins to load and use. */
-      plugins?: any[];
+    /** List of plugins to load and use. */
+    plugins?: any[];
 
-      /** List of presets (a set of plugins) to load and use. */
-      presets?: any[];
+    /** List of presets (a set of plugins) to load and use. */
+    presets?: any[];
 
-      /** Retain line numbers - will result in really ugly code. Default: `false` */
-      retainLines?: boolean;
+    /** Retain line numbers - will result in really ugly code. Default: `false` */
+    retainLines?: boolean;
 
-      /** Resolve a module source ie. import "SOURCE"; to a custom value. */
-      resolveModuleSource?(source: string, filename: string): string;
+    /** Resolve a module source ie. import "SOURCE"; to a custom value. */
+    resolveModuleSource?(source: string, filename: string): string;
 
-      /**
+    /**
        * An optional callback that controls whether a comment should be output or not. Called as
        * `shouldPrintComment(commentContents)`. **NOTE**: This overrides the `comments` option when used.
        */
-      shouldPrintComment?(comment: string): boolean;
+    shouldPrintComment?(comment: string): boolean;
 
-      /** Set `sources[0]` on returned source map. */
-      sourceFileName?: string;
+    /** Set `sources[0]` on returned source map. */
+    sourceFileName?: string;
 
-      /**
+    /**
        * If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a `sourceMappingURL`
        * directive is added to the bottom of the returned code. If set to `"both"` then a map property is returned as well
        * as a source map comment appended.
        */
-      sourceMaps?: boolean | "inline" | "both";
+    sourceMaps?: boolean | "inline" | "both";
 
-      /** Set `file` on returned source map. */
-      sourceMapTarget?: string;
+    /** Set `file` on returned source map. */
+    sourceMapTarget?: string;
 
-      /** The root from which all sources are relative. */
-      sourceRoot?: string;
+    /** The root from which all sources are relative. */
+    sourceRoot?: string;
 
-      /** Indicate the mode the code should be parsed in. Can be either “script” or “module”. Default: "module" */
-      sourceType?: "script" | "module";
+    /** Indicate the mode the code should be parsed in. Can be either “script” or “module”. Default: "module" */
+    sourceType?: "script" | "module";
 
-      /**
+    /**
        * An optional callback that can be used to wrap visitor methods.
        * NOTE: This is useful for things like introspection, and not really needed for implementing anything.
        */
-      wrapPluginVisitorMethod?(pluginAlias: string, visitorType: 'enter' | 'exit', callback: (path: NodePath, state: any) => void): (path: NodePath, state: any) => void ;
+    wrapPluginVisitorMethod?(pluginAlias: string, visitorType: 'enter' | 'exit', callback: (path: NodePath, state: any) => void): (path: NodePath, state: any) => void ;
   }
 
   export interface BabelFileModulesMetadata {
-      imports: object[];
-      exports: {
-          exported: object[],
-          specifiers: object[]
-      };
+    imports: object[];
+    exports: {
+      exported: object[],
+      specifiers: object[]
+    };
   }
 
   export interface BabelFileMetadata {
-      usedHelpers: string[];
-      marked: Array<{
-          type: string;
-          message: string;
-          loc: object;
-      }>;
-      modules: BabelFileModulesMetadata;
+    usedHelpers: string[];
+    marked: Array<{
+      type: string;
+      message: string;
+      loc: object;
+    }>;
+    modules: BabelFileModulesMetadata;
   }
 
   export interface BabelFileResult {
-      ast?: Node;
-      code?: string;
-      ignored?: boolean;
-      map?: object;
-      metadata?: BabelFileMetadata;
+    ast?: Node;
+    code?: string;
+    ignored?: boolean;
+    map?: object;
+    metadata?: BabelFileMetadata;
   }
 
   export default babel;

--- a/types/broccoli-funnel/index.d.ts
+++ b/types/broccoli-funnel/index.d.ts
@@ -15,5 +15,4 @@ declare module 'broccoli-funnel' {
     build(): Promise<void>;
     protected srcDir: string;
   }
-
 }

--- a/types/broccoli-persistent-filter/index.d.ts
+++ b/types/broccoli-persistent-filter/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'broccoli-persistent-filter' {
-  import Plugin, { Tree } from "broccoli-plugin";
+  import Plugin, { Tree } from 'broccoli-plugin';
 
   interface Options {
     persist: boolean;
@@ -9,7 +9,7 @@ declare module 'broccoli-persistent-filter' {
   }
 
   export default abstract class Filter implements Plugin {
-    constructor(inputTree: Tree, options: Options)
+    constructor(inputTree: Tree, options: Options);
     inputPaths: string[];
     outputPath: string;
     cachePath: string;

--- a/types/broccoli-plugin/index.d.ts
+++ b/types/broccoli-plugin/index.d.ts
@@ -11,7 +11,6 @@ declare module 'broccoli-plugin' {
     needsCache?: boolean;
   }
 
-
   export default abstract class Plugin implements Tree {
     constructor(inputTrees: Tree[], options: Options)
     inputPaths: string[];

--- a/types/broccoli-plugin/index.d.ts
+++ b/types/broccoli-plugin/index.d.ts
@@ -1,5 +1,4 @@
 declare module 'broccoli-plugin' {
-
   export interface Tree {
     __broccoliGetInfo__(): any;
   }
@@ -12,12 +11,11 @@ declare module 'broccoli-plugin' {
   }
 
   export default abstract class Plugin implements Tree {
-    constructor(inputTrees: Tree[], options: Options)
+    constructor(inputTrees: Tree[], options: Options);
     inputPaths: string[];
     outputPath: string;
     cachePath: string;
     __broccoliGetInfo__(): any;
     abstract build(): Promise<void> | void;
   }
-
 }

--- a/types/broccoli-source/index.d.ts
+++ b/types/broccoli-source/index.d.ts
@@ -10,5 +10,4 @@ declare module 'broccoli-source' {
     __broccoliGetInfo__(): any;
     constructor(inputDir: string);
   }
-
 }

--- a/types/broccoli/index.d.ts
+++ b/types/broccoli/index.d.ts
@@ -1,10 +1,8 @@
 declare module 'broccoli' {
-
   export class Builder {
-    constructor(tree: unknown)
+    constructor(tree: unknown);
     build(): Promise<void>;
     cleanup(): Promise<void>;
     outputPath: string;
   }
-
 }

--- a/types/console-ui/index.d.ts
+++ b/types/console-ui/index.d.ts
@@ -1,4 +1,3 @@
-
 declare module 'console-ui/mock' {
   export default class MockUI {
     constructor();

--- a/types/ember-cli-htmlbars/index.d.ts
+++ b/types/ember-cli-htmlbars/index.d.ts
@@ -1,21 +1,18 @@
-
 declare module 'ember-cli-htmlbars' {
-
-  import Plugin, { Tree } from "broccoli-plugin";
+  import Plugin, { Tree } from 'broccoli-plugin';
 
   export interface Options {
     templateCompilerPath: string;
     name?: string;
     plugins?: {
-      [type: string]: unknown[]
+      [type: string]: unknown[];
     };
   }
 
   export default class HTMLBarsTransform extends Plugin {
-    constructor(inputTree: Tree, options: Options)
+    constructor(inputTree: Tree, options: Options);
     build(): Promise<void>;
     protected cacheKeyProcessString(contents: string, relativePath: string): string;
     protected targetExtension: string | null;
   }
-
 }

--- a/types/ember-cli-htmlbars/index.d.ts
+++ b/types/ember-cli-htmlbars/index.d.ts
@@ -8,7 +8,7 @@ declare module 'ember-cli-htmlbars' {
     name?: string;
     plugins?: {
       [type: string]: unknown[]
-    }
+    };
   }
 
   export default class HTMLBarsTransform extends Plugin {
@@ -17,6 +17,5 @@ declare module 'ember-cli-htmlbars' {
     protected cacheKeyProcessString(contents: string, relativePath: string): string;
     protected targetExtension: string | null;
   }
-
 
 }

--- a/types/ember-cli/index.d.ts
+++ b/types/ember-cli/index.d.ts
@@ -1,4 +1,3 @@
-
 declare module 'ember-cli/lib/broccoli/ember-app' {
   export default class EmberApp {
     constructor(...optLists: any[]);

--- a/types/fast-sourcemap-concat/index.d.ts
+++ b/types/fast-sourcemap-concat/index.d.ts
@@ -1,11 +1,7 @@
 declare module 'fast-sourcemap-concat' {
   // this is not exhaustive, just what we're using
   export default class {
-    constructor(opts: {
-      outputFile?: string,
-      mapCommentType?: "line" | "block",
-      baseDir?: string,
-    });
+    constructor(opts: { outputFile?: string; mapCommentType?: 'line' | 'block'; baseDir?: string });
     addFile(filename: string): void;
     addSpace(source: string): void;
     end(): Promise<void>;

--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -1,4 +1,4 @@
 declare module 'handlebars' {
-  export function compile(template: string) : (params: object) => string;
+  export function compile(template: string): (params: object) => string;
   export function registerHelper(name: string, fn: Function): void;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,6 +1279,23 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.10.tgz#17a8ec65cd8e88f51b418ceb271af18d3137df67"
   integrity sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==
 
+"@typescript-eslint/parser@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.5.0.tgz#a96114d195dff2a49534e4c4850fb676f905a072"
+  integrity sha512-pRWTnJrnxuT0ragdY26hZL+bxqDd4liMlftpH2CBlMPryOIOb1J+MdZuw6R4tIu6bWVdwbHKPTs+Q34LuGvfGw==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "1.5.0"
+    eslint-scope "^4.0.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.5.0.tgz#986b356ecdf5a0c3bc9889d221802149cf5dbd4e"
+  integrity sha512-XqR14d4BcYgxcrpxIwcee7UEjncl9emKc/MgkeUfIk2u85KlsGYyaxC7Zxjmb17JtWERk/NaO+KnBsqgpIXzwA==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
+
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
@@ -1477,6 +1494,11 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
+acorn-jsx@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
+  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
+
 acorn-walk@^6.0.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
@@ -1496,6 +1518,11 @@ acorn@^6.0.1, acorn@^6.0.2, acorn@^6.0.5:
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.7.tgz#490180ce18337270232d9488a44be83d9afb7fd3"
   integrity sha512-HNJNgE60C9eOTgn974Tlp3dpLZdUr+SoxxDwPaY9J/kDNOLQTkaDgwBUXAF4SSsrAwD9RpdxuHK/EbuF+W9Ahw==
+
+acorn@^6.0.7:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
 after@0.8.2:
   version "0.8.2"
@@ -1531,6 +1558,16 @@ ajv@^6.1.0, ajv@^6.5.5:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.8.1.tgz#0890b93742985ebf8973cd365c5b23920ce3cb20"
   integrity sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.9.1:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1586,6 +1623,11 @@ ansi-regex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
   integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -4190,7 +4232,7 @@ cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -4338,7 +4380,7 @@ debug@^3.0.1, debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -4507,6 +4549,13 @@ doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
@@ -5410,6 +5459,11 @@ emit-function@0.0.2:
   resolved "https://registry.yarnpkg.com/emit-function/-/emit-function-0.0.2.tgz#e3a50b3d61be1bf8ca88b924bf713157a5bec124"
   integrity sha1-46ULPWG+G/jKiLkkv3ExV6W+wSQ=
 
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -5614,6 +5668,14 @@ eslint-scope@^4.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-utils@^1.3.0, eslint-utils@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
@@ -5668,6 +5730,48 @@ eslint@^4.0.0:
     table "4.0.2"
     text-table "~0.2.0"
 
+eslint@^5.15.3:
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.15.3.tgz#c79c3909dc8a7fa3714fb340c11e30fd2526b8b5"
+  integrity sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.9.1"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.1"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.2.2"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+
 esm@^3.2.4:
   version "3.2.17"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.17.tgz#ae74c34f502ab2ee8f03c64cc785ebeb1786526a"
@@ -5680,6 +5784,15 @@ espree@^3.5.4:
   dependencies:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
+
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
 
 esprima@^3.1.3, esprima@~3.1.0:
   version "3.1.3"
@@ -5696,7 +5809,7 @@ esprima@~3.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
   integrity sha1-U88kes2ncxPlUcOqLnM0LT+099k=
 
-esquery@^1.0.0:
+esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
@@ -6046,6 +6159,13 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
+
 fileset@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
@@ -6215,6 +6335,20 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     rimraf "~2.6.2"
     write "^0.2.1"
+
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
+  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
 flush-write-stream@^1.0.0:
   version "1.1.0"
@@ -6613,7 +6747,7 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-globals@^11.0.1:
+globals@^11.0.1, globals@^11.7.0:
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
   integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
@@ -7052,10 +7186,18 @@ ignore@^3.3.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
-ignore@^4.0.2, ignore@^4.0.3:
+ignore@^4.0.2, ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-local@^2.0.0:
   version "2.0.0"
@@ -7171,7 +7313,7 @@ inquirer@^3.0.6, inquirer@^3.3.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@^6:
+inquirer@^6, inquirer@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
   integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
@@ -8729,6 +8871,11 @@ lodash.templatesettings@~2.3.0:
     lodash._reinterpolate "~2.3.0"
     lodash.escape "~2.3.0"
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
 lodash.uniq@^4.2.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -9824,6 +9971,13 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
+parent-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"
+  integrity sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==
+  dependencies:
+    callsites "^3.0.0"
+
 parse-asn1@^5.0.0:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.3.tgz#1600c6cc0727365d68b97f3aa78939e735a75204"
@@ -10807,6 +10961,11 @@ resolve-from@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
 resolve-package-path@^1.0.11:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-1.2.4.tgz#814c5fcfb5f6e4151d95ec6e5653707c43706670"
@@ -10883,7 +11042,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -11108,6 +11267,11 @@ scss-tokenizer@^0.2.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -11244,6 +11408,15 @@ slice-ansi@1.0.0:
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
   integrity sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==
   dependencies:
+    is-fullwidth-code-point "^2.0.0"
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
 snake-case@^2.1.0:
@@ -11627,6 +11800,15 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@0.10, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -11667,6 +11849,13 @@ strip-ansi@^5.0.0:
   dependencies:
     ansi-regex "^4.0.0"
 
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -11691,7 +11880,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -11756,6 +11945,16 @@ table@4.0.2:
     lodash "^4.17.4"
     slice-ansi "1.0.0"
     string-width "^2.1.1"
+
+table@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
+  integrity sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==
+  dependencies:
+    ajv "^6.9.1"
+    lodash "^4.17.11"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 tap-parser@^7.0.0:
   version "7.0.0"
@@ -11868,7 +12067,7 @@ testem@^2.9.2:
     tmp "0.0.33"
     xmldom "^0.1.19"
 
-text-table@~0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
@@ -12710,6 +12909,13 @@ write-file-atomic@^2.0.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 write@^0.2.1:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,7 +1279,17 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.10.tgz#17a8ec65cd8e88f51b418ceb271af18d3137df67"
   integrity sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==
 
-"@typescript-eslint/parser@^1.5.0":
+"@typescript-eslint/eslint-plugin@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.5.0.tgz#85c509bcfc2eb35f37958fa677379c80b7a8f66f"
+  integrity sha512-TZ5HRDFz6CswqBUviPX8EfS+iOoGbclYroZKT3GWGYiGScX0qo6QjHc5uuM7JN920voP2zgCkHgF5SDEVlCtjQ==
+  dependencies:
+    "@typescript-eslint/parser" "1.5.0"
+    "@typescript-eslint/typescript-estree" "1.5.0"
+    requireindex "^1.2.0"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/parser@1.5.0", "@typescript-eslint/parser@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.5.0.tgz#a96114d195dff2a49534e4c4850fb676f905a072"
   integrity sha512-pRWTnJrnxuT0ragdY26hZL+bxqDd4liMlftpH2CBlMPryOIOb1J+MdZuw6R4tIu6bWVdwbHKPTs+Q34LuGvfGw==
@@ -10926,6 +10936,11 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -12306,6 +12321,13 @@ tsutils@^2.27.2:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.7.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.9.1.tgz#2a40dc742943c71eca6d5c1994fcf999956be387"
+  integrity sha512-hrxVtLtPqQr//p8/msPT1X1UYXUjizqSit5d9AQ5k38TcV38NyecL5xODNxa73cLe/5sdiJ+w1FqzDhRBA/anA==
   dependencies:
     tslib "^1.8.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5634,6 +5634,13 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz#181364895899fff9fd3605fecb5c4f20e7d5f395"
+  integrity sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-plugin-ember@^5.2.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-5.4.0.tgz#2980a4389119b37d0450fff8e82d59c9aab126d0"
@@ -5661,6 +5668,13 @@ eslint-plugin-node@^7.0.1:
     minimatch "^3.0.4"
     resolve "^1.8.1"
     semver "^5.5.0"
+
+eslint-plugin-prettier@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz#19d521e3981f69dd6d14f64aec8c6a6ac6eb0b0d"
+  integrity sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-scope@^3.7.1:
   version "3.7.3"
@@ -6078,6 +6092,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.6:
   version "2.2.6"
@@ -6614,6 +6633,11 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
@@ -10305,6 +10329,18 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@1.16.4:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
 pretty-format@^24.5.0:
   version "24.5.0"


### PR DESCRIPTION
This is step 1 to replace TSLint with ESLint and the https://github.com/typescript-eslint/typescript-eslint plugin. This PR also adds integration with prettier to enforce a consistent code style.