### PR TITLE
Ignore built-in components: Input, LinkTo, Textarea

### DIFF
--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -75,6 +75,8 @@ const builtInHelpers = [
   'yield',
 ];
 
+const builtInComponents = ['input', 'link-to', 'textarea'];
+
 // this is a subset of the full Options. We care about serializability, and we
 // only needs parts that are easily serializable, which is why we don't keep the
 // whole thing.
@@ -401,6 +403,10 @@ export default class CompatResolver implements Resolver {
     }
 
     let dName = dasherize(tagName);
+
+    if (builtInComponents.includes(dName)) {
+      return null;
+    }
 
     let found = this.tryComponent(dName, from);
     if (found) {

--- a/packages/compat/tests/resolver-test.ts
+++ b/packages/compat/tests/resolver-test.ts
@@ -506,6 +506,7 @@ QUnit.module('compat-resolver', function(hooks) {
         {{yield bar}}
         {{#with (hash submit=(action doit)) as |thing| }}
         {{/with}}
+        <LinkTo @route="index"/>
       `
       ),
       []


### PR DESCRIPTION
Ember 3.10 introduced a few ["built-in components"](https://blog.emberjs.com/2019/05/21/ember-3-10-released.html), this ignores them in `compat` resolver.

This avoids having to use workaround with `packageRules`:

```js
packageRules: [{
  package: 'my-app',
  components: {
    // TODO: remove when embroider ignores angle bracket built-ins
    '<LinkTo />': { safeToIgnore: true }
  }
}]
```