### PR TITLE
fix a path relativization case

### DIFF
--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,4 +1,4 @@
-import { relative, isAbsolute } from 'path';
+import { relative, isAbsolute, dirname, join, basename } from 'path';
 
 // by "explicit", I mean that we want "./local/thing" instead of "local/thing"
 // because
@@ -7,7 +7,7 @@ import { relative, isAbsolute } from 'path';
 //     import "local/thing"
 //
 export function explicitRelative(fromDir: string, toFile: string) {
-  let result = relative(fromDir, toFile);
+  let result = join(relative(fromDir, dirname(toFile)), basename(toFile));
   if (!result.startsWith('/') && !result.startsWith('.')) {
     result = './' + result;
   }

--- a/packages/core/tests/path.test.ts
+++ b/packages/core/tests/path.test.ts
@@ -1,0 +1,16 @@
+import { explicitRelative } from '../src';
+
+describe('core path utils', function() {
+  test('explicit relative', function() {
+    // when there's no common parts, paths stay absolute
+    expect(explicitRelative('/a/b/c', '/d/e/f')).toEqual('/d/e/f');
+
+    // the first arg is always interpreted as a directory, the second as a file,
+    // so this is correct answer:
+    expect(explicitRelative('/a/b/c', '/a/b/c')).toEqual('../c');
+
+    expect(explicitRelative('/a/b/c', '/a/b/d/e/f.js')).toEqual('../d/e/f.js');
+    expect(explicitRelative('/a/b/c', '/a/d/e/f.js')).toEqual('../../d/e/f.js');
+    expect(explicitRelative('/a/b/c', '/a/b/c/d.js')).toEqual('./d.js');
+  });
+});


### PR DESCRIPTION
The relative path from *directory* "/a/b/c" to *file* "/a/b/c" is not ".", it's "../c"