### PR TITLE
Convert TSLint rules to ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   plugins: ['prettier', '@typescript-eslint'],
   extends: ['prettier', 'prettier/@typescript-eslint'],
   rules: {
+    eqeqeq: ['error', 'smart'],
     'no-debugger': 'error',
     'no-new-wrappers': 'error',
     'no-var': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'no-var': 'error',
 
     '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
+    '@typescript-eslint/no-inferrable-types': 'error',
 
     'prettier/prettier': 'error',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   plugins: ['prettier', '@typescript-eslint'],
   extends: ['prettier', 'prettier/@typescript-eslint'],
   rules: {
+    'no-new-wrappers': 'error',
     'no-var': 'error',
 
     '@typescript-eslint/no-angle-bracket-type-assertion': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   plugins: ['prettier', '@typescript-eslint'],
   extends: ['prettier', 'prettier/@typescript-eslint'],
   rules: {
+    'no-debugger': 'error',
     'no-new-wrappers': 'error',
     'no-var': 'error',
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,8 @@ module.exports = {
   rules: {
     'no-var': 'error',
 
+    '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
+
     'prettier/prettier': 'error',
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,8 @@ module.exports = {
   plugins: ['prettier', '@typescript-eslint'],
   extends: ['prettier', 'prettier/@typescript-eslint'],
   rules: {
+    'no-var': 'error',
+
     'prettier/prettier': 'error',
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
 
     '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
     '@typescript-eslint/no-inferrable-types': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 
     'prettier/prettier': 'error',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'no-new-wrappers': 'error',
     'no-var': 'error',
 
+    '@typescript-eslint/class-name-casing': 'error',
     '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
     '@typescript-eslint/no-inferrable-types': 'error',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],

--- a/test-packages/macro-sample-addon.test.js
+++ b/test-packages/macro-sample-addon.test.js
@@ -7,4 +7,3 @@ test('macro-addon', async () => {
     cwd: `${__dirname}/macro-sample-addon`,
   });
 });
-

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,6 @@
 {
   "rules": {
     "label-position": true,
-    "no-angle-bracket-type-assertion": true,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-variable": true,

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
     "label-position": true,
     "no-duplicate-variable": true,
     "no-implicit-dependencies": true,
-    "no-unused-expression": true,
     "triple-equals": [true, "allow-null-check"],
     "class-name": true,
     "no-require-imports": true

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "no-var-keyword": true,
     "label-position": true,
     "no-angle-bracket-type-assertion": true,
     "no-construct": true,

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
     "label-position": true,
     "no-duplicate-variable": true,
     "no-implicit-dependencies": true,
-    "class-name": true,
     "no-require-imports": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
     "label-position": true,
     "no-duplicate-variable": true,
     "no-implicit-dependencies": true,
-    "triple-equals": [true, "allow-null-check"],
     "class-name": true,
     "no-require-imports": true
   }

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,6 @@
 {
   "rules": {
     "label-position": true,
-    "no-debugger": true,
     "no-duplicate-variable": true,
     "no-inferrable-types": [true],
     "no-implicit-dependencies": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,6 @@
 {
   "rules": {
     "label-position": true,
-    "no-construct": true,
     "no-debugger": true,
     "no-duplicate-variable": true,
     "no-inferrable-types": [true],

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,6 @@
   "rules": {
     "label-position": true,
     "no-duplicate-variable": true,
-    "no-inferrable-types": [true],
     "no-implicit-dependencies": true,
     "no-unused-expression": true,
     "triple-equals": [true, "allow-null-check"],


### PR DESCRIPTION
This PR converts some of the enabled TSLint rules to ESLint rules instead. I could not find a suitable replacement for all of them yet and some of the ESLint replacements are a little more strict, but this is the subset that could be converted without issues.