### PR TITLE
Copy ember-font-awesome font files

### DIFF
--- a/packages/compat/src/compat-adapters/ember-font-awesome.ts
+++ b/packages/compat/src/compat-adapters/ember-font-awesome.ts
@@ -1,0 +1,16 @@
+import V1Addon from '../v1-addon';
+import { AddonMeta } from '@embroider/core';
+
+export default class EmberFontAwesome extends V1Addon {
+  get packageMeta(): Partial<AddonMeta> {
+    let meta = super.packageMeta || {};
+    meta['public-assets'] = {
+      'node_modules/font-awesome/fonts/FontAwesome.otf': '/fonts/FontAwesome.otf',
+    };
+    for (let extension of ['eot', 'svg', 'ttf', 'woff', 'woff2']) {
+      let fileName = `fontawesome-webfont.${extension}`;
+      meta['public-assets'][`node_modules/font-awesome/fonts/${fileName}`] = `/fonts/${fileName}`;
+    }
+    return meta;
+  }
+}

--- a/packages/compat/src/compat-adapters/ember-font-awesome.ts
+++ b/packages/compat/src/compat-adapters/ember-font-awesome.ts
@@ -1,15 +1,17 @@
 import V1Addon from '../v1-addon';
 import { AddonMeta } from '@embroider/core';
+import walkSync from 'walk-sync';
 
 export default class EmberFontAwesome extends V1Addon {
   get packageMeta(): Partial<AddonMeta> {
-    let meta = super.packageMeta || {};
-    meta['public-assets'] = {
-      'node_modules/font-awesome/fonts/FontAwesome.otf': '/fonts/FontAwesome.otf',
-    };
-    for (let extension of ['eot', 'svg', 'ttf', 'woff', 'woff2']) {
-      let fileName = `fontawesome-webfont.${extension}`;
-      meta['public-assets'][`node_modules/font-awesome/fonts/${fileName}`] = `/fonts/${fileName}`;
+    let meta = super.packageMeta;
+    if (!meta['public-assets']) {
+      meta['public-assets'] = {};
+    }
+    let fontFiles = walkSync('node_modules/font-awesome/fonts/');
+    for (let path of fontFiles) {
+      let [fileName] = path.split('/').reverse();
+      meta['public-assets'][path] = `/fonts/${fileName}`;
     }
     return meta;
   }


### PR DESCRIPTION
The problem I bumped into is that the fonts ["vendored by"](https://github.com/martndemus/ember-font-awesome/blob/master/index.js#L35-L51) ember-font-awesome weren't copied to the build output when using it with Embroider.

As far as I could tell, the way to fix this is using a compat adapter that specifies those files as public-assets so that they are copied over.