### PR TITLE
AMD followup

### DIFF
--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -67,7 +67,17 @@ export function isDefineExpression(t: any, path: any) {
   );
 }
 
-function adjustSpecifier(specifier: string, sourceFile: AdjustFile, opts: State['opts']) {
+function adjustSpecifier(specifier: string, file: AdjustFile, opts: Options) {
+  specifier = handleRenaming(specifier, file, opts);
+  specifier = handleExternal(specifier, file, opts);
+  if (file.isRelocated) {
+    specifier = handleRelocation(specifier, file);
+  }
+  specifier = makeHBSExplicit(specifier, file);
+  return specifier;
+}
+
+function handleRenaming(specifier: string, sourceFile: AdjustFile, opts: State['opts']) {
   let packageName = getPackageName(specifier);
   if (!packageName) {
     return specifier;
@@ -300,11 +310,7 @@ export default function main({ types: t }: { types: any }) {
           t.assertStringLiteral(source);
 
           let specifier = adjustSpecifier(source.value, state.adjustFile, opts);
-          specifier = handleExternal(specifier, state.adjustFile, opts);
-          if (state.adjustFile.isRelocated) {
-            specifier = handleRelocation(specifier, state.adjustFile);
-          }
-          specifier = makeHBSExplicit(specifier, state.adjustFile);
+
           if (specifier !== source.value) {
             source.value = specifier;
           }
@@ -328,11 +334,6 @@ export default function main({ types: t }: { types: any }) {
         }
 
         let specifier = adjustSpecifier(source.value, state.adjustFile, opts);
-        specifier = handleExternal(specifier, state.adjustFile, opts);
-        if (state.adjustFile.isRelocated) {
-          specifier = handleRelocation(specifier, state.adjustFile);
-        }
-        specifier = makeHBSExplicit(specifier, state.adjustFile);
         if (specifier !== source.value) {
           emberCLIVanillaJobs.push(() => (source.value = specifier));
         }

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -295,6 +295,16 @@ export default function main({ types: t }: { types: any }) {
         if (isDefineExpression(t, path) === false) {
           return;
         }
+
+        let pkg = state.adjustFile.owningPackage();
+        if (pkg && pkg.isV2Ember() && !pkg.meta['auto-upgraded']) {
+          throw new Error(
+            `The file ${state.adjustFile.originalFile} in package ${
+              pkg.name
+            } tried to use AMD define. Native V2 Ember addons are forbidden from using AMD define, they must use ECMA export only.`
+          );
+        }
+
         let { opts } = state;
 
         const dependencies = path.node.arguments[1];
@@ -372,7 +382,7 @@ function amdDefine(runtimeName: string, importCounter: number) {
 }
 
 class AdjustFile {
-  private originalFile: string;
+  readonly originalFile: string;
 
   constructor(public name: string, relocatedFiles: Options['relocatedFiles']) {
     this.originalFile = relocatedFiles[name] || name;


### PR DESCRIPTION
 - improve shared caching of per-file information in babel-plugin-adjust-imports
 - factored shared `adjustImports` logic into one place so it's less likely to diverge in the future
 - added a hard error if a native V2 package tries to give us AMD
