### PR TITLE
fastboot support + tests

### DIFF
--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -1,5 +1,5 @@
 import { App, Addons as CompatAddons, Options, PrebuiltAddons } from '.';
-import { toBroccoliPlugin, Packager } from '@embroider/core';
+import { toBroccoliPlugin, Packager, AppBuilder } from '@embroider/core';
 import { Tree } from 'broccoli-plugin';
 
 interface PipelineOptions<PackagerOptions> extends Options {
@@ -13,6 +13,7 @@ export default function defaultPipeline<PackagerOptions>(
   options?: PipelineOptions<PackagerOptions>
 ): Tree {
   let addons;
+  AppBuilder.activateMacroConfig();
   if (process.env.REUSE_WORKSPACE) {
     addons = new PrebuiltAddons(emberApp, options, process.env.REUSE_WORKSPACE);
   } else {

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -253,15 +253,16 @@ class AppFiles {
 export class AppBuilder<TreeNames> {
   // for each relativePath, an Asset we have already emitted
   private assets: Map<string, InternalAsset> = new Map();
+  static activateMacroConfig() {
+    MacrosConfig.shared().setOwnConfig(__filename, { active: true });
+  }
 
   constructor(
     private root: string,
     private app: Package,
     private adapter: AppAdapter<TreeNames>,
     private options: Required<Options>
-  ) {
-    MacrosConfig.shared().setOwnConfig(__filename, { active: true });
-  }
+  ) {}
 
   private scriptPriority(pkg: Package) {
     switch (pkg.name) {

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -60,7 +60,7 @@ export default class MacrosConfig {
 
   private internalSetConfig(fromPath: string, packageName: string | undefined, config: unknown) {
     if (this.cachedUserConfigs) {
-      throw new Error(`attempted to set config after we have already emitted our config`);
+      throw new Error(`attempted to set config after we have already emitted our config` + fromPath);
     }
     let targetPackage = this.resolvePackage(fromPath, packageName);
     let peers = getOrCreate(this.configs, targetPackage.root, () => []);

--- a/test-packages/macro-tests/ember-cli-build.js
+++ b/test-packages/macro-tests/ember-cli-build.js
@@ -44,6 +44,8 @@ module.exports = function(defaults) {
   app.import('vendor/prepend/three.js', { prepend: true });
   app.import('vendor/prepend/four.js', { prepend: true });
 
+  app.import('vendor/prepend/order.js', { prepend: true });
+
   if (process.env.CLASSIC) {
     return app.toTree();
   }

--- a/test-packages/macro-tests/package.json
+++ b/test-packages/macro-tests/package.json
@@ -22,6 +22,7 @@
     "@ember/optional-features": "^0.7.0",
     "@embroider/compat": "0.6.0",
     "@embroider/core": "0.6.0",
+    "@embroider/funky-sample-addon": "0.0.0",
     "@embroider/macros": "0.6.0",
     "@embroider/webpack": "0.6.0",
     "ember-ajax": "^5.0.0",
@@ -48,7 +49,6 @@
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
     "macro-sample-addon": "0.0.0",
-    "@embroider/funky-sample-addon": "0.0.0",
     "qunit-dom": "^0.8.4"
   },
   "engines": {

--- a/test-packages/macro-tests/package.json
+++ b/test-packages/macro-tests/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "ember-cli-babel-polyfills": "1.0.4",
-    "ember-cli-fastboot": "^2.2.0"
+    "ember-cli-fastboot": "^2.2.1"
   }
 }

--- a/test-packages/macro-tests/package.json
+++ b/test-packages/macro-tests/package.json
@@ -55,6 +55,7 @@
     "node": "8.* || >= 10.*"
   },
   "dependencies": {
-    "ember-cli-babel-polyfills": "1.0.4"
+    "ember-cli-babel-polyfills": "1.0.4",
+    "ember-cli-fastboot": "^2.2.0"
   }
 }

--- a/test-packages/macro-tests/vendor/prepend/order.js
+++ b/test-packages/macro-tests/vendor/prepend/order.js
@@ -1,0 +1,1 @@
+self.ORDER = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,6 +4274,18 @@ charm@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
+cheerio@^1.0.0-rc.3:
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
+  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.1"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chokidar@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
@@ -4933,6 +4945,16 @@ css-select-base-adapter@~0.1.0:
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
   integrity sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-select@~1.3.0-rc0:
   version "1.3.0-rc0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.3.0-rc0.tgz#6f93196aaae737666ea1036a8cb14a8fcb7a9231"
@@ -5291,7 +5313,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
   integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
@@ -5304,7 +5326,7 @@ domain-browser@^1.1.1:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
-domelementtype@1, domelementtype@^1.3.0:
+domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
@@ -5316,10 +5338,25 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+  dependencies:
+    domelementtype "1"
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
   integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -5606,16 +5643,18 @@ ember-cli-eslint@^5.1.0:
     rsvp "^4.6.1"
     walk-sync "^1.0.0"
 
-ember-cli-fastboot@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-fastboot/-/ember-cli-fastboot-2.2.0.tgz#202d4c3ebcf6e392d5348e17208dec9f04bab98f"
-  integrity sha512-9nbHJvQAwxN2i9FgUzsjhKclzSxJw6rmli8qwiblUkKVhs7PqKsjMszxA/Ssk3UjqCNkecEsNzaJoycPgrIChQ==
+ember-cli-fastboot@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-fastboot/-/ember-cli-fastboot-2.2.1.tgz#8c646fe3f93331c61ba87149cfecf327de79826f"
+  integrity sha512-veT089wHsYNyx+IZyjG38+RMzHiiLNX2zwRAmv31VWT1NyaEcHv7+u9iOV3KdA1wVgpicJQ2PVIOw8OuIHo+1A==
   dependencies:
     broccoli-concat "^3.7.1"
+    broccoli-file-creator "^2.1.1"
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^3.0.1"
     broccoli-plugin "^1.3.1"
     chalk "^2.4.1"
+    cheerio "^1.0.0-rc.3"
     ember-cli-babel "^7.1.0"
     ember-cli-lodash-subset "2.0.1"
     ember-cli-preprocess-registry "^3.1.2"
@@ -8071,6 +8110,18 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+htmlparser2@^3.9.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+  dependencies:
+    domelementtype "^1.3.1"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
+
 http-cache-semantics@3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
@@ -9920,6 +9971,11 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4,
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.15.0:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -10748,7 +10804,7 @@ npm-run-path@^2.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@^1.0.1:
+nth-check@^1.0.1, nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
@@ -11123,6 +11179,13 @@ parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
+  dependencies:
+    "@types/node" "*"
 
 parseqs@0.0.5:
   version "0.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,10 +1245,36 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@simple-dom/interface@1.4.0":
+"@simple-dom/document@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@simple-dom/document/-/document-1.4.0.tgz#af60855f957f284d436983798ef1006cca1a1678"
+  integrity sha512-/RUeVH4kuD3rzo5/91+h4Z1meLSLP66eXqpVAw/4aZmYozkeqUkMprq0znL4psX/adEed5cBgiNJcfMz/eKZLg==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
+"@simple-dom/interface@1.4.0", "@simple-dom/interface@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
   integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
+
+"@simple-dom/parser@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@simple-dom/parser/-/parser-1.4.0.tgz#b1fee1a23f48a37d6bdd98f5242db0cab5b67abc"
+  integrity sha512-TNjDkOehueRIKr1df416qk9ELj+qWuVVJNIT25y1aZg3pQvxv4UPGrgaDFte7dsWBTbF3V8NYPNQ5FDUZQ8Wlg==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
+"@simple-dom/serializer@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@simple-dom/serializer/-/serializer-1.4.0.tgz#98470f357f418d72b1a1ec78d68191e60aefe215"
+  integrity sha512-mI1yRahsVs8atXLiQksineDsFEFqeG7RHwnnBTDOK6inbzl4tZQgjR+Z7edjgIJq5j5RhZvwPI6EuCji9B3eQw==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
+"@simple-dom/void-map@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@simple-dom/void-map/-/void-map-1.4.0.tgz#f15f07568fe1076740407266aa5e6eac249bc78c"
+  integrity sha512-VDhLEyVCbuhOBBgHol9ShzIv9O8UCzdXeH4FoXu2DOcu/nnvTjLTck+BgXsCLv5ynDiUdoqsREEVFnoyPpFKVw==
 
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
@@ -4727,7 +4753,7 @@ cookie@0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
-cookie@0.4.0:
+cookie@0.4.0, cookie@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
@@ -5580,6 +5606,28 @@ ember-cli-eslint@^5.1.0:
     rsvp "^4.6.1"
     walk-sync "^1.0.0"
 
+ember-cli-fastboot@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-fastboot/-/ember-cli-fastboot-2.2.0.tgz#202d4c3ebcf6e392d5348e17208dec9f04bab98f"
+  integrity sha512-9nbHJvQAwxN2i9FgUzsjhKclzSxJw6rmli8qwiblUkKVhs7PqKsjMszxA/Ssk3UjqCNkecEsNzaJoycPgrIChQ==
+  dependencies:
+    broccoli-concat "^3.7.1"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^3.0.1"
+    broccoli-plugin "^1.3.1"
+    chalk "^2.4.1"
+    ember-cli-babel "^7.1.0"
+    ember-cli-lodash-subset "2.0.1"
+    ember-cli-preprocess-registry "^3.1.2"
+    ember-cli-version-checker "^3.0.0"
+    fastboot "^2.0.0"
+    fastboot-express-middleware "^2.0.0"
+    fastboot-transform "^0.1.3"
+    fs-extra "^7.0.0"
+    json-stable-stringify "^1.0.1"
+    md5-hex "^2.0.0"
+    silent-error "^1.1.0"
+
 ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
@@ -5629,7 +5677,7 @@ ember-cli-is-package-missing@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-is-package-missing/-/ember-cli-is-package-missing-1.0.0.tgz#6e6184cafb92635dd93ca6c946b104292d4e3390"
   integrity sha1-bmGEyvuSY13ZPKbJRrEEKS1OM5A=
 
-ember-cli-lodash-subset@^2.0.1:
+ember-cli-lodash-subset@2.0.1, ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
   integrity sha1-IMtop5D+D94kiN39jvu332/nZvI=
@@ -5654,7 +5702,7 @@ ember-cli-polyfill-importer@^0.0.2:
     browserslist "^4.4.1"
     caniuse-api "^3.0.0"
 
-ember-cli-preprocess-registry@^3.3.0:
+ember-cli-preprocess-registry@^3.1.2, ember-cli-preprocess-registry@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-3.3.0.tgz#685837a314fbe57224bd54b189f4b9c23907a2de"
   integrity sha512-60GYpw7VPeB7TvzTLZTuLTlHdOXvayxjAQ+IxM2T04Xkfyu75O2ItbWlftQW7NZVGkaCsXSRAmn22PG03VpLMA==
@@ -6989,6 +7037,15 @@ fast-sourcemap-concat@^1.4.0:
     source-map-url "^0.3.0"
     sourcemap-validator "^1.1.0"
 
+fastboot-express-middleware@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fastboot-express-middleware/-/fastboot-express-middleware-2.0.0.tgz#3cb2c4b744e738a709b4336c4166f1a059ab0ffb"
+  integrity sha512-sJHZrHpo/8jh56t+DTzaDcg6cnHbmXlTSAdfhRZbBa8XDY3TfN+TjHsHd4Z7vouLFU+ISuaZkzKfwGwipW5xwQ==
+  dependencies:
+    chalk "^2.0.1"
+    fastboot "^2.0.1"
+    request "^2.81.0"
+
 fastboot-transform@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/fastboot-transform/-/fastboot-transform-0.1.3.tgz#7dea0b117594afd8772baa6c9b0919644e7f7dcd"
@@ -6996,6 +7053,20 @@ fastboot-transform@^0.1.3:
   dependencies:
     broccoli-stew "^1.5.0"
     convert-source-map "^1.5.1"
+
+fastboot@^2.0.0, fastboot@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-2.0.3.tgz#0b712e6c590f1b463dc5b12138893bcbbafa2459"
+  integrity sha512-NNH/o+XhITAQUnW2CC9IDXlcnI74W2BONjtRSRmc01N3uJl/7pcvX9iWTUWu2PYQbQZUBu8HzVFt7GmQ9qw9JQ==
+  dependencies:
+    chalk "^2.0.1"
+    cookie "^0.4.0"
+    debug "^4.1.0"
+    najax "^1.0.3"
+    resolve "^1.8.1"
+    rsvp "^4.8.0"
+    simple-dom "^1.4.0"
+    source-map-support "^0.5.0"
 
 fastparse@^1.1.1:
   version "1.1.2"
@@ -12024,7 +12095,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.87.0, request@^2.88.0:
+request@^2.81.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -12285,6 +12356,11 @@ rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.1, rsvp@^4.8.2, rsvp@^4.8.3, rsvp@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
   integrity sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==
+
+rsvp@^4.8.0:
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
+  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 rsvp@~3.2.1:
   version "3.2.1"
@@ -12595,6 +12671,17 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0, silent-error@^1.1
   dependencies:
     debug "^2.2.0"
 
+simple-dom@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/simple-dom/-/simple-dom-1.4.0.tgz#78ad1f41b8b70d16f82b7e0d458441c9262565b7"
+  integrity sha512-TnBPkmOyjdaOqyBMb4ick+n8c0Xv9Iwg1PykFV7hz9Se3UCiacTbRb+25cPmvozFNJLBUNvUzX/KsPfXF14ivA==
+  dependencies:
+    "@simple-dom/document" "^1.4.0"
+    "@simple-dom/interface" "^1.4.0"
+    "@simple-dom/parser" "^1.4.0"
+    "@simple-dom/serializer" "^1.4.0"
+    "@simple-dom/void-map" "^1.4.0"
+
 simple-fmt@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-fmt/-/simple-fmt-0.1.0.tgz#191bf566a59e6530482cb25ab53b4a8dc85c3a6b"
@@ -12766,6 +12853,14 @@ source-map-support@^0.4.15:
   integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
   dependencies:
     source-map "^0.5.6"
+
+source-map-support@^0.5.0:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.5.6:
   version "0.5.11"


### PR DESCRIPTION
I realized we don't yet have fastboot in our test suite, so I figured I would take the smallest step possible and add it to macro-test.


Once ember-cli-fastboot is added to an embroider app, that app will fail to build.
It will error with:

 `Error: attempted to set config after we have already emitted our config`

<details>
=================================================================================

ENV Summary:

  TIME: Wed Sep 11 2019 13:52:37 GMT-0600 (MDT)
  TITLE: ember
  ARGV:
  - /Users/spenner/.volta/tools/image/node/8.16.1/6.4.1/bin/node
  - /Users/spenner/src/embroider-build/embroider/test-packages/macro-tests/node_modules/.bin/ember
  - test
  - --test-port=0
  EXEC_PATH: /Users/spenner/.volta/tools/image/node/8.16.1/6.4.1/bin/node
  TMPDIR: /var/folders/4r/whc65vwj1xggvvky3yy1cp9m000mw4/T
  SHELL: /usr/local/bin/fish
  PATH:
  - /var/folders/4r/whc65vwj1xggvvky3yy1cp9m000mw4/T/yarn--1568231541278-0.06136183649502702
  - /Users/spenner/src/embroider-build/embroider/test-packages/macro-tests/node_modules/.bin
  - /Users/spenner/.config/yarn/link/node_modules/.bin
  - /Users/spenner/src/embroider-build/embroider/node_modules/.bin
  - /Users/spenner/src/embroider-build/embroider/test-packages/macro-tests/node_modules/.bin
  - /Users/spenner/.config/yarn/link/node_modules/.bin
  - /Users/spenner/src/embroider-build/embroider/node_modules/.bin
  - /Users/spenner/.volta/tools/image/node/8.16.1/6.4.1/libexec/lib/node_modules/npm/bin/node-gyp-bin
  - /Users/spenner/.volta/tools/image/node/8.16.1/6.4.1/lib/node_modules/npm/bin/node-gyp-bin
  - /Users/spenner/.volta/tools/image/node/8.16.1/6.4.1/bin/node_modules/npm/bin/node-gyp-bin
  - /Users/spenner/.volta/tools/image/node/8.16.1/6.4.1/bin
  - /Users/spenner/.volta/tools/image/yarn/1.16.0/bin
  - /Users/spenner/.cargo/bin
  - /Users/spenner/.fzf/bin
  - /Users/spenner/.yarn/bin
  - /Users/spenner/.local/bin
  - /Applications/Racket v7.1/bin/
  - /Users/spenner/libs/nvim-osx64/bin
  - /usr/local/bin
  - /usr/bin
  - /bin
  - /usr/sbin
  - /sbin
  - /usr/local/linkedin/bin
  - /Applications/VMware
  - Fusion.app/Contents/Public
  - /export/content/linkedin/bin
  - /export/content/granular/bin
  - /Applications/Wireshark.app/Contents/MacOS
  - /Users/spenner/.local/bin
  - /Applications/Racket v7.1/bin/
  - /Users/spenner/libs/nvim-osx64/bin
  PLATFORM: darwin x64
  FREEMEM: 1617211392
  TOTALMEM: 17179869184
  UPTIME: 613700
  LOADAVG: 7.8388671875,5.50732421875,4.03955078125
  CPUS:
  - Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz - 3100
  - Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz - 3100
  - Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz - 3100
  - Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz - 3100
  - Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz - 3100
  - Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz - 3100
  - Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz - 3100
  - Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz - 3100
  ENDIANNESS: LE
  VERSIONS:
  - ares: 1.10.1-DEV
  - cldr: 32.0
  - http_parser: 2.8.0
  - icu: 60.1
  - modules: 57
  - napi: 4
  - nghttp2: 1.39.2
  - node: 8.16.1
  - openssl: 1.0.2r
  - tz: 2017c
  - unicode: 10.0
  - uv: 1.23.2
  - v8: 6.2.414.77
  - zlib: 1.2.11

ERROR Summary:

  - broccoliBuilderErrorStack: Error: attempted to set config after we have already emitted our config
    at MacrosConfig.internalSetConfig (/Users/spenner/src/embroider-build/embroider/packages/macros/src/macros-config.js:58:19)
    at MacrosConfig.setOwnConfig (/Users/spenner/src/embroider-build/embroider/packages/macros/src/macros-config.js:54:21)
    at new AppBuilder (/Users/spenner/src/embroider-build/embroider/packages/core/src/app.js:144:40)
    at CompatApp.instantiate (/Users/spenner/src/embroider-build/embroider/packages/compat/src/compat-app.js:46:16)
    at WaitForTrees.wait_for_trees_1.default [as buildHook] (/Users/spenner/src/embroider-build/embroider/packages/core/src/build-stage.js:34:42)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
  - code: [undefined]
  - codeFrame: attempted to set config after we have already emitted our config
  - errorMessage: attempted to set config after we have already emitted our config
        at WaitForTrees (@embroider/compat/app)
-~- created here: -~-
    at new Plugin (/Users/spenner/src/embroider-build/embroider/packages/core/node_modules/broccoli-plugin/dist/index.js:42:31)
    at new WaitForTrees (/Users/spenner/src/embroider-build/embroider/packages/core/src/wait-for-trees.js:30:9)
    at CompatApp.get tree (/Users/spenner/src/embroider-build/embroider/packages/core/src/build-stage.js:26:16)
    at CompatApp.<anonymous> (/Users/spenner/src/embroider-build/embroider/node_modules/typescript-memoize/dist/memoize-decorator.js:67:52)
    at new PackagerRunner (/Users/spenner/src/embroider-build/embroider/packages/core/src/to-broccoli-plugin.js:10:26)
    at Object.defaultPipeline [as compatBuild] (/Users/spenner/src/embroider-build/embroider/packages/compat/src/default-pipeline.js:35:12)
    at module.exports (/Users/spenner/src/embroider-build/embroider/test-packages/macro-tests/ember-cli-build.js:52:39)
    at Builder.readBuildFile (/Users/spenner/src/embroider-build/embroider/node_modules/ember-cli/lib/models/builder.js:51:14)
    at Builder.setupBroccoliBuilder (/Users/spenner/src/embroider-build/embroider/node_modules/ember-cli/lib/models/builder.js:65:22)
    at new Builder (/Users/spenner/src/embroider-build/embroider/node_modules/ember-cli/lib/models/builder.js:31:10)
-~- (end) -~-
  - errorType: Build Error
  - location:
    - column: [undefined]
    - file: [undefined]
    - line: [undefined]
    - treeDir: [undefined]
  - message: attempted to set config after we have already emitted our config
        at WaitForTrees (@embroider/compat/app)
-~- created here: -~-
    at new Plugin (/Users/spenner/src/embroider-build/embroider/packages/core/node_modules/broccoli-plugin/dist/index.js:42:31)
    at new WaitForTrees (/Users/spenner/src/embroider-build/embroider/packages/core/src/wait-for-trees.js:30:9)
    at CompatApp.get tree (/Users/spenner/src/embroider-build/embroider/packages/core/src/build-stage.js:26:16)
    at CompatApp.<anonymous> (/Users/spenner/src/embroider-build/embroider/node_modules/typescript-memoize/dist/memoize-decorator.js:67:52)
    at new PackagerRunner (/Users/spenner/src/embroider-build/embroider/packages/core/src/to-broccoli-plugin.js:10:26)
    at Object.defaultPipeline [as compatBuild] (/Users/spenner/src/embroider-build/embroider/packages/compat/src/default-pipeline.js:35:12)
    at module.exports (/Users/spenner/src/embroider-build/embroider/test-packages/macro-tests/ember-cli-build.js:52:39)
    at Builder.readBuildFile (/Users/spenner/src/embroider-build/embroider/node_modules/ember-cli/lib/models/builder.js:51:14)
    at Builder.setupBroccoliBuilder (/Users/spenner/src/embroider-build/embroider/node_modules/ember-cli/lib/models/builder.js:65:22)
    at new Builder (/Users/spenner/src/embroider-build/embroider/node_modules/ember-cli/lib/models/builder.js:31:10)
-~- (end) -~-
  - name: BuildError
  - nodeAnnotation: @embroider/compat/app
  - nodeName: WaitForTrees
  - originalErrorMessage: attempted to set config after we have already emitted our config
  - stack: Error: attempted to set config after we have already emitted our config
    at MacrosConfig.internalSetConfig (/Users/spenner/src/embroider-build/embroider/packages/macros/src/macros-config.js:58:19)
    at MacrosConfig.setOwnConfig (/Users/spenner/src/embroider-build/embroider/packages/macros/src/macros-config.js:54:21)
    at new AppBuilder (/Users/spenner/src/embroider-build/embroider/packages/core/src/app.js:144:40)
    at CompatApp.instantiate (/Users/spenner/src/embroider-build/embroider/packages/compat/src/compat-app.js:46:16)
    at WaitForTrees.wait_for_trees_1.default [as buildHook] (/Users/spenner/src/embroider-build/embroider/packages/core/src/build-stage.js:34:42)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)

=================================================================================

</details>

Some investigation:

It appears that ember-cli-fastboot via https://github.com/ember-fastboot/ember-cli-fastboot/blob/6a4c8b813f67ba5c0f14e174bdc2b15f8b827a46/index.js#L198 is causing babel configs to be created. A side affect of this is that MacroConfig's `userConfig`  is accessed, locking `userConfig` down for future mutation.

Later in the flow, while instantiating `AppBuilder` we once again attempt to set the user config via `MacrosConfig.shared().setOwnConfig(__filename, { active: true });` unfortunately, since it has already been cached, we error out.


(I'm continuing to debug, just figured I would share as I go)

- [x] get all the needed fastboot stuff released
- [x] fix missing devDeps
- [x] POC fix for MacroConfig issue
- [ ] figure out the appropriate fix for the MacroConfig issue
- [x] initial works
- [x] debug rebuild issues: It appears something is looking for `assets/macro-tests.js` https://github.com/ember-fastboot/ember-cli-fastboot/pull/727
- [ ] fix above ember-cli-fastboot issue for rebuilds.
 
```
Reloading FastBoot...
ENOENT: no such file or directory, open '/var/folders/4r/whc65vwj1xggvvky3yy1cp9m000mw4/T/broccoli-5957SSSrbsufbxqg/out-203-packager_runner_embroider_webpack/assets/macro-tests.js'
```
- [ ] rebuild works