### PR TITLE
[fixes #216] upgrade to latest babel-plugin-ember-modules-api-polyfill

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -44,7 +44,7 @@
     "assert-never": "^1.1.0",
     "babel-core": "^6.26.3",
     "babel-plugin-debug-macros": "^0.3.0",
-    "babel-plugin-ember-modules-api-polyfill": "git+https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill#d0c7772bc9f995f83641a4292afd5e05e7e9bbba",
+    "babel-plugin-ember-modules-api-polyfill": "^2.9.0",
     "babylon": "^6.18.0",
     "broccoli": "^2.2.0",
     "broccoli-funnel": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,11 +2425,12 @@ babel-plugin-ember-modules-api-polyfill@^2.8.0:
   dependencies:
     ember-rfc176-data "^0.3.8"
 
-"babel-plugin-ember-modules-api-polyfill@git+https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill#d0c7772bc9f995f83641a4292afd5e05e7e9bbba":
-  version "2.6.0"
-  resolved "git+https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill#d0c7772bc9f995f83641a4292afd5e05e7e9bbba"
+babel-plugin-ember-modules-api-polyfill@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
+  integrity sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==
   dependencies:
-    ember-rfc176-data "^0.3.6"
+    ember-rfc176-data "^0.3.9"
 
 babel-plugin-feature-flags@^0.3.1:
   version "0.3.1"
@@ -5770,15 +5771,15 @@ ember-rfc176-data@^0.3.5, ember-rfc176-data@^0.3.7:
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.7.tgz#ecff7d74987d09296d3703343fed934515a4be33"
   integrity sha512-AbTlD+q7sfyrD4diZqE7r9Y9/Je+HntVn7TlpHAe+nP5BNXxUXJIfDs5w5e3MxPcMs6Dz/yY90YfW8h1oKEvGg==
 
-ember-rfc176-data@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.6.tgz#7138db8dfccec39c9a832adfbd4c49d670028907"
-  integrity sha512-kPY94VCukPUPj+/6sZ9KvphD42KnpX2IS31p5z07OFVIviDogR0cQuld5c7Irzfgq7a0YACj0HlToROFn7dLYQ==
-
 ember-rfc176-data@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.8.tgz#d46bbef9a0d57c803217b258cfd2e90d8e191848"
   integrity sha512-SQup3iG7SDLZNuf7nMMx5BC5truO8AYKRi80gApeQ07NsbuXV4LH75i5eOaxF0i8l9+H1tzv34kGe6rEh0C1NQ==
+
+ember-rfc176-data@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz#44b6e051ead6c044ea87bd551f402e2cf89a7e3d"
+  integrity sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q==
 
 ember-router-generator@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Which, according to https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/commit/d0c7772bc9f995f83641a4292afd5e05e7e9bbba, includes the fix we pinned too earlier