### PR TITLE
babel-loader caching and thread-loader warmup

### DIFF
--- a/types/thread-loader/index.d.ts
+++ b/types/thread-loader/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'thread-loader' {
+  export function warmup(options: any, loaders: string[]): void;
+}


### PR DESCRIPTION
This avoids a performance regression for rebuilds when using parallel babel, and it makes babel caching in stage3 work.