### PR TITLE
Docs - Add common options to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ You can pass options into Embroider by passing them into the `compatBuild` funct
 
 ```js
 return require('@embroider/compat').compatBuild(app, Webpack, {
-  // options go here
+  // staticAddonTestSupportTrees: true,
+  // staticAddonTrees: true,
+  // staticHelpers: true,
+  // staticComponents: true,
+  // packagerOptions: {
+  //    webpackConfig: { }
+  // }
 });
 ```
 


### PR DESCRIPTION
I found myself hunting through other apps to get the block of text to copy-paste that would turn on the more strict features. This PR adds them right into the options example.