### PR TITLE
compatibility with new ember-cli-htmlbars

### DIFF
--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -365,7 +365,7 @@ class TemplateCompileTree extends Filter {
 }
 
 function matchesSourceFile(filename: string) {
-  return /htmlbars-inline-precompile\/(index|lib\/require-from-worker)(\.js)?$/.test(filename);
+  return /(htmlbars-inline-precompile|ember-cli-htmlbars)\/(index|lib\/require-from-worker)(\.js)?$/.test(filename);
 }
 
 function hasProperties(item: any) {


### PR DESCRIPTION
The inline-precompile plugin has moved into ember-cli-htmlbars, so we need to expand our detector.

We always detect and replace the inline template precompile because we need to use our own template compiler instead (to get component and helper dependency resolution, and because ours supports a serialization strategy that works inside webpack's thread-loader).

Fixes #339 