### PR TITLE
core: Convert tests to Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compile": "tsc",
     "lint": "eslint . --ext=js,ts --cache",
     "clean": "git clean -x -f",
-    "node-test": "qunit packages/*/tests",
+    "node-test": "qunit packages/*/tests --require ./test-packages/support/qunit-jest-shim.js",
     "test": "jest"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,11 @@
     "execa": "^1.0.0",
     "jest": "^24.5.0",
     "prettier": "1.16.4"
+  },
+  "jest": {
+    "projects": [
+      "<rootDir>/packages/*",
+      "<rootDir>/test-packages/"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@types/jest": "^24.0.11",
     "@typescript-eslint/eslint-plugin": "^1.5.0",
     "@typescript-eslint/parser": "^1.5.0",
     "eslint": "^5.15.3",

--- a/packages/compat/jest.config.js
+++ b/packages/compat/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: [
+    '<rootDir>/tests/**/*.test.js',
+  ],
+};

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: [
+    '<rootDir>/tests/**/*.test.js',
+  ],
+};

--- a/packages/core/tests/inline-hbs.test.ts
+++ b/packages/core/tests/inline-hbs.test.ts
@@ -1,61 +1,58 @@
-import 'qunit';
 import { allBabelVersions, emberTemplateCompilerPath } from '@embroider/test-support';
 import { join } from 'path';
 import TemplateCompiler from '../src/template-compiler';
 import sampleTransform from '@embroider/sample-transforms/lib/glimmer-plugin';
 
-const { test } = QUnit;
-
 function stage1Tests(transform: (code: string) => string) {
-  test('template literal form', function(assert) {
+  test('template literal form', () => {
     let code = transform(`
       import hbs from 'htmlbars-inline-precompile';
       export default function() {
         return hbs${'`'}<div class={{embroider-sample-transforms-target}}></div>${'`'};
       }
       `);
-    assert.ok(/import hbs from 'htmlbars-inline-precompile'/.test(code), 'still has hbs import');
-    assert.ok(/return hbs`<div/.test(code), 'still in hbs format');
-    assert.ok(/embroider-sample-transforms-result/.test(code), 'transform ran');
+    expect(code).toMatch(/import hbs from 'htmlbars-inline-precompile'/);
+    expect(code).toMatch(/return hbs`<div/);
+    expect(code).toMatch(/embroider-sample-transforms-result/);
   });
-  test('call form', function(assert) {
+  test('call form', () => {
     let code = transform(`
       import hbs from 'htmlbars-inline-precompile';
       export default function() {
         return hbs("<div class={{embroider-sample-transforms-target}}></div>");
       }
       `);
-    assert.ok(/import hbs from 'htmlbars-inline-precompile'/.test(code), 'still has hbs import');
-    assert.ok(/return hbs\("<div/.test(code), 'still in hbs format');
-    assert.ok(/embroider-sample-transforms-result/.test(code), 'transform ran');
+    expect(code).toMatch(/import hbs from 'htmlbars-inline-precompile'/);
+    expect(code).toMatch(/return hbs\("<div/);
+    expect(code).toMatch(/embroider-sample-transforms-result/);
   });
 }
 
 function stage3Tests(transform: (code: string) => string) {
-  test('tagged template literal form', function(assert) {
+  test('tagged template literal form', () => {
     let code = transform(`
       import hbs from 'htmlbars-inline-precompile';
       export default function() {
         return hbs${'`'}<div class={{embroider-sample-transforms-target}}></div>${'`'};
       }
       `);
-    assert.ok(!/import hbs from 'htmlbars-inline-precompile'/.test(code), 'hbs import stripped');
-    assert.ok(/return Ember.HTMLBars.template\({/.test(code), 'no longer in hbs format');
+    expect(code).not.toMatch(/import hbs from 'htmlbars-inline-precompile'/);
+    expect(code).toMatch(/return Ember.HTMLBars.template\({/);
   });
-  test('call form', function(assert) {
+  test('call form', () => {
     let code = transform(`
       import hbs from 'htmlbars-inline-precompile';
       export default function() {
         return hbs("<div class={{embroider-sample-transforms-target}}></div>");
       }
       `);
-    assert.ok(!/import hbs from 'htmlbars-inline-precompile'/.test(code), 'hbs import stripped');
-    assert.ok(/return Ember.HTMLBars.template\({/.test(code), 'no longer in hbs format');
+    expect(code).not.toMatch(/import hbs from 'htmlbars-inline-precompile'/);
+    expect(code).toMatch(/return Ember.HTMLBars.template\({/);
   });
 }
 
-QUnit.module('inline-hbs', function() {
-  QUnit.module('stage1', function() {
+describe('inline-hbs', () => {
+  describe('stage1', () => {
     allBabelVersions({
       babelConfig() {
         let templateCompiler = new TemplateCompiler({
@@ -73,7 +70,7 @@ QUnit.module('inline-hbs', function() {
     });
   });
 
-  QUnit.module('stage3 no presets', function() {
+  describe('stage3 no presets', () => {
     allBabelVersions({
       babelConfig() {
         let templateCompiler = new TemplateCompiler({
@@ -91,7 +88,7 @@ QUnit.module('inline-hbs', function() {
     });
   });
 
-  QUnit.module('stage3 with presets', function() {
+  describe('stage3 with presets', () => {
     allBabelVersions({
       babelConfig(major: number) {
         let templateCompiler = new TemplateCompiler({

--- a/packages/core/tests/multi-tree-diff.test.ts
+++ b/packages/core/tests/multi-tree-diff.test.ts
@@ -1,13 +1,10 @@
-import 'qunit';
 import MultiTreeDiff from '../src/multi-tree-diff';
 import { Entry, Patch } from 'fs-tree-diff';
 import { join } from 'path';
 import cloneDeep from 'lodash/cloneDeep';
 
-const { test } = QUnit;
-
-QUnit.module('tracked-merge-dirs', function() {
-  test('it combines files from all inDirs', function(assert) {
+describe('tracked-merge-dirs', () => {
+  test('it combines files from all inDirs', () => {
     let a = new MockTree(['alpha', 'tomster']);
     let b = new MockTree({ beta: ['x'] });
     let c = new MockTree(['charlie']);
@@ -15,7 +12,7 @@ QUnit.module('tracked-merge-dirs', function() {
     let t = new MultiTreeDiff([a, b, c]);
     let { ops, sources } = t.update();
 
-    assert.deepEqual(fileOps(ops), [
+    expect(fileOps(ops)).toEqual([
       ['create', 'alpha'],
       ['mkdir', 'beta'],
       ['create', 'beta/x'],
@@ -23,28 +20,28 @@ QUnit.module('tracked-merge-dirs', function() {
       ['create', 'tomster'],
     ]);
 
-    assert.equal(sources.get('alpha'), 0);
-    assert.equal(sources.get('beta'), 1);
-    assert.equal(sources.get('beta/x'), 1);
-    assert.equal(sources.get('charlie'), 2);
-    assert.equal(sources.get('tomster'), 0);
+    expect(sources.get('alpha')).toBe(0);
+    expect(sources.get('beta')).toBe(1);
+    expect(sources.get('beta/x')).toBe(1);
+    expect(sources.get('charlie')).toBe(2);
+    expect(sources.get('tomster')).toBe(0);
   });
 
-  test('it prioritizes files from later dirs', function(assert) {
+  test('it prioritizes files from later dirs', () => {
     let a = new MockTree(['alpha', 'tomster']);
     let c = new MockTree(['charlie', 'alpha']);
 
     let t = new MultiTreeDiff([a, c]);
     let { ops, sources } = t.update();
 
-    assert.deepEqual(fileOps(ops), [['create', 'alpha'], ['create', 'charlie'], ['create', 'tomster']]);
+    expect(fileOps(ops)).toEqual([['create', 'alpha'], ['create', 'charlie'], ['create', 'tomster']]);
 
-    assert.equal(sources.get('alpha'), 1);
-    assert.equal(sources.get('charlie'), 1);
-    assert.equal(sources.get('tomster'), 0);
+    expect(sources.get('alpha')).toBe(1);
+    expect(sources.get('charlie')).toBe(1);
+    expect(sources.get('tomster')).toBe(0);
   });
 
-  test('it emits nothing when stable', function(assert) {
+  test('it emits nothing when stable', () => {
     let a = new MockTree(['alpha', 'tomster']);
     let b = new MockTree({ beta: ['x'] });
     let c = new MockTree(['charlie']);
@@ -52,10 +49,10 @@ QUnit.module('tracked-merge-dirs', function() {
     let t = new MultiTreeDiff([a, b, c]);
     t.update();
     let { ops } = t.update();
-    assert.deepEqual(fileOps(ops), []);
+    expect(fileOps(ops)).toEqual([]);
   });
 
-  test('it emits a changed file', function(assert) {
+  test('it emits a changed file', () => {
     let a = new MockTree(['alpha', 'tomster']);
     let b = new MockTree({ beta: ['x'] });
     let c = new MockTree(['charlie']);
@@ -64,34 +61,34 @@ QUnit.module('tracked-merge-dirs', function() {
     t.update();
     dirty(a.entries[0]);
     let { ops, sources } = t.update();
-    assert.deepEqual(fileOps(ops), [['change', 'alpha']]);
-    assert.equal(sources.get('alpha'), 0);
+    expect(fileOps(ops)).toEqual([['change', 'alpha']]);
+    expect(sources.get('alpha')).toBe(0);
   });
 
-  test('it falls back to earlier source at deletion', function(assert) {
+  test('it falls back to earlier source at deletion', () => {
     let a = new MockTree(['alpha', 'tomster']);
     let c = new MockTree(['charlie', 'alpha']);
 
     let t = new MultiTreeDiff([a, c]);
 
     let result = t.update();
-    assert.equal(result.sources.get('alpha'), 1);
+    expect(result.sources.get('alpha')).toBe(1);
 
     c.entries.splice(0, 1);
 
     result = t.update();
-    assert.deepEqual(fileOps(result.ops), [['change', 'alpha']]);
-    assert.equal(result.sources.get('alpha'), 0);
+    expect(fileOps(result.ops)).toEqual([['change', 'alpha']]);
+    expect(result.sources.get('alpha')).toBe(0);
   });
 
-  test('it switches to later source at creation', function(assert) {
+  test('it switches to later source at creation', () => {
     let a = new MockTree(['alpha', 'tomster']);
     let b = new MockTree(['charlie']);
 
     let t = new MultiTreeDiff([a, b]);
 
     let result = t.update();
-    assert.equal(result.sources.get('alpha'), 0);
+    expect(result.sources.get('alpha')).toBe(0);
 
     b.entries.push({
       relativePath: 'alpha',
@@ -102,11 +99,11 @@ QUnit.module('tracked-merge-dirs', function() {
     });
 
     result = t.update();
-    assert.deepEqual(fileOps(result.ops), [['change', 'alpha']]);
-    assert.equal(result.sources.get('alpha'), 1);
+    expect(fileOps(result.ops)).toEqual([['change', 'alpha']]);
+    expect(result.sources.get('alpha')).toBe(1);
   });
 
-  test('it hides changes in occluded files', function(assert) {
+  test('it hides changes in occluded files', () => {
     let a = new MockTree(['alpha']);
     let b = new MockTree(['alpha']);
 
@@ -114,17 +111,17 @@ QUnit.module('tracked-merge-dirs', function() {
     t.update();
     dirty(a.entries[0]);
     let { ops } = t.update();
-    assert.deepEqual(fileOps(ops), []);
+    expect(fileOps(ops)).toEqual([]);
   });
 
-  test('it respects mayChange', function(assert) {
+  test('it respects mayChange', () => {
     let a = new MockTree(['alpha', 'tomster']);
     a.mayChange = false;
     let t = new MultiTreeDiff([a]);
     t.update();
     dirty(a.entries[0]);
     let { ops } = t.update();
-    assert.deepEqual(fileOps(ops), []);
+    expect(fileOps(ops)).toEqual([]);
   });
 });
 

--- a/packages/core/tests/portable-plugin-config.test.ts
+++ b/packages/core/tests/portable-plugin-config.test.ts
@@ -1,7 +1,5 @@
-import 'qunit';
 import PortableBabelConfig from '../src/portable-babel-config';
 import { join } from 'path';
-const { test } = QUnit;
 
 function resolvableNames(...names: string[]) {
   return {
@@ -36,84 +34,84 @@ function run(config: PortableBabelConfig): any {
   return module.exports.config;
 }
 
-QUnit.module('portable-plugin-config', function() {
-  test('absolute path', function(assert) {
+describe('portable-plugin-config', () => {
+  test('absolute path', () => {
     let config = new PortableBabelConfig(
       {
         plugins: ['/path/to/some/plugin.js'],
       },
       resolvableNames()
     );
-    assert.deepEqual(runParallelSafe(config).plugins, ['/path/to/some/plugin.js']);
+    expect(runParallelSafe(config).plugins).toEqual(['/path/to/some/plugin.js']);
   });
 
-  test('local path', function(assert) {
+  test('local path', () => {
     let config = new PortableBabelConfig(
       {
         plugins: ['./path/to/some/plugin.js'],
       },
       resolvableNames()
     );
-    assert.deepEqual(runParallelSafe(config).plugins, ['/notional-base-dir/path/to/some/plugin.js']);
+    expect(runParallelSafe(config).plugins).toEqual(['/notional-base-dir/path/to/some/plugin.js']);
   });
 
-  test('package name', function(assert) {
+  test('package name', () => {
     let config = new PortableBabelConfig(
       {
         plugins: ['my-package'],
       },
       resolvableNames('my-package')
     );
-    assert.deepEqual(runParallelSafe(config).plugins, ['/notional-base-dir/node_modules/my-package/index.js']);
+    expect(runParallelSafe(config).plugins).toEqual(['/notional-base-dir/node_modules/my-package/index.js']);
   });
 
-  test('package name shorthand', function(assert) {
+  test('package name shorthand', () => {
     let config = new PortableBabelConfig(
       {
         plugins: ['my-package'],
       },
       resolvableNames('babel-plugin-my-package')
     );
-    assert.deepEqual(runParallelSafe(config).plugins, [
+    expect(runParallelSafe(config).plugins).toEqual([
       '/notional-base-dir/node_modules/babel-plugin-my-package/index.js',
     ]);
   });
 
-  test('namespaced package name', function(assert) {
+  test('namespaced package name', () => {
     let config = new PortableBabelConfig(
       {
         plugins: ['@me/my-package'],
       },
       resolvableNames('@me/my-package')
     );
-    assert.deepEqual(runParallelSafe(config).plugins, ['/notional-base-dir/node_modules/@me/my-package/index.js']);
+    expect(runParallelSafe(config).plugins).toEqual(['/notional-base-dir/node_modules/@me/my-package/index.js']);
   });
 
-  test('namespaced package name shorthand', function(assert) {
+  test('namespaced package name shorthand', () => {
     let config = new PortableBabelConfig(
       {
         plugins: ['@me/my-package'],
       },
       resolvableNames('@me/babel-plugin-my-package')
     );
-    assert.deepEqual(runParallelSafe(config).plugins, [
+    expect(runParallelSafe(config).plugins).toEqual([
       '/notional-base-dir/node_modules/@me/babel-plugin-my-package/index.js',
     ]);
   });
 
-  test('resolves name with json-safe config', function(assert) {
+  test('resolves name with json-safe config', () => {
     let config = new PortableBabelConfig(
       {
         plugins: [['my-package', { theOptions: 'cool' }]],
       },
       resolvableNames('babel-plugin-my-package')
     );
-    assert.deepEqual(runParallelSafe(config).plugins, [
+    expect(runParallelSafe(config).plugins).toEqual([
       ['/notional-base-dir/node_modules/babel-plugin-my-package/index.js', { theOptions: 'cool' }],
     ]);
   });
 
-  test('resolves name with arbitrary config', function(assert) {
+  test('resolves name with arbitrary config', () => {
     let options = {
       precompile() {
         return 'cool';
@@ -125,13 +123,13 @@ QUnit.module('portable-plugin-config', function() {
       },
       resolvableNames('babel-plugin-my-package')
     );
-    assert.ok(!config.isParallelSafe);
-    assert.deepEqual(run(config).plugins, [
+    expect(config.isParallelSafe).toBeFalsy();
+    expect(run(config).plugins).toEqual([
       ['/notional-base-dir/node_modules/babel-plugin-my-package/index.js', options],
     ]);
   });
 
-  test('passes through bare function', function(assert) {
+  test('passes through bare function', () => {
     let func = function() {};
     let config = new PortableBabelConfig(
       {
@@ -139,11 +137,11 @@ QUnit.module('portable-plugin-config', function() {
       },
       resolvableNames()
     );
-    assert.ok(!config.isParallelSafe);
-    assert.deepEqual(run(config).plugins, [func]);
+    expect(config.isParallelSafe).toBeFalsy();
+    expect(run(config).plugins).toEqual([func]);
   });
 
-  test('passes through function with args', function(assert) {
+  test('passes through function with args', () => {
     let func = function() {};
     let args = { theArgs: 'here' };
     let config = new PortableBabelConfig(
@@ -152,11 +150,11 @@ QUnit.module('portable-plugin-config', function() {
       },
       resolvableNames()
     );
-    assert.ok(!config.isParallelSafe);
-    assert.deepEqual(run(config).plugins, [[func, args]]);
+    expect(config.isParallelSafe).toBeFalsy();
+    expect(run(config).plugins).toEqual([[func, args]]);
   });
 
-  test('respects _parallelBabel api with buildUsing on PluginTarget', function(assert) {
+  test('respects _parallelBabel api with buildUsing on PluginTarget', () => {
     (exampleFunction as any)._parallelBabel = {
       requireFile: __filename,
       buildUsing: 'exampleFunction',
@@ -170,12 +168,12 @@ QUnit.module('portable-plugin-config', function() {
       },
       resolvableNames()
     );
-    assert.ok(config.isParallelSafe);
+    expect(config.isParallelSafe).toBeTruthy();
     let output = runParallelSafe(config);
-    assert.equal(output.plugins[0], 'this is the example function with theParams=are here');
+    expect(output.plugins[0]).toBe('this is the example function with theParams=are here');
   });
 
-  test('respects _parallelBabel api with useMethod on PluginTarget', function(assert) {
+  test('respects _parallelBabel api with useMethod on PluginTarget', () => {
     (exampleFunction as any)._parallelBabel = {
       requireFile: __filename,
       useMethod: 'exampleFunction',
@@ -186,12 +184,12 @@ QUnit.module('portable-plugin-config', function() {
       },
       resolvableNames()
     );
-    assert.ok(config.isParallelSafe);
+    expect(config.isParallelSafe).toBeTruthy();
     let output = runParallelSafe(config);
-    assert.equal(output.plugins[0](), 'this is the example function with no params');
+    expect(output.plugins[0]()).toBe('this is the example function with no params');
   });
 
-  test('respects _parallelBabel api with with only requireFile on PluginTarget', function(assert) {
+  test('respects _parallelBabel api with with only requireFile on PluginTarget', () => {
     (exampleFunction as any)._parallelBabel = {
       requireFile: __filename,
     };
@@ -201,12 +199,12 @@ QUnit.module('portable-plugin-config', function() {
       },
       resolvableNames()
     );
-    assert.ok(config.isParallelSafe);
+    expect(config.isParallelSafe).toBeTruthy();
     let output = runParallelSafe(config);
-    assert.equal(output.plugins[0].exampleFunction(), 'this is the example function with no params');
+    expect(output.plugins[0].exampleFunction()).toBe('this is the example function with no params');
   });
 
-  test('respects _parallelBabel api on PluginOptions', function(assert) {
+  test('respects _parallelBabel api on PluginOptions', () => {
     function precompile() {}
     precompile._parallelBabel = {
       requireFile: __filename,
@@ -220,10 +218,10 @@ QUnit.module('portable-plugin-config', function() {
       },
       resolvableNames('my-plugin')
     );
-    assert.ok(config.isParallelSafe);
+    expect(config.isParallelSafe).toBeTruthy();
     let output = runParallelSafe(config);
-    assert.equal(output.plugins[0][0], '/notional-base-dir/node_modules/my-plugin/index.js');
-    assert.deepEqual(output.plugins[0][1], {
+    expect(output.plugins[0][0]).toBe('/notional-base-dir/node_modules/my-plugin/index.js');
+    expect(output.plugins[0][1]).toEqual({
       precompile: 'this is the example function with theParams=reconstituted precompile',
     });
   });

--- a/packages/macros/jest.config.js
+++ b/packages/macros/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: [
+    '<rootDir>/tests/**/*.test.js',
+  ],
+};

--- a/packages/macros/tests/dependency-satisfies.test.ts
+++ b/packages/macros/tests/dependency-satisfies.test.ts
@@ -1,97 +1,95 @@
-import 'qunit';
 import { allBabelVersions, runDefault } from './helpers';
-const { test } = QUnit;
 
-QUnit.module(`dependencySatisfies`, function() {
+describe(`dependencySatisfies`, function() {
   allBabelVersions(function(transform: (code: string) => string) {
-    test('is satisfied', function(assert) {
+    test('is satisfied', () => {
       let code = transform(`
       import { dependencySatisfies } from '@embroider/macros';
       export default function() {
         return dependencySatisfies('qunit', '^2.8.0');
       }
       `);
-      assert.equal(runDefault(code), true);
+      expect(runDefault(code)).toBe(true);
     });
 
-    test('is not satisfied', function(assert) {
+    test('is not satisfied', () => {
       let code = transform(`
       import { dependencySatisfies } from '@embroider/macros';
       export default function() {
         return dependencySatisfies('qunit', '^10.0.0');
       }
       `);
-      assert.equal(runDefault(code), false);
+      expect(runDefault(code)).toBe(false);
     });
 
-    test('is not present', function(assert) {
+    test('is not present', () => {
       let code = transform(`
       import { dependencySatisfies } from '@embroider/macros';
       export default function() {
         return dependencySatisfies('not-a-real-dep', '^10.0.0');
       }
       `);
-      assert.equal(runDefault(code), false);
+      expect(runDefault(code)).toBe(false);
     });
 
-    test('import gets removed', function(assert) {
+    test('import gets removed', () => {
       let code = transform(`
       import { dependencySatisfies } from '@embroider/macros';
       export default function() {
         return dependencySatisfies('not-a-real-dep', '1');
       }
       `);
-      assert.ok(!/dependencySatisfies/.test(code), `dependencySatisfies should not be in the output: ${code}`);
+      expect(code).not.toMatch(/dependencySatisfies/);
     });
 
-    test('entire import statement gets removed', function(assert) {
+    test('entire import statement gets removed', () => {
       let code = transform(`
       import { dependencySatisfies } from '@embroider/macros';
       export default function() {
         return dependencySatisfies('not-a-real-dep', '*');
       }
       `);
-      assert.ok(!/dependencySatisfies/.test(code), `dependencySatisfies should not be in the output: ${code}`);
-      assert.ok(!/@embroider\/macros/.test(code), `entire import statement should not be in the output: ${code}`);
+      expect(code).not.toMatch(/dependencySatisfies/);
+      expect(code).not.toMatch(/@embroider\/macros/);
     });
 
-    test('unused import gets removed', function(assert) {
+    test('unused import gets removed', () => {
       let code = transform(`
       import { dependencySatisfies } from '@embroider/macros';
       export default function() {
         return 1;
       }
       `);
-      assert.ok(!/dependencySatisfies/.test(code), `dependencySatisfies should not be in the output: ${code}`);
-      assert.ok(!/@embroider\/macros/.test(code), `entire import statement should not be in the output: ${code}`);
+      expect(code).not.toMatch(/dependencySatisfies/);
+      expect(code).not.toMatch(/@embroider\/macros/);
     });
 
-    test('non call error', function(assert) {
-      assert.throws(() => {
+    test('non call error', () => {
+      expect(() => {
         transform(`
           import { dependencySatisfies } from '@embroider/macros';
           let x = dependencySatisfies;
         `);
-      }, /You can only use dependencySatisfies as a function call/);
+      }).toThrow(/You can only use dependencySatisfies as a function call/);
     });
 
-    test('args length error', function(assert) {
-      assert.throws(() => {
+    test('args length error', () => {
+      expect(() => {
         transform(`
           import { dependencySatisfies } from '@embroider/macros';
           dependencySatisfies('foo', 'bar', 'baz');
         `);
-      }, /dependencySatisfies takes exactly two arguments, you passed 3/);
+      }).toThrow(/dependencySatisfies takes exactly two arguments, you passed 3/);
     });
 
-    test('non literal arg error', function(assert) {
-      assert.throws(() => {
+    test('non literal arg error', () => {
+      expect(() => {
         transform(`
           import { dependencySatisfies } from '@embroider/macros';
           let name = 'qunit';
           dependencySatisfies(name, '*');
         `);
-      }, /the first argument to dependencySatisfies must be a string literal/);
+      }).toThrow(/the first argument to dependencySatisfies must be a string literal/);
     });
   });
 });

--- a/packages/macros/tests/get-config.test.ts
+++ b/packages/macros/tests/get-config.test.ts
@@ -1,61 +1,59 @@
-import 'qunit';
 import { allBabelVersions, runDefault } from './helpers';
 import { MacrosConfig } from '..';
-const { test } = QUnit;
 
-QUnit.module(`getConfig`, function() {
+describe(`getConfig`, function() {
   allBabelVersions(function(transform: (code: string) => string, config: MacrosConfig) {
     config.setOwnConfig(__filename, { beverage: 'coffee' });
     config.setConfig(__filename, '@babel/core', [1, 2, 3]);
 
-    test(`returns correct value for own package's config`, function(assert) {
+    test(`returns correct value for own package's config`, () => {
       let code = transform(`
       import { getOwnConfig } from '@embroider/macros';
       export default function() {
         return getOwnConfig();
       }
       `);
-      assert.deepEqual(runDefault(code), { beverage: 'coffee' });
+      expect(runDefault(code)).toEqual({ beverage: 'coffee' });
     });
 
-    test(`returns correct value for another package's config`, function(assert) {
+    test(`returns correct value for another package's config`, () => {
       let code = transform(`
       import { getConfig } from '@embroider/macros';
       export default function() {
         return getConfig('@babel/core');
       }
       `);
-      assert.deepEqual(runDefault(code), [1, 2, 3]);
+      expect(runDefault(code)).toEqual([1, 2, 3]);
     });
 
-    test(`returns undefined when there's no config but the package exists`, function(assert) {
+    test(`returns undefined when there's no config but the package exists`, () => {
       let code = transform(`
       import { getConfig } from '@embroider/macros';
       export default function() {
         return getConfig('qunit');
       }
       `);
-      assert.equal(runDefault(code), undefined);
+      expect(runDefault(code)).toBe(undefined);
     });
 
-    test(`returns undefined when there's no such package`, function(assert) {
+    test(`returns undefined when there's no such package`, () => {
       let code = transform(`
       import { getConfig } from '@embroider/macros';
       export default function() {
         return getConfig('not-a-thing');
       }
       `);
-      assert.equal(runDefault(code), undefined);
+      expect(runDefault(code)).toBe(undefined);
     });
 
-    test('import gets removed', function(assert) {
+    test('import gets removed', () => {
       let code = transform(`
       import { dependencySatisfies } from '@embroider/macros';
       export default function() {
         return dependencySatisfies('not-a-real-dep', '1');
       }
       `);
-      assert.ok(!/dependencySatisfies/.test(code), `dependencySatisfies should not be in the output: ${code}`);
+      expect(code).not.toMatch(/dependencySatisfies/);
     });
   });
 });

--- a/packages/macros/tests/helpers.ts
+++ b/packages/macros/tests/helpers.ts
@@ -8,7 +8,7 @@ export { runDefault };
 export function allBabelVersions(createTests: (transform: (code: string) => string, config: MacrosConfig) => void) {
   let config: MacrosConfig;
 
-  QUnit.module('without presets', function() {
+  describe('without presets', function() {
     allBabel({
       babelConfig() {
         config = new MacrosConfig();
@@ -24,7 +24,7 @@ export function allBabelVersions(createTests: (transform: (code: string) => stri
     });
   });
 
-  QUnit.module('with presets', function() {
+  describe('with presets', function() {
     allBabel({
       babelConfig(major: number) {
         config = new MacrosConfig();

--- a/packages/macros/tests/macro-if.test.ts
+++ b/packages/macros/tests/macro-if.test.ts
@@ -1,50 +1,48 @@
-import 'qunit';
 import { allBabelVersions, runDefault } from './helpers';
 import { MacrosConfig } from '../src';
-const { test } = QUnit;
 
-QUnit.module('macroIf', function() {
+describe('macroIf', function() {
   allBabelVersions(function createTests(transform: (code: string) => string, config: MacrosConfig) {
     config.setConfig(__filename, 'qunit', { items: [{ approved: true, other: null, size: 2.3 }] });
 
-    test('select consequent, drop alternate', function(assert) {
+    test('select consequent, drop alternate', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       export default function() {
         return macroIf(true, () => 'alpha', () => 'beta');
       }
       `);
-      assert.equal(runDefault(code), 'alpha');
-      assert.ok(!/beta/.test(code), 'beta should be dropped');
-      assert.ok(!/macroIf/.test(code), 'macroIf should be dropped');
-      assert.ok(!/@embroider\/macros/.test(code), '@embroider/macros should be dropped');
+      expect(runDefault(code)).toBe('alpha');
+      expect(code).not.toMatch(/beta/);
+      expect(code).not.toMatch(/macroIf/);
+      expect(code).not.toMatch(/@embroider\/macros/);
     });
 
-    test('select consequent, drop alternate', function(assert) {
+    test('select consequent, drop alternate', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       export default function() {
         return macroIf(false, () => 'alpha', () => 'beta');
       }
       `);
-      assert.equal(runDefault(code), 'beta');
-      assert.ok(!/alpha/.test(code), 'alpha should be dropped');
-      assert.ok(!/macroIf/.test(code), 'macroIf should be dropped');
-      assert.ok(!/@embroider\/macros/.test(code), '@embroider/macros should be dropped');
+      expect(runDefault(code)).toBe('beta');
+      expect(code).not.toMatch(/alpha/);
+      expect(code).not.toMatch(/macroIf/);
+      expect(code).not.toMatch(/@embroider\/macros/);
     });
 
-    test('works with block forms', function(assert) {
+    test('works with block forms', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       export default function() {
         return macroIf(false, () => { return 'alpha'; }, () => { return 'beta'; });
       }
       `);
-      assert.equal(runDefault(code), 'beta');
-      assert.ok(!/alpha/.test(code), 'alpha should be dropped');
+      expect(runDefault(code)).toBe('beta');
+      expect(code).not.toMatch(/alpha/);
     });
 
-    test('block lifting', function(assert) {
+    test('block lifting', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       export default function() {
@@ -55,10 +53,10 @@ QUnit.module('macroIf', function() {
         return value;
       }
       `);
-      assert.equal(runDefault(code), 2);
+      expect(runDefault(code)).toBe(2);
     });
 
-    test('preserves this when using single-expression arrows', function(assert) {
+    test('preserves this when using single-expression arrows', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
 
@@ -75,10 +73,10 @@ QUnit.module('macroIf', function() {
         return new Example().method();
       }
       `);
-      assert.equal(runDefault(code), 'Quint');
+      expect(runDefault(code)).toBe('Quint');
     });
 
-    test('preserves this when using block arrows', function(assert) {
+    test('preserves this when using block arrows', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
 
@@ -95,32 +93,32 @@ QUnit.module('macroIf', function() {
         return new Example().method();
       }
       `);
-      assert.equal(runDefault(code), 'Quint');
+      expect(runDefault(code)).toBe('Quint');
     });
 
-    test('select consequent, no alternate', function(assert) {
+    test('select consequent, no alternate', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       export default function() {
         return macroIf(true, () => 'alpha');
       }
       `);
-      assert.equal(runDefault(code), 'alpha');
-      assert.ok(!/macroIf/.test(code), 'macroIf should be dropped');
-      assert.ok(!/@embroider\/macros/.test(code), '@embroider/macros should be dropped');
+      expect(runDefault(code)).toBe('alpha');
+      expect(code).not.toMatch(/macroIf/);
+      expect(code).not.toMatch(/@embroider\/macros/);
     });
 
-    test('drop consequent, no alternate', function(assert) {
+    test('drop consequent, no alternate', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       export default function() {
         return macroIf(false, () => 'alpha');
       }
       `);
-      assert.equal(runDefault(code), undefined);
+      expect(runDefault(code)).toBe(undefined);
     });
 
-    test('drops imports that are only used in the unused branch', function(assert) {
+    test('drops imports that are only used in the unused branch', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       import a from 'module-a';
@@ -130,12 +128,12 @@ QUnit.module('macroIf', function() {
         return macroIf(true, () => a, () => b);
       }
       `);
-      assert.ok(/module-a/.test(code), 'have module-a');
-      assert.ok(!/module-b/.test(code), 'do not have module-b');
+      expect(code).toMatch(/module-a/);
+      expect(code).not.toMatch(/module-b/);
     });
 
-    test('non-static predicate refuses to build', function(assert) {
-      assert.throws(() => {
+    test('non-static predicate refuses to build', () => {
+      expect(() => {
         transform(`
         import { macroIf } from '@embroider/macros';
         import other from 'other';
@@ -143,10 +141,10 @@ QUnit.module('macroIf', function() {
           return macroIf(other, () => a, () => b);
         }
         `);
-      }, /the first argument to macroIf must be statically known/);
+      }).toThrow(/the first argument to macroIf must be statically known/);
     });
 
-    test('leaves unrelated unused imports alone', function(assert) {
+    test('leaves unrelated unused imports alone', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       import a from 'module-a';
@@ -156,10 +154,10 @@ QUnit.module('macroIf', function() {
         return macroIf(true, () => a, () => b);
       }
       `);
-      assert.ok(/module-c/.test(code), 'unrelated unused imports are left alone');
+      expect(code).toMatch(/module-c/);
     });
 
-    test('leaves unrelated used imports alone', function(assert) {
+    test('leaves unrelated used imports alone', () => {
       let code = transform(`
       import { macroIf } from '@embroider/macros';
       import a from 'module-a';
@@ -170,21 +168,21 @@ QUnit.module('macroIf', function() {
         return macroIf(true, () => a, () => b);
       }
       `);
-      assert.ok(/module-c/.test(code), 'unrelated unused imports are left alone');
+      expect(code).toMatch(/module-c/);
     });
 
-    test('composes with other macros', function(assert) {
+    test('composes with other macros', () => {
       let code = transform(`
       import { macroIf, dependencySatisfies } from '@embroider/macros';
       export default function() {
         return macroIf(dependencySatisfies('qunit', '*'), () => 'alpha', () => 'beta');
       }
       `);
-      assert.equal(runDefault(code), 'alpha');
-      assert.ok(!/beta/.test(code), 'beta should be dropped');
+      expect(runDefault(code)).toBe('alpha');
+      expect(code).not.toMatch(/beta/);
     });
 
-    test('can see booleans inside getConfig', function(assert) {
+    test('can see booleans inside getConfig', () => {
       let code = transform(`
       import { macroIf, getConfig } from '@embroider/macros';
       export default function() {
@@ -193,11 +191,11 @@ QUnit.module('macroIf', function() {
         return macroIf(getConfig('qunit').items[0]["approved"], () => 'alpha', () => 'beta');
       }
       `);
-      assert.equal(runDefault(code), 'alpha');
-      assert.ok(!/beta/.test(code), 'beta should be dropped');
+      expect(runDefault(code)).toBe('alpha');
+      expect(code).not.toMatch(/beta/);
     });
 
-    test(`direct export of macroIf`, function(assert) {
+    test(`direct export of macroIf`, () => {
       let code = transform(`
       import { dependencySatisfies, macroIf } from '@embroider/macros';
 
@@ -215,7 +213,7 @@ QUnit.module('macroIf', function() {
         () => b,
       );
       `);
-      assert.equal(runDefault(code), 'b');
+      expect(runDefault(code)).toBe('b');
     });
   });
 });

--- a/packages/webpack/jest.config.js
+++ b/packages/webpack/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: [
+    '<rootDir>/tests/**/*.test.js',
+  ],
+};

--- a/test-packages/jest.config.js
+++ b/test-packages/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/test-packages/support/.gitignore
+++ b/test-packages/support/.gitignore
@@ -2,3 +2,6 @@
 *.js
 *.d.ts
 *.map
+
+!vendor/ember-template-compiler.js
+!qunit-jest-shim.js

--- a/test-packages/support/index.ts
+++ b/test-packages/support/index.ts
@@ -6,6 +6,7 @@ import MockUI from 'console-ui/mock';
 import Instrumentation from 'ember-cli/lib/models/instrumentation';
 import PackageInfoCache from 'ember-cli/lib/models/package-info-cache';
 import 'qunit';
+import 'jest';
 import { transform as transform6, TransformOptions as Options6 } from 'babel-core';
 import { transform as transform7, TransformOptions as Options7 } from '@babel/core';
 
@@ -46,7 +47,9 @@ export function allBabelVersions(params: {
   babelConfig(major: 7): Options7;
   createTests(transform: (code: string) => string): void;
 }) {
-  QUnit.module('babel6', function() {
+  let _describe = typeof QUnit !== 'undefined' ? (QUnit.module as any) : describe;
+
+  _describe('babel6', function() {
     let options6: Options6 = params.babelConfig(6);
     if (!options6.filename) {
       options6.filename = 'sample.js';
@@ -55,7 +58,8 @@ export function allBabelVersions(params: {
       return transform6(code, options6).code!;
     });
   });
-  QUnit.module('babel7', function() {
+
+  _describe('babel7', function() {
     let options7: Options7 = params.babelConfig(7);
     if (!options7.filename) {
       options7.filename = 'sample.js';

--- a/test-packages/support/qunit-jest-shim.js
+++ b/test-packages/support/qunit-jest-shim.js
@@ -1,0 +1,1 @@
+global.describe = function () {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,6 +1160,18 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
 
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.11":
+  version "24.0.11"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.11.tgz#1f099bea332c228ea6505a88159bfa86a5858340"
+  integrity sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/js-string-escape@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/js-string-escape/-/js-string-escape-1.0.0.tgz#96738a64ea912f7d4b87ee097231d68fd1813332"


### PR DESCRIPTION
This is step one for getting rid of the Jest-running-QUnit redirection.

- if you want to run just the test for e.g. core you can now do: `yarn test -c packages/core/jest.config.js`

- Jest will only run tests in files ending in `.test.js` and will complain about matching files not having any tests inside them

- QUnit will run all files in the `tests` folders, but will ignore files that don't have `QUnit.module()` in them

- I've added a temporary shim for `global.describe` so that QUnit does not throw up when running a Jest test file