### PR TITLE
blank pod prefix support

### DIFF
--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -312,6 +312,14 @@ export default class CompatResolver implements Resolver {
         runtimeName: `${this.modulePrefix}/templates/components/${path}`,
         absPath: join(this.root, 'templates', 'components', path) + '.js',
       },
+      {
+        runtimeName: `${this.modulePrefix}/components/${path}/template`,
+        absPath: join(this.root, 'templates', 'components', path, 'template') + '.hbs',
+      },
+      {
+        runtimeName: `${this.modulePrefix}/components/${path}/component`,
+        absPath: join(this.root, 'components', path, 'component') + '.js',
+      },
     ].filter(candidate => pathExistsSync(candidate.absPath));
 
     if (componentModules.length > 0) {

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -314,7 +314,7 @@ export default class CompatResolver implements Resolver {
       },
       {
         runtimeName: `${this.modulePrefix}/components/${path}/template`,
-        absPath: join(this.root, 'templates', 'components', path, 'template') + '.hbs',
+        absPath: join(this.root, 'components', path, 'template') + '.hbs',
       },
       {
         runtimeName: `${this.modulePrefix}/components/${path}/component`,

--- a/packages/compat/tests/resolver-test.ts
+++ b/packages/compat/tests/resolver-test.ts
@@ -77,6 +77,44 @@ QUnit.module('compat-resolver', function(hooks) {
     ]);
   });
 
+  test('podded, dasherized component, with blank modulePrefix, js only', function(assert) {
+    let findDependencies = configure({ staticComponents: true });
+    givenFile('components/hello-world/component.js');
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}}`), [
+      {
+        path: '../components/hello-world/component.js',
+        runtimeName: 'the-app/components/hello-world/component',
+      },
+    ]);
+  });
+
+  test('podded, dasherized component, with blank modulePrefix, hbs only', function(assert) {
+    let findDependencies = configure({ staticComponents: true });
+    givenFile('components/hello-world/template.hbs');
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}}`), [
+      {
+        path: '../components/hello-world/template.hbs',
+        runtimeName: 'the-app/components/hello-world/template',
+      },
+    ]);
+  });
+
+  test('podded, dasherized component, with blank modulePrefix, js and hbs', function(assert) {
+    let findDependencies = configure({ staticComponents: true });
+    givenFile('components/hello-world/component.js');
+    givenFile('components/hello-world/template.hbs');
+    assert.deepEqual(findDependencies('templates/application.hbs', `{{hello-world}}`), [
+      {
+        path: '../components/hello-world/component.js',
+        runtimeName: 'the-app/components/hello-world/component',
+      },
+      {
+        path: '../components/hello-world/template.hbs',
+        runtimeName: 'the-app/components/hello-world/template',
+      },
+    ]);
+  });
+
   test('bare dasherized component, hbs only', function(assert) {
     let findDependencies = configure({ staticComponents: true });
     givenFile('templates/components/hello-world.hbs');


### PR DESCRIPTION
* given: 

`podModulePrefix` = '';

`ember g component my-component --pod`

->

```
app/components/my-component/component.js
app/components/my-component/template.hbs

```