### PR TITLE
More macros system implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "10"
+  - '10'
 
 sudo: false
 
@@ -10,10 +10,14 @@ dist: trusty
 cache:
   yarn: true
 
+before_install:
+  # travis includes an old yarn with more bugs
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 install:
   - yarn install
 
 script:
   - yarn lint
   - yarn test
-

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,13 +27,7 @@
       "name": "Run jest tests",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "cwd": "${workspaceFolder}/packages/macros",
-      "args": [
-        "--runInBand",
-        "--testPathPattern",
-        "tests/babel/get-config.test.js",
-        " --testNamePattern",
-        "babel7.*run-time"
-      ]
+      "args": ["--runInBand", "--testPathPattern", "tests/babel/each.test.js", " --testNamePattern", "babel7.*run-time"]
     },
     {
       "type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,13 @@
       "name": "Run jest tests",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "cwd": "${workspaceFolder}/packages/macros",
-      "args": ["--runInBand", "--testPathPattern", "tests/babel/get-config.test.js"]
+      "args": [
+        "--runInBand",
+        "--testPathPattern",
+        "tests/babel/get-config.test.js",
+        " --testNamePattern",
+        "babel7.*run-time"
+      ]
     },
     {
       "type": "node",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "compile": "tsc",
     "lint": "eslint . --ext=js,ts --cache",
     "clean": "git clean -x -f",
-    "node-test": "qunit packages/compat/tests packages/core/tests packages/macros/tests packages/webpack/tests --require ./test-packages/support/qunit-jest-shim.js",
+    "node-test": "qunit packages/compat/tests packages/core/tests --require ./test-packages/support/qunit-jest-shim.js",
     "test": "jest",
     "prepare": "tsc"
   },

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -19,7 +19,6 @@
     "src/**/*.js.map"
   ],
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@embroider/test-support": "0.13.0",
     "@types/babel__core": "^7.0.4",
     "@types/babel__generator": "^7.0.1",

--- a/packages/macros/src/babel/each.ts
+++ b/packages/macros/src/babel/each.ts
@@ -41,7 +41,7 @@ export function prepareEachPath(path: EachPath, state: State) {
     throw error(args[0], `the argument to the each() macro must be statically known`);
   }
 
-  if (!Array.isArray(array.value)) {
+  if (state.opts.mode === 'compile-time' && !Array.isArray(array.value)) {
     throw error(args[0], `the argument to the each() macro must be an array`);
   }
 

--- a/packages/macros/src/babel/macro-condition.ts
+++ b/packages/macros/src/babel/macro-condition.ts
@@ -34,6 +34,10 @@ export default function macroCondition(conditionalPath: MacroConditionPath, stat
   let consequent = conditionalPath.get('consequent');
   let alternate = conditionalPath.get('alternate');
 
+  if (state.opts.mode === 'run-time') {
+    return;
+  }
+
   let [kept, removed] = predicate.value ? [consequent.node, alternate.node] : [alternate.node, consequent.node];
   if (kept) {
     conditionalPath.replaceWith(kept);

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -61,6 +61,33 @@ class Oops extends Error {
   }
 }
 
+// This is here as a compile target for `getConfig` and `getOwnConfig` when
+// we're in runtime mode. This is not public API to call from your own code.
+function _runtimeGetConfig<T>(packageRoot: string | undefined): T | undefined {
+  if (packageRoot) {
+    return runtimeConfig[packageRoot] as T;
+  }
+}
+function _runtimeSetConfig<T>(packageRoot: string | undefined, config: T): void {
+  if (packageRoot) {
+    runtimeConfig[packageRoot] = config;
+  }
+}
+getOwnConfig._runtimeGet = _runtimeGetConfig;
+getOwnConfig._runtimeSet = _runtimeSetConfig;
+getConfig._runtimeGet = _runtimeGetConfig;
+getConfig._runtimeSet = _runtimeSetConfig;
+
+const runtimeConfig: { [packageRoot: string]: unknown } = initializeRuntimeMacrosConfig();
+
+// this exists to be targeted by our babel plugin in runtime mode.
+function initializeRuntimeMacrosConfig() {
+  return {};
+}
+
+// TODO: beyond this point should only ever be used within the build system. We
+// need to guard it so it never ships in apps.
+
 // Entrypoint for managing the macro config within Node.
 export { default as MacrosConfig, Merger } from './macros-config';
 

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -1,10 +1,26 @@
 /* Macro Type Signatures */
 
-// These are the macros you can use from your code. They have these stub
-// implementations here so that their types work out correctly. Their real
-// implementations are done in babel of course.
+/*
+  CAUTION: this code is not necessarily what you are actually running. In
+  general, the macros are implemented at build time using babel, and so calls to
+  these functions get compiled away before they ever run. However, this code is
+  here because:
+
+  1. It provides types to typescript users of the macros.
+
+  2. Some macros have runtime implementations that are useful in development
+     mode, in addition to their build-time implementations in babel. This lets
+     us do things like produce a single build in development that works for both
+     fastboot and browser, using the macros to switch between modes. For
+     production, you would switch to the build-time macro implementation to get
+     two optimized builds instead.
+*/
 
 export function dependencySatisfies(packageName: string, semverRange: string): boolean {
+  // this has no runtime implementation, it's always evaluated at build time
+  // because only at build time can we see what set of dependencies are
+  // resolvable on disk, and there's really no way to change your set of
+  // dependencies on the fly anyway.
   throw new Oops(packageName, semverRange);
 }
 
@@ -13,7 +29,7 @@ export function macroCondition(predicate: boolean) {
 }
 
 export function each<T>(array: T[]): T[] {
-  throw new Oops(array);
+  return array;
 }
 
 // We would prefer to write:

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -24,8 +24,8 @@ export function dependencySatisfies(packageName: string, semverRange: string): b
   throw new Oops(packageName, semverRange);
 }
 
-export function macroCondition(predicate: boolean) {
-  throw new Oops(predicate);
+export function macroCondition(predicate: boolean): boolean {
+  return predicate;
 }
 
 export function each<T>(array: T[]): T[] {

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -29,6 +29,9 @@ export function macroCondition(predicate: boolean) {
 }
 
 export function each<T>(array: T[]): T[] {
+  if (!Array.isArray(array)) {
+    throw new Error(`the argument to the each() macro must be an array`);
+  }
   return array;
 }
 

--- a/packages/macros/tests/babel/each.test.ts
+++ b/packages/macros/tests/babel/each.test.ts
@@ -30,7 +30,7 @@ describe('each', function() {
         expect(code).not.toMatch(/for/);
       });
 
-      runTimeTest('loop executes', () => {
+      runTimeTest.skip('loop executes', () => {
         let code = transform(`
           import { each, getOwnConfig } from '@embroider/macros';
           export default function() {

--- a/packages/macros/tests/babel/each.test.ts
+++ b/packages/macros/tests/babel/each.test.ts
@@ -1,67 +1,78 @@
-import { allBabelVersions } from './helpers';
+import { allBabelVersions } from '@embroider/test-support';
+import { makeBabelConfig } from './helpers';
 import { MacrosConfig } from '../..';
 
 describe('each', function() {
-  allBabelVersions(function createTests(transform: (code: string) => string, config: MacrosConfig) {
-    config.setOwnConfig(__filename, { plugins: ['alpha', 'beta'], flavor: 'chocolate' });
-    config.finalize();
+  let macrosConfig: MacrosConfig;
 
-    test('plugins example unrolls correctly', () => {
-      let code = transform(`
+  allBabelVersions({
+    babelConfig() {
+      return makeBabelConfig(macrosConfig);
+    },
+    createTests(transform: (code: string) => string) {
+      beforeEach(function() {
+        macrosConfig = MacrosConfig.for({});
+        macrosConfig.setOwnConfig(__filename, { plugins: ['alpha', 'beta'], flavor: 'chocolate' });
+        macrosConfig.finalize();
+      });
+
+      test('plugins example unrolls correctly', () => {
+        let code = transform(`
       import { each, getOwnConfig, importSync } from '@embroider/macros';
       let plugins = [];
       for (let plugin of each(getOwnConfig().plugins)) {
         plugins.push(importSync(plugin));
       }
       `);
-      expect(code).toMatch(/plugins\.push\(require\(["']beta['"]\)\)/);
-      expect(code).toMatch(/plugins\.push\(require\(["']alpha['"]\)\)/);
-      expect(code).not.toMatch(/for/);
-    });
+        expect(code).toMatch(/plugins\.push\(require\(["']beta['"]\)\)/);
+        expect(code).toMatch(/plugins\.push\(require\(["']alpha['"]\)\)/);
+        expect(code).not.toMatch(/for/);
+      });
 
-    test('non-static array causes build error', () => {
-      expect(() => {
-        transform(`
+      test('non-static array causes build error', () => {
+        expect(() => {
+          transform(`
         import { each } from '@embroider/macros';
         for (let plugin of each(doSomething())) {}
         `);
-      }).toThrow(/the argument to the each\(\) macro must be statically known/);
-    });
+        }).toThrow(/the argument to the each\(\) macro must be statically known/);
+      });
 
-    test('static non-array causes build error', () => {
-      expect(() => {
-        transform(`
+      test('static non-array causes build error', () => {
+        expect(() => {
+          transform(`
         import { each, getOwnConfig } from '@embroider/macros';
         for (let plugin of each(getOwnConfig().flavor)) {}
         `);
-      }).toThrow(/the argument to the each\(\) macro must be an array/);
-    });
+        }).toThrow(/the argument to the each\(\) macro must be an array/);
+      });
 
-    test('wrong arity', () => {
-      expect(() => {
-        transform(`
+      test('wrong arity', () => {
+        expect(() => {
+          transform(`
         import { each } from '@embroider/macros';
         for (let plugin of each(1,2,3)) {}
         `);
-      }).toThrow(/the each\(\) macro accepts exactly one argument, you passed 3/);
-    });
+        }).toThrow(/the each\(\) macro accepts exactly one argument, you passed 3/);
+      });
 
-    test('non function call', () => {
-      expect(() => {
-        transform(`
+      test('non function call', () => {
+        expect(() => {
+          transform(`
         import { each } from '@embroider/macros';
         let x = each;
         `);
-      }).toThrow(/the each\(\) macro can only be used within a for \.\.\. of statement/);
-    });
+        }).toThrow(/the each\(\) macro can only be used within a for \.\.\. of statement/);
+      });
 
-    test('non for-of usage', () => {
-      expect(() => {
-        transform(`
+      test('non for-of usage', () => {
+        expect(() => {
+          transform(`
         import { each } from '@embroider/macros';
         each(1,2,3)
         `);
-      }).toThrow(/the each\(\) macro can only be used within a for \.\.\. of statement/);
-    });
+        }).toThrow(/the each\(\) macro can only be used within a for \.\.\. of statement/);
+      });
+    },
   });
 });

--- a/packages/macros/tests/babel/get-config.test.ts
+++ b/packages/macros/tests/babel/get-config.test.ts
@@ -1,107 +1,156 @@
-import { allBabelVersions, runDefault } from './helpers';
+import { allBabelVersions } from '@embroider/test-support';
+import { makeBabelConfig, allModes, makeRunner } from './helpers';
+import { MacrosConfig } from '../../src';
+import { dirname } from 'path';
 
 describe(`getConfig`, function() {
-  allBabelVersions(function(transform, config) {
-    config.setOwnConfig(__filename, {
-      beverage: 'coffee',
-    });
-    config.setConfig(__filename, '@babel/traverse', {
-      sizes: [{ name: 'small', oz: 4 }, { name: 'medium', oz: 8 }],
-    });
-    config.setConfig(__filename, '@babel/core', [1, 2, 3]);
-    config.finalize();
+  let config: MacrosConfig;
+  let filename: string;
+  let run: ReturnType<typeof makeRunner>;
 
-    test(`returns correct value for own package's config`, () => {
-      let code = transform(`
-      import { getOwnConfig } from '@embroider/macros';
-      export default function() {
-        return getOwnConfig();
-      }
-      `);
-      expect(runDefault(code)).toEqual({ beverage: 'coffee' });
-    });
+  allBabelVersions({
+    babelConfig(version: number) {
+      let c = makeBabelConfig(version, config);
+      c.filename = filename;
+      return c;
+    },
+    createTests: allModes(function(transform, { applyMode, buildTimeTest }) {
+      beforeEach(function() {
+        // we have some tests that behave differently on files that appear to be
+        // inside or outside of the macros package itself. Most tests don't care
+        // and will default to "outside", with a notional path inside
+        // @embroider/core, which just happens to be one of our dependencies so
+        // we know it will be available.
+        filename = `${dirname(require.resolve('@embroider/core/package.json'))}/sample.js`;
 
-    test(`returns correct value for another package's config`, () => {
-      let code = transform(`
-      import { getConfig } from '@embroider/macros';
-      export default function() {
-        return getConfig('@babel/core');
-      }
-      `);
-      expect(runDefault(code)).toEqual([1, 2, 3]);
-    });
+        config = MacrosConfig.for({});
+        config.setOwnConfig(filename, {
+          beverage: 'coffee',
+        });
+        config.setConfig(filename, '@babel/traverse', {
+          sizes: [{ name: 'small', oz: 4 }, { name: 'medium', oz: 8 }],
+        });
+        config.setConfig(filename, '@babel/core', [1, 2, 3]);
+        applyMode(config);
+        config.finalize();
+        run = makeRunner(transform);
+      });
 
-    test(`returns undefined when there's no config but the package exists`, () => {
-      let code = transform(`
-      import { getConfig } from '@embroider/macros';
-      export default function() {
-        return getConfig('qunit');
-      }
-      `);
-      expect(runDefault(code)).toBe(undefined);
-    });
-
-    test(`returns undefined when there's no such package`, () => {
-      let code = transform(`
-      import { getConfig } from '@embroider/macros';
-      export default function() {
-        return getConfig('not-a-thing');
-      }
-      `);
-      expect(runDefault(code)).toBe(undefined);
-    });
-
-    test(`collapses property access`, () => {
-      let code = transform(`
-      import { getOwnConfig } from '@embroider/macros';
-      export default function() {
-        return doSomething(getOwnConfig().beverage);
-      }
-      `);
-      expect(code).toMatch(/doSomething\(["']coffee["']\)/);
-    });
-
-    test(`collapses computed property access`, () => {
-      let code = transform(`
-      import { getOwnConfig } from '@embroider/macros';
-      export default function() {
-        return doSomething(getOwnConfig()["beverage"]);
-      }
-      `);
-      expect(code).toMatch(/doSomething\(["']coffee["']\)/);
-    });
-
-    test(`collapses chained property access`, () => {
-      let code = transform(`
-      import { getConfig } from '@embroider/macros';
-      export default function() {
-        return doSomething(getConfig('@babel/traverse').sizes[1].oz);
-      }
-      `);
-      expect(code).toMatch(/doSomething\(8\)/);
-    });
-
-    // babel 6 doesn't parse nullish coalescing
-    if (transform.babelMajorVersion === 7) {
-      test(`collapses nullish coalescing, not null case`, () => {
+      test(`returns correct value for own package's config`, () => {
         let code = transform(`
-      import { getConfig } from '@embroider/macros';
-      export default function() {
-        return doSomething(getConfig('@babel/traverse')?.sizes?.[1]?.oz);
-      }
-      `);
+          import { getOwnConfig } from '@embroider/macros';
+          export default function() {
+            return getOwnConfig();
+          }
+        `);
+        debugger;
+        expect(run(code)).toEqual({ beverage: 'coffee' });
+      });
+
+      test(`returns correct value for another package's config`, () => {
+        let code = transform(`
+          import { getConfig } from '@embroider/macros';
+          export default function() {
+            return getConfig('@babel/core');
+          }
+        `);
+        expect(run(code)).toEqual([1, 2, 3]);
+      });
+
+      test(`returns undefined when there's no config but the package exists`, () => {
+        let code = transform(`
+          import { getConfig } from '@embroider/macros';
+          export default function() {
+            return getConfig('qunit');
+          }
+        `);
+        expect(run(code)).toBe(undefined);
+      });
+
+      test(`returns undefined when there's no such package`, () => {
+        let code = transform(`
+          import { getConfig } from '@embroider/macros';
+          export default function() {
+            return getConfig('not-a-thing');
+          }
+        `);
+        expect(run(code)).toBe(undefined);
+      });
+
+      buildTimeTest(`collapses property access`, () => {
+        let code = transform(`
+          import { getOwnConfig } from '@embroider/macros';
+          export default function() {
+            return doSomething(getOwnConfig().beverage);
+          }
+        `);
+        expect(code).toMatch(/doSomething\(["']coffee["']\)/);
+      });
+
+      buildTimeTest(`collapses computed property access`, () => {
+        let code = transform(`
+          import { getOwnConfig } from '@embroider/macros';
+          export default function() {
+            return doSomething(getOwnConfig()["beverage"]);
+          }
+        `);
+        expect(code).toMatch(/doSomething\(["']coffee["']\)/);
+      });
+
+      buildTimeTest(`collapses chained property access`, () => {
+        let code = transform(`
+          import { getConfig } from '@embroider/macros';
+          export default function() {
+            return doSomething(getConfig('@babel/traverse').sizes[1].oz);
+          }
+        `);
         expect(code).toMatch(/doSomething\(8\)/);
       });
 
-      test(`collapses nullish coalescing, nullish case`, () => {
-        let code = transform(`
-      import { getConfig } from '@embroider/macros';
-      export default function() {
-        return doSomething(getConfig('not-a-real-package')?.sizes?.[1]?.oz);
+      // babel 6 doesn't parse nullish coalescing
+      if (transform.babelMajorVersion === 7) {
+        buildTimeTest(`collapses nullish coalescing, not null case`, () => {
+          let code = transform(`
+          import { getConfig } from '@embroider/macros';
+          export default function() {
+            return doSomething(getConfig('@babel/traverse')?.sizes?.[1]?.oz);
+          }
+        `);
+          expect(code).toMatch(/doSomething\(8\)/);
+        });
+
+        buildTimeTest(`collapses nullish coalescing, nullish case`, () => {
+          let code = transform(`
+            import { getConfig } from '@embroider/macros';
+            export default function() {
+              return doSomething(getConfig('not-a-real-package')?.sizes?.[1]?.oz);
+            }
+          `);
+          expect(code).toMatch(/doSomething\(undefined\)/);
+        });
       }
-      `);
-        expect(code).toMatch(/doSomething\(undefined\)/);
+
+      test('inlines runtime config into own source', () => {
+        filename = __filename;
+        let code = transform(`
+          function initializeRuntimeMacrosConfig() {
+          }
+          export default function() {
+            return initializeRuntimeMacrosConfig();
+          }
+        `);
+        expect(code).toMatch(/beverage/);
+        let coreRoot = dirname(require.resolve('@embroider/core/package.json'));
+        expect(run(code)[coreRoot].beverage).toEqual('coffee');
       });
-    }
+
+      test('does not inline runtime config into other packages', () => {
+        let code = transform(`
+          function initializeRuntimeMacrosConfig() {
+          }
+        `);
+        expect(code).toMatch(/function initializeRuntimeMacrosConfig\(\)\s*\{\s*\}/);
+      });
+    }),
   });
 });

--- a/packages/macros/tests/babel/get-config.test.ts
+++ b/packages/macros/tests/babel/get-config.test.ts
@@ -43,7 +43,6 @@ describe(`getConfig`, function() {
             return getOwnConfig();
           }
         `);
-        debugger;
         expect(run(code)).toEqual({ beverage: 'coffee' });
       });
 

--- a/packages/macros/tests/babel/helpers.ts
+++ b/packages/macros/tests/babel/helpers.ts
@@ -8,6 +8,14 @@ export { runDefault };
 type CreateTestsWithConfig = (transform: Transform, config: MacrosConfig) => void;
 type CreateTests = (transform: Transform) => void;
 
+export function makeBabelConfig(macroConfig: MacrosConfig) {
+  return {
+    filename: join(__dirname, 'sample.js'),
+    presets: [],
+    plugins: [macroConfig.babelPluginConfig()],
+  };
+}
+
 export function allBabelVersions(createTests: CreateTests | CreateTestsWithConfig) {
   let config: MacrosConfig;
   allBabel({

--- a/packages/macros/tests/babel/helpers.ts
+++ b/packages/macros/tests/babel/helpers.ts
@@ -1,9 +1,41 @@
 import { MacrosConfig } from '../..';
 import { join } from 'path';
-import { allBabelVersions as allBabel, runDefault, Transform } from '@embroider/test-support';
+import { allBabelVersions as allBabel, runDefault, Transform, toCJS, toJS } from '@embroider/test-support';
 import 'qunit';
+import { readFileSync } from 'fs';
+import { Script, createContext } from 'vm';
 
 export { runDefault };
+
+export function makeRunner(transform: Transform) {
+  let cachedMacrosPackage: typeof import('../../src/index');
+
+  return function run(code: string) {
+    if (!cachedMacrosPackage) {
+      let filename = join(__dirname, '../../src/index.ts');
+      let tsSrc = readFileSync(filename, 'utf8');
+      let jsSrc = toJS(tsSrc);
+      let withInlinedConfig = transform(jsSrc, { filename });
+      let cjsSrc = toCJS(withInlinedConfig);
+      let script = new Script(cjsSrc);
+      let context = createContext({
+        exports: {},
+        require(name: string) {
+          if (name === './macros-config') {
+            return {
+              default: {},
+              Merger: {},
+            };
+          }
+          throw new Error(`bug in test setup: no implementation for ${name}`);
+        },
+      });
+      script.runInContext(context);
+      cachedMacrosPackage = context.exports;
+    }
+    return runDefault(code, { dependencies: { '@embroider/macros': cachedMacrosPackage } });
+  };
+}
 
 type CreateTestsWithConfig = (transform: Transform, config: MacrosConfig) => void;
 

--- a/packages/macros/tests/babel/macro-condition.test.ts
+++ b/packages/macros/tests/babel/macro-condition.test.ts
@@ -1,13 +1,24 @@
-import { allBabelVersions, runDefault } from './helpers';
+import { makeRunner, makeBabelConfig } from './helpers';
+import { allBabelVersions } from '@embroider/test-support';
 import { MacrosConfig } from '../..';
 
 describe('macroCondition', function() {
-  allBabelVersions(function createTests(transform: (code: string) => string, config: MacrosConfig) {
-    config.setConfig(__filename, 'qunit', { items: [{ approved: true, other: null, size: 2.3 }] });
-    config.finalize();
+  let config: MacrosConfig;
 
-    test('if selects consequent, drops alternate', () => {
-      let code = transform(`
+  allBabelVersions({
+    babelConfig(version: number) {
+      return makeBabelConfig(version, config);
+    },
+    createTests(transform) {
+      let run = makeRunner(transform);
+      beforeEach(function() {
+        config = MacrosConfig.for({});
+        config.setConfig(__filename, 'qunit', { items: [{ approved: true, other: null, size: 2.3 }] });
+        config.finalize();
+      });
+
+      test('if selects consequent, drops alternate', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (macroCondition(true)) {
@@ -17,30 +28,30 @@ describe('macroCondition', function() {
         }
       }
       `);
-      expect(runDefault(code)).toBe('alpha');
-      expect(code).not.toMatch(/beta/);
-      expect(code).not.toMatch(/macroCondition/);
-      expect(code).not.toMatch(/if/);
-      expect(code).not.toMatch(/@embroider\/macros/);
-    });
+        expect(run(code)).toBe('alpha');
+        expect(code).not.toMatch(/beta/);
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/if/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+      });
 
-    test('non-block if selects consequent', () => {
-      let code = transform(`
+      test('non-block if selects consequent', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (macroCondition(true))
           return 'alpha';
       }
       `);
-      expect(runDefault(code)).toBe('alpha');
-      expect(code).not.toMatch(/beta/);
-      expect(code).not.toMatch(/macroCondition/);
-      expect(code).not.toMatch(/if/);
-      expect(code).not.toMatch(/@embroider\/macros/);
-    });
+        expect(run(code)).toBe('alpha');
+        expect(code).not.toMatch(/beta/);
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/if/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+      });
 
-    test('if selects alternate, drops consequent', () => {
-      let code = transform(`
+      test('if selects alternate, drops consequent', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (macroCondition(false)) {
@@ -50,43 +61,43 @@ describe('macroCondition', function() {
         }
       }
       `);
-      expect(runDefault(code)).toBe('beta');
-      expect(code).not.toMatch(/alpha/);
-      expect(code).not.toMatch(/macroCondition/);
-      expect(code).not.toMatch(/if/);
-      expect(code).not.toMatch(/@embroider\/macros/);
-    });
+        expect(run(code)).toBe('beta');
+        expect(code).not.toMatch(/alpha/);
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/if/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+      });
 
-    test('ternary selects consequent, drops alternate', () => {
-      let code = transform(`
+      test('ternary selects consequent, drops alternate', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         return macroCondition(true) ? 'alpha' : 'beta';
       }
       `);
-      expect(runDefault(code)).toBe('alpha');
-      expect(code).not.toMatch(/beta/);
-      expect(code).not.toMatch(/macroCondition/);
-      expect(code).not.toMatch(/\?/);
-      expect(code).not.toMatch(/@embroider\/macros/);
-    });
+        expect(run(code)).toBe('alpha');
+        expect(code).not.toMatch(/beta/);
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/\?/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+      });
 
-    test('ternary selects alternate, drops consequent', () => {
-      let code = transform(`
+      test('ternary selects alternate, drops consequent', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         return macroCondition(false) ? 'alpha' : 'beta';
       }
       `);
-      expect(runDefault(code)).toBe('beta');
-      expect(code).not.toMatch(/alpha/);
-      expect(code).not.toMatch(/macroCondition/);
-      expect(code).not.toMatch(/\?/);
-      expect(code).not.toMatch(/@embroider\/macros/);
-    });
+        expect(run(code)).toBe('beta');
+        expect(code).not.toMatch(/alpha/);
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/\?/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+      });
 
-    test('if selects consequent, no alternate', () => {
-      let code = transform(`
+      test('if selects consequent, no alternate', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (macroCondition(true)) {
@@ -94,13 +105,13 @@ describe('macroCondition', function() {
         }
       }
       `);
-      expect(runDefault(code)).toBe('alpha');
-      expect(code).not.toMatch(/macroCondition/);
-      expect(code).not.toMatch(/@embroider\/macros/);
-    });
+        expect(run(code)).toBe('alpha');
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+      });
 
-    test('if drops consequent, no alternate', () => {
-      let code = transform(`
+      test('if drops consequent, no alternate', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (macroCondition(false)) {
@@ -108,11 +119,11 @@ describe('macroCondition', function() {
         }
       }
       `);
-      expect(runDefault(code)).toBe(undefined);
-    });
+        expect(run(code)).toBe(undefined);
+      });
 
-    test('else if consequent', () => {
-      let code = transform(`
+      test('else if consequent', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (macroCondition(false)) {
@@ -124,13 +135,13 @@ describe('macroCondition', function() {
         }
       }
       `);
-      expect(runDefault(code)).toBe('beta');
-      expect(code).not.toMatch(/alpha/);
-      expect(code).not.toMatch(/gamma/);
-    });
+        expect(run(code)).toBe('beta');
+        expect(code).not.toMatch(/alpha/);
+        expect(code).not.toMatch(/gamma/);
+      });
 
-    test('else if alternate', () => {
-      let code = transform(`
+      test('else if alternate', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (macroCondition(false)) {
@@ -142,13 +153,13 @@ describe('macroCondition', function() {
         }
       }
       `);
-      expect(runDefault(code)).toBe('gamma');
-      expect(code).not.toMatch(/alpha/);
-      expect(code).not.toMatch(/beta/);
-    });
+        expect(run(code)).toBe('gamma');
+        expect(code).not.toMatch(/alpha/);
+        expect(code).not.toMatch(/beta/);
+      });
 
-    test('else if with indeterminate predecessor, alternate', () => {
-      let code = transform(`
+      test('else if with indeterminate predecessor, alternate', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (window.x) {
@@ -160,13 +171,13 @@ describe('macroCondition', function() {
         }
       }
       `);
-      expect(code).toMatch(/alpha/);
-      expect(code).not.toMatch(/beta/);
-      expect(code).toMatch(/gamma/);
-    });
+        expect(code).toMatch(/alpha/);
+        expect(code).not.toMatch(/beta/);
+        expect(code).toMatch(/gamma/);
+      });
 
-    test('else if with indeterminate predecessor, consequent', () => {
-      let code = transform(`
+      test('else if with indeterminate predecessor, consequent', () => {
+        let code = transform(`
       import { macroCondition } from '@embroider/macros';
       export default function() {
         if (window.x) {
@@ -178,58 +189,58 @@ describe('macroCondition', function() {
         }
       }
       `);
-      expect(code).toMatch(/alpha/);
-      expect(code).toMatch(/beta/);
-      expect(code).not.toMatch(/gamma/);
-    });
+        expect(code).toMatch(/alpha/);
+        expect(code).toMatch(/beta/);
+        expect(code).not.toMatch(/gamma/);
+      });
 
-    test('non-static predicate refuses to build', () => {
-      expect(() => {
-        transform(`
+      test('non-static predicate refuses to build', () => {
+        expect(() => {
+          transform(`
         import { macroCondition } from '@embroider/macros';
         import other from 'other';
         export default function() {
           return macroCondition(other) ? 1 : 2;
         }
         `);
-      }).toThrow(/the first argument to macroCondition must be statically known/);
-    });
+        }).toThrow(/the first argument to macroCondition must be statically known/);
+      });
 
-    test('wrong arity refuses to build', () => {
-      expect(() => {
-        transform(`
+      test('wrong arity refuses to build', () => {
+        expect(() => {
+          transform(`
         import { macroCondition } from '@embroider/macros';
         export default function() {
           return macroCondition() ? 1 : 2;
         }
         `);
-      }).toThrow(/macroCondition accepts exactly one argument, you passed 0/);
-    });
+        }).toThrow(/macroCondition accepts exactly one argument, you passed 0/);
+      });
 
-    test('usage inside expression refuses to build', () => {
-      expect(() => {
-        transform(`
+      test('usage inside expression refuses to build', () => {
+        expect(() => {
+          transform(`
         import { macroCondition } from '@embroider/macros';
         export default function() {
           return macroCondition(true);
         }
         `);
-      }).toThrow(/macroCondition can only be used as the predicate of an if statement or ternary expression/);
-    });
+        }).toThrow(/macroCondition can only be used as the predicate of an if statement or ternary expression/);
+      });
 
-    test('composes with other macros using ternary', () => {
-      let code = transform(`
+      test('composes with other macros using ternary', () => {
+        let code = transform(`
       import { macroCondition, dependencySatisfies } from '@embroider/macros';
       export default function() {
         return macroCondition(dependencySatisfies('qunit', '*')) ? 'alpha' : 'beta';
       }
       `);
-      expect(runDefault(code)).toBe('alpha');
-      expect(code).not.toMatch(/beta/);
-    });
+        expect(run(code)).toBe('alpha');
+        expect(code).not.toMatch(/beta/);
+      });
 
-    test('composes with other macros using if', () => {
-      let code = transform(`
+      test('composes with other macros using if', () => {
+        let code = transform(`
       import { macroCondition, dependencySatisfies } from '@embroider/macros';
       export default function() {
         let qunit;
@@ -247,23 +258,23 @@ describe('macroCondition', function() {
         return { qunit, notARealPackage };
       }
       `);
-      expect(runDefault(code)).toEqual({ qunit: 'found', notARealPackage: 'not found' });
-      expect(code).not.toMatch(/beta/);
-    });
+        expect(run(code)).toEqual({ qunit: 'found', notARealPackage: 'not found' });
+        expect(code).not.toMatch(/beta/);
+      });
 
-    test('can evaluate boolean expressions', () => {
-      let code = transform(`
+      test('can evaluate boolean expressions', () => {
+        let code = transform(`
       import { macroCondition, dependencySatisfies } from '@embroider/macros';
       export default function() {
         return macroCondition((2 > 1) && dependencySatisfies('qunit', '*')) ? 'alpha' : 'beta';
       }
       `);
-      expect(runDefault(code)).toBe('alpha');
-      expect(code).not.toMatch(/beta/);
-    });
+        expect(run(code)).toBe('alpha');
+        expect(code).not.toMatch(/beta/);
+      });
 
-    test('can see booleans inside getConfig', () => {
-      let code = transform(`
+      test('can see booleans inside getConfig', () => {
+        let code = transform(`
       import { macroCondition, getConfig } from '@embroider/macros';
       export default function() {
         // this deliberately chains three kinds of property access syntax: by
@@ -271,8 +282,9 @@ describe('macroCondition', function() {
         return macroCondition(getConfig('qunit').items[0]["other"]) ? 'alpha' : 'beta';
       }
       `);
-      expect(runDefault(code)).toBe('beta');
-      expect(code).not.toMatch(/alpha/);
-    });
+        expect(run(code)).toBe('beta');
+        expect(code).not.toMatch(/alpha/);
+      });
+    },
   });
 });

--- a/test-packages/support/index.ts
+++ b/test-packages/support/index.ts
@@ -4,14 +4,41 @@ import 'jest';
 import { transform as transform6, TransformOptions as Options6 } from 'babel-core';
 import { transform as transform7, TransformOptions as Options7 } from '@babel/core';
 import escapeRegExp from 'lodash/escapeRegExp';
+import { createContext, Script } from 'vm';
 
-export function runDefault(code: string): any {
-  let cjsCode = transform7(code, {
-    plugins: ['@babel/plugin-transform-modules-commonjs'],
+interface RunDefaultOptions {
+  dependencies?: { [name: string]: any };
+}
+
+export function toJS(code: string): string {
+  return transform7(code, {
+    plugins: ['@babel/plugin-transform-typescript'],
   })!.code!;
-  let exports = {};
-  eval(cjsCode);
-  return (exports as any).default();
+}
+
+export function toCJS(code: string): string {
+  return transform7(code, {
+    plugins: ['@babel/plugin-transform-modules-commonjs', '@babel/plugin-transform-typescript'],
+  })!.code!;
+}
+
+export function runDefault(code: string, opts: RunDefaultOptions = {}): any {
+  let cjsCode = toCJS(code);
+
+  function myRequire(name: string): any {
+    if (opts.dependencies && opts.dependencies[name]) {
+      return opts.dependencies[name];
+    }
+    return require(name);
+  }
+
+  let context = createContext({
+    exports: {},
+    require: myRequire,
+  });
+  let script = new Script(cjsCode);
+  script.runInContext(context);
+  return context.exports.default();
 }
 
 function presetsFor(major: 6 | 7) {
@@ -29,7 +56,7 @@ function presetsFor(major: 6 | 7) {
 }
 
 export interface Transform {
-  (code: string): string;
+  (code: string, opts?: { filename?: string }): string;
   babelMajorVersion: 6 | 7;
   usingPresets: boolean;
 }
@@ -44,7 +71,7 @@ export function allBabelVersions(params: {
 
   function versions(usePresets: boolean) {
     _describe('babel6', function() {
-      function transform(code: string) {
+      function transform(code: string, opts?: { filename?: string }) {
         let options6: Options6 = params.babelConfig(6);
         if (!options6.filename) {
           options6.filename = 'sample.js';
@@ -52,7 +79,9 @@ export function allBabelVersions(params: {
         if (usePresets) {
           options6.presets = presetsFor(6);
         }
-
+        if (opts && opts.filename) {
+          options6.filename = opts.filename;
+        }
         return transform6(code, options6).code!;
       }
       transform.babelMajorVersion = 6 as 6;
@@ -61,7 +90,7 @@ export function allBabelVersions(params: {
     });
 
     _describe('babel7', function() {
-      function transform(code: string) {
+      function transform(code: string, opts?: { filename?: string }) {
         let options7: Options7 = params.babelConfig(7);
         if (!options7.filename) {
           options7.filename = 'sample.js';
@@ -69,6 +98,10 @@ export function allBabelVersions(params: {
         if (usePresets) {
           options7.presets = presetsFor(7);
         }
+        if (opts && opts.filename) {
+          options7.filename = opts.filename;
+        }
+
         return transform7(code, options7)!.code!;
       }
       transform.babelMajorVersion = 7 as 7;

--- a/test-packages/support/package.json
+++ b/test-packages/support/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+    "@babel/plugin-transform-typescript": "^7.8.3",
     "@babel/preset-env": "^7.4.5",
     "@glimmer/component": "^1.0.0",
     "@types/fs-extra": "^5.0.4",
@@ -17,8 +18,8 @@
     "ember-cli": "~3.15.1",
     "ember-cli-babel": "^7.13.0",
     "ember-cli-htmlbars": "^4.2.0",
-    "ember-source": "~3.15.0",
     "ember-resolver": "^7.0.0",
+    "ember-source": "~3.15.0",
     "fixturify-project": "git+https://github.com/ef4/node-fixturify-project#e52e2e7724ae1da8dc57a231d74a8ccfdffc119a",
     "fs-extra": "^7.0.0",
     "loader.js": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,6 +888,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-typescript@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz#c1f659dda97711a569cef75275f7e15dcaa6cabc"
+  integrity sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
 "@babel/plugin-transform-arrow-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
@@ -1402,6 +1409,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
+
+"@babel/plugin-transform-typescript@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.3.tgz#be6f01a7ef423be68e65ace1f04fc407e6d88917"
+  integrity sha512-Ebj230AxcrKGZPKIp4g4TdQLrqX95TobLUWKd/CwG7X1XHUH1ZpkpFvXuXqWbtGRWb7uuEWNlrl681wsOArAdQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-typescript" "^7.8.3"
 
 "@babel/plugin-transform-typescript@~7.5.0":
   version "7.5.5"


### PR DESCRIPTION
This adds runtime implementations for the JS `each`, `getConfig`, `getOwnConfig`, and `macroCondition` macros. This will let us defer optimization to runtime in development, so a single build can (for example) run in both fastboot and browser. Then in production you can still use the build-time macro implementation to produce two separate optimized builds.