### PR TITLE
Rebuild bugs

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -4,11 +4,10 @@ import { compile } from './js-handlebars';
 import Package, { V2AddonPackage } from './package';
 import resolve from 'resolve';
 import { Memoize } from 'typescript-memoize';
-import { writeFileSync, ensureDirSync, copySync, unlinkSync, statSync, existsSync } from 'fs-extra';
+import { writeFileSync, ensureDirSync, copySync, unlinkSync, statSync } from 'fs-extra';
 import { join, dirname, sep, resolve as resolvePath } from 'path';
 import { todo, debug, warn } from './messages';
 import cloneDeep from 'lodash/cloneDeep';
-import merge from 'lodash/merge';
 import sortBy from 'lodash/sortBy';
 import flatten from 'lodash/flatten';
 import AppDiffer from './app-differ';
@@ -662,13 +661,6 @@ export class AppBuilder<TreeNames> {
     }
     pkg['ember-addon'] = Object.assign({}, pkg['ember-addon'], meta);
     const pkgPath = join(this.root, 'package.json');
-
-    // if package exists in the root, merge properties in pkg
-    if (existsSync(pkgPath)) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const existingPkg = require(pkgPath);
-      merge(pkg, existingPkg);
-    }
     writeFileSync(pkgPath, JSON.stringify(pkg, null, 2), 'utf8');
   }
 

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -593,12 +593,14 @@ export class AppBuilder<TreeNames> {
     for (let pkg of this.adapter.allActiveAddons) {
       if (pkg.meta['public-assets']) {
         for (let [filename, appRelativeURL] of Object.entries(pkg.meta['public-assets'] || {})) {
+          let sourcePath = resolvePath(pkg.root, filename);
+          let stats = statSync(sourcePath);
           assets.push({
             kind: 'on-disk',
-            sourcePath: resolvePath(pkg.root, filename),
+            sourcePath,
             relativePath: appRelativeURL,
-            mtime: 0,
-            size: 0,
+            mtime: stats.mtimeMs,
+            size: stats.size,
           });
         }
       }

--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -38,10 +38,10 @@ export function warn(message: string, ...params: any[]) {
 // for use in our test suites
 let hardFailMode = 0;
 export function throwOnWarnings(hooks: any) {
-  hooks.beforeEach(() => {
+  hooks.before(() => {
     hardFailMode++;
   });
-  hooks.afterEach(() => {
+  hooks.after(() => {
     hardFailMode--;
   });
 }

--- a/test-packages/sample-transforms/lib/glimmer-plugin.js
+++ b/test-packages/sample-transforms/lib/glimmer-plugin.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-module.exports = function sampleTransform(env) {
+function sampleTransform(env) {
   return {
     name: '@embroider/sample-transforms',
 
@@ -8,7 +8,16 @@ module.exports = function sampleTransform(env) {
         if (node.path.type === 'PathExpression' && node.path.original === 'embroider-sample-transforms-target') {
           return env.syntax.builders.mustache(env.syntax.builders.path('embroider-sample-transforms-result'));
         }
-      }
-    }
+      },
+    },
   };
 }
+
+sampleTransform.parallelBabel = {
+  requireFile: __filename,
+  buildUsing: 'restore',
+};
+
+sampleTransform.restore = () => sampleTransform;
+
+module.exports = sampleTransform;

--- a/test-packages/support/build.ts
+++ b/test-packages/support/build.ts
@@ -75,6 +75,10 @@ export default class BuildResult {
     }
   }
 
+  async rebuild() {
+    await this.builder.build();
+  }
+
   shouldTranspile(fileAssert: BoundFileAssert) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     let shouldTranspile = require(join(this.outputPath, '_babel_filter_'));

--- a/test-packages/support/file-assertions.ts
+++ b/test-packages/support/file-assertions.ts
@@ -54,6 +54,15 @@ export class BoundFileAssert {
     });
   }
 
+  doesNotExist(message?: string) {
+    this.assert.pushResult({
+      result: !pathExistsSync(this.fullPath),
+      actual: 'file present',
+      expected: 'file missing',
+      message: message || `${this.path} should not exist`,
+    });
+  }
+
   private doMatch(pattern: string | RegExp, message: string | undefined, invert: boolean) {
     if (!this.contents.result) {
       this.assert.pushResult(this.contents);
@@ -182,6 +191,19 @@ export class JSONAssert {
       actual: this.contents.data,
       expected,
       message: message || `expected value missing from array`,
+    });
+  }
+
+  doesNotInclude(notExpected: any, message?: string): void {
+    if (!this.contents.result) {
+      this.assert.pushResult(this.contents);
+      return;
+    }
+    this.assert.pushResult({
+      result: Array.isArray(this.contents.data) && !this.contents.data.includes(notExpected),
+      actual: this.contents.data,
+      expected: `not ${notExpected}`,
+      message: message || `expected array to not include ${notExpected}`,
     });
   }
 


### PR DESCRIPTION
This fixes two bugs around rebuilds:

 - changes to app CSS were not being reflected in the output
 - changes to public assets were not being reflected in the output

As part of this I had to undo https://github.com/embroider-build/embroider/pull/178. It turns out it was incorrect because:

 - it wasn't really reading the `package.json` as produced by the V1App. Instead it was reading its own output, which would cause it to merge the previous build on top of the current build
 - lodash merge's semantics are incorrect for our arrays like `ember-addon.assets`, so even if the merge was merging the right thing, it would still be wrong.

There's now test coverage for the things that broke, so a second try at fixing the fastboot package.json merging should be able to do better.