### PR TITLE
Portable plugin config bugfixes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -606,7 +606,7 @@ Status: internal use only
 
 Boolean. Marks a package as having been compiled on the fly from v1 to v2. It's probably not a good idea to ever publish a package to NPM with this set.
 
-## babel-config
+## babel.filename
 
 ```
 Allowed in: apps
@@ -616,6 +616,26 @@ Status: encouraged
 Path to a Javascript file that exports a babel config.
 
 Note that this is for use in apps, which means in _compiled_ apps that are being handed off for final stage packaging. Mostly this is relevant only to authors of final stage packagers.
+
+## babel.isParallelSafe
+
+```
+Allowed in: apps
+Status: encouraged
+```
+
+Boolean that indicates whether it's safe to load our babel config in a new node process.
+
+
+## babel.majorVersion
+
+```
+Allowed in: apps
+Status: encouraged
+```
+
+Which babel major version is our babel config expecting to run inside.
+
 
 ## build
 
@@ -763,16 +783,26 @@ Status: encouraged
 
 The public URL at which the root of the app will be served. Defaults to '/' when not provided.
 
-## template-compiler
+## template-compiler.filename
 
 ```
 Allowed in: apps
 Status: encouraged
 ```
 
-Path to a Javascript file that provides the preconfigured HBS template compiler.
+Path to a Javascript file that provides the preconfigured HBS template compiler. Stage3 packagers should grab the `compile` function off the default export and just use that.
 
 Note that this is for use in apps, which means in _compiled_ apps that are being handed off for final stage packaging. Mostly this is relevant only to authors of final stage packagers.
+
+## template-compiler.isParalleSafe
+
+```
+Allowed in: apps
+Status: encouraged
+```
+
+Boolean. Indicates whether this template compiler is safe to use in a new node process.
+
 
 ## version
 

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -4,7 +4,7 @@ import { ComponentRules } from './dependency-rules';
 // This is the AST transform that resolves components and helpers at build time
 // and puts them into `dependencies`.
 export function makeResolverTransform(resolver: Resolver) {
-  return function resolverTransform(env: { moduleName: string }) {
+  function resolverTransform(env: { moduleName: string }) {
     resolver.enter(env.moduleName);
 
     let scopeStack = new ScopeStack();
@@ -136,6 +136,12 @@ export function makeResolverTransform(resolver: Resolver) {
       },
     };
   };
+  resolverTransform.parallelBabel = {
+    requireFile: __filename,
+    buildUsing: 'makeResolverTransform',
+    params: Resolver,
+  };
+  return resolverTransform;
 }
 
 type ScopeEntry =

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -135,7 +135,7 @@ export function makeResolverTransform(resolver: Resolver) {
         },
       },
     };
-  };
+  }
   resolverTransform.parallelBabel = {
     requireFile: __filename,
     buildUsing: 'makeResolverTransform',

--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -112,7 +112,7 @@ QUnit.module('stage2 build', function() {
           return templateCompiler.compile(fileAssert.fullPath, contents);
         } else if (fileAssert.path.endsWith('.js')) {
           // eslint-disable-next-line @typescript-eslint/no-require-imports
-          let babelConfig = require(join(fileAssert.basePath, '_babel_config_')).config as TransformOptions;
+          let babelConfig = require(join(fileAssert.basePath, '_babel_config_')) as TransformOptions;
           return transform(contents, Object.assign({ filename: fileAssert.fullPath }, babelConfig))!.code!;
         } else {
           return contents;

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -497,8 +497,9 @@ export class AppBuilder<TreeNames> {
 
     let finalAssets = await this.updateAssets(assets, appFiles, emberENV);
     let templateCompiler = this.templateCompiler(emberENV);
+    let babelConfig = this.babelConfig(templateCompiler);
     this.addTemplateCompiler(templateCompiler);
-    this.addBabelConfig(templateCompiler);
+    this.addBabelConfig(babelConfig);
 
     let externals = this.combineExternals();
 
@@ -516,8 +517,15 @@ export class AppBuilder<TreeNames> {
       version: 2,
       externals,
       assets: assetPaths,
-      'template-compiler': '_template_compiler_.js',
-      'babel-config': '_babel_config_.js',
+      'template-compiler': {
+        filename: '_template_compiler_.js',
+        isParallelSafe: templateCompiler.isParallelSafe,
+      },
+      'babel': {
+        filename: '_babel_config_.js',
+        isParallelSafe: babelConfig.isParallelSafe,
+        majorVersion: 6, // TODO
+      },
       'root-url': this.adapter.rootURL(),
     };
 
@@ -573,8 +581,7 @@ export class AppBuilder<TreeNames> {
     writeFileSync(join(this.root, '_template_compiler_.js'), templateCompiler.serialize(), 'utf8');
   }
 
-  private addBabelConfig(templateCompiler: TemplateCompiler) {
-    let babelConfig = this.babelConfig(templateCompiler);
+  private addBabelConfig(babelConfig: PortableBabelConfig) {
     if (!babelConfig.isParallelSafe) {
       warn('Your build is slower because some babel plugins are non-serializable');
     }

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -521,7 +521,7 @@ export class AppBuilder<TreeNames> {
         filename: '_template_compiler_.js',
         isParallelSafe: templateCompiler.isParallelSafe,
       },
-      'babel': {
+      babel: {
         filename: '_babel_config_.js',
         isParallelSafe: babelConfig.isParallelSafe,
         majorVersion: 6, // TODO

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -7,8 +7,15 @@ export interface AppMeta {
   version: 2;
   assets: filename[];
   externals?: string[];
-  'template-compiler': filename;
-  'babel-config': filename;
+  'template-compiler': {
+    filename: string,
+    isParallelSafe: boolean,
+  };
+  'babel': {
+    filename: string,
+    isParallelSafe: boolean,
+    majorVersion: 6 | 7,
+  }
   'root-url': string;
 }
 

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -8,14 +8,14 @@ export interface AppMeta {
   assets: filename[];
   externals?: string[];
   'template-compiler': {
-    filename: string,
-    isParallelSafe: boolean,
+    filename: string;
+    isParallelSafe: boolean;
   };
-  'babel': {
-    filename: string,
-    isParallelSafe: boolean,
-    majorVersion: 6 | 7,
-  }
+  babel: {
+    filename: string;
+    isParallelSafe: boolean;
+    majorVersion: 6 | 7;
+  };
   'root-url': string;
 }
 

--- a/packages/core/src/portable-plugin-config.ts
+++ b/packages/core/src/portable-plugin-config.ts
@@ -90,6 +90,7 @@ export class PortablePluginConfig {
       case 'string':
       case 'number':
       case 'boolean':
+      case 'undefined':
         return value;
       case 'object':
         return mapValues(value, (propertyValue, key) => this.makePortable(propertyValue, accessPath.concat(key)));

--- a/packages/core/src/portable-plugin-config.ts
+++ b/packages/core/src/portable-plugin-config.ts
@@ -8,11 +8,8 @@ const { globalValues, nonce } = setupGlobals();
 
 const template = compile(`
 const { PortablePluginConfig } = require('{{{js-string-escape here}}}');
-module.exports = {
-  config: PortablePluginConfig.load({{{json-stringify portable 2}}}),
-  isParallelSafe: {{ isParallelSafe }},
-};
-`) as (params: { portable: any; here: string; isParallelSafe: boolean }) => string;
+module.exports = PortablePluginConfig.load({{{json-stringify portable 2}}});
+`) as (params: { portable: any; here: string; }) => string;
 
 export type ResolveOptions = { basedir: string } | { resolve: (name: string) => any };
 
@@ -68,7 +65,7 @@ export class PortablePluginConfig {
   }
 
   serialize(): string {
-    return template({ portable: this.portable, here: this.here, isParallelSafe: this.isParallelSafe });
+    return template({ portable: this.portable, here: this.here });
   }
 
   protected makePortable(value: any, accessPath: string[] = []): any {

--- a/packages/core/src/portable-plugin-config.ts
+++ b/packages/core/src/portable-plugin-config.ts
@@ -209,9 +209,9 @@ function maybeHTMLBars(object: any): HTMLBarsParallelPlaceholder | undefined {
     return {
       embroiderPlaceholder: true,
       type: 'htmlbars-parallel',
-      requireFile: object._parallelBabel.requireFile,
-      buildUsing: String(object._parallelBabel.buildUsing),
-      params: object._parallelBabel.params,
+      requireFile: object.parallelBabel.requireFile,
+      buildUsing: String(object.parallelBabel.buildUsing),
+      params: object.parallelBabel.params,
     };
   }
 }

--- a/packages/core/src/portable-plugin-config.ts
+++ b/packages/core/src/portable-plugin-config.ts
@@ -9,7 +9,7 @@ const { globalValues, nonce } = setupGlobals();
 const template = compile(`
 const { PortablePluginConfig } = require('{{{js-string-escape here}}}');
 module.exports = PortablePluginConfig.load({{{json-stringify portable 2}}});
-`) as (params: { portable: any; here: string; }) => string;
+`) as (params: { portable: any; here: string }) => string;
 
 export type ResolveOptions = { basedir: string } | { resolve: (name: string) => any };
 
@@ -58,7 +58,9 @@ export class PortablePluginConfig {
         this.resolve = (name: string) => resolve.sync(name, { basedir: resolveOptions.basedir });
       }
     } else {
-      this.resolve = (_: string) => { throw new Error(`No file resolving is configured for this PortablePluginConfig`) };
+      this.resolve = (_: string) => {
+        throw new Error(`No file resolving is configured for this PortablePluginConfig`);
+      };
     }
     this.portable = this.makePortable(this.config);
     this.isParallelSafe = this.parallelSafeFlag;

--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -146,7 +146,7 @@ export default class TemplateCompiler {
         requireFile: __filename,
         buildUsing: rehydrate,
         params: this.portableConfig.portable,
-      }
+      };
     }
   }
 

--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -90,7 +90,7 @@ interface SetupCompilerParams {
   plugins: Plugins;
 }
 
-export function rehydrate(portable: SetupCompilerParams) {
+export function rehydrate(portable: unknown) {
   return new TemplateCompiler(PortableTemplateCompiler.load(portable));
 }
 
@@ -144,7 +144,7 @@ export default class TemplateCompiler {
     if (this.portableConfig.isParallelSafe) {
       return {
         requireFile: __filename,
-        buildUsing: rehydrate,
+        buildUsing: 'rehydrate',
         params: this.portableConfig.portable,
       };
     }
@@ -155,6 +155,12 @@ export default class TemplateCompiler {
   // instance.
   serialize(): string {
     return this.portableConfig.serialize();
+  }
+
+  // This allows us to survive even naive stringification in places like
+  // thread-loader and babel-loader.
+  toJSON() {
+    return this.portableConfig.portable;
   }
 
   private get syntax(): GlimmerSyntax {

--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -301,7 +301,7 @@ class TemplateCompileTree extends Filter {
 }
 
 function matchesSourceFile(filename: string) {
-  return /babel-plugin-htmlbars-inline-precompile\/(index|lib\/require-from-worker)\.js$/.test(filename);
+  return /htmlbars-inline-precompile\/(index|lib\/require-from-worker)(\.js)?$/.test(filename);
 }
 
 function hasProperties(item: any) {

--- a/packages/core/tests/portable-plugin-config-test.ts
+++ b/packages/core/tests/portable-plugin-config-test.ts
@@ -227,6 +227,18 @@ QUnit.module('portable-plugin-config', function() {
       precompile: 'this is the example function with theParams=reconstituted precompile',
     });
   });
+
+  test('undefined is a serializable value', function(assert) {
+    let config = new PortableBabelConfig(
+      {
+        plugins: ['./x', { value: undefined }],
+      },
+      resolvableNames()
+    );
+    assert.ok(config.isParallelSafe);
+    let output = runParallelSafe(config);
+    assert.equal(output.plugins[0][1].value, undefined, 'value should be undefined');
+  });
 });
 
 export function exampleFunction(params: any) {

--- a/packages/core/tests/portable-plugin-config-test.ts
+++ b/packages/core/tests/portable-plugin-config-test.ts
@@ -33,7 +33,7 @@ function runParallelSafe(config: PortableBabelConfig): any {
 function run(config: PortableBabelConfig): any {
   let module = { exports: {} } as any;
   eval(config.serialize());
-  return module.exports.config;
+  return module.exports;
 }
 
 QUnit.module('portable-plugin-config', function() {

--- a/packages/core/tests/portable-plugin-config.test.ts
+++ b/packages/core/tests/portable-plugin-config.test.ts
@@ -226,16 +226,16 @@ describe('portable-plugin-config', () => {
     });
   });
 
-  test('undefined is a serializable value', function(assert) {
+  test('undefined is a serializable value', function() {
     let config = new PortableBabelConfig(
       {
         plugins: ['./x', { value: undefined }],
       },
       resolvableNames()
     );
-    assert.ok(config.isParallelSafe);
+    expect(config.isParallelSafe).toBeTruthy();
     let output = runParallelSafe(config);
-    assert.equal(output.plugins[0][1].value, undefined, 'value should be undefined');
+    expect(output.plugins[0][1].value).toBeUndefined();
   });
 });
 

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -3,7 +3,7 @@ import getConfig from './get-config';
 import dependencySatisfies from './dependency-satisfies';
 import { macroIfBlock, macroIfExpression, maybeAttrs } from './macro-if';
 
-export function makeFirstTransform(opts: {userConfigs: {[packageRoot: string]: unknown }, baseDir?: string}) {
+export function makeFirstTransform(opts: { userConfigs: { [packageRoot: string]: unknown }; baseDir?: string }) {
   function embroiderFirstMacrosTransform(env: { syntax: { builders: any }; meta: { moduleName: string } }) {
     let scopeStack: string[][] = [];
 
@@ -31,10 +31,16 @@ export function makeFirstTransform(opts: {userConfigs: {[packageRoot: string]: u
             return;
           }
           if (node.path.original === 'macroGetOwnConfig') {
-            return literal(getConfig(node, opts.userConfigs, opts.baseDir, env.meta.moduleName, true), env.syntax.builders);
+            return literal(
+              getConfig(node, opts.userConfigs, opts.baseDir, env.meta.moduleName, true),
+              env.syntax.builders
+            );
           }
           if (node.path.original === 'macroGetConfig') {
-            return literal(getConfig(node, opts.userConfigs, opts.baseDir, env.meta.moduleName, false), env.syntax.builders);
+            return literal(
+              getConfig(node, opts.userConfigs, opts.baseDir, env.meta.moduleName, false),
+              env.syntax.builders
+            );
           }
           if (node.path.original === 'macroDependencySatisfies') {
             return literal(dependencySatisfies(node, opts.baseDir, env.meta.moduleName), env.syntax.builders);
@@ -75,7 +81,7 @@ export function makeFirstTransform(opts: {userConfigs: {[packageRoot: string]: u
         userConfigs: opts.userConfigs,
         baseDir: opts.baseDir,
       };
-    }
+    },
   };
   return embroiderFirstMacrosTransform;
 }

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -1,10 +1,9 @@
-import { MacrosConfig } from '..';
 import literal from './literal';
 import getConfig from './get-config';
 import dependencySatisfies from './dependency-satisfies';
 import { macroIfBlock, macroIfExpression, maybeAttrs } from './macro-if';
 
-export function makeFirstTransform(config: MacrosConfig, baseDir?: string) {
+export function makeFirstTransform(opts: {userConfigs: {[packageRoot: string]: unknown }, baseDir?: string}) {
   function embroiderFirstMacrosTransform(env: { syntax: { builders: any }; meta: { moduleName: string } }) {
     let scopeStack: string[][] = [];
 
@@ -32,13 +31,13 @@ export function makeFirstTransform(config: MacrosConfig, baseDir?: string) {
             return;
           }
           if (node.path.original === 'macroGetOwnConfig') {
-            return literal(getConfig(node, config, baseDir, env.meta.moduleName, true), env.syntax.builders);
+            return literal(getConfig(node, opts.userConfigs, opts.baseDir, env.meta.moduleName, true), env.syntax.builders);
           }
           if (node.path.original === 'macroGetConfig') {
-            return literal(getConfig(node, config, baseDir, env.meta.moduleName, false), env.syntax.builders);
+            return literal(getConfig(node, opts.userConfigs, opts.baseDir, env.meta.moduleName, false), env.syntax.builders);
           }
           if (node.path.original === 'macroDependencySatisfies') {
-            return literal(dependencySatisfies(node, config, baseDir, env.meta.moduleName), env.syntax.builders);
+            return literal(dependencySatisfies(node, opts.baseDir, env.meta.moduleName), env.syntax.builders);
           }
         },
         MustacheStatement(node: any) {
@@ -50,17 +49,17 @@ export function makeFirstTransform(config: MacrosConfig, baseDir?: string) {
           }
           if (node.path.original === 'macroGetOwnConfig') {
             return env.syntax.builders.mustache(
-              literal(getConfig(node, config, baseDir, env.meta.moduleName, true), env.syntax.builders)
+              literal(getConfig(node, opts.userConfigs, opts.baseDir, env.meta.moduleName, true), env.syntax.builders)
             );
           }
           if (node.path.original === 'macroGetConfig') {
             return env.syntax.builders.mustache(
-              literal(getConfig(node, config, baseDir, env.meta.moduleName, false), env.syntax.builders)
+              literal(getConfig(node, opts.userConfigs, opts.baseDir, env.meta.moduleName, false), env.syntax.builders)
             );
           }
           if (node.path.original === 'macroDependencySatisfies') {
             return env.syntax.builders.mustache(
-              literal(dependencySatisfies(node, config, baseDir, env.meta.moduleName), env.syntax.builders)
+              literal(dependencySatisfies(node, opts.baseDir, env.meta.moduleName), env.syntax.builders)
             );
           }
         },
@@ -68,6 +67,16 @@ export function makeFirstTransform(config: MacrosConfig, baseDir?: string) {
     };
   }
   (embroiderFirstMacrosTransform as any).embroiderMacrosASTMarker = true;
+  (embroiderFirstMacrosTransform as any).parallelBabel = {
+    requireFile: __filename,
+    buildUsing: 'makeFirstTransform',
+    get params() {
+      return {
+        userConfigs: opts.userConfigs,
+        baseDir: opts.baseDir,
+      };
+    }
+  };
   return embroiderFirstMacrosTransform;
 }
 
@@ -143,6 +152,11 @@ export function makeSecondTransform() {
     };
   }
   (embroiderSecondMacrosTransform as any).embroiderMacrosASTMarker = true;
+  (embroiderSecondMacrosTransform as any).parallelBabel = {
+    requireFile: __filename,
+    buildUsing: 'makeSecondTransform',
+    params: undefined,
+  };
   return embroiderSecondMacrosTransform;
 }
 

--- a/packages/macros/src/glimmer/dependency-satisfies.ts
+++ b/packages/macros/src/glimmer/dependency-satisfies.ts
@@ -31,7 +31,7 @@ export default function dependencySatisfies(
   let pkg;
   try {
     pkg = packageCache.resolve(packageName, us);
-  } catch(err) {
+  } catch (err) {
     // it's not an error if we can't resolve it, we just don't satisfy it.
   }
 

--- a/packages/macros/src/glimmer/dependency-satisfies.ts
+++ b/packages/macros/src/glimmer/dependency-satisfies.ts
@@ -1,9 +1,10 @@
-import { MacrosConfig } from '..';
 import { satisfies } from 'semver';
+import { PackageCache } from '@embroider/core';
+
+let packageCache = PackageCache.shared('embroider-stage3');
 
 export default function dependencySatisfies(
   node: any,
-  config: MacrosConfig,
   // when we're running in traditional ember-cli, baseDir is configured and we
   // do all lookups relative to that (single) package. But when we're running in
   // embroider stage3 we process all packages simultaneously, so baseDir is left
@@ -21,9 +22,22 @@ export default function dependencySatisfies(
 
   let packageName = node.params[0].value;
   let range = node.params[1].value;
+
+  let us = packageCache.ownerOfFile(baseDir || moduleName);
+  if (!us) {
+    return false;
+  }
+
   let pkg;
   try {
-    pkg = config.resolvePackage(baseDir || moduleName, packageName);
-  } catch (err) {}
-  return (pkg && satisfies(pkg.version, range)) || false;
+    pkg = packageCache.resolve(packageName, us);
+  } catch(err) {
+    // it's not an error if we can't resolve it, we just don't satisfy it.
+  }
+
+  if (pkg) {
+    return satisfies(pkg.version, range);
+  } else {
+    return false;
+  }
 }

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -132,14 +132,17 @@ export default class MacrosConfig {
 
   astPlugins(owningPackageRoot?: string): Function[] {
     let self = this;
-    return [makeFirstTransform({
-      // this is deliberately lazy because we want to allow everyone to finish
-      // setting config before we generate the userConfigs
-      get userConfigs() {
-        return self.userConfigs;
-      },
-      baseDir: owningPackageRoot,
-    }), makeSecondTransform()].reverse();
+    return [
+      makeFirstTransform({
+        // this is deliberately lazy because we want to allow everyone to finish
+        // setting config before we generate the userConfigs
+        get userConfigs() {
+          return self.userConfigs;
+        },
+        baseDir: owningPackageRoot,
+      }),
+      makeSecondTransform(),
+    ].reverse();
   }
 
   private mergerFor(pkgRoot: string) {

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -131,7 +131,15 @@ export default class MacrosConfig {
   }
 
   astPlugins(owningPackageRoot?: string): Function[] {
-    return [makeFirstTransform(this, owningPackageRoot), makeSecondTransform()].reverse();
+    let self = this;
+    return [makeFirstTransform({
+      // this is deliberately lazy because we want to allow everyone to finish
+      // setting config before we generate the userConfigs
+      get userConfigs() {
+        return self.userConfigs;
+      },
+      baseDir: owningPackageRoot,
+    }), makeSecondTransform()].reverse();
   }
 
   private mergerFor(pkgRoot: string) {

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -131,9 +131,9 @@ interface AppInfo {
   externals: string[];
   templateCompiler: Function;
   babel: {
-    filename: string,
-    majorVersion: 6 | 7,
-    isParallelSafe: boolean,
+    filename: string;
+    majorVersion: 6 | 7;
+    isParallelSafe: boolean;
   };
   rootURL: string;
 }
@@ -240,6 +240,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
               process.env.JOBS === '1' || !babel.isParallelSafe ? null : 'thread-loader',
               {
                 loader: 'babel-loader', // todo use babel.version to ensure the correct loader
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
                 options: require(join(this.pathToVanillaApp, babel.filename)),
               },
             ].filter(Boolean),

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -130,7 +130,11 @@ interface AppInfo {
   otherAssets: string[];
   externals: string[];
   templateCompiler: Function;
-  babel: any;
+  babel: {
+    filename: string,
+    majorVersion: 6 | 7,
+    isParallelSafe: boolean,
+  };
   rootURL: string;
 }
 
@@ -193,14 +197,9 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
 
     let externals = meta.externals || [];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    let templateCompiler = require(join(this.pathToVanillaApp, meta['template-compiler'])).compile;
+    let templateCompiler = require(join(this.pathToVanillaApp, meta['template-compiler'].filename)).compile;
     let rootURL = meta['root-url'];
-    let babelConfigFile = meta['babel-config'];
-    let babel;
-    if (babelConfigFile) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      babel = require(join(this.pathToVanillaApp, babelConfigFile));
-    }
+    let babel = meta['babel'];
     return { entrypoints, otherAssets, externals, templateCompiler, babel, rootURL };
   }
 
@@ -241,7 +240,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
               process.env.JOBS === '1' || !babel.isParallelSafe ? null : 'thread-loader',
               {
                 loader: 'babel-loader', // todo use babel.version to ensure the correct loader
-                options: Object.assign({}, babel.config),
+                options: require(join(this.pathToVanillaApp, babel.filename)),
               },
             ].filter(Boolean),
           },


### PR DESCRIPTION
This fixes issues in our portable plugin config and restores our support for parallel babel, which broke during one of the previous template compiler refactors.

