### PR TITLE
[WIP] Standardize addon ordering

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "broccoli-persistent-filter": "^2.2.2",
     "broccoli-plugin": "^3.0.0",
     "broccoli-source": "^1.1.0",
+    "dag-map": "^2.0.2",
     "debug": "^3.1.0",
     "fast-sourcemap-concat": "^1.4.0",
     "filesize": "^4.1.2",

--- a/packages/core/src/dependency-ordering-utils.ts
+++ b/packages/core/src/dependency-ordering-utils.ts
@@ -1,0 +1,39 @@
+// These functions are taken from https://github.com/ember-cli/ember-cli/commit/098a9b304b551fe235bd42399ce6975af2a1bc48
+// and are used to ensure the correct order of dependency addons.
+
+export function lexicographically(a: string, b: string): number {
+  const aIsString = typeof a === 'string';
+  const bIsString = typeof b === 'string';
+
+  if (aIsString && bIsString) {
+    return a.localeCompare(b);
+  } else if (aIsString) {
+    return -1;
+  } else if (bIsString) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+export function pushUnique<T>(array: T[], entry: T) {
+  const index = array.indexOf(entry);
+
+  if (index > -1) {
+    // the entry already exists in the array, but since the presedence between
+    // addons is "last right wins". We first remove the duplicate entry, and
+    // append it to the end of the array.
+    array.splice(index, 1);
+  }
+
+  // At this point, the entry is not in the array. So we must append it.
+  array.push(entry);
+
+  // All this ensures:
+  // pushUnique([a1,a2,a3], a1)
+  // results in:
+  //
+  // [a2, a3, a1]
+  //
+  // which results in the most "least surprising" addon ordering.
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,3 +17,4 @@ export { AppAdapter, AppBuilder, EmberENV } from './app';
 export { todo, unsupported, warn, debug, expectWarning, throwOnWarnings } from './messages';
 export { explicitRelative, extensionsPattern } from './paths';
 export { default as babelFilter } from './babel-filter';
+// export { lexicographically, pushUnique } from './dependency-ordering-utils';

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -2,6 +2,7 @@ import { Memoize } from 'typescript-memoize';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import get from 'lodash/get';
+//import DAGMap from 'dag-map';
 import { AddonMeta, AppMeta } from './metadata';
 import PackageCache from './package-cache';
 import flatMap from 'lodash/flatMap';
@@ -103,14 +104,31 @@ export default class Package {
   // because it will effect "who wins" when it comes to merging the appTree.
   @Memoize()
   get dependencies(): Package[] {
-    let names = flatMap(this.dependencyKeys, key => {
+    let sortedDependencies = flatMap(this.dependencyKeys, key => {
       let keys = Object.keys(this.packageJSON[key] || {});
       return keys.sort(lexicographically);
     });
 
-    let sorted_list: string[] = [];
-    names.forEach(name => pushUnique(sorted_list, name));
-    return sorted_list.map(name => this.packageCache.resolve(name, this));
+    let unqiuelySortedDeps: string[] = [];
+    sortedDependencies.forEach(dep => pushUnique(unqiuelySortedDeps, dep));
+
+    // let graph = new DAGMap<Package>();
+    // unqiuelySortedDeps.forEach(name => {
+    //   let cache = this.packageCache.resolve(name, this);
+    //   let emberAddonConfig = cache.meta;
+
+    //   graph.add(name, cache, emberAddonConfig.before, emberAddonConfig.after);
+    // });
+
+    // let values: Package[] = [];
+    // graph.each((_, val) => {
+    //   if (val) {
+    //     values.push(val);
+    //   }
+    // });
+    // return values;
+
+    return unqiuelySortedDeps.map(name => this.packageCache.resolve(name, this));
   }
 
   hasDependency(name: string): boolean {

--- a/packages/core/tests/dependency-ordering-utils.test.ts
+++ b/packages/core/tests/dependency-ordering-utils.test.ts
@@ -1,0 +1,29 @@
+import { lexicographically, pushUnique } from '../src/dependency-ordering-utils';
+
+describe('lexicographically', function() {
+  it('works', function() {
+    expect(['c', 'z/b/z', 'z/b/d', 'z/a/d', 'z/a/c', 'b', 'z/a/d', 'a'].sort(lexicographically)).toEqual([
+      'a',
+      'b',
+      'c',
+      'z/a/c',
+      'z/a/d',
+      'z/a/d',
+      'z/b/d',
+      'z/b/z',
+    ]);
+  });
+});
+
+describe('pushUnique', function() {
+  it('works (and does last write win)', function() {
+    let a = 'a';
+    let b = 'b';
+    let c = 'c';
+
+    let result: string[] = [];
+    [a, a, a, b, a, c, a, c].forEach(entry => pushUnique(result, entry));
+
+    expect(result).toEqual([b, a, c]);
+  });
+});

--- a/packages/core/tests/package.test.ts
+++ b/packages/core/tests/package.test.ts
@@ -1,8 +1,9 @@
 import Package from '../src/package';
 import PackageCache from '../src/package-cache';
 import tmp from 'tmp';
+import path from 'path';
 import fixturify from 'fixturify';
-//import { Project } from '@embroider/test-support';
+import { Project } from '@embroider/test-support';
 
 tmp.setGracefulCleanup();
 
@@ -32,5 +33,134 @@ describe('package', () => {
     expect(packageInstance.mayRebuild).toBe(false);
 
     process.env['BROCCOLI_ENABLED_MEMOIZE'] = originalProcessValue;
+  });
+
+  test('ordering without before/after', () => {
+    let { name: tmpLocation } = tmp.dirSync();
+    let app = Project.emberNew();
+    app.addAddon('foo', '', '1.0.0');
+    app.addAddon('bar', '', '1.0.0');
+    app.addAddon('qux', '', '1.0.0');
+
+    app.addDevAddon('foo', '', '2.0.0');
+    app.addDevAddon('bar', '', '2.0.0');
+    app.addDevAddon('qux', '', '2.0.0');
+
+    app.addDevAddon('a', '', '2.0.0');
+    app.addDevAddon('b', '', '2.0.0');
+    app.addDevAddon('c', '', '2.0.0');
+
+    app.writeSync(tmpLocation);
+
+    let packageCache = new PackageCache();
+    let packageInstance = new Package(path.join(tmpLocation, app.name), packageCache, true);
+    expect(packageInstance.dependencies.map(a => ({ name: a.name, version: a.version }))).toEqual([
+      { name: 'a', version: '2.0.0' },
+      { name: 'b', version: '2.0.0' },
+      { name: 'c', version: '2.0.0' },
+      { name: '@embroider/compat', version: '0.13.0' },
+      { name: '@embroider/core', version: '0.13.0' },
+      { name: '@embroider/webpack', version: '0.13.0' },
+      { name: '@glimmer/component', version: '1.0.0' },
+      { name: 'bar', version: '1.0.0' },
+      { name: 'ember-cli', version: '3.15.1' },
+      { name: 'ember-cli-babel', version: '7.13.2' },
+      { name: 'ember-cli-htmlbars', version: '4.2.2' },
+      { name: 'ember-resolver', version: '7.0.0' },
+      { name: 'ember-source', version: '3.15.0' },
+      { name: 'foo', version: '1.0.0' },
+      { name: 'loader.js', version: '4.7.0' },
+      { name: 'qux', version: '1.0.0' },
+    ]);
+  });
+
+  test('ordering with before specified', function() {
+    let { name: tmpLocation } = tmp.dirSync();
+    let app = Project.emberNew();
+
+    app.addAddon('foo', '', '1.0.0');
+    app.addAddon('bar', '', '1.0.0');
+    let addon = app.addAddon('qux', '', '1.0.0');
+    addon.pkg['ember-addon'].before = 'foo';
+
+    app.writeSync(tmpLocation);
+
+    let packageCache = new PackageCache();
+    let packageInstance = new Package(path.join(tmpLocation, app.name), packageCache, true);
+
+    expect(packageInstance.dependencies.map(a => a.name)).toEqual([
+      '@embroider/compat',
+      '@embroider/core',
+      '@embroider/webpack',
+      '@glimmer/component',
+      'bar',
+      'ember-cli',
+      'ember-cli-babel',
+      'ember-cli-htmlbars',
+      'ember-resolver',
+      'ember-source',
+      'qux',
+      'loader.js',
+      'foo',
+    ]);
+  });
+
+  test('ordering with after specified', function() {
+    let { name: tmpLocation } = tmp.dirSync();
+    let app = Project.emberNew();
+
+    app.addAddon('foo', '', '1.0.0');
+    app.addAddon('bar', '', '1.0.0');
+    let addon = app.addAddon('qux', '', '1.0.0');
+    addon.pkg['ember-addon'].after = 'foo';
+
+    app.writeSync(tmpLocation);
+
+    let packageCache = new PackageCache();
+    let packageInstance = new Package(path.join(tmpLocation, app.name), packageCache, true);
+    expect(packageInstance.dependencies.map(a => a.name)).toEqual([
+      '@embroider/compat',
+      '@embroider/core',
+      '@embroider/webpack',
+      '@glimmer/component',
+      'bar',
+      'ember-cli',
+      'ember-cli-babel',
+      'ember-cli-htmlbars',
+      'ember-resolver',
+      'ember-source',
+      'foo',
+      'loader.js',
+      'qux',
+    ]);
+  });
+
+  test('ordering always matches package.json name (index.js name is ignored)', function() {
+    let { name: tmpLocation } = tmp.dirSync();
+    let app = Project.emberNew();
+
+    app.addAddon('lol', 'module.exports = { name: "foo" };', '1.0.0');
+    let addon = app.addAddon('qux', '', '1.0.0');
+    addon.pkg['ember-addon'].after = 'foo';
+
+    app.writeSync(tmpLocation);
+
+    let packageCache = new PackageCache();
+    let packageInstance = new Package(path.join(tmpLocation, app.name), packageCache, true);
+
+    expect(packageInstance.dependencies.map(a => a.name)).toEqual([
+      '@embroider/compat',
+      '@embroider/core',
+      '@embroider/webpack',
+      '@glimmer/component',
+      'ember-cli',
+      'ember-cli-babel',
+      'ember-cli-htmlbars',
+      'ember-resolver',
+      'ember-source',
+      'foo',
+      'loader.js',
+      'qux',
+    ]);
   });
 });

--- a/packages/core/tests/package.test.ts
+++ b/packages/core/tests/package.test.ts
@@ -2,6 +2,7 @@ import Package from '../src/package';
 import PackageCache from '../src/package-cache';
 import tmp from 'tmp';
 import fixturify from 'fixturify';
+//import { Project } from '@embroider/test-support';
 
 tmp.setGracefulCleanup();
 

--- a/test-packages/support/project.ts
+++ b/test-packages/support/project.ts
@@ -216,6 +216,10 @@ export class Project extends FixturifyProject {
     return super.addDependency(name, version, cb) as Project;
   }
 
+  addDevDependency(name: string | Project, version?: string, cb?: (project: FixturifyProject) => void): Project {
+    return super.addDevDependency(name, version, cb) as Project;
+  }
+
   writeSync(root?: string) {
     super.writeSync(root);
     let stack: { project: Project; root: string }[] = [{ project: this, root: root || this.root }];
@@ -233,8 +237,27 @@ export class Project extends FixturifyProject {
     }
   }
 
-  addAddon(name: string, indexContent = '') {
-    let addon = this.addDependency(name);
+  addAddon(name: string, indexContent = '', version: string = '1.0.0') {
+    let addon = this.addDependency(name, version);
+    addon.files = {
+      'index.js': addonIndexFile(indexContent),
+      addon: {
+        templates: {
+          components: {},
+        },
+      },
+      app: {},
+    };
+    addon.linkPackage('ember-cli-htmlbars');
+    addon.linkPackage('ember-cli-babel');
+
+    addon.pkg.keywords = ['ember-addon'];
+    addon.pkg['ember-addon'] = {};
+    return addon;
+  }
+
+  addDevAddon(name: string, indexContent = '', version: string = '1.0.0') {
+    let addon = this.addDevDependency(name, version);
     addon.files = {
       'index.js': addonIndexFile(indexContent),
       addon: {


### PR DESCRIPTION
Ember CLI defines the addon ordering based on the [following logic](https://github.com/ember-cli/ember-cli/commit/098a9b304b551fe235bd42399ce6975af2a1bc48).

This is an initial spike on aligning the ordering to be consistent with the way ember-cli does it. Currently some of the ported tests are failing and I will need to discuss some ideas with folks.

Fixes #410 