### PR TITLE
fix resolution from treeForApp files

### DIFF
--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -193,15 +193,15 @@ QUnit.module('stage2 build', function() {
       assertFile.matches(/import a. from ["']\.\.\/node_modules\/my-addon\/synthetic-import-1/);
       assertFile.matches(/window\.define\(["']my-addon\/synthetic-import-1["']/);
       assertFile.matches(
-        /export \{ default \} from ['"]my-addon\/components\/hello-world['"]/,
-        'retains absolute package name import'
+        /export \{ default \} from ['"]\.\.\/node_modules\/my-addon\/components\/hello-world['"]/,
+        'remapped to precise copy of my-addon'
       );
     });
 
     test('app/templates/components/direct-template-reexport.js', function(assert) {
       let assertFile = assert.file('./templates/components/direct-template-reexport.js').transform(build.transpile);
       assertFile.matches(
-        /export \{ default \} from ['"]my-addon\/templates\/components\/hello-world.hbs['"]/,
+        /export \{ default \} from ['"]\.\.\/\.\.\/node_modules\/my-addon\/templates\/components\/hello-world.hbs['"]/,
         'rewrites absolute imports of templates to explicit hbs'
       );
     });

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -40,6 +40,9 @@ interface State {
     activeAddons: {
       [packageName: string]: string;
     };
+    relocatedFiles: {
+      [relativePath: string]: string;
+    };
   };
 }
 
@@ -263,7 +266,7 @@ export default function main({ types: t }: { types: any }) {
           return;
         }
 
-        let file = new AdjustFile(path.hub.file.opts.filename);
+        let file = new AdjustFile(path.hub.file.opts.filename, opts.relocatedFiles);
 
         let specifier = adjustSpecifier(source.value, file, opts);
         specifier = handleExternal(specifier, file, opts);
@@ -306,10 +309,14 @@ function amdDefine(runtimeName: string, importCounter: number) {
 }
 
 class AdjustFile {
-  constructor(public name: string) {}
+  private originalFile: string;
+
+  constructor(public name: string, relocatedFiles: Options['relocatedFiles']) {
+    this.originalFile = relocatedFiles[name] || name;
+  }
 
   @Memoize()
   owningPackage(): Package | undefined {
-    return packageCache.ownerOfFile(this.name);
+    return packageCache.ownerOfFile(this.originalFile);
   }
 }

--- a/test-packages/support/project.ts
+++ b/test-packages/support/project.ts
@@ -234,6 +234,7 @@ export class Project extends FixturifyProject {
           components: {},
         },
       },
+      app: {},
     };
     addon.linkPackage('ember-cli-htmlbars');
     addon.linkPackage('ember-cli-babel');


### PR DESCRIPTION
Fixes #191. This should cause the adjust-imports plugin to always treat files in the app that came from addons as if they were resolving from within their original authored location.