### PR TITLE
[WIP] Enable addons to be rebuilt

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -64,6 +64,7 @@
     "resolve-package-path": "^1.2.2",
     "semver": "^5.5.0",
     "symlink-or-copy": "^1.2.0",
+    "tree-sync": "^2.0.0",
     "typescript-memoize": "^1.0.0-alpha.3",
     "walk-sync": "^1.1.3"
   },

--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -10,12 +10,14 @@ import buildCompatAddon from './build-compat-addon';
 import Options, { optionsWithDefaults } from './options';
 import V1App from './v1-app';
 import { createHash } from 'crypto';
+import TreeSync from 'tree-sync';
 
 export default class CompatAddons implements Stage {
   private didBuild = false;
   private destDir: string;
   private packageCache: MovedPackageCache;
   private nonResolvableDeps: Package[];
+  private treeSyncMap: WeakMap<Package, any>;
   readonly inputPath: string;
   readonly tree: Tree;
 
@@ -43,6 +45,7 @@ export default class CompatAddons implements Stage {
       this.build.bind(this)
     );
     this.inputPath = v1Cache.app.root;
+    this.treeSyncMap = new WeakMap();
   }
 
   async ready(): Promise<{ outputPath: string; packageCache: PackageCache }> {
@@ -64,35 +67,58 @@ export default class CompatAddons implements Stage {
     return this.packageCache.app;
   }
 
-  private async build({
-    movedAddons,
-    synthVendor,
-    synthStyles,
-  }: {
-    movedAddons: string[];
-    synthVendor: string;
-    synthStyles: string;
-  }) {
-    if (this.didBuild) {
-      // TODO: we can selectively allow some addons to rebuild, equivalent to
-      // the old isDevelopingAddon. This should be based off Package#mayRebuild.
-      return;
+  private async build(
+    {
+      movedAddons,
+      synthVendor,
+      synthStyles,
+    }: {
+      movedAddons: string[];
+      synthVendor: string;
+      synthStyles: string;
+    },
+    changedMap?: Map<string, boolean>
+  ) {
+    // empty the directory only on the first pass
+    // TODO: should we still do this?
+    if (!this.didBuild) {
+      emptyDirSync(this.destDir);
     }
 
-    emptyDirSync(this.destDir);
+    [...this.packageCache.moved.values()].forEach((value, index) => {
+      let treeInstance = this.treeSyncMap.get(value);
 
-    [...this.packageCache.moved.values()].forEach((movedPkg, index) => {
-      copySync(movedAddons[index], movedPkg.root, { dereference: true });
-      this.linkNonCopiedDeps(movedPkg, movedPkg.root);
+      if (!treeInstance) {
+        treeInstance = new TreeSync(movedAddons[index], value.root, {
+          ignore: ['**/node_modules'],
+        });
+
+        this.treeSyncMap.set(value, treeInstance);
+      }
+
+      if (changedMap && changedMap.get(movedAddons[index])) {
+        treeInstance.sync();
+        this.linkNonCopiedDeps(value, value.root);
+      }
     });
+
     this.linkNonCopiedDeps(this.app, this.appDestDir);
     await this.packageCache.updatePreexistingResolvableSymlinks();
-    copySync(synthVendor, join(this.appDestDir, 'node_modules', '@embroider', 'synthesized-vendor'), {
-      dereference: true,
-    });
-    copySync(synthStyles, join(this.appDestDir, 'node_modules', '@embroider', 'synthesized-styles'), {
-      dereference: true,
-    });
+
+    if (changedMap && changedMap.get(synthVendor)) {
+      copySync(synthVendor, join(this.appDestDir, 'node_modules', '@embroider', 'synthesized-vendor'), {
+        dereference: true,
+        overwrite: true,
+      });
+    }
+
+    if (changedMap && changedMap.get(synthStyles)) {
+      copySync(synthStyles, join(this.appDestDir, 'node_modules', '@embroider', 'synthesized-styles'), {
+        dereference: true,
+        overwrite: true,
+      });
+    }
+
     this.handleNonResolvableDeps();
     this.didBuild = true;
     this.deferReady.resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -13508,6 +13508,17 @@ tree-sync@^1.2.2, tree-sync@^1.4.0:
     quick-temp "^0.1.5"
     walk-sync "^0.3.3"
 
+tree-sync@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tree-sync/-/tree-sync-2.0.0.tgz#e51456731d5ac93b92f9a1d58dd383f76f0f2f39"
+  integrity sha512-AzeJnbmJjGVfWMTJ0T152fv8NDTbQc9ERY4nEs7Lmxd94Xah2bUS56+CcoTh6FB8qn2KjBMjC0mLNc731aVBqw==
+  dependencies:
+    debug "^2.2.0"
+    fs-tree-diff "^0.5.6"
+    mkdirp "^0.5.1"
+    quick-temp "^0.1.5"
+    walk-sync "^0.3.3"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"


### PR DESCRIPTION
A POC of how addons could be selectively rebuilt if Broccoli passed change information into the plugin. The goal of this PR is to get overall feedback on the strategy and to confirm this is a viable path forward. I will add tests once we work out the higher level vision of this.

Overall Strategy:

* Broccoli passes change information to WaitForTrees (not yet added to broccoli).
* WaitForTrees translates that information down to the build callback in compat-addon
* The build callback uses tree-sync to conditionally "sync" to the workspaceDir based on if the addon has changed (for the first build all addons are considered "changed")

Perf:

Measuring the execution time of the build callback for a brand new app: 

With change tracking: ~50ms
Without: ~75ms 

I have not tested this in a large app but change tracking should stay relatively constant were as without will obviously grow with the number of addons.

Limitations:

This conditional checking would only be available for those that are using the version of broccoli were this is enabled. These changes are backwards compatible however there would be performance implications for those not on it. 

Open Questions for Reviewers:

* How should plugins and broccoli communicate change? In this POC broccoli passes change info down to the plugin or should it be where the plugin "calls" up and asks broccoli for this information?
* Should we only enable rebuilding for those only on the latest broccoli?