### PR TITLE
short-circuit template compilation

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -295,7 +295,7 @@ export default class V1Addon implements V1Package {
     tree = this.addonInstance.preprocessJs(tree, '/', this.moduleName, {
       registry: this.addonInstance.registry,
     });
-    if (this.addonInstance.registry.load('template').length > 0) {
+    if (this.addonInstance.shouldCompileTemplates() && this.addonInstance.registry.load('template').length > 0) {
       tree = this.app.preprocessRegistry.preprocessTemplates(tree, {
         registry: this.addonInstance.registry,
       });


### PR DESCRIPTION
Classic ember-cli uses this check to avoid instantiating any template preprocessors for addons that have no templates. In addition to being an optimization, there are addons in the ecosystem that rely on this for correctness, because they have broken template preprocessors that throw on instantiation, but no actual templates.

We checked and `shouldCompileTemplates` has been stable since before ember-cli 3.0 through current master.

Co-authored-by: Jen Weber <j@jenweber.me>