### PR TITLE
Merge exisiting package.json to package.json created by emberoider build

### DIFF
--- a/packages/compat/tests/stage2-test.ts
+++ b/packages/compat/tests/stage2-test.ts
@@ -108,6 +108,9 @@ QUnit.module('stage2 build', function() {
             },
           },
         },
+        public: {
+          'package.json': JSON.stringify({ customStuff: { fromMyAddon: true }, name: 'should-be-overridden' }),
+        },
       });
 
       let deepAddon = addon.addAddon('deep-addon');
@@ -369,6 +372,13 @@ QUnit.module('stage2 build', function() {
         .file('./does-dynamic-import.js')
         .transform(build.transpile)
         .matches(/return import\(['"]some-library['"]\)/);
+    });
+
+    test('addons can merge additional content into package.json', function(assert) {
+      let file = assert.file('./package.json').json();
+      file.get('ember-addon.version').equals(2, 'our own content is present');
+      file.get('customStuff').deepEquals({ fromMyAddon: true }, 'the addons content is present');
+      file.get('name').equals('my-app', 'app takes precedence over addon');
     });
   });
 });


### PR DESCRIPTION
This uses the same logic from #178. I have reversed the order in which merging is done. 
In #178 We merged `new package.json` content with `old package.json` content. That's why rebuild failed. If we just reverse the input values to the `merge` call it will fix the issue. 