### PR TITLE
use app's custom babel config

### DIFF
--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -215,6 +215,7 @@ export default class V1App implements V1Package {
 
   @Memoize()
   babelConfig(): TransformOptions {
+    // this finds all the built-in babel configuration that comes with ember-cli-babel
     const babelAddon = (this.app.project as any).findAddonByName('ember-cli-babel');
     const babelConfig = babelAddon.buildBabelOptions({
       'ember-cli-babel': {
@@ -229,6 +230,19 @@ export default class V1App implements V1Package {
 
     let plugins = babelConfig.plugins as any[];
     let presets = babelConfig.presets;
+
+    // this finds any custom babel configuration that's on the app (either
+    // because the app author explicitly added some, or because addons have
+    // pushed plugins into it).
+    let appBabel = this.app.options.babel;
+    if (appBabel) {
+      if (appBabel.plugins) {
+        plugins = plugins.concat(appBabel.plugins);
+      }
+      if (appBabel.presets) {
+        presets = presets.concat(appBabel.presets);
+      }
+    }
 
     plugins = plugins.filter(p => {
       // even if the app was using @embroider/macros, we drop it from the config

--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -13,6 +13,7 @@ QUnit.module('stage2 build', function() {
 
     hooks.before(async function(assert) {
       let app = Project.emberNew();
+      app.linkPackage('@embroider/sample-transforms');
       (app.files.app as Project['files']).templates = {
         'index.hbs': `
           <HelloWorld @useDynamic="first-choice" />
@@ -41,6 +42,10 @@ QUnit.module('stage2 build', function() {
 
       (app.files.app as Project['files'])['use-deep-addon.js'] = `
       import thing from 'deep-addon';
+      `;
+
+      (app.files.app as Project['files'])['custom-babel-needed.js'] = `
+        console.log('embroider-sample-transforms-target');
       `;
 
       let addon = app.addAddon('my-addon');
@@ -290,6 +295,11 @@ QUnit.module('stage2 build', function() {
 
     test('transpilation runs for non-ember package that is not explicitly skipped', async function(assert) {
       assert.ok(build.shouldTranspile(assert.file('node_modules/babel-filter-test4/index.js')));
+    });
+
+    test(`app's babel plugins ran`, async function(assert) {
+      let assertFile = assert.file('custom-babel-needed.js').transform(build.transpile);
+      assertFile.matches(/console\.log\(['"]embroider-sample-transforms-result['"]\)/);
     });
   });
 });


### PR DESCRIPTION
I think the recent switch to calling ember-cli-babel to get its default babel config accidentally dropped our use of the app's babel config, which should layer on top.