### PR TITLE
fix externals cache lifetime

### DIFF
--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -190,7 +190,7 @@ QUnit.module('stage2 build', function() {
       assertFile.matches(/import a. from ["']\.\.\/\.\.\/\.\.\/templates\/components\/second-choice\.hbs["']/);
       assertFile.matches(/window\.define\(["']my-app\/templates\/components\/second-choice["']/);
       assertFile.matches(
-        /import somethingExternal from ["']\.\.\/\.\.\/@embroider\/externals\/not-a-resolvable-package["']/,
+        /import somethingExternal from ["'].*\/embroider\/externals\/not-a-resolvable-package["']/,
         'externals are handled correctly'
       );
     });

--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -190,7 +190,7 @@ QUnit.module('stage2 build', function() {
       assertFile.matches(/import a. from ["']\.\.\/\.\.\/\.\.\/templates\/components\/second-choice\.hbs["']/);
       assertFile.matches(/window\.define\(["']my-app\/templates\/components\/second-choice["']/);
       assertFile.matches(
-        /import somethingExternal from ["'].*\/embroider\/externals\/not-a-resolvable-package["']/,
+        /import somethingExternal from ["'].*\/externals\/not-a-resolvable-package["']/,
         'externals are handled correctly'
       );
     });

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -23,6 +23,7 @@ import { TemplateCompilerPlugins } from '.';
 import TemplateCompiler from './template-compiler';
 import { Resolver } from './resolver';
 import { Options as AdjustImportsOptions } from './babel-plugin-adjust-imports';
+import { tmpdir } from 'os';
 
 export type EmberENV = unknown;
 
@@ -322,7 +323,11 @@ export class AppBuilder<TreeNames> {
     let adjustOptions: AdjustImportsOptions = {
       rename,
       extraImports: this.adapter.extraImports(),
-      externalsDir: join(this.root, 'node_modules', '@embroider/externals'),
+
+      // it's important that this is a persistent location, because we fill it
+      // up as a side-effect of babel transpilation, and babel is subject to
+      // persistent caching.
+      externalsDir: join(tmpdir(), 'embroider', 'externals'),
     };
     return [require.resolve('./babel-plugin-adjust-imports'), adjustOptions];
   }

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -242,6 +242,10 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
                 loader: babel.majorVersion === 6 ? 'babel-loader-7' : 'babel-loader-8',
                 // eslint-disable-next-line @typescript-eslint/no-require-imports
                 options: Object.assign({}, require(join(this.pathToVanillaApp, babel.filename)), {
+                  // all stage3 packagers should keep persistent caches under
+                  // `join(tmpdir(), 'embroider')`. An important reason is that
+                  // they should have exactly the same lifetime as some of
+                  // embroider's own caches.
                   cacheDirectory: join(tmpdir(), 'embroider', 'webpack-babel-loader'),
                 }),
               },


### PR DESCRIPTION
We generate our shim externals modules as a side-effect of babel. But that means they need to live as long (on disk) as our persistent babel cache, or we can end up in a state where they are missing.