### PR TITLE
add ember-classic-decorator to our test cases

### DIFF
--- a/test-packages/macro-tests/.eslintrc.js
+++ b/test-packages/macro-tests/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'
@@ -15,6 +16,8 @@ module.exports = {
     browser: true
   },
   rules: {
+    'ember/classic-decorator-hooks': 'error',
+    'ember/classic-decorator-no-classic-methods': 'error'
   },
   overrides: [
     // node files

--- a/test-packages/macro-tests/app/util/random-ember-object.js
+++ b/test-packages/macro-tests/app/util/random-ember-object.js
@@ -1,0 +1,5 @@
+
+import EmberObject from '@ember/object';
+import classic from 'ember-classic-decorator';
+
+export default @classic class Foo extends EmberObject {}

--- a/test-packages/macro-tests/package.json
+++ b/test-packages/macro-tests/package.json
@@ -22,8 +22,10 @@
     "@ember/optional-features": "^0.7.0",
     "@embroider/compat": "0.6.0",
     "@embroider/core": "0.6.0",
+    "@embroider/funky-sample-addon": "0.0.0",
     "@embroider/macros": "0.6.0",
     "@embroider/webpack": "0.6.0",
+    "babel-eslint": "^10.0.3",
     "ember-ajax": "^5.0.0",
     "ember-cli": "~3.10.1",
     "ember-cli-app-version": "^3.2.0",
@@ -48,13 +50,13 @@
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
     "macro-sample-addon": "0.0.0",
-    "@embroider/funky-sample-addon": "0.0.0",
     "qunit-dom": "^0.8.4"
   },
   "engines": {
     "node": "8.* || >= 10.*"
   },
   "dependencies": {
+    "ember-classic-decorator": "^0.1.3",
     "ember-cli-babel-polyfills": "1.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2277,6 +2277,18 @@ babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
     slash "^1.0.0"
     source-map "^0.5.7"
 
+babel-eslint@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
+  integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
+
 babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
@@ -2518,6 +2530,14 @@ babel-plugin-filter-imports@^2.0.4:
   integrity sha512-Ra4VylqMFsmTJCUeLRJ/OP2ZqO0cCJQK2HKihNTnoKP4f8IhxHKL4EkbmfkwGjXCeDyXd0xQ6UTK8Nd+h9V/SQ==
   dependencies:
     "@babel/types" "^7.1.5"
+    lodash "^4.17.11"
+
+babel-plugin-filter-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-3.0.0.tgz#a849683837ad29960da17492fb32789ab6b09a11"
+  integrity sha512-p/chjzVTgCxUqyLM0q/pfWVZS7IJTwGQMwNg0LOvuQpKiTftQgZDtkGB8XvETnUw19rRcL7bJCTopSwibTN2tA==
+  dependencies:
+    "@babel/types" "^7.4.0"
     lodash "^4.17.11"
 
 babel-plugin-htmlbars-inline-precompile@^1.0.0:
@@ -5425,6 +5445,14 @@ ember-basic-dropdown@^1.0.0, ember-basic-dropdown@^1.1.0:
     ember-cli-babel "^7.2.0"
     ember-cli-htmlbars "^3.0.1"
     ember-maybe-in-element "^0.2.0"
+
+ember-classic-decorator@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ember-classic-decorator/-/ember-classic-decorator-0.1.3.tgz#d155e0687a51097e049961f55f0e474beb97168f"
+  integrity sha512-4zLUyjTNzh0/YOwya1QjpxGAtwIuC89QEYl9BJFxE+WgZXKlxJTqC55S3IQM9nduzDY+o+4RXy5ER90A2emsTA==
+  dependencies:
+    babel-plugin-filter-imports "^3.0.0"
+    ember-cli-babel "^7.7.3"
 
 ember-cli-app-version@^3.2.0:
   version "3.2.0"
@@ -12179,6 +12207,13 @@ resolve@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
Note this is currently failing:

- [x] eslint failures (even after following instructions on the ember-classic-decorators readme) cc @pzuraq
- [ ] fully understand build crash 
- [ ] fix build crash 
```
Module not found: Error: Can't resolve 'ember-classic-decorator' in '/private/var/folders/4r/whc65vwj1xggvvky3yy1cp9m000mw4/T/embroider/e81a6f/test-packages/macro-tests/util'
  - stack: ModuleNotFoundError: Module not found: Error: Can't resolve 'ember-classic-decorator' in '/private/var/folders/4r/whc65vwj1xggvvky3yy1cp9m000mw4/T/embroider/e81a6f/test-packages/macro-tests/util'
    at factory.create (/Users/spenner/src/embroider-build/embroider/node_modules/webpack/lib/Compilation.js:821:10)
    at factory (/Users/spenner/src/embroider-build/embroider/node_modules/webpack/lib/NormalModuleFactory.js:397:22)
    at resolver (/Users/spenner/src/embroider-build/embroider/node_modules/webpack/lib/NormalModuleFactory.js:130:21)
    at asyncLib.parallel (/Users/spenner/src/embroider-build/embroider/node_modules/webpack/lib/NormalModuleFactory.js:224:22)
    at /Users/spenner/src/embroider-build/embroider/node_modules/neo-async/async.js:2825:7
    at /Users/spenner/src/embroider-build/embroider/node_modules/neo-async/async.js:6886:13
    at normalResolver.resolve (/Users/spenner/src/embroider-build/embroider/node_modules/webpack/lib/NormalModuleFactory.js:214:25)
    at doResolve (/Users/spenner/src/embroider-build/embroider/node_modules/enhanced-resolve/lib/Resolver.js:184:12)
    at hook.callAsync (/Users/spenner/src/embroider-build/embroider/node_modules/enhanced-resolve/lib/Resolver.js:238:5)
    at _fn0 (eval at create (/Users/spenner/src/embroider-build/embroider/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:15:1)
```