### PR TITLE
teach resolver about dot rule

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -27,6 +27,13 @@ export function makeResolverTransform(resolver: Resolver) {
           if (scopeStack.inScope(node.path.parts[0])) {
             return;
           }
+          if (node.path.parts.length > 1) {
+            // paths with a dot in them (which therefore split into more than
+            // one "part") are classically understood by ember to be contextual
+            // components, which means there's nothing to resolve at this
+            // location.
+            return;
+          }
           if (node.path.original === 'component' && node.params.length > 0) {
             handleComponentHelper(node.params[0], resolver, filename, scopeStack);
             return;
@@ -64,6 +71,13 @@ export function makeResolverTransform(resolver: Resolver) {
             return;
           }
           if (scopeStack.inScope(node.path.parts[0])) {
+            return;
+          }
+          if (node.path.parts.length > 1) {
+            // paths with a dot in them (which therefore split into more than
+            // one "part") are classically understood by ember to be contextual
+            // components, which means there's nothing to resolve at this
+            // location.
             return;
           }
           if (node.path.original === 'component' && node.params.length > 0) {

--- a/packages/compat/tests/resolver-test.ts
+++ b/packages/compat/tests/resolver-test.ts
@@ -552,6 +552,33 @@ QUnit.module('compat-resolver', function(hooks) {
     );
   });
 
+  test('ignores dot-rule curly component invocation, inline', function(assert) {
+    let findDependencies = configure({ staticHelpers: true, staticComponents: true });
+    assert.deepEqual(
+      findDependencies(
+        'templates/application.hbs',
+        `
+        {{thing.body x=1}}
+        `
+      ),
+      []
+    );
+  });
+
+  test('ignores dot-rule curly component invocation, block', function(assert) {
+    let findDependencies = configure({ staticHelpers: true, staticComponents: true });
+    assert.deepEqual(
+      findDependencies(
+        'templates/application.hbs',
+        `
+        {{#thing.body}}
+        {{/thing.body}}
+        `
+      ),
+      []
+    );
+  });
+
   test('respects yieldsSafeComponents rule, position 0', function(assert) {
     assert.expect(0);
     let packageRules = [


### PR DESCRIPTION
Curly component invocations of paths that include a `.` are understood by Ember to be contextual components.