### PR TITLE
fix stage2 externals resolution

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -7,6 +7,7 @@ import { Memoize } from 'typescript-memoize';
 import { writeFileSync, ensureDirSync, copySync, unlinkSync, statSync } from 'fs-extra';
 import { join, dirname, relative } from 'path';
 import { todo, unsupported, debug, warn } from './messages';
+import absolutePackageName from './package-name';
 import cloneDeep from 'lodash/cloneDeep';
 import sortBy from 'lodash/sortBy';
 import flatten from 'lodash/flatten';
@@ -586,7 +587,8 @@ export class AppBuilder<TreeNames> {
         continue;
       }
       for (let name of addon.meta.externals) {
-        if (allAddonNames.has(name)) {
+        let pkgName = absolutePackageName(name);
+        if (pkgName && allAddonNames.has(pkgName)) {
           unsupported(`${addon.name} imports ${name} but does not directly depend on it.`);
         } else {
           externals.add(name);
@@ -595,7 +597,8 @@ export class AppBuilder<TreeNames> {
     }
 
     for (let name of this.adapter.externals()) {
-      if (allAddonNames.has(name)) {
+      let pkgName = absolutePackageName(name);
+      if (pkgName && allAddonNames.has(pkgName)) {
         unsupported(`your app imports ${name} but does not directly depend on it.`);
       } else {
         externals.add(name);


### PR DESCRIPTION
It is somewhat common for apps and/or addons to try to import things from other addons that are not listed in `dependencies` (or for apps, `devDependencies`). As stage1 compiles each package, it will flag these things as `externals`.

Then at stage2, we double-check to see if any of the externals refer to other ember addons that are present in the build. If they do, we remove them from the externals list, and allow them to statically link up.

This PR fixes that linkage so it works for any path imported from an addon (like `@ember-decorators/object/computed`) not just the package's own top level (like `@ember-decorators/object`).