### PR TITLE
Make resolvable extensions configurable

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -763,6 +763,19 @@ And then in an app that depends on `ember-lodash`, our Babel plugin will rewrite
 
 This is a backward compatibility feature and you should stop doing this. Exposing a module under some other package's name is Not Nice.
 
+## resolvable-extensions
+
+```
+Allowed in: apps
+Status: required
+```
+
+A list of file extensions that are considered resolvable as modules. In priority order. Example:
+
+```
+"resolvable-extensions": [".ts", ".js", ".hbs"]
+```
+
 ## root-url
 
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -99,7 +99,7 @@ Notice that a package’s **allowed dependencies** do not include the package it
 
 Modules in **Own Javascript** are also allowed to use the (currently stage 3) ECMA dynamic `import()`, and the specifiers have the same meanings as in static import. We impose one caveat: only string-literal specifiers are supported. So `import('./lang-en')` is OK but `import("./lang-"+language)` is not. We retain the option to relax this restriction in the future. The restriction allows us to do better analysis of possible inter-module dependencies (see **Build-time Conditionals** below for an example).
 
-Modules in **Own Javascript** are allowed to import template files. This is common in today’s addons (they import their own layout to set it explicitly). But import specifiers of templates are required to include the `.hbs` extension.
+Modules in **Own Javascript** are allowed to import template files. This is common in today’s addons (they import their own layout to set it explicitly).
 
 Modules in **Own Javascript** are allowed to use `hbs` tagged template strings as provided by `ember-cli-htmlbars-inline-precompile`, and we promise to compile the templates at app build time.
 

--- a/packages/compat/tests/resolver-test.ts
+++ b/packages/compat/tests/resolver-test.ts
@@ -20,14 +20,15 @@ QUnit.module('compat-resolver', function(hooks) {
     let EmberENV = {};
     let plugins = { ast: [] };
     appDir = mkdtempSync(join(tmpdir(), 'embroider-compat-tests-'));
-    let resolver = new Resolver(
-      appDir,
-      'the-app',
-      optionsWithDefaults(options),
-      optionsWithDefaults(options).packageRules.map(rule => {
+    let resolver = new Resolver({
+      root: appDir,
+      modulePrefix: 'the-app',
+      options: optionsWithDefaults(options),
+      activePackageRules: optionsWithDefaults(options).packageRules.map(rule => {
         return Object.assign({ roots: [appDir] }, rule);
-      })
-    );
+      }),
+      resolvableExtensions: ['.js', '.hbs'],
+    });
     let compiler = new TemplateCompiler({ compilerPath, resolver, EmberENV, plugins });
     return function(relativePath: string, contents: string) {
       let moduleName = givenFile(relativePath);

--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -239,8 +239,8 @@ QUnit.module('stage2 build', function() {
     test('app/templates/components/direct-template-reexport.js', function(assert) {
       let assertFile = assert.file('./templates/components/direct-template-reexport.js').transform(build.transpile);
       assertFile.matches(
-        /export \{ default \} from ['"]\.\.\/\.\.\/node_modules\/my-addon\/templates\/components\/hello-world.hbs['"]/,
-        'rewrites absolute imports of templates to explicit hbs'
+        /export \{ default \} from ['"]\.\.\/\.\.\/node_modules\/my-addon\/templates\/components\/hello-world['"]/,
+        'rewrites reexports of templates'
       );
     });
 
@@ -254,7 +254,7 @@ QUnit.module('stage2 build', function() {
       let assertFile = assert
         .file('node_modules/my-addon/components/has-relative-template.js')
         .transform(build.transpile);
-      assertFile.matches(/import layout from ["']\.\/t.hbs['"]/, 'arbitrary relative template gets hbs extension');
+      assertFile.matches(/import layout from ["']\.\/t['"]/, 'arbitrary relative template remains the same');
     });
 
     test('app can import a deep addon', function(assert) {

--- a/packages/core/src/babel-filter.ts
+++ b/packages/core/src/babel-filter.ts
@@ -4,7 +4,7 @@ import semver from 'semver';
 
 export default function babelFilter(skipBabel: Required<Options>['skipBabel']) {
   return function shouldTranspileFile(filename: string) {
-    if (!isJS(filename)) {
+    if (!babelCanHandle(filename)) {
       // quick exit for non JS extensions
       return false;
     }
@@ -26,6 +26,10 @@ export default function babelFilter(skipBabel: Required<Options>['skipBabel']) {
   };
 }
 
-function isJS(filename: string) {
-  return /\.js$/i.test(filename);
+function babelCanHandle(filename: string) {
+  // we can handle .js and .ts files with babel. If typescript is enabled, .ts
+  // files become resolvable and stage3 will be asking us if they should get
+  // transpiled and the answer is yes. If typescript is not enbled, they will
+  // not be resolvable, so stage3 won't ask us about them.
+  return /\.[jt]s$/i.test(filename);
 }

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -1,5 +1,5 @@
 import getPackageName from './package-name';
-import { join, dirname, resolve } from 'path';
+import { join, dirname } from 'path';
 import { NodePath } from '@babel/traverse';
 import {
   blockStatement,
@@ -25,7 +25,7 @@ import {
 } from '@babel/types';
 import PackageCache from './package-cache';
 import Package, { V2Package } from './package';
-import { pathExistsSync, writeFileSync, ensureDirSync } from 'fs-extra';
+import { writeFileSync, ensureDirSync } from 'fs-extra';
 import { Memoize } from 'typescript-memoize';
 import { compile } from './js-handlebars';
 import { explicitRelative } from './paths';
@@ -88,7 +88,6 @@ function adjustSpecifier(specifier: string, file: AdjustFile, opts: Options) {
   if (file.isRelocated) {
     specifier = handleRelocation(specifier, file);
   }
-  specifier = makeHBSExplicit(specifier, file);
   return specifier;
 }
 
@@ -234,43 +233,6 @@ function handleRelocation(specifier: string, sourceFile: AdjustFile) {
   }
   let targetPkg = packageCache.resolve(packageName, pkg);
   return explicitRelative(dirname(sourceFile.name), specifier.replace(packageName, targetPkg.root));
-}
-
-function makeHBSExplicit(specifier: string, sourceFile: AdjustFile) {
-  if (/\.(hbs)|(js)|(css)$/.test(specifier)) {
-    // already has a well-known explicit extension, so nevermind
-    return specifier;
-  }
-
-  // our own externals by definition aren't things we can find on disk, so no
-  // point trying
-  if (specifier.startsWith('@embroider/externals/')) {
-    return specifier;
-  }
-
-  let pkg = sourceFile.owningPackage();
-  if (!pkg || !pkg.isV2Ember() || !pkg.meta['auto-upgraded']) {
-    // only auto-upgraded packages get this adjustment, native v2 packages are
-    // supposed to already say '.hbs' explicitly whenever they import a
-    // template.
-    return specifier;
-  }
-
-  let target;
-  let packageName = getPackageName(specifier);
-
-  if (packageName) {
-    let base = packageCache.resolve(packageName, pkg).root;
-    target = resolve(base, specifier.replace(packageName, '.') + '.hbs');
-  } else {
-    target = resolve(dirname(sourceFile.name), specifier + '.hbs');
-  }
-
-  if (pathExistsSync(target)) {
-    return specifier + '.hbs';
-  }
-
-  return specifier;
 }
 
 export default function main() {

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -50,6 +50,7 @@ interface State {
       [packageName: string]: string;
     };
     relocatedFiles: { [relativePath: string]: string };
+    resolvableExtensions: string[];
   };
 }
 
@@ -101,11 +102,13 @@ function handleRenaming(specifier: string, sourceFile: AdjustFile, opts: State['
     if (candidate === specifier) {
       return replacement;
     }
-    if (candidate === specifier + '/index.js') {
-      return replacement;
-    }
-    if (candidate === specifier + '.js') {
-      return replacement;
+    for (let extension of opts.resolvableExtensions) {
+      if (candidate === specifier + '/index' + extension) {
+        return replacement;
+      }
+      if (candidate === specifier + extension) {
+        return replacement;
+      }
     }
   }
 

--- a/packages/core/src/babel-plugin-inline-hbs.ts
+++ b/packages/core/src/babel-plugin-inline-hbs.ts
@@ -124,7 +124,7 @@ function handleCalled(path: NodePath<CallExpression>, state: State) {
   let template = arg.value;
   if (state.opts.stage === 1) {
     let compiled = compiler(state.opts).applyTransforms(state.file.opts.filename, template);
-    path.get('arguments')[0].replaceWith(stringLiteral(compiled));
+    (path.get('arguments')[0] as NodePath).replaceWith(stringLiteral(compiled));
   } else {
     let { compiled, dependencies } = compiler(state.opts).precompile(state.file.opts.filename, template);
     for (let dep of dependencies) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,5 +15,5 @@ export { getOrCreate } from './get-or-create';
 export { compile as jsHandlebarsCompile } from './js-handlebars';
 export { AppAdapter, AppBuilder, EmberENV } from './app';
 export { todo, unsupported, warn, debug, expectWarning, throwOnWarnings } from './messages';
-export { explicitRelative } from './paths';
+export { explicitRelative, extensionsPattern } from './paths';
 export { default as babelFilter } from './babel-filter';

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -14,6 +14,7 @@ export interface AppMeta {
     majorVersion: 6 | 7;
     fileFilter: string;
   };
+  'resolvable-extensions': string[];
   'root-url': string;
   'template-compiler': {
     filename: string;

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -20,3 +20,9 @@ export function explicitRelative(fromDir: string, toFile: string) {
   }
   return result;
 }
+
+// given a list like ['.js', '.ts'], return a regular expression for files ending
+// in those extensions.
+export function extensionsPattern(extensions: string[]): RegExp {
+  return new RegExp(`(${extensions.map(e => `${e.replace('.', '\\.')}`).join('|')})$`, 'i');
+}

--- a/packages/core/tests/babel-plugin-adjust-imports-test.ts
+++ b/packages/core/tests/babel-plugin-adjust-imports-test.ts
@@ -55,6 +55,7 @@ test('main', function(assert) {
     extraImports: [],
     relocatedFiles: {},
     externalsDir: 'test',
+    resolvableExtensions: ['.js', '.hbs'],
   };
 
   {

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -143,12 +143,10 @@ class HTMLEntrypoint {
 interface AppInfo {
   entrypoints: HTMLEntrypoint[];
   otherAssets: string[];
-  templateCompiler: {
-    filename: string;
-    isParallelSafe: boolean;
-  };
+  templateCompiler: AppMeta['template-compiler'];
   babel: AppMeta['babel'];
-  rootURL: string;
+  rootURL: AppMeta['root-url'];
+  resolvableExtensions: AppMeta['resolvable-extensions'];
 }
 
 // AppInfos are equal if they result in the same webpack config.
@@ -210,12 +208,20 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     let templateCompiler = meta['template-compiler'];
     let rootURL = meta['root-url'];
     let babel = meta['babel'];
-    return { entrypoints, otherAssets, templateCompiler, babel, rootURL };
+    let resolvableExtensions = meta['resolvable-extensions'];
+
+    return { entrypoints, otherAssets, templateCompiler, babel, rootURL, resolvableExtensions };
   }
 
   private mode: 'production' | 'development' = process.env.EMBER_ENV === 'production' ? 'production' : 'development';
 
-  private configureWebpack({ entrypoints, templateCompiler, babel, rootURL }: AppInfo): Configuration {
+  private configureWebpack({
+    entrypoints,
+    templateCompiler,
+    babel,
+    rootURL,
+    resolvableExtensions,
+  }: AppInfo): Configuration {
     let entry: { [name: string]: string } = {};
     for (let entrypoint of entrypoints) {
       for (let moduleName of entrypoint.modules) {
@@ -280,6 +286,9 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
         splitChunks: {
           chunks: 'all',
         },
+      },
+      resolve: {
+        extensions: resolvableExtensions,
       },
       resolveLoader: {
         alias: {


### PR DESCRIPTION
...and use them to support typescript in apps.

Since we now need to teach stage3 about resolvable extensions, we can use that to support `.hbs` too, and drop our strict requirement that all imports of templates have an explicit extension.