### PR TITLE
fix ember-data compat adapter for v3.15

### DIFF
--- a/packages/compat/src/compat-adapters/ember-data.ts
+++ b/packages/compat/src/compat-adapters/ember-data.ts
@@ -23,13 +23,23 @@ export default class EmberData extends V1Addon {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       versionTree = require(join(this.root, 'lib/version'));
     } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
-        throw err;
+      handleErr(err);
+      try {
+        // ember-data 3.11 to 3.14 keep the version module here.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        versionTree = require(resolveSync('@ember-data/-build-infra/src/create-version-module', {
+          basedir: this.root,
+        }));
+      } catch (err) {
+        handleErr(err);
+        // ember-data 3.15+ keeps the version module here.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        versionTree = require(resolveSync('@ember-data/private-build-infra/src/create-version-module', {
+          basedir: this.root,
+        }));
       }
-      // ember-data 3.11 and later keep the version module here.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      versionTree = require(resolveSync('@ember-data/-build-infra/src/create-version-module', { basedir: this.root }));
     }
+
     let trees = super.v2Trees;
     trees.push(versionTree());
     return trees;
@@ -58,4 +68,10 @@ function isProductionEnv() {
 
 function isInstrumentedBuild() {
   return process.argv.includes('--instrument');
+}
+
+function handleErr(err: any) {
+  if (err.code !== 'MODULE_NOT_FOUND') {
+    throw err;
+  }
 }


### PR DESCRIPTION
closes #363

ember-data renamed the -build-infra directory to private-build-infra for the upcoming 3.15 release.

A nested try-catch isn't very nice. Any suggestions?