### PR TITLE
Fix dummy app and in-repo-addon resolution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,12 +10,7 @@
       "name": "Run tests",
       "program": "${workspaceFolder}/node_modules/.bin/qunit",
       "cwd": "${workspaceFolder}",
-      "args": [
-        "packages/compat/tests",
-        "packages/core/tests",
-        "packages/macros/tests",
-        //"--filter", "acceptsComponentArguments on mustache with component subexpression"
-      ]
+      "args": ["packages/compat/tests", "packages/core/tests", "packages/macros/tests", "--filter", "addon dummy app"]
     },
     {
       "type": "node",
@@ -23,9 +18,7 @@
       "name": "Build macro-tests app",
       "program": "${workspaceFolder}/node_modules/.bin/ember",
       "cwd": "${workspaceFolder}/test-packages/macro-tests",
-      "args": [
-        "build"
-      ],
+      "args": ["build"],
       "env": {
         "JOBS": "1"
       },
@@ -37,12 +30,10 @@
       "name": "Serve macro-tests app",
       "program": "${workspaceFolder}/node_modules/.bin/ember",
       "cwd": "${workspaceFolder}/test-packages/macro-tests",
-      "args": [
-        "s"
-      ],
+      "args": ["s"],
       "env": {
         //"CLASSIC": "true",
-        "JOBS": "1",
+        "JOBS": "1"
       }
     },
     {
@@ -51,11 +42,9 @@
       "name": "Build macro-sample-addon",
       "program": "${workspaceFolder}/node_modules/.bin/ember",
       "cwd": "${workspaceFolder}/test-packages/macro-sample-addon",
-      "args": [
-        "build"
-      ],
+      "args": ["build"],
       "env": {
-        "JOBS": "1",
+        "JOBS": "1"
         //"CLASSIC": "true",
       }
     },
@@ -65,14 +54,12 @@
       "name": "Build static-app",
       "program": "${workspaceFolder}/node_modules/.bin/ember",
       "cwd": "${workspaceFolder}/test-packages/static-app",
-      "args": [
-        "build"
-      ],
+      "args": ["build"],
       "env": {
-        "JOBS": "1",
+        "JOBS": "1"
         //"CLASSIC": "true",
       },
       "outputCapture": "std"
-    },
+    }
   ]
 }

--- a/packages/compat/src/extended-package.ts
+++ b/packages/compat/src/extended-package.ts
@@ -1,0 +1,28 @@
+import { Package, PackageCache } from '@embroider/core';
+import { Memoize } from 'typescript-memoize';
+import cloneDeep from 'lodash/cloneDeep';
+
+export default class ExtendedPackage extends Package {
+  private originalPackage: Package;
+  constructor(root: string, private extraDevDeps: Package[], packageCache: PackageCache) {
+    super(root, true, packageCache);
+    this.originalPackage = packageCache.getApp(root);
+  }
+
+  @Memoize()
+  get packageJSON() {
+    let pkg = cloneDeep(this.originalPackage.packageJSON);
+    if (!pkg.devDependencies) {
+      pkg.devDependencies = {};
+    }
+    for (let dep of this.extraDevDeps) {
+      pkg.devDependencies[dep.name] = dep.version;
+    }
+    return pkg;
+  }
+
+  @Memoize()
+  get dependencies(): Package[] {
+    return this.originalPackage.dependencies.concat(this.extraDevDeps);
+  }
+}

--- a/packages/compat/src/moved-package-cache.ts
+++ b/packages/compat/src/moved-package-cache.ts
@@ -82,7 +82,7 @@ export class MovedPackageCache extends PackageCache {
   }
 
   // hunt for symlinks that may be needed to do node_modules resolution from the
-  // given path, going up a maximum of `depth` levels.
+  // given path.
   async updatePreexistingResolvableSymlinks(): Promise<void> {
     let roots = this.originalRoots();
     await Promise.all(

--- a/packages/compat/tests/stage1-test.ts
+++ b/packages/compat/tests/stage1-test.ts
@@ -62,6 +62,29 @@ QUnit.module('stage1 build', function() {
       addon.linkPackage('ember-cli-htmlbars-inline-precompile');
       addon.linkPackage('@embroider/macros');
 
+      // our app will include an in-repo addon
+      app.pkg['ember-addon'] = {
+        paths: ['lib/in-repo-addon'],
+      };
+      app.files.lib = {
+        'in-repo-addon': {
+          'package.json': JSON.stringify(
+            {
+              name: 'in-repo-addon',
+              keywords: ['ember-addon'],
+            },
+            null,
+            2
+          ),
+          'index.js': `module.exports = { name: 'in-repo-addon' };`,
+          addon: {
+            helpers: {
+              'helper-from-in-repo-addon.js': '',
+            },
+          },
+        },
+      };
+
       app.writeSync();
       let compat = new CompatAddons(emberApp(app.baseDir));
       builder = new Builder(compat.tree);
@@ -131,6 +154,11 @@ QUnit.module('stage1 build', function() {
         /<span>{{macroDependencySatisfies ['"]ember-source['"] ['"]>3['"]}}<\/span>/,
         'template macros have not run'
       );
+    });
+
+    test('in-repo-addon is available', function(assert) {
+      assert.expect(0);
+      resolve.sync('in-repo-addon/helpers/helper-from-in-repo-addon', { basedir: assert.basePath });
     });
   });
 

--- a/test-packages/support/index.ts
+++ b/test-packages/support/index.ts
@@ -1,5 +1,7 @@
 import Project from 'ember-cli/lib/models/project';
 import EmberApp from 'ember-cli/lib/broccoli/ember-app';
+import EmberAddon from 'ember-cli/lib/broccoli/ember-addon';
+
 import { readJSONSync } from 'fs-extra';
 import { join } from 'path';
 import MockUI from 'console-ui/mock';
@@ -31,6 +33,12 @@ export function emberApp(dir: string, userOpts: any = {}): any {
   let cli = new MockCLI();
   let project = new Project(dir, readJSONSync(join(dir, 'package.json')), cli.ui, cli);
   return new EmberApp({ project }, userOpts);
+}
+
+export function emberAddon(dir: string, userOpts: any = {}): any {
+  let cli = new MockCLI();
+  let project = new Project(dir, readJSONSync(join(dir, 'package.json')), cli.ui, cli);
+  return new EmberAddon({ project }, userOpts);
 }
 
 export function runDefault(code: string): any {

--- a/types/ember-cli/index.d.ts
+++ b/types/ember-cli/index.d.ts
@@ -4,6 +4,12 @@ declare module 'ember-cli/lib/broccoli/ember-app' {
   }
 }
 
+declare module 'ember-cli/lib/broccoli/ember-addon' {
+  export default class EmberAddon {
+    constructor(...optLists: any[]);
+  }
+}
+
 declare module 'ember-cli/lib/models/project' {
   export default class Project {
     constructor(root: string, pkg: any, ui: any, cli: any);


### PR DESCRIPTION
Dummy apps and in-repo-addons are quite similar. Both are fake packages with custom behaviors.

In stage1 we compile both to real packages, so there's nothing special about them in core or stage3.