### PR TITLE
importSync macro

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -881,16 +881,16 @@ export class AppBuilder<TreeNames> {
 }
 
 const entryTemplate = compile(`
-import { require as r } from '@embroider/core';
+import { importSync as i } from '@embroider/macros';
 let w = window;
 let d = w.define;
 
 {{#each amdModules as |amdModule| ~}}
-  d("{{js-string-escape amdModule.runtime}}", function(){ return r("{{js-string-escape amdModule.buildtime}}");});
+  d("{{js-string-escape amdModule.runtime}}", function(){ return i("{{js-string-escape amdModule.buildtime}}").default;});
 {{/each}}
 
 {{#each eagerModules as |eagerModule| ~}}
-  r("{{js-string-escape eagerModule}}");
+  i("{{js-string-escape eagerModule}}");
 {{/each}}
 
 {{#if lazyRoutes}}
@@ -907,7 +907,7 @@ let d = w.define;
 {{/if}}
 
 {{#if autoRun ~}}
-  r("{{js-string-escape mainModule}}").default.create({{{json-stringify appConfig}}});
+  i("{{js-string-escape mainModule}}").default.create({{{json-stringify appConfig}}});
 {{/if}}
 
 {{#if testSuffix ~}}
@@ -921,7 +921,7 @@ let d = w.define;
   }
 
   {{!- this is the traditional tests-suffix.js -}}
-  r('../tests/test-helper');
+  i('../tests/test-helper');
   EmberENV.TESTS_FILE_LOADED = true;
 {{/if}}
 `) as (params: {
@@ -935,10 +935,10 @@ let d = w.define;
 }) => string;
 
 const routeEntryTemplate = compile(`
-import { require as r } from '@embroider/core';
+import { importSync as i } from '@embroider/macros';
 let d = window.define;
 {{#each files as |amdModule| ~}}
-d("{{js-string-escape amdModule.runtime}}", function(){ return r("{{js-string-escape amdModule.buildtime}}");});
+d("{{js-string-escape amdModule.runtime}}", function(){ return i("{{js-string-escape amdModule.buildtime}}").default;});
 {{/each}}
 `) as (params: { files: { runtime: string; buildtime: string }[] }) => string;
 

--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -12,197 +12,188 @@ This package works in both Embroider builds and normal ember-cli builds, so that
 
 ## Javascript macros
 
- - `getOwnConfig()`: a macro that returns arbitrary JSON-serializable configuration that was sent to your package. See "Setting Configuration" for how to get configuration in.
+- `getOwnConfig()`: a macro that returns arbitrary JSON-serializable configuration that was sent to your package. See "Setting Configuration" for how to get configuration in.
 
-    Assuming a config of `{ flavor: 'chocolate' }`, this code:
+  Assuming a config of `{ flavor: 'chocolate' }`, this code:
 
-    ```js
-    import { getOwnConfig } from '@embroider/macros';
-    console.log(getOwnConfig().flavor);
-    ```
+  ```js
+  import { getOwnConfig } from '@embroider/macros';
+  console.log(getOwnConfig().flavor);
+  ```
 
-    Compiles to:
+  Compiles to:
 
-    ```js
-    console.log({ "flavor": "chocolate" }.flavor);
-    ```
+  ```js
+  console.log({ flavor: 'chocolate' }.flavor);
+  ```
 
- - `getConfig(packageName)`: like `getOwnConfig`, but will retrieve the configuration that was sent to another package. We will resolve which one based on node_modules resolution rules from your package.
+- `getConfig(packageName)`: like `getOwnConfig`, but will retrieve the configuration that was sent to another package. We will resolve which one based on node_modules resolution rules from your package.
 
- - `dependencySatisfies(packagename, semverRange)`: a macro that compiles to a boolean literal. It will be true if the given package can be resolved (via normal node_modules resolution rules) and meets the stated semver requirement. The package version will be `semver.coerce()`'d first, such that nonstandard versions like "3.9.0-beta.0" will appropriately satisfy constraints like "> 3.8".
+- `dependencySatisfies(packagename, semverRange)`: a macro that compiles to a boolean literal. It will be true if the given package can be resolved (via normal node_modules resolution rules) and meets the stated semver requirement. The package version will be `semver.coerce()`'d first, such that nonstandard versions like "3.9.0-beta.0" will appropriately satisfy constraints like "> 3.8".
 
-    Assuming you have `ember-source` 3.9.0 available, this code:
+  Assuming you have `ember-source` 3.9.0 available, this code:
 
-    ```js
-    import { dependencySatisfies } from '@embroider/macros';
-    let hasNativeArrayHelper = dependencySatisfies('ember-source', '>=3.8.0');
-    ```
+  ```js
+  import { dependencySatisfies } from '@embroider/macros';
+  let hasNativeArrayHelper = dependencySatisfies('ember-source', '>=3.8.0');
+  ```
 
-    Compiles to:
+  Compiles to:
 
-    ```js
-    let hasNativeArrayHelper = true;
-    ```
+  ```js
+  let hasNativeArrayHelper = true;
+  ```
 
+* `macroIf(predicate, consequent, alternate)`: a compile time conditional. Lets you choose between two blocks of code and only include one of them. Critically, it will also strip import statements that are used only inside the dead block. The predicate is usually one of the other macros.
 
-- `macroIf(predicate, consequent, alternate)`: a compile time conditional. Lets you choose between two blocks of code and only include one of them. Critically, it will also strip import statements that are used only inside the dead block. The predicate is usually one of the other macros.
+  This code:
 
-    This code:
+  ```js
+  import { dependencySatisfies, macroIf } from '@embroider/macros';
+  import OldComponent from './old-component';
+  import NewComponent from './new-component';
+  export default macroIf(dependencySatisfies('ember-source', '>=3.8.0'), () => NewComponent, () => OldComponent);
+  ```
 
-    ```js
-    import { dependencySatisfies, macroIf } from '@embroider/macros';
-    import OldComponent from './old-component';
-    import NewComponent from './new-component';
-    export default macroIf(
-      dependencySatisfies('ember-source', '>=3.8.0'),
-      () => NewComponent,
-      () => OldComponent,
-    );
-    ```
+  Will compile to either this:
 
-    Will compile to either this:
+  ```js
+  import NewComponent from './new-component';
+  export default NewComponent;
+  ```
 
-    ```js
-    import NewComponent from './new-component';
-    export default NewComponent;
-    ```
+  Or this:
 
-    Or this:
+  ```js
+  import OldComponent from './old-component';
+  export default OldComponent;
+  ```
 
-    ```js
-    import OldComponent from './old-component';
-    export default OldComponent;
-    ```
-
-- `failBuild(message, ...params)`: cause a compile-time build failure. Generally only useful if you put it inside a `macroIf`. All the arguments must be statically analyzable, and they get passed to Node's standard `utils.format()`.
+* `failBuild(message, ...params)`: cause a compile-time build failure. Generally only useful if you put it inside a `macroIf`. All the arguments must be statically analyzable, and they get passed to Node's standard `utils.format()`.
 
   ```js
   import { macroIf, failBuild, dependencySatisfies } from '@embroider/macros';
   macroIf(
     dependencySatisfies('ember-source', '>=3.8.0'),
     () => true,
-    () => failBuild("You need to have ember-source >= 3.8.0")
+    () => failBuild('You need to have ember-source >= 3.8.0')
   );
   ```
 
+* `importSync(moduleSpecifier)`: exactly like standard ECMA `import()` except instead of returning `Promise<Module>` it returns `Module`. Under Emroider this is interpreted at build-time. Under classic ember-cli it is interpreted at runtime. This exists to provide synchronous & dynamic import. That's not a think ECMA supports, but it's a thing Ember historically has done, so we sometimes need this macro to bridge the worlds.
 
 ## Template macros
 
 These are analogous to the Javascript macros, although here (because we don't import them) they are all prefixed with "macro".
 
- - `macroGetOwnConfig`: works like a helper that pulls values out of your config. For example, assuming you have the config:
+- `macroGetOwnConfig`: works like a helper that pulls values out of your config. For example, assuming you have the config:
 
-   ```json
-   {
-     "items": [
-      { "score": 42 }
-    ]
-   }
-   ```
+  ```json
+  {
+    "items": [{ "score": 42 }]
+  }
+  ```
 
-    Then:
+  Then:
 
-   ```hbs
-   <SomeComponent @score={{macroGetOwnConfig "items" "0" "score" }} />
-   {{! ⬆️compiles to ⬇️ }}
-   <SomeComponent @score={{42}} />
-   ```
+  ```hbs
+  <SomeComponent @score={{macroGetOwnConfig "items" "0" "score" }} />
+  {{! ⬆️compiles to ⬇️ }}
+  <SomeComponent @score={{42}} />
+  ```
 
-    If you don't pass any keys, you can get the whole thing (although this makes your template bigger, so use keys when you can):
+  If you don't pass any keys, you can get the whole thing (although this makes your template bigger, so use keys when you can):
 
-   ```hbs
-   <SomeComponent @config={{macroGetOwnConfig}} />
-   {{! ⬆️compiles to ⬇️ }}
-   <SomeComponent @config={{hash items=(array (hash score=42))}} />
-   ```
+  ```hbs
+  <SomeComponent @config={{macroGetOwnConfig}} />
+  {{! ⬆️compiles to ⬇️ }}
+  <SomeComponent @config={{hash items=(array (hash score=42))}} />
+  ```
 
+* `macroGetConfig`: similar to `macroGetOwnConfig`, but takes the name of another package and gets that package's config. We will locate the other package following node_modules rules from your package. Additional extra arguments are treated as property keys just like in the previous examples.
 
- - `macroGetConfig`: similar to `macroGetOwnConfig`, but takes the name of another package and gets that package's config. We will locate the other package following node_modules rules from your package. Additional extra arguments are treated as property keys just like in the previous examples.
+  ```hbs
+  <SomeComponent @config={{macroGetConfig "liquid-fire"}} />
+  ```
 
-   ```hbs
-   <SomeComponent @config={{macroGetConfig "liquid-fire"}} />
-   ```
+* `macroDependencySatisfies`
 
- - `macroDependencySatisfies`
+  ```hbs
+  <SomeComponent @canAnimate={{macroDependencySatisfies "liquid-fire" "*"}} />
+  {{! ⬆️compiles to ⬇️ }}
+  <SomeComponent @canAnimate={{true}} />
+  ```
 
-   ```hbs
-   <SomeComponent @canAnimate={{macroDependencySatisfies "liquid-fire" "*"}} />
-   {{! ⬆️compiles to ⬇️ }}
-   <SomeComponent @canAnimate={{true}} />
-   ```
+* `macroIf`: Like Ember's own `if`, this can be used in both block form and expresion form. The block form looks like:
 
- - `macroIf`: Like Ember's own `if`, this can be used in both block form and expresion form. The block form looks like:
+  ```hbs
+  {{#macroIf (macroGetOwnConfig "shouldUseThing") }}
+    <Thing />
+  {{else}}
+    <OtherThing />
+  {{/macroIf}}
 
-   ```hbs
-   {{#macroIf (macroGetOwnConfig "shouldUseThing") }}
-     <Thing />
-   {{else}}
-     <OtherThing />
-   {{/macroIf}}
+  {{! ⬆️compiles to ⬇️ }}
+  <Thing />
+  ```
 
-   {{! ⬆️compiles to ⬇️ }}
-   <Thing />
-   ```
+  The expression form looks like:
 
-   The expression form looks like:
+  ```hbs
+  <div class="box {{macroIf (macroGetOwnConfig "extraModeEnabled") extraClass regularClass}}" />
+  {{! ⬆️compiles to ⬇️ }}
+  <div class="box {{extraClass}}"/>
+  ```
 
-   ```hbs
-   <div class="box {{macroIf (macroGetOwnConfig "extraModeEnabled") extraClass regularClass}}" />
-   {{! ⬆️compiles to ⬇️ }}
-   <div class="box {{extraClass}}"/>
-   ```
+- `macroMaybeAttrs`: This macro allows you to include or strip HTML attributes themselves (not just change their values). It works like an element modifier:
 
+  ```hbs
+  <div {{macroMaybeAttr (macroGetConfig "ember-test-selectors" "enabled") data-test-here data-test-there=42}} >
+  {{! ⬆️compiles to either this ⬇️ }}
+  <div data-test-here data-test-there=42 >
+  {{! or this ⬇️ }}
+  <div>
+  ```
 
- - `macroMaybeAttrs`: This macro allows you to include or strip HTML attributes themselves (not just change their values). It works like an element modifier:
+- `macroFailBuild`: cause a compile-time build failure. Generally only useful if you put it inside a `macroIf`. All the arguments must be statically analyzable, and they get passed to Node's standard `utils.format()`.
 
-   ```hbs
-   <div {{macroMaybeAttr (macroGetConfig "ember-test-selectors" "enabled") data-test-here data-test-there=42}} >
-   {{! ⬆️compiles to either this ⬇️ }}
-   <div data-test-here data-test-there=42 >
-   {{! or this ⬇️ }}
-   <div>
-   ```
-
- - `macroFailBuild`: cause a compile-time build failure. Generally only useful if you put it inside a `macroIf`. All the arguments must be statically analyzable, and they get passed to Node's standard `utils.format()`.
-
-    ```hbs
-    {{#macroIf (dependencySatisfies "important-thing" ">= 1.0")}}
-      <UseThing />
-    {{else}}
-      {{macroFailBuild "You need to have import-thing >= 1.0"}}
-    {{/macroIf}}
-    ```
-
+  ```hbs
+  {{#macroIf (dependencySatisfies "important-thing" ">= 1.0")}}
+    <UseThing />
+  {{else}}
+    {{macroFailBuild "You need to have import-thing >= 1.0"}}
+  {{/macroIf}}
+  ```
 
 ## Setting Configuration: from an Ember app
 
 1. Add `@embroider/macros` as `devDependency`.
 2. In `ember-cli-build.js`, do:
 
-    ```js
-    let app = new EmberApp(defaults, {
-    '@embroider/macros': {
-      // this is how you configure your own package
-      setOwnConfig: {
-        // your config goes here
-      },
-      // this is how you can optionally send configuration into your
-      // dependencies, if those dependencies choose to use
-      // @embroider/macros configs.
-      setConfig: {
-        'some-dependency': {
-          // config for some-dependency
-        }
-      }
-    }
-    ```
+   ```js
+   let app = new EmberApp(defaults, {
+   '@embroider/macros': {
+     // this is how you configure your own package
+     setOwnConfig: {
+       // your config goes here
+     },
+     // this is how you can optionally send configuration into your
+     // dependencies, if those dependencies choose to use
+     // @embroider/macros configs.
+     setConfig: {
+       'some-dependency': {
+         // config for some-dependency
+       }
+     }
+   }
+   ```
 
 ## Setting Configuration: from an Ember Addon
 
 1. Add `@embroider/macros` as `dependency`.
 2. In `index.js`, do:
 
-    ```js
+   ```js
    module.exports = {
      name: require('./package').name,
      options: {
@@ -213,14 +204,12 @@ These are analogous to the Javascript macros, although here (because we don't im
          setConfig: {
            'some-dependency': {
              // config for some-dependency
-           }
-         }
-       }
-     }
+           },
+         },
+       },
+     },
    };
-
-    ```
-
+   ```
 
 ## Setting Configuration: Low Level API
 
@@ -230,6 +219,8 @@ Configuration gets set during the build process, from within Node.
 
 The entrypoints to the low level API are:
 
- - `import { MacrosConfig } from '@embroider/macros'`: constructs the shared global object that stores config. It has methods for setting configuration and for retrieving the necessary Babel and HTMLBars plugins that will implment the config. See `macros-config.ts` for details.
+- `import { MacrosConfig } from '@embroider/macros'`: constructs the shared global object that stores config. It has methods for setting configuration and for retrieving the necessary Babel and HTMLBars plugins that will implment the config. See `macros-config.ts` for details.
+
+```
 
 ```

--- a/packages/macros/src/babel/state.ts
+++ b/packages/macros/src/babel/state.ts
@@ -1,8 +1,9 @@
-import { NodePath } from '@babel/traverse';
+import { NodePath, Node } from '@babel/traverse';
 
 export default interface State {
   removed: NodePath[];
   pendingTasks: (() => void)[];
+  generatedRequires: Set<Node>;
   opts: {
     userConfigs: {
       [pkgRoot: string]: unknown;

--- a/packages/macros/tests/babel/import-sync.test.ts
+++ b/packages/macros/tests/babel/import-sync.test.ts
@@ -1,0 +1,34 @@
+import { allBabelVersions } from './helpers';
+
+describe('importSync', function() {
+  allBabelVersions(function createTests(transform: (code: string) => string) {
+    test('importSync becomes require', () => {
+      let code = transform(`
+      import { importSync } from '@embroider/macros';
+      importSync('foo');
+      `);
+      expect(code).toMatch(/require\(['"]foo['"]\)/);
+      expect(code).not.toMatch(/window/);
+    });
+    test('aliased importSync becomes require', () => {
+      let code = transform(`
+      import { importSync as i } from '@embroider/macros';
+      i('foo');
+      `);
+      expect(code).toMatch(/require\(['"]foo['"]\)/);
+      expect(code).not.toMatch(/window/);
+    });
+    test('import of importSync itself gets removed', () => {
+      let code = transform(`
+      import { importSync } from '@embroider/macros';
+      `);
+      expect(code).toEqual('');
+    });
+    test('require becomes window.require', () => {
+      let code = transform(`
+      require('foo');
+      `);
+      expect(code).toMatch(/window\.require\(['"]foo['"]\)/);
+    });
+  });
+});


### PR DESCRIPTION
This replaces the previous `import { require } from '@embroider/core'` macro that was internal-only.

`importSync` is intended to be a public macro.

Ember itself really already needs synchronous dynamic imports to exists, so we're not really imposing any extra burden on ourselves by making this a public macro. And making it public helps with #150 because we'll be able to implement conditional imports like:

```js
import { getOwnConfig, importSync } from '@embroider/macros';
let implementation;
if (getOwnConfig().classicMode) {
  implementation = importSync('./classic-mode');  
} else {
  implementation = importSync('./new-mode');
}
export const Thing = implementation.default;
```

Without waiting for ecosystem tooling that supports the more standards-track version that uses top-level await:

```js
import { getOwnConfig } from '@embroider/macros';
let implementation;
if (getOwnConfig().classicMode) {
  implementation = await import('./classic-mode');  
} else {
  implementation = await import('./new-mode');
}
export const Thing = implementation.default;
```

