### PR TITLE
progress on engines

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,6 +44,18 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Build engines-host-app",
+      "program": "${workspaceFolder}/node_modules/.bin/ember",
+      "cwd": "${workspaceFolder}/test-packages/engines-host-app",
+      "args": ["build"],
+      "env": {
+        "JOBS": "1"
+      },
+      "outputCapture": "std"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Serve macro-tests app",
       "program": "${workspaceFolder}/node_modules/.bin/ember",
       "cwd": "${workspaceFolder}/test-packages/macro-tests",

--- a/packages/compat/src/compat-adapters/ember-asset-loader.ts
+++ b/packages/compat/src/compat-adapters/ember-asset-loader.ts
@@ -1,0 +1,20 @@
+import V1Addon from '../v1-addon';
+import Funnel from 'broccoli-funnel';
+
+// ember-asset-loader's ManifestGenerator (which is used as the Addon base class
+// for by ember-engines) has an "all" postprocessTree hook. We can't / won't run
+// those in embroider. The hook inserts the asset manifest into index.html.
+//
+// This patch removes the code that would explode if it tries to read from that
+// manifest. ember-asset-loader itself has a mode that excludes these files, so
+// it's tolerant of them being missing.
+//
+// We mostly just want ember-asset-loader to sit down and be quiet, because lazy
+// loading is a thing that is natively handled by embroider.
+export default class extends V1Addon {
+  get v2Tree() {
+    return new Funnel(super.v2Tree, {
+      exclude: ['_app/config/asset-manifest.js', '_app_/instance-initializers/load-asset-manifest.js'],
+    });
+  }
+}

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -212,7 +212,7 @@ export default class V1App implements V1Package {
     }
   }
 
-  get indexTree() {
+  private get indexTree() {
     let indexFilePath = this.app.options.outputPaths.app.html;
     let index = new Funnel(this.app.trees.app, {
       allowEmpty: true,
@@ -228,7 +228,7 @@ export default class V1App implements V1Package {
     });
   }
 
-  get testIndexTree() {
+  private get testIndexTree() {
     let index = new Funnel(this.app.trees.tests, {
       allowEmpty: true,
       include: [`index.html`],


### PR DESCRIPTION
This adds a compat adapter to keep ember-asset-loader from blowing up. We mostly don't want it doing anything anyway, because embroider handles lazy assets natively.