### PR TITLE
Remove bad `only`

### DIFF
--- a/packages/core/tests/babel-plugin-adjust-imports-test.ts
+++ b/packages/core/tests/babel-plugin-adjust-imports-test.ts
@@ -1,9 +1,8 @@
 import 'qunit';
 import main, { isDefineExpression, Options as AdjustImportsOptions } from '../src/babel-plugin-adjust-imports';
-import Types from '@babel/types';
 import { transformSync } from '@babel/core';
 
-const { test, only } = QUnit;
+const { test } = QUnit;
 
 QUnit.module('babel-plugin-adjust-imports');
 
@@ -30,7 +29,7 @@ function getFirstCallExpresssionPath(source: string) {
 }
 
 function isDefineExpressionFromSource(source: string) {
-  return isDefineExpression(Types, getFirstCallExpresssionPath(source));
+  return isDefineExpression(getFirstCallExpresssionPath(source));
 }
 
 test('isDefineExpression works', function(assert) {
@@ -48,7 +47,7 @@ test('isDefineExpression works', function(assert) {
   assert.equal(isDefineExpressionFromSource(`define('apple'); import foo from 'foo'`), false);
 });
 
-only('main', function(assert) {
+test('main', function(assert) {
   const options: AdjustImportsOptions = {
     activeAddons: {},
     renameModules: { a: 'c' },


### PR DESCRIPTION
An `only` snuck in from PR #223.

Once removed, one of the new tests added in that PR wasn't passing. I refactored it and cleaned up the usage of `@babel/types` so typescript can see what's going on.

This way of using `@babel/types` isn't obvious and I have no idea how one would discover it from documentation. I picked it up by reading what other typescript babel plugins were doing.