### PR TITLE
 implement cacheKeyForTree

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -337,16 +337,8 @@ export default class V1Addon implements V1Package {
     if (typeof this.addonInstance.cacheKeyForTree === 'function') {
       cacheKey = this.addonInstance.cacheKeyForTree(name);
       if (cacheKey) {
-        // why do we add a category? Because we don't actually want to share the
-        // cache with any usage that is inside the traditional addon.js, because
-        // it is caching trees that recurse. Our trees are different. They don't
-        // recurse.
-        //
-        // Similarly, our `invokeOriginalTreeFor` and `stockTree` are different.
-        // `stockTree` is optimized for how we want to consume it, which we can
-        // only do if there's no customized treeFor* implementation.
         cacheKey = cacheKey + category;
-        let cachedTree = this.app.addonTreeCache.getItem(cacheKey);
+        let cachedTree = this.app.addonTreeCache.get(cacheKey);
         if (cachedTree) {
           debug('cache hit %s %s %s', this.name, name, category);
           return cachedTree;
@@ -356,7 +348,7 @@ export default class V1Addon implements V1Package {
     debug('cache miss %s %s %s', this.name, name, category);
     let tree = fn();
     if (tree && cacheKey) {
-      this.app.addonTreeCache.setItem(cacheKey, tree);
+      this.app.addonTreeCache.set(cacheKey, tree);
     }
     return tree;
   }

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -77,6 +77,16 @@ export default class V1App implements V1Package {
     return this.requireFromEmberCLI('./lib/utilities/ember-app-utils');
   }
 
+  @Memoize()
+  get addonTreeCache(): { getItem(key: string): Tree | null; setItem(key: string, value: Tree): void } {
+    return this.requireFromEmberCLI('./lib/models/addon')._treeCache;
+  }
+
+  @Memoize()
+  get preprocessRegistry() {
+    return this.requireFromEmberCLI('ember-cli-preprocess-registry/preprocessors');
+  }
+
   get shouldBuildTests(): boolean {
     return this.app.tests || false;
   }

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -78,8 +78,8 @@ export default class V1App implements V1Package {
   }
 
   @Memoize()
-  get addonTreeCache(): { getItem(key: string): Tree | null; setItem(key: string, value: Tree): void } {
-    return this.requireFromEmberCLI('./lib/models/addon')._treeCache;
+  get addonTreeCache(): Map<string, Tree> {
+    return new Map();
   }
 
   @Memoize()

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -55,7 +55,7 @@ export default class V1InstanceCache {
 
   private addAddon(addonInstance: any) {
     let Klass = this.adapterClass(addonInstance.pkg.name);
-    let v1Addon = new Klass(addonInstance, this.packageCache, this.options);
+    let v1Addon = new Klass(addonInstance, this.packageCache, this.options, this.app);
     let pkgs = this.addons.get(v1Addon.root);
     if (!pkgs) {
       this.addons.set(v1Addon.root, (pkgs = []));


### PR DESCRIPTION
This implements the `cacheKeyForTree` optimization used in stock ember-cli so that we don't rebuild multiple copies of the same addon's trees when that addon is used multiple times. For us it's only relevant in possibly speeding up stage1.

I tested the impact of this in ember-observer and it didn't make a measurable difference. One possible reason is that the trees we are caching here are smaller and simpler -- they don't recurse the way the stock `treeFor()` does.

