### PR TITLE
Fix macroCondition when if-param is a subexpression

### DIFF
--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -2,7 +2,7 @@ import literal from './literal';
 import getConfig from './get-config';
 import dependencySatisfies from './dependency-satisfies';
 import { maybeAttrs } from './macro-maybe-attrs';
-import { macroIfBlock, macroIfExpression } from './macro-condition';
+import { macroIfBlock, macroIfExpression, macroIfMustache } from './macro-condition';
 import { failBuild } from './fail-build';
 
 export function makeFirstTransform(opts: { userConfigs: { [packageRoot: string]: unknown }; baseDir?: string }) {
@@ -162,7 +162,7 @@ export function makeSecondTransform() {
             return;
           }
           if (node.path.original === 'if') {
-            return env.syntax.builders.mustache(macroIfExpression(node, env.syntax.builders));
+            return macroIfMustache(node, env.syntax.builders);
           }
           if (node.path.original === 'macroFailBuild') {
             failBuild(node);

--- a/packages/macros/src/glimmer/macro-condition.ts
+++ b/packages/macros/src/glimmer/macro-condition.ts
@@ -3,7 +3,7 @@ import evaluate from './evaluate';
 export function macroIfBlock(node: any) {
   let condition = node.params[0];
 
-  if (condition.type !== 'SubExpression' || condition.path.original !== 'macroCondition') {
+  if (!condition || condition.type !== 'SubExpression' || condition.path.original !== 'macroCondition') {
     return node;
   }
 
@@ -30,7 +30,7 @@ export function macroIfBlock(node: any) {
 export function macroIfExpression(node: any, builders: any) {
   let condition = node.params[0];
 
-  if (condition.type !== 'SubExpression' || condition.path.original !== 'macroCondition') {
+  if (!condition || condition.type !== 'SubExpression' || condition.path.original !== 'macroCondition') {
     return node;
   }
 
@@ -48,4 +48,18 @@ export function macroIfExpression(node: any, builders: any) {
   } else {
     return node.params[2] || builders.undefined();
   }
+}
+
+export function macroIfMustache(node: any, builders: any) {
+  let result = macroIfExpression(node, builders);
+
+  if (result === node) {
+    return node;
+  }
+
+  if (result.type === 'SubExpression') {
+    return builders.mustache(result.path, result.params, result.hash);
+  }
+
+  return builders.mustache(result);
 }

--- a/packages/macros/tests/glimmer/macro-condition.test.ts
+++ b/packages/macros/tests/glimmer/macro-condition.test.ts
@@ -34,6 +34,11 @@ describe(`macroCondition`, function() {
       expect(code).toMatch(/class="target \{\{['"]red['"]\}\}"/);
     });
 
+    test('macroCondition inside string with subexpressions', function() {
+      let code = transform(`<div class="target {{if (macroCondition true) (if this.error "red") }}"></div>`);
+      expect(code).toMatch(/class="target \{\{if this.error ['"]red['"]\}\}"/);
+    });
+
     test('leaves regular if-subexpression untouched', function() {
       let code = transform(`{{my-assertion (if this.error "red" "blue")}}`);
       expect(code).toEqual(`{{my-assertion (if this.error "red" "blue")}}`);


### PR DESCRIPTION
I ran into `Maximum call stack size exceeded` errors. This was caused by an infinite loop in the template compiler, caused by nesting a SubExpression directly inside of a MustacheStatement (`{{(if ...)}}`), which could happen if one of the if-branches was a subexpression.