### PR TITLE
Prevent addonTree from escaping own module namespace

### DIFF
--- a/packages/compat/src/rewrite-addon-tree.ts
+++ b/packages/compat/src/rewrite-addon-tree.ts
@@ -8,8 +8,8 @@ import { pathExistsSync, moveSync } from 'fs-extra';
 import { join } from 'path';
 
 /*
-  The traditional addon-test-support tree allows you to emit modules under any
-  package you feel like. Which we are NOT COOL WITH.
+  The traditional addon and addon-test-support trees allows you to emit modules
+  under any package you feel like. Which we are NOT COOL WITH.
 
   This transform re-captures anything you try to put into other people's
   packages, puts them back into your own, and tracks what renaming is required
@@ -42,7 +42,7 @@ import { join } from 'path';
 
 type GetMeta = () => Partial<AddonMeta>;
 
-export default function rewriteAddonTestSupport(tree: Tree, ownName: string): { tree: Tree; getMeta: GetMeta } {
+export default function rewriteAddonTree(tree: Tree, ownName: string): { tree: Tree; getMeta: GetMeta } {
   let renamed: { [name: string]: string } = {};
 
   let movedIndex = new AddToTree(tree, outputPath => {
@@ -59,12 +59,16 @@ export default function rewriteAddonTestSupport(tree: Tree, ownName: string): { 
       foundBadPaths: (badPaths: string[]) => {
         for (let badPath of badPaths) {
           let name = packageName(badPath)!;
+          if (!name) {
+            throw new Error(`WAT ${badPath}`);
+          }
           renamed[name] = `${ownName}/${name}`;
         }
       },
     },
     {
       srcDir: ownName,
+      allowEmpty: true,
     }
   );
   let badParts = new Funnel(tree, {

--- a/packages/compat/src/snitch.ts
+++ b/packages/compat/src/snitch.ts
@@ -1,4 +1,4 @@
-import Funnel from 'broccoli-funnel';
+import Funnel, { Options as FunnelOptions } from 'broccoli-funnel';
 import walkSync from 'walk-sync';
 import { Tree } from 'broccoli-plugin';
 
@@ -15,7 +15,11 @@ export default class Snitch extends Funnel {
   private foundBadPaths: Function;
   private mustCheck = true;
 
-  constructor(inputTree: Tree, snitchOptions: { allowedPaths: RegExp; foundBadPaths: Function }, funnelOptions: any) {
+  constructor(
+    inputTree: Tree,
+    snitchOptions: { allowedPaths: RegExp; foundBadPaths: Function },
+    funnelOptions: FunnelOptions
+  ) {
     super(inputTree, funnelOptions);
     this.allowedPaths = snitchOptions.allowedPaths;
     this.foundBadPaths = snitchOptions.foundBadPaths;
@@ -25,6 +29,9 @@ export default class Snitch extends Funnel {
     if (this.mustCheck) {
       let badPaths: string[] = [];
       walkSync(this.inputPaths[0], { directories: false }).map(filename => {
+        if (filename === '.gitkeep') {
+          return;
+        }
         if (!this.allowedPaths.test(filename)) {
           badPaths.push(filename);
         }


### PR DESCRIPTION
We already had support for noticing if `treeForAddonTestSupport` was trying to escape its package's own namespace and rewriting it so it doesn't.

Apparently `treeForAddon` can also do that, so this applies the same fix there.

This PR changes the role of MultiFunnel from what it was doing before. Before it was doing two jobs -- handling the possible wrapping `modules` directory, and stripping off the addon's own name directory. Now the addon's own name directory is handled by rewriteAddonTree instead, and MultiFunnel only deals with `modules`.