### PR TITLE
Handle appTree relocation for all deps 

### DIFF
--- a/packages/compat/src/dependency-rules.ts
+++ b/packages/compat/src/dependency-rules.ts
@@ -51,6 +51,24 @@ export interface ComponentRules {
   //
   yieldsSafeComponents?: (boolean | { [name: string]: boolean })[];
 
+  // This declares that our component yields some of its arguments unchanged.
+  //
+  // The array corresponds to your yielded positional arguments. Each value can
+  // be:
+  //   false, meaning this yielded value is not one of our arguments
+  //   a string, meaning this yielded value is our argument with that name
+  //   or a POJO, whose individual properties are string naming which arguments
+  //     from whence they came.
+  //
+  // Examples:
+  //
+  //    If you do: {{yield @foo}}
+  //    Then say: yieldsArguments: ['foo']
+  //
+  //    If you do: {{yield (hash x=@foo) }}
+  //    Then say: yieldsArguments: [{ x: 'foo' }]
+  yieldsArguments?: (string | { [name: string]: string })[];
+
   // This declares that our component accepts arguments that will be invoked
   // with the {{component}} helper. This silences warnings in the places where
   // we consume them, while introducing warnings in the places where people are

--- a/packages/compat/src/dependency-rules.ts
+++ b/packages/compat/src/dependency-rules.ts
@@ -131,6 +131,7 @@ type ComponentSnippet = string;
 
 export interface PreprocessedComponentRule {
   yieldsSafeComponents: Required<ComponentRules>['yieldsSafeComponents'];
+  yieldsArguments: Required<ComponentRules>['yieldsArguments'];
   argumentsAreComponents: string[];
   safeInteriorPaths: string[];
 }
@@ -160,6 +161,7 @@ export function preprocessComponentRule(componentRules: ComponentRules): Preproc
     argumentsAreComponents,
     safeInteriorPaths,
     yieldsSafeComponents: componentRules.yieldsSafeComponents || [],
+    yieldsArguments: componentRules.yieldsArguments || [],
   };
 }
 

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -16,20 +16,22 @@ import { Memoize } from 'typescript-memoize';
 import { ResolvedDep } from '@embroider/core/src/resolver';
 import resolve from 'resolve';
 
-type ResolutionResult =
-  | {
-      type: 'component';
-      modules: ResolvedDep[];
-      yieldsComponents: Required<ComponentRules>['yieldsSafeComponents'];
-      yieldsArguments: Required<ComponentRules>['yieldsArguments'];
-      argumentsAreComponents: string[];
-    }
-  | {
-      type: 'helper';
-      modules: ResolvedDep[];
-    };
+export interface ComponentResolution {
+  type: 'component';
+  modules: ResolvedDep[];
+  yieldsComponents: Required<ComponentRules>['yieldsSafeComponents'];
+  yieldsArguments: Required<ComponentRules>['yieldsArguments'];
+  argumentsAreComponents: string[];
+}
 
-interface ResolutionFail {
+export interface HelperResolution {
+  type: 'helper';
+  modules: ResolvedDep[];
+}
+
+export type ResolutionResult = ComponentResolution | HelperResolution;
+
+export interface ResolutionFail {
   type: 'error';
   hardFail: boolean;
   message: string;

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -21,6 +21,7 @@ type ResolutionResult =
       type: 'component';
       modules: ResolvedDep[];
       yieldsComponents: Required<ComponentRules>['yieldsSafeComponents'];
+      yieldsArguments: Required<ComponentRules>['yieldsArguments'];
       argumentsAreComponents: string[];
     }
   | {
@@ -324,6 +325,7 @@ export default class CompatResolver implements Resolver {
           runtimeName: p.runtimeName,
         })),
         yieldsComponents: componentRules ? componentRules.yieldsSafeComponents : [],
+        yieldsArguments: componentRules ? componentRules.yieldsArguments : [],
         argumentsAreComponents: componentRules ? componentRules.argumentsAreComponents : [],
       };
     }

--- a/packages/compat/tests/renaming-tests.ts
+++ b/packages/compat/tests/renaming-tests.ts
@@ -82,7 +82,13 @@ QUnit.module('renaming tests', function(origHooks) {
     (firstAddonWithAppTreeImport.files.app as Project['files'])[
       'first.js'
     ] = `export { default } from 'has-app-tree-import';`;
+    (firstAddonWithAppTreeImport.files.app as Project['files'])[
+      'imports-dep.js'
+    ] = `export { default } from 'inner-dep';`;
     (firstAddonWithAppTreeImport.files.addon as Project['files'])['index.js'] = `export default "first-copy";`;
+
+    let innerDep = firstAddonWithAppTreeImport.addAddon('inner-dep');
+    (innerDep.files.addon as Project['files'])['index.js'] = `export default "inner-dep";`;
 
     let secondAddonWithAppTreeImport = app.addAddon('intermediate').addAddon('has-app-tree-import');
     (secondAddonWithAppTreeImport.files.app as Project['files'])[
@@ -166,6 +172,12 @@ QUnit.module('renaming tests', function(origHooks) {
     assertFile = assert.file('second.js').transform(build.transpile);
     assertFile.matches(
       /export \{ default \} from ['"]\.\/node_modules\/intermediate\/node_modules\/has-app-tree-import['"]/
+    );
+  });
+  test(`files copied into app from addons resolve the addon's deps`, function(assert) {
+    let assertFile = assert.file('imports-dep.js').transform(build.transpile);
+    assertFile.matches(
+      /export \{ default \} from ['"]\.\/node_modules\/has-app-tree-import\/node_modules\/inner-dep['"]/
     );
   });
 });

--- a/packages/compat/tests/resolver-test.ts
+++ b/packages/compat/tests/resolver-test.ts
@@ -9,7 +9,7 @@ import { emberTemplateCompilerPath } from '@embroider/test-support';
 import Resolver from '../src/resolver';
 import { PackageRules } from '../src';
 
-const { test, skip } = QUnit;
+const { test } = QUnit;
 const compilerPath = emberTemplateCompilerPath();
 
 QUnit.module('compat-resolver', function(hooks) {
@@ -989,7 +989,7 @@ QUnit.module('compat-resolver', function(hooks) {
     ]);
   });
 
-  skip('respects yieldsArguments rule for positional block param, angle', function(assert) {
+  test('respects yieldsArguments rule for positional block param, angle', function(assert) {
     let packageRules: PackageRules[] = [
       {
         package: 'the-test-package',
@@ -1015,18 +1015,18 @@ QUnit.module('compat-resolver', function(hooks) {
       ),
       [
         {
-          path: './form-builder.hbs',
-          runtimeName: 'the-app/templates/components/form-builder',
-        },
-        {
           path: './fancy-navbar.hbs',
           runtimeName: 'the-app/templates/components/fancy-navbar',
+        },
+        {
+          path: './form-builder.hbs',
+          runtimeName: 'the-app/templates/components/form-builder',
         },
       ]
     );
   });
 
-  skip('respects yieldsArguments rule for positional block param, curly', function(assert) {
+  test('respects yieldsArguments rule for positional block param, curly', function(assert) {
     let packageRules: PackageRules[] = [
       {
         package: 'the-test-package',
@@ -1052,18 +1052,18 @@ QUnit.module('compat-resolver', function(hooks) {
       ),
       [
         {
-          path: './form-builder.hbs',
-          runtimeName: 'the-app/templates/components/form-builder',
-        },
-        {
           path: './fancy-navbar.hbs',
           runtimeName: 'the-app/templates/components/fancy-navbar',
+        },
+        {
+          path: './form-builder.hbs',
+          runtimeName: 'the-app/templates/components/form-builder',
         },
       ]
     );
   });
 
-  skip('respects yieldsArguments rule for hash block param', function(assert) {
+  test('respects yieldsArguments rule for hash block param', function(assert) {
     let packageRules: PackageRules[] = [
       {
         package: 'the-test-package',
@@ -1089,18 +1089,18 @@ QUnit.module('compat-resolver', function(hooks) {
       ),
       [
         {
-          path: './form-builder.hbs',
-          runtimeName: 'the-app/templates/components/form-builder',
-        },
-        {
           path: './fancy-navbar.hbs',
           runtimeName: 'the-app/templates/components/fancy-navbar',
+        },
+        {
+          path: './form-builder.hbs',
+          runtimeName: 'the-app/templates/components/form-builder',
         },
       ]
     );
   });
 
-  skip('yieldsArguments causes warning to propagate up lexically, angle', function(assert) {
+  test('yieldsArguments causes warning to propagate up lexically, angle', function(assert) {
     let packageRules: PackageRules[] = [
       {
         package: 'the-test-package',
@@ -1134,7 +1134,7 @@ QUnit.module('compat-resolver', function(hooks) {
     });
   });
 
-  skip('yieldsArguments causes warning to propagate up lexically, curl', function(assert) {
+  test('yieldsArguments causes warning to propagate up lexically, curl', function(assert) {
     let packageRules: PackageRules[] = [
       {
         package: 'the-test-package',
@@ -1155,6 +1155,42 @@ QUnit.module('compat-resolver', function(hooks) {
           `
           {{#form-builder navbar=this.unknown as |bar|}}
             {{component bar}}
+          {{/form-builder}}
+          `
+        ),
+        [
+          {
+            path: './form-builder.hbs',
+            runtimeName: 'the-app/templates/components/form-builder',
+          },
+        ]
+      );
+    });
+  });
+
+  test('yieldsArguments causes warning to propagate up lexically, multiple levels', function(assert) {
+    let packageRules: PackageRules[] = [
+      {
+        package: 'the-test-package',
+        components: {
+          '<FormBuilder />': {
+            yieldsArguments: ['navbar'],
+          },
+        },
+      },
+    ];
+    let findDependencies = configure({ staticComponents: true, packageRules });
+    givenFile('templates/components/form-builder.hbs');
+
+    assertWarning(/ignoring dynamic component this\.unknown/, () => {
+      assert.deepEqual(
+        findDependencies(
+          'templates/components/x.hbs',
+          `
+          {{#form-builder navbar=this.unknown as |bar1|}}
+            {{#form-builder navbar=bar1 as |bar2|}}
+              {{component bar2}}
+            {{/form-builder}}
           {{/form-builder}}
           `
         ),

--- a/test-packages/node.test.js
+++ b/test-packages/node.test.js
@@ -1,7 +1,7 @@
 const execa = require('execa');
 
 test('node', async () => {
-  jest.setTimeout(60000);
+  jest.setTimeout(1200000);
 
   await execa('yarn', ['node-test'], {
     cwd: `${__dirname}/..`,


### PR DESCRIPTION
PR #207 implemented support for resolving a package's own name correctly out of its treeForApp, but not for resolving all its other dependencies.

This implements the rest.
