### PR TITLE
Move import adjustments to stage3 babel

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -211,6 +211,10 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     return 'ember-source/vendor/ember/ember-template-compiler';
   }
 
+  strictV2Format() {
+    return false;
+  }
+
   @Memoize()
   private activeRules() {
     return activePackageRules(this.options.packageRules.concat(defaultAddonPackageRules()), [

--- a/packages/compat/src/observe-tree.ts
+++ b/packages/compat/src/observe-tree.ts
@@ -1,16 +1,11 @@
 import { Tree } from 'broccoli-plugin';
 import Funnel from 'broccoli-funnel';
 
-export default class AddToTree extends Funnel {
+export default class ObserveTree extends Funnel {
   constructor(combinedVendor: Tree, private hook: (outputPath: string) => Promise<void> | void) {
     super(combinedVendor, {
-      annotation: '@embroider/compat/synthvendor',
+      annotation: '@embroider/compat/observe-tree',
     });
-  }
-  shouldLinkRoots() {
-    // We want to force funnel to copy things rather than just linking the whole
-    // directory, because we're planning to mutate it.
-    return false;
   }
   async build() {
     await super.build();

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -313,7 +313,7 @@ export default class V1Addon implements V1Package {
       disableEmberModulesAPIPolyfill: true,
     });
 
-    if (version && semver.satisfies(version, '^5')) {
+    if (version && semver.satisfies(semver.coerce(version) || version, '^5')) {
       unsupported(`${this.name} is using babel 5. Not installing our custom plugin.`);
       return;
     }

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -294,8 +294,7 @@ export default class V1Addon implements V1Package {
     let version;
 
     if (emberCLIBabelInstance) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      version = require(join(emberCLIBabelInstance.root, 'package')).version;
+      version = emberCLIBabelInstance.pkg.version;
     }
 
     if (!packageOptions['ember-cli-babel']) {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -20,7 +20,7 @@ import { mergeWithAppend } from './merges';
 import { Package, PackageCache, AddonMeta, TemplateCompiler, debug } from '@embroider/core';
 import Options from './options';
 import walkSync from 'walk-sync';
-import AddToTree from './add-to-tree';
+import ObserveTree from './observe-tree';
 import { Options as HTMLBarsOptions } from 'ember-cli-htmlbars';
 import { isEmbroiderMacrosPlugin } from '@embroider/macros';
 import { TransformOptions, PluginItem } from '@babel/core';
@@ -461,7 +461,7 @@ export default class V1Addon implements V1Package {
     let addonStylesTree = this.addonStylesTree();
     if (addonStylesTree) {
       let discoveredFiles: string[] = [];
-      let tree = new AddToTree(addonStylesTree, outputPath => {
+      let tree = new ObserveTree(addonStylesTree, outputPath => {
         discoveredFiles = readdirSync(outputPath).filter(name => name.endsWith('.css'));
       });
       built.trees.push(tree);
@@ -530,7 +530,7 @@ export default class V1Addon implements V1Package {
         return {};
       }
     });
-    return new AddToTree(tree, (outputPath: string) => {
+    return new ObserveTree(tree, (outputPath: string) => {
       dirExists = pathExistsSync(join(outputPath, appPublicationDir));
     });
   }
@@ -611,7 +611,7 @@ export default class V1Addon implements V1Package {
     }
     if (publicTree) {
       let publicAssets: { [filename: string]: string } = {};
-      publicTree = new AddToTree(publicTree, (outputPath: string) => {
+      publicTree = new ObserveTree(publicTree, (outputPath: string) => {
         publicAssets = {};
         for (let filename of walkSync(join(outputPath, 'public'))) {
           if (!filename.endsWith('/')) {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -25,6 +25,7 @@ import { Options as HTMLBarsOptions } from 'ember-cli-htmlbars';
 import { isEmbroiderMacrosPlugin } from '@embroider/macros';
 import { TransformOptions, PluginItem } from '@babel/core';
 import V1App from './v1-app';
+import { Options as AdjustImportsOptions } from '@embroider/core/src/babel-plugin-adjust-imports';
 
 const stockTreeNames = Object.freeze([
   'addon',
@@ -328,11 +329,12 @@ export default class V1Addon implements V1Package {
       babelConfig.plugins.push(this.templateCompiler.inlineTransformsBabelPlugin());
     }
 
+    let adjustImportsOptions: AdjustImportsOptions = {
+      ownName: this.name,
+    };
     babelConfig.plugins.push([
       require.resolve('@embroider/core/src/babel-plugin-adjust-imports'),
-      {
-        ownName: this.name,
-      },
+      adjustImportsOptions,
     ]);
   }
 

--- a/packages/compat/tests/stage1-test.ts
+++ b/packages/compat/tests/stage1-test.ts
@@ -40,6 +40,14 @@ QUnit.module('stage1 build', function() {
               extra: hbs("<div class={{embroider-sample-transforms-target}}>Extra</div>")
             });
           `,
+          'has-relative-template.js': `
+            import Component from '@ember/component';
+            import layout from './t';
+            export default Component.extend({
+              layout
+            });
+          `,
+          't.hbs': ``,
         },
         templates: {
           components: {
@@ -154,6 +162,11 @@ QUnit.module('stage1 build', function() {
         /<span>{{macroDependencySatisfies ['"]ember-source['"] ['"]>3['"]}}<\/span>/,
         'template macros have not run'
       );
+    });
+
+    test.skip('component with relative import of arbitrarily placed template', function(assert) {
+      let assertFile = assert.file('node_modules/my-addon/components/has-relative-template.js');
+      assertFile.matches(`import layout from './t.hbs'`, 'arbitrary relative template gets hbs extension');
     });
 
     test('in-repo-addon is available', function(assert) {

--- a/packages/compat/tests/stage1-test.ts
+++ b/packages/compat/tests/stage1-test.ts
@@ -40,14 +40,6 @@ QUnit.module('stage1 build', function() {
               extra: hbs("<div class={{embroider-sample-transforms-target}}>Extra</div>")
             });
           `,
-          'has-relative-template.js': `
-            import Component from '@ember/component';
-            import layout from './t';
-            export default Component.extend({
-              layout
-            });
-          `,
-          't.hbs': ``,
         },
         templates: {
           components: {
@@ -61,11 +53,6 @@ QUnit.module('stage1 build', function() {
       addon.files.app = {
         components: {
           'hello-world.js': `export { default } from 'my-addon/components/hello-world'`,
-        },
-        templates: {
-          components: {
-            'direct-template-reexport.js': `export { default } from 'my-addon/templates/components/hello-world';`,
-          },
         },
       };
 
@@ -111,14 +98,8 @@ QUnit.module('stage1 build', function() {
       await builder.cleanup();
     });
 
-    test('component in app tree retains own-name import', function(assert) {
-      let assertFile = assert.file('node_modules/my-addon/_app_/components/hello-world.js');
-      assertFile.matches(/export \{ default \} from ['"']my-addon\/components\/hello-world['"]/);
-    });
-
-    test('component in app tree gets explicit hbs import', function(assert) {
-      let assertFile = assert.file('node_modules/my-addon/_app_/templates/components/direct-template-reexport.js');
-      assertFile.matches(/export \{ default \} from ['"]my-addon\/templates\/components\/hello-world.hbs['"]/);
+    test('component in app tree', function(assert) {
+      assert.file('node_modules/my-addon/_app_/components/hello-world.js').exists();
     });
 
     test('addon metadata', function(assert) {
@@ -139,10 +120,6 @@ QUnit.module('stage1 build', function() {
 
     test('component in addon tree', function(assert) {
       let assertFile = assert.file('node_modules/my-addon/components/hello-world.js');
-      assertFile.matches(
-        /import layout from ['"']\.\.\/templates\/components\/hello-world\.hbs['"]/,
-        `template imports have explicit .hbs extension added`
-      );
       assertFile.matches(`getOwnConfig()`, `JS macros have not run yet`);
       assertFile.matches(`embroider-sample-transforms-result`, `custom babel plugins have run`);
     });
@@ -173,11 +150,6 @@ QUnit.module('stage1 build', function() {
         /<span>{{macroDependencySatisfies ['"]ember-source['"] ['"]>3['"]}}<\/span>/,
         'template macros have not run'
       );
-    });
-
-    test.skip('component with relative import of arbitrarily placed template', function(assert) {
-      let assertFile = assert.file('node_modules/my-addon/components/has-relative-template.js');
-      assertFile.matches(`import layout from './t.hbs'`, 'arbitrary relative template gets hbs extension');
     });
 
     test('in-repo-addon is available', function(assert) {

--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -83,6 +83,11 @@ QUnit.module('stage2 build', function() {
         components: {
           'hello-world.js': `export { default } from 'my-addon/components/hello-world'`,
         },
+        templates: {
+          components: {
+            'direct-template-reexport.js': `export { default } from 'my-addon/templates/components/hello-world';`,
+          },
+        },
       };
       app.writeSync();
       let legacyAppInstance = emberApp(app.baseDir, { tests: false });
@@ -192,6 +197,14 @@ QUnit.module('stage2 build', function() {
       assertFile.matches(
         /export \{ default \} from ['"]my-addon\/components\/hello-world['"]/,
         'retains absolute package name import'
+      );
+    });
+
+    test('app/templates/components/direct-template-reexport.js', function(assert) {
+      let assertFile = assert.file('./templates/components/direct-template-reexport.js').transform(transpile);
+      assertFile.matches(
+        /export \{ default \} from ['"]my-addon\/templates\/components\/hello-world.hbs['"]/,
+        'rewrites absolute imports of templates to explicit hbs'
       );
     });
 

--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -201,9 +201,9 @@ QUnit.module('stage2 build', function() {
       assertFile.matches(/window\.define\(["']\my-app\/templates\/components\/first-choice["']/);
     });
 
-    test.skip('component with relative import of arbitrarily placed template', function(assert) {
+    test('component with relative import of arbitrarily placed template', function(assert) {
       let assertFile = assert.file('node_modules/my-addon/components/has-relative-template.js').transform(transpile);
-      assertFile.matches(`import layout from './t.hbs'`, 'arbitrary relative template gets hbs extension');
+      assertFile.matches(/import layout from ["']\.\/t.hbs['"]/, 'arbitrary relative template gets hbs extension');
     });
   });
 });

--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -61,6 +61,14 @@ QUnit.module('stage2 build', function() {
               layout
             });
           `,
+          'has-relative-template.js': `
+            import Component from '@ember/component';
+            import layout from './t';
+            export default Component.extend({
+              layout
+            });
+          `,
+          't.hbs': ``,
         },
         'synthetic-import-1.js': '',
         templates: {
@@ -181,12 +189,21 @@ QUnit.module('stage2 build', function() {
       let assertFile = assert.file('./components/hello-world.js').transform(transpile);
       assertFile.matches(/import a. from ["']\.\.\/node_modules\/my-addon\/synthetic-import-1/);
       assertFile.matches(/window\.define\(["']my-addon\/synthetic-import-1["']/);
+      assertFile.matches(
+        /export \{ default \} from ['"]my-addon\/components\/hello-world['"]/,
+        'retains absolute package name import'
+      );
     });
 
     test('uses-inline-template.js', function(assert) {
       let assertFile = assert.file('./components/uses-inline-template.js').transform(transpile);
       assertFile.matches(/import a. from ["']\.\.\/templates\/components\/first-choice.hbs/);
       assertFile.matches(/window\.define\(["']\my-app\/templates\/components\/first-choice["']/);
+    });
+
+    test.skip('component with relative import of arbitrarily placed template', function(assert) {
+      let assertFile = assert.file('node_modules/my-addon/components/has-relative-template.js').transform(transpile);
+      assertFile.matches(`import layout from './t.hbs'`, 'arbitrary relative template gets hbs extension');
     });
   });
 });

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -4,6 +4,7 @@ type appRelativeURL = string;
 // This describes the ember-specific parts of package.json of an app after the
 // stage 2 build (the app that we hand off to a packager).
 export interface AppMeta {
+  'auto-upgraded'?: true;
   assets: filename[];
   babel: {
     filename: string;


### PR DESCRIPTION
The main benefit of this switch is that we get to fix up v1 addon imports at a point in time when we have full node_modules resolution of all dependencies already in place. Which means we can reliably detect which imports refer to templates without any heuristics.

It also means we run babel fewer times, because many packages won't need any babel transpilation in stage1 now, because our import adjustment was the only babel plugin involved, and that now runs exclusively in stage3.

This leverages the `auto-updated` flag in the addon package metadata, which is effectively an internal optimization that lets us have a slightly less strict v2 addon format in the output of stage1, which lets us put off some work to stage3 where it can be done better.

Fixes #10.