### PR TITLE
Add compat support for ember-basic-dropdown v2

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-basic-dropdown.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-basic-dropdown.ts
@@ -1,7 +1,8 @@
 import { PackageRules } from '..';
 
-let rules: PackageRules = {
+let rulesForV1: PackageRules = {
   package: 'ember-basic-dropdown',
+  semverRange: '1.x',
   addonModules: {
     'components/basic-dropdown.js': {
       dependsOnComponents: ['{{basic-dropdown/trigger}}', '{{basic-dropdown/content}}'],
@@ -17,4 +18,22 @@ let rules: PackageRules = {
   },
 };
 
-export default [rules];
+let rulesForV2: PackageRules = {
+  package: 'ember-basic-dropdown',
+  semverRange: '>=2.0.0',
+  addonModules: {
+    'components/basic-dropdown.js': {
+      dependsOnComponents: ['{{basic-dropdown-trigger}}', '{{basic-dropdown-content}}'],
+    },
+  },
+  components: {
+    '{{basic-dropdown}}': {
+      layout: {
+        addonPath: 'templates/components/basic-dropdown.hbs',
+      },
+      acceptsComponentArguments: ['triggerComponent', 'contentComponent'],
+    },
+  },
+};
+
+export default [rulesForV1, rulesForV2];


### PR DESCRIPTION
Version 2 of ember-basic-dropdown changed a few component names/location. This adds support for it. 

Let me know if the approach taken here is correct.