### PR TITLE
Move extra module definitions to start of file

### DIFF
--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -135,12 +135,12 @@ function addExtraImports(path: NodePath<Program>, extraImports: Required<State['
   for (let { absPath, target, runtimeName } of extraImports) {
     if (absPath === path.hub.file.opts.filename) {
       if (runtimeName) {
-        path.node.body.push(
-          importDeclaration([importDefaultSpecifier(identifier(`a${counter}`))], stringLiteral(target))
+        path.node.body.unshift(amdDefine(runtimeName, counter));
+        path.node.body.unshift(
+          importDeclaration([importDefaultSpecifier(identifier(`a${counter++}`))], stringLiteral(target))
         );
-        path.node.body.push(amdDefine(runtimeName, counter++));
       } else {
-        path.node.body.push(importDeclaration([], stringLiteral(target)));
+        path.node.body.unshift(importDeclaration([], stringLiteral(target)));
       }
     }
   }


### PR DESCRIPTION
Semantically, import statements always behave as if they were hoisted to the beginning of the file. So I initially didn't bother putting synthesized ones at the actual beginning, because they would run alongside the other imports anyway.

But our corresponding `window.define()` won't get this automatic behavior, and probably should run first. Also, it's nice even for pure imports to come before all the other preexisting imports.

So this change moves them all to the beginning.