### PR TITLE
change smooshing order

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -41,7 +41,7 @@ function buildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): T
 
   let needsSmooshing = oldPackages[0].hasAnyTrees();
   if (needsSmooshing) {
-    let trees = oldPackages.map(pkg => pkg.v2Tree);
+    let trees = oldPackages.map(pkg => pkg.v2Tree).reverse();
     let smoosher = new SmooshPackageJSON(trees);
     return broccoliMergeTrees([...trees, smoosher], { overwrite: true });
   } else {


### PR DESCRIPTION
When combining multiple copies of the same addon, ember-cli gives priority to ones closer to the app in the dependency graph. That is, for each addon it builds the dependencies first, then overwrites the dependencies with the addon itself.

Our addon discovery returns each addon before its dependencies, so we were going in the opposite priority.

This all only affects v1 packages. V2 packages are designed so that no smooshing happens.