### PR TITLE
allow explicitly declared relative externals

### DIFF
--- a/packages/compat/src/compat-adapters/ember-macro-helpers.ts
+++ b/packages/compat/src/compat-adapters/ember-macro-helpers.ts
@@ -1,0 +1,12 @@
+import V1Addon from '../v1-addon';
+
+export default class extends V1Addon {
+  get packageMeta() {
+    let meta = super.packageMeta;
+    if (!meta.externals) {
+      meta.externals = [];
+    }
+    meta.externals.push('./-computed-store');
+    return meta;
+  }
+}


### PR DESCRIPTION
We automatically detect when an addon is trying to import something from another package that is not build-time resolvable, and we defer it to runtime. This is pretty necessary given how many built-in things work that way, relying on runtime `define()`.

But within an addon, we do not automatically detect broken relative imports and defer them to runtime. That pattern is rare, so we can afford to be more strict there.

But there are *some* addons that need this, and they can get it explicitly by declaring some of their own modules as externals.