### PR TITLE
Added support for custom app-boot type in contentFor

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -48,6 +48,7 @@ function setup(legacyEmberAppInstance: object, options: Required<Options>) {
   let htmlTree = oldPackage.htmlTree;
   let publicTree = oldPackage.publicTree;
   let configTree = oldPackage.config;
+  let appBootTree = oldPackage.appBoot;
 
   if (options.extraPublicTrees.length > 0) {
     publicTree = mergeTrees([publicTree, ...options.extraPublicTrees].filter(Boolean));
@@ -58,6 +59,7 @@ function setup(legacyEmberAppInstance: object, options: Required<Options>) {
     htmlTree,
     publicTree,
     configTree,
+    appBootTree,
   };
 
   let instantiate = async (root: string, appSrcDir: string, packageCache: PackageCache) => {
@@ -212,6 +214,10 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
 
   autoRun(): boolean {
     return this.oldPackage.autoRun;
+  }
+
+  appBoot(): string | undefined {
+    return this.oldPackage.appBoot.readAppBoot();
   }
 
   mainModule(): string {

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -8,6 +8,7 @@ import resolve from 'resolve';
 import V1Package from './v1-package';
 import { Tree } from 'broccoli-plugin';
 import { V1Config, WriteV1Config } from './v1-config';
+import { WriteV1AppBoot, ReadV1AppBoot } from './v1-appboot';
 import { PackageCache, TemplateCompiler, TemplateCompilerPlugins, AddonMeta, Package } from '@embroider/core';
 import { writeJSONSync, ensureDirSync, copySync, readdirSync, pathExistsSync } from 'fs-extra';
 import AddToTree from './add-to-tree';
@@ -170,6 +171,22 @@ export default class V1App implements V1Package {
 
   get autoRun(): boolean {
     return this.app.options.autoRun;
+  }
+
+  @Memoize()
+  get appBoot(): ReadV1AppBoot {
+    let env = this.app.env;
+    let appBootContentTree = new WriteV1AppBoot();
+
+    let patterns = this.configReplacePatterns;
+
+    appBootContentTree = new this.configReplace(appBootContentTree, this.configTree, {
+      configPath: join('environments', `${env}.json`),
+      files: ['config/app-boot.js'],
+      patterns,
+    });
+
+    return new ReadV1AppBoot(appBootContentTree);
   }
 
   private get storeConfigInMeta(): boolean {

--- a/packages/compat/src/v1-appboot.ts
+++ b/packages/compat/src/v1-appboot.ts
@@ -1,0 +1,39 @@
+import Plugin, { Tree } from 'broccoli-plugin';
+import { join } from 'path';
+import { readFileSync, outputFileSync } from 'fs-extra';
+
+export class WriteV1AppBoot extends Plugin {
+  private lastContents: string | undefined;
+  constructor() {
+    super([], {
+      persistentOutput: true,
+    });
+  }
+  build() {
+    let filename = join(this.outputPath, 'config/app-boot.js');
+    let contents = `{{content-for "app-boot"}}`;
+    if (!this.lastContents || this.lastContents !== contents) {
+      outputFileSync(filename, contents);
+    }
+    this.lastContents = contents;
+  }
+}
+
+export class ReadV1AppBoot extends Plugin {
+  private appBoot: string | undefined;
+  constructor(appBootTree: Tree) {
+    super([appBootTree], {
+      persistentOutput: true,
+    });
+  }
+  build() {
+    this.appBoot = readFileSync(join(this.inputPaths[0], `config/app-boot.js`), 'utf8');
+  }
+
+  readAppBoot() {
+    if (!this.appBoot) {
+      throw new Error(`AppBoot not available until after the build`);
+    }
+    return this.appBoot;
+  }
+}

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -58,6 +58,9 @@ export interface AppAdapter<TreeNames> {
   // whether the ember app should boot itself automatically
   autoRun(): boolean;
 
+  // custom app-boot logic when the autoRun is set to false
+  appBoot(): string | undefined;
+
   // the ember app's main module
   mainModule(): string;
 
@@ -837,6 +840,7 @@ export class AppBuilder<TreeNames> {
     let source = entryTemplate({
       amdModules,
       autoRun: this.adapter.autoRun(),
+      appBoot: !this.adapter.autoRun() ? this.adapter.appBoot() : '',
       mainModule: explicitRelative(dirname(relativePath), this.adapter.mainModule()),
       appConfig: this.adapter.mainModuleConfig(),
       lazyRoutes,
@@ -964,6 +968,8 @@ let d = w.define;
   if (typeof EMBER_DISABLE_AUTO_BOOT === 'undefined' || !EMBER_DISABLE_AUTO_BOOT) {
     i("{{js-string-escape mainModule}}").default.create({{{json-stringify appConfig}}});
   }
+{{else  if appBoot ~}}
+  {{{ appBoot }}}
 {{/if}}
 
 {{#if testSuffix ~}}
@@ -984,6 +990,7 @@ let d = w.define;
   amdModules?: ({ runtime: string; buildtime: string })[];
   eagerModules?: string[];
   autoRun?: boolean;
+  appBoot?: string;
   mainModule?: string;
   appConfig?: unknown;
   testSuffix?: boolean;

--- a/test-packages/macro-sample-addon/index.js
+++ b/test-packages/macro-sample-addon/index.js
@@ -9,6 +9,10 @@ module.exports = {
       }
     }
   },
+  included(app) {
+    app.options.autoRun = false;
+    this._super.included.apply(this, arguments);
+  },
   contentFor(type, config, contents) {
     if (type === 'config-module') {
       const originalContents = contents.join('');
@@ -19,6 +23,16 @@ module.exports = {
         'return config;'
       );
       return;
+    }
+
+    if (type === 'app-boot') {
+      let appSuffix = 'app';
+      let prefix = config.modulePrefix;
+      let configAppAsString = JSON.stringify(config.APP || {});
+      return [
+        "require('{{MODULE_PREFIX}}/" + appSuffix + "')['default'].create({{CONFIG_APP}});",
+        "window.LoadedFromCustomAppBoot = true",
+      ].join("\n").replace(/\{\{MODULE_PREFIX\}\}/g, prefix).replace(/\{\{CONFIG_APP\}\}/g, configAppAsString);
     }
   }
 };

--- a/test-packages/macro-sample-addon/tests/acceptance/app-boot-test.js
+++ b/test-packages/macro-sample-addon/tests/acceptance/app-boot-test.js
@@ -1,0 +1,7 @@
+import { module, test } from 'qunit';
+
+module('Acceptance | Custom app boot', function () {
+  test('ensure app boot up is happening from custom app-boot', function (assert) {
+    assert.equal(window.LoadedFromCustomAppBoot, true, `expected: 'This addon to inject custom app-boot`);
+  });
+});

--- a/test-packages/macro-sample-addon/tests/integration/helpers/reflect-config-test.js
+++ b/test-packages/macro-sample-addon/tests/integration/helpers/reflect-config-test.js
@@ -4,12 +4,12 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { helper } from '@ember/component/helper';
 
-module('Integration | Helper | reflect-config', function(hooks) {
+module('Integration | Helper | reflect-config', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it accesses our config', async function(assert) {
+  test('it accesses our config', async function (assert) {
     assert.expect(1);
-    this.owner.register('helper:my-assertion', helper(function([value]) {
+    this.owner.register('helper:my-assertion', helper(function ([value]) {
       assert.deepEqual(value, { hello: 'world' });
     }));
     await render(hbs`{{my-assertion (reflect-config) }}`);


### PR DESCRIPTION
Fix for #183 

This includes the following:
1. Adds support to use custom `app-boot` of contentFor.
2. Updates that fixes Macro-config error came when building test app with fastboot support. Applied the patch provided by @stefanpenner 
3. Fixed vendor files in Macro-test app.
4. Test that asserts application is booting using custom boot logic added by ember-cli-fastboot addon as part of a separate fastboot app. @stefanpenner.
5. Added test for custom app-boot as part of Macro-test app.
6. Verified by linking to ember app using the ember-cli-fastboot add-on.

cc: @stefanpenner @ef4 