### PR TITLE
avoid port collisions

### DIFF
--- a/test-packages/sample-transforms/package.json
+++ b/test-packages/sample-transforms/package.json
@@ -17,7 +17,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "ember test",
+    "test": "ember test --test-port=0",
     "test:all": "ember try:each"
   },
   "dependencies": {

--- a/test-packages/static-app/package.json
+++ b/test-packages/static-app/package.json
@@ -15,7 +15,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "ember test"
+    "test": "ember test --test-port=0"
   },
   "devDependencies": {
     "@ember/jquery": "^0.5.2",


### PR DESCRIPTION
This should really be ember-cli's default.

It can cause sporadic test failures when we're running multiple test suites in parallel.