### PR TITLE
Add basic engine usage + tests

### DIFF
--- a/test-packages/macro-tests/app/router.js
+++ b/test-packages/macro-tests/app/router.js
@@ -7,6 +7,9 @@ const Router = EmberRouter.extend({
 });
 
 Router.map(function() {
+  this.mount('eager');
+  this.mount('routeless');
+  this.mount('lazy');
 });
 
 export default Router;

--- a/test-packages/macro-tests/lib/eager/addon/engine.js
+++ b/test-packages/macro-tests/lib/eager/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from './resolver';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/test-packages/macro-tests/lib/eager/addon/resolver.js
+++ b/test-packages/macro-tests/lib/eager/addon/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/test-packages/macro-tests/lib/eager/addon/routes.js
+++ b/test-packages/macro-tests/lib/eager/addon/routes.js
@@ -1,0 +1,5 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function() {
+  // Define your engine's route map here
+});

--- a/test-packages/macro-tests/lib/eager/addon/templates/application.hbs
+++ b/test-packages/macro-tests/lib/eager/addon/templates/application.hbs
@@ -1,0 +1,2 @@
+<h1 id="engine-title">Eager</h1>
+{{outlet}}

--- a/test-packages/macro-tests/lib/eager/config/environment.js
+++ b/test-packages/macro-tests/lib/eager/config/environment.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'eager',
+    environment
+  };
+
+  return ENV;
+};

--- a/test-packages/macro-tests/lib/eager/index.js
+++ b/test-packages/macro-tests/lib/eager/index.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+'use strict';
+
+const EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'eager',
+
+  lazyLoading: Object.freeze({
+    enabled: false
+  }),
+
+  isDevelopingAddon() {
+    return true;
+  }
+});

--- a/test-packages/macro-tests/lib/eager/package.json
+++ b/test-packages/macro-tests/lib/eager/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "eager",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  }
+}

--- a/test-packages/macro-tests/lib/lazy/addon/engine.js
+++ b/test-packages/macro-tests/lib/lazy/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from './resolver';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/test-packages/macro-tests/lib/lazy/addon/resolver.js
+++ b/test-packages/macro-tests/lib/lazy/addon/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/test-packages/macro-tests/lib/lazy/addon/routes.js
+++ b/test-packages/macro-tests/lib/lazy/addon/routes.js
@@ -1,0 +1,5 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function() {
+  // Define your engine's route map here
+});

--- a/test-packages/macro-tests/lib/lazy/addon/templates/application.hbs
+++ b/test-packages/macro-tests/lib/lazy/addon/templates/application.hbs
@@ -1,0 +1,2 @@
+<h1 id="engine-title">Lazy</h1>
+{{outlet}}

--- a/test-packages/macro-tests/lib/lazy/config/environment.js
+++ b/test-packages/macro-tests/lib/lazy/config/environment.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'lazy',
+    environment
+  };
+
+  return ENV;
+};

--- a/test-packages/macro-tests/lib/lazy/index.js
+++ b/test-packages/macro-tests/lib/lazy/index.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+'use strict';
+
+const EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'lazy',
+
+  lazyLoading: Object.freeze({
+    enabled: true
+  }),
+
+  isDevelopingAddon() {
+    return true;
+  }
+});

--- a/test-packages/macro-tests/lib/lazy/package.json
+++ b/test-packages/macro-tests/lib/lazy/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "lazy",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  }
+}

--- a/test-packages/macro-tests/lib/routeless/addon/engine.js
+++ b/test-packages/macro-tests/lib/routeless/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from './resolver';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/test-packages/macro-tests/lib/routeless/addon/resolver.js
+++ b/test-packages/macro-tests/lib/routeless/addon/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/test-packages/macro-tests/lib/routeless/config/environment.js
+++ b/test-packages/macro-tests/lib/routeless/config/environment.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'routeless',
+    environment
+  };
+
+  return ENV;
+};

--- a/test-packages/macro-tests/lib/routeless/index.js
+++ b/test-packages/macro-tests/lib/routeless/index.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+'use strict';
+
+const EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'routeless',
+
+  lazyLoading: Object.freeze({
+    enabled: false
+  }),
+
+  isDevelopingAddon() {
+    return true;
+  }
+});

--- a/test-packages/macro-tests/lib/routeless/package.json
+++ b/test-packages/macro-tests/lib/routeless/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "routeless",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  }
+}

--- a/test-packages/macro-tests/package.json
+++ b/test-packages/macro-tests/package.json
@@ -22,6 +22,7 @@
     "@ember/optional-features": "^0.7.0",
     "@embroider/compat": "0.6.0",
     "@embroider/core": "0.6.0",
+    "@embroider/funky-sample-addon": "0.0.0",
     "@embroider/macros": "0.6.0",
     "@embroider/webpack": "0.6.0",
     "ember-ajax": "^5.0.0",
@@ -37,6 +38,7 @@
     "ember-cli-template-lint": "^1.0.0-beta.3",
     "ember-cli-uglify": "^2.1.0",
     "ember-data": "~3.10.0",
+    "ember-engines": "^0.8.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
@@ -48,7 +50,6 @@
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
     "macro-sample-addon": "0.0.0",
-    "@embroider/funky-sample-addon": "0.0.0",
     "qunit-dom": "^0.8.4"
   },
   "engines": {
@@ -56,5 +57,12 @@
   },
   "dependencies": {
     "ember-cli-babel-polyfills": "1.0.4"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/eager",
+      "lib/lazy",
+      "lib/routeless"
+    ]
   }
 }

--- a/test-packages/macro-tests/tests/acceptance/basic-test.js
+++ b/test-packages/macro-tests/tests/acceptance/basic-test.js
@@ -37,4 +37,11 @@ module('Acceptance | smoke tests', function(hooks) {
       'FOUR', 'TWO', 'THREE', 'ONE'
     ]);
   });
+
+  test('navigate to engines', async function(assert) {
+    await visit('eager');
+    assert.equal(document.querySelector('#engine-title').textContent, 'Eager');
+    await visit('lazy');
+    assert.equal(document.querySelector('#engine-title').textContent, 'Lazy');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,6 +1523,11 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
   integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
 
+"@types/tmp@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
+  integrity sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=
+
 "@types/tmp@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
@@ -1787,7 +1792,7 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
   integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
 
-acorn@^5.0.0, acorn@^5.2.1, acorn@^5.5.3, acorn@^5.6.2:
+acorn@^5.0.0, acorn@^5.1.1, acorn@^5.2.1, acorn@^5.5.3, acorn@^5.6.2:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
@@ -1860,13 +1865,20 @@ amd-name-resolver@1.2.0:
   dependencies:
     ensure-posix-path "^1.0.1"
 
-amd-name-resolver@^1.2.0, amd-name-resolver@^1.2.1, amd-name-resolver@^1.3.1:
+amd-name-resolver@1.3.1, amd-name-resolver@^1.2.0, amd-name-resolver@^1.2.1, amd-name-resolver@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.3.1.tgz#ffe71c683c6e7191fc4ae1bb3aaed15abea135d9"
   integrity sha512-26qTEWqZQ+cxSYygZ4Cf8tsjDBLceJahhtewxtKZA3SRa4PluuqYCuheemDQD+7Mf5B7sr+zhTDWAHDh02a1Dw==
   dependencies:
     ensure-posix-path "^1.0.1"
     object-hash "^1.3.1"
+
+amd-name-resolver@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz#d3e4ba2dfcaab1d820c1be9de947c67828cfe595"
+  integrity sha1-0+S6Lfyqsdggwb6d6UfGeCjP5ZU=
+  dependencies:
+    ensure-posix-path "^1.0.1"
 
 amdefine@>=0.0.4:
   version "1.0.1"
@@ -2445,6 +2457,11 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-compact-reexports@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-compact-reexports/-/babel-plugin-compact-reexports-1.1.0.tgz#d329cf70ff882e1b3c916da15b312338caf29490"
+  integrity sha512-+KgjNJ5yMeZzJxYZdLEy9m82m92aL7FLvNJcK6dYJbW06t+UTpFJ2FVSs35zMfURcPnrQELYhLG4VC+kt/4gvw==
+
 babel-plugin-constant-folding@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz#8361d364c98e449c3692bdba51eff0844290aa8e"
@@ -2475,6 +2492,13 @@ babel-plugin-debug-macros@^0.3.0:
   integrity sha512-E+NI8TKpxJDBbVkdWkwHrKgJi696mnRL8XYrOPYw82veNHPDORM9WIQifl6TpIo8PNy2tU2skPqbfkmHXrHKQA==
   dependencies:
     semver "^5.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.12.0.tgz#a5e703205ba4e625a7fab9bb1aea64ef3222cf75"
+  integrity sha512-ZQU4quX0TJ1yYyosPy5PFigKdCFEVHJ6H0b3hwjxekIP9CDwzk0OhQuKhCOPti+d52VWjjCjxu2BrXEih29mFw==
+  dependencies:
+    ember-rfc176-data "^0.3.12"
 
 babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.7.0:
   version "2.7.0"
@@ -3372,6 +3396,21 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.4, broccoli-debug@^0.6.5:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-dependency-funnel@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-dependency-funnel/-/broccoli-dependency-funnel-2.1.2.tgz#44126dd67ef2c68c4e78edeb0315e78fae9ab0ff"
+  integrity sha512-k6b0OnNuRcUnJ9TXA0o6RvqXOkTQ6APKoLsZeMJHAe/YjLjE1uTlfw4Z88GfGmi8gwtLHdnkrhBoJ7YdIkcVZA==
+  dependencies:
+    broccoli-plugin "^1.3.1"
+    fs-tree-diff "^0.5.9"
+    heimdalljs "^0.2.5"
+    heimdalljs-logger "^0.1.9"
+    mkdirp "^0.5.1"
+    mr-dep-walk "^1.4.0"
+    path-posix "^1.0.0"
+    rimraf "^2.6.2"
+    symlink-or-copy "^1.2.0"
+
 broccoli-file-creator@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
@@ -3781,6 +3820,18 @@ broccoli-stew@^2.1.0:
     symlink-or-copy "^1.2.0"
     walk-sync "^0.3.3"
 
+broccoli-test-helper@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-test-helper/-/broccoli-test-helper-2.0.0.tgz#1cfbb76f7e856ad8df96d55ee2f5e0dddddf5d4f"
+  integrity sha512-TKwh8dBT+RcxKEG+vAoaRRhZsCMwZIHPZbCzBNCA0nUi1aoFB/LVosqwMC6H9Ipe06FxY5hpQxDLFbnBMdUPsA==
+  dependencies:
+    "@types/tmp" "^0.0.33"
+    broccoli "^2.0.0"
+    fixturify "^0.3.2"
+    fs-tree-diff "^0.5.9"
+    tmp "^0.0.33"
+    walk-sync "^0.3.3"
+
 broccoli-uglify-sourcemap@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.2.0.tgz#2ff49389bdf342a550c3596750ba2dde95a8f7d4"
@@ -3798,10 +3849,10 @@ broccoli-uglify-sourcemap@^2.1.1:
     walk-sync "^0.3.2"
     workerpool "^2.3.0"
 
-broccoli@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-2.2.0.tgz#52f3cfdd4b2463030de211de8ebb36898734fe5b"
-  integrity sha512-g+3h+vpxTccfhIXkVqb+Ep43Cp0I9RjL27BY63/IpjOLlBI9RGcAjL5aYnCxB7ewfb4y0212xp4tFj+oDWAe+A==
+broccoli@^2.0.0, broccoli@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-2.3.0.tgz#b3f71b2c3d02fc042988e208827a09c75dd7b350"
+  integrity sha512-TeYMYlCGFK8EGk4Wce1G1uU3i52+YxRqP3WPOVDojC1zUk+Gi40wHBzUT2fncQZDl26dmCQMNugtHKjvUpcGQg==
   dependencies:
     broccoli-node-info "1.1.0"
     broccoli-slow-trees "^3.0.1"
@@ -3823,10 +3874,10 @@ broccoli@^2.2.0:
     underscore.string "^3.2.2"
     watch-detector "^0.1.0"
 
-broccoli@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-2.3.0.tgz#b3f71b2c3d02fc042988e208827a09c75dd7b350"
-  integrity sha512-TeYMYlCGFK8EGk4Wce1G1uU3i52+YxRqP3WPOVDojC1zUk+Gi40wHBzUT2fncQZDl26dmCQMNugtHKjvUpcGQg==
+broccoli@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-2.2.0.tgz#52f3cfdd4b2463030de211de8ebb36898734fe5b"
+  integrity sha512-g+3h+vpxTccfhIXkVqb+Ep43Cp0I9RjL27BY63/IpjOLlBI9RGcAjL5aYnCxB7ewfb4y0212xp4tFj+oDWAe+A==
   dependencies:
     broccoli-node-info "1.1.0"
     broccoli-slow-trees "^3.0.1"
@@ -5374,6 +5425,19 @@ ember-ajax@^5.0.0:
     ember-cli-babel "^7.5.0"
     najax "^1.0.3"
 
+ember-asset-loader@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/ember-asset-loader/-/ember-asset-loader-0.6.1.tgz#2eb81221406164d19127eba5b3d10f908df89a17"
+  integrity sha512-e2zafQJBMLhzl69caTG/+mQMH20uMHYrm7KcmdbmnX0oY2dZ48bhm0Wh1SPLXS/6G2T9NsNMWX6J2pVSnI+xyA==
+  dependencies:
+    broccoli-caching-writer "^3.0.3"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    ember-cli-babel "^7.5.0"
+    fs-extra "^7.0.1"
+    object-assign "^4.1.0"
+    walk-sync "^1.1.3"
+
 ember-assign-polyfill@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.6.0.tgz#07847e3357ee35b33f886a0b5fbec6873f6860eb"
@@ -5539,6 +5603,33 @@ ember-cli-babel@^7.1.2:
     broccoli-funnel "^2.0.1"
     broccoli-source "^1.1.0"
     clone "^2.1.2"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.8.0:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.11.0.tgz#a2f4e4f123a4690968b512b87b4ff4bfa57ec244"
+  integrity sha512-ykEsr7XoEPaADCBCJMViycCok1grtBRGvZ1k/atlL/gQYCQ1W4E4OROY/Mm2YBgyLftBv6buH7IZsULyQRZUmg==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-proposal-class-properties" "^7.3.4"
+    "@babel/plugin-proposal-decorators" "^7.3.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/runtime" "^7.2.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.0"
+    babel-plugin-ember-modules-api-polyfill "^2.12.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.0"
     ember-cli-version-checker "^2.1.2"
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
@@ -5960,6 +6051,29 @@ ember-disable-prototype-extensions@^1.1.3:
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
   integrity sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=
 
+ember-engines@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/ember-engines/-/ember-engines-0.8.2.tgz#d1be1929217c5454b37ec2e6b07a0057075447b8"
+  integrity sha512-Lhwkj02b9/MjOyl3MFToL4Pa1djFtDjQOxI8SY86P81XUBbRDdeZ3pg5tDxU/upEeQ7La7uepoZWTBRj6Lxx0Q==
+  dependencies:
+    amd-name-resolver "1.3.1"
+    babel-plugin-compact-reexports "^1.1.0"
+    broccoli-babel-transpiler "^7.2.0"
+    broccoli-concat "^3.7.3"
+    broccoli-debug "^0.6.5"
+    broccoli-dependency-funnel "^2.1.2"
+    broccoli-file-creator "^2.1.1"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-test-helper "^2.0.0"
+    calculate-cache-key-for-tree "^2.0.0"
+    ember-asset-loader "^0.6.1"
+    ember-cli-babel "^7.8.0"
+    ember-cli-preprocess-registry "^3.3.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-version-checker "^3.1.3"
+    lodash "^4.17.11"
+
 ember-export-application-global@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
@@ -6109,6 +6223,11 @@ ember-resolver@^5.0.1:
     ember-cli-babel "^6.16.0"
     ember-cli-version-checker "^3.0.0"
     resolve "^1.10.0"
+
+ember-rfc176-data@^0.3.12:
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz#90d82878e69e2ac9a5438e8ce14d12c6031c5bd2"
+  integrity sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g==
 
 ember-rfc176-data@^0.3.7:
   version "0.3.7"
@@ -7176,7 +7295,7 @@ fixturify-project@^1.8.0:
     fixturify "^0.3.4"
     tmp "^0.0.33"
 
-fixturify@^0.3.4:
+fixturify@^0.3.2, fixturify@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-0.3.4.tgz#c676de404a7f8ee8e64d0b76118e62ec95ab7b25"
   integrity sha512-Gx+KSB25b6gMc4bf7UFRTA85uE0iZR+RYur0JHh6dg4AGBh0EksOv4FCHyM7XpGmiJO7Bc7oV7vxENQBT+2WEQ==
@@ -7300,6 +7419,15 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  integrity sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -7348,7 +7476,7 @@ fs-readdir-recursive@^0.1.0:
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
   integrity sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=
 
-fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6, fs-tree-diff@^0.5.7:
+fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6, fs-tree-diff@^0.5.7, fs-tree-diff@^0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz#a4ec6182c2f5bd80b9b83c8e23e4522e6f5fd946"
   integrity sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==
@@ -9218,6 +9346,13 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  integrity sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -10336,6 +10471,15 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
+
+mr-dep-walk@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/mr-dep-walk/-/mr-dep-walk-1.4.0.tgz#c8cd4223ceb10544ac7a4dd405c08451a328e054"
+  integrity sha512-UaDUqkLsd0ep3jAx2+A7BIpfw8wKxhthDj3yPNLBnevipK1CUFJJiz24jRVLw18q7R2aEiRq13WwUBlnwfbQqQ==
+  dependencies:
+    acorn "^5.1.1"
+    amd-name-resolver "^0.0.6"
+    fs-extra "^3.0.1"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This currently fails as soon and ember-engines is added as a dependency with:
```
ERROR: Uncaught Error: Failed to load asset manifest. For browser environments, verify the meta tag with name "macro-tests/config/asset-manifest" is present. For non-browser environments, verify that you included the node-asset-manifest module. at webpack:///./config/asset-manifest.js?, line 22
```

But I have added some basic examples that I believe should be functional...

**aims to be a local reproduction of #320**
 
- [ ] work properly + tests
- [ ] refactor to test-packages/ember-engines