### PR TITLE
minor cleanup

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -11,7 +11,6 @@ import { todo, unsupported } from '@embroider/core/src/messages';
 import { Tree } from 'broccoli-plugin';
 import mergeTrees from 'broccoli-merge-trees';
 import semver from 'semver';
-import Snitch from './snitch';
 import rewriteAddonTree from './rewrite-addon-tree';
 import { mergeWithAppend } from './merges';
 import { AddonMeta, TemplateCompiler, debug, PackageCache } from '@embroider/core';
@@ -651,20 +650,9 @@ export default class V1Addon implements V1Package {
     if (this.customizes('treeForPublic')) {
       let original = this.invokeOriginalTreeFor('public');
       if (original) {
-        publicTree = new Snitch(
-          original,
-          {
-            // The normal behavior is to namespace your public files under your
-            // own name. But addons can flaunt that, and that goes beyond what
-            // the v2 format is allowed to do.
-            allowedPaths: new RegExp(`^${this.name}/`),
-            foundBadPaths: (badPaths: string[]) =>
-              `${this.name} treeForPublic contains unsupported paths: ${badPaths.join(', ')}`,
-          },
-          {
-            destDir: 'public',
-          }
-        );
+        publicTree = new Funnel(original, {
+          destDir: 'public',
+        });
       }
     } else if (this.hasStockTree('public')) {
       publicTree = this.stockTree('public');


### PR DESCRIPTION
I noticed this code is now unnecessary because the latest draft RFC doesn't require addons to namespace their public assets.

It was considered in earlier drafts, but URLs are not always free to change, so v2 packages keep the same powers that v1 packages have. However, we are still a little better at being strict because we error if there are collisions.