### PR TITLE
[WIP] Ensure correct addon ordering by introducing orderIdx

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -128,11 +128,26 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     // todo: filter by addon-provided hook
     let shouldInclude = (dep: Package) => dep.isEmberPackage();
 
+    let orderAddons = (depA: Package, depB: Package) => {
+      let depAIdx = 0;
+      let depBIdx = 0;
+
+      if (depA && depA.meta && depA.isV2Addon()) {
+        depAIdx = depA.meta.orderIdx || 0;
+      }
+      if (depB && depB.meta && depB.isV2Addon()) {
+        depBIdx = depB.meta.orderIdx || 0;
+      }
+
+      return depAIdx - depBIdx;
+    };
+
     let result = this.appPackage.findDescendants(shouldInclude) as AddonPackage[];
     let extras = [this.synthVendor, this.synthStyles].filter(shouldInclude) as AddonPackage[];
     let extraDescendants = flatMap(extras, dep => dep.findDescendants(shouldInclude)) as AddonPackage[];
     result = [...result, ...extras, ...extraDescendants];
-    return result;
+
+    return result.sort(orderAddons);
   }
 
   @Memoize()

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -133,10 +133,10 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
       let depBIdx = 0;
 
       if (depA && depA.meta && depA.isV2Addon()) {
-        depAIdx = depA.meta.orderIdx || 0;
+        depAIdx = depA.meta['order-index'] || 0;
       }
       if (depB && depB.meta && depB.isV2Addon()) {
-        depBIdx = depB.meta.orderIdx || 0;
+        depBIdx = depB.meta['order-index'] || 0;
       }
 
       return depAIdx - depBIdx;

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -61,7 +61,8 @@ export default class V1Addon implements V1Package {
     protected addonInstance: any,
     protected addonOptions: Required<Options>,
     private app: V1App,
-    private packageCache: PackageCache
+    private packageCache: PackageCache,
+    private orderIdx: number
   ) {
     if (addonInstance.registry) {
       this.updateRegistry(addonInstance.registry);
@@ -389,7 +390,7 @@ export default class V1Addon implements V1Package {
   // things to the package metadata.
   protected get packageMeta(): Partial<AddonMeta> {
     let built = this.build();
-    return mergeWithAppend({}, built.staticMeta, ...built.dynamicMeta.map(d => d()));
+    return mergeWithAppend({ orderIdx: this.orderIdx }, built.staticMeta, ...built.dynamicMeta.map(d => d()));
   }
 
   @Memoize()
@@ -729,7 +730,13 @@ export default class V1Addon implements V1Package {
 }
 
 export interface V1AddonConstructor {
-  new (addonInstance: any, options: Required<Options>, app: V1App, packageCache: PackageCache): V1Addon;
+  new (
+    addonInstance: any,
+    options: Required<Options>,
+    app: V1App,
+    packageCache: PackageCache,
+    orderIdx: number
+  ): V1Addon;
 }
 
 class IntermediateBuild {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -390,7 +390,7 @@ export default class V1Addon implements V1Package {
   // things to the package metadata.
   protected get packageMeta(): Partial<AddonMeta> {
     let built = this.build();
-    return mergeWithAppend({ orderIdx: this.orderIdx }, built.staticMeta, ...built.dynamicMeta.map(d => d()));
+    return mergeWithAppend(built.staticMeta, ...built.dynamicMeta.map(d => d()));
   }
 
   @Memoize()
@@ -704,6 +704,7 @@ export default class V1Addon implements V1Package {
   @Memoize()
   private build(): IntermediateBuild {
     let built = new IntermediateBuild();
+    built.staticMeta['order-index'] = this.orderIdx;
 
     if (this.moduleName !== this.name) {
       built.staticMeta['renamed-packages'] = {

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -29,10 +29,12 @@ export default class V1InstanceCache {
 
   app: V1App;
   packageCache: MovablePackageCache;
+  orderIdx: number;
 
   private constructor(oldApp: any, private options: Required<Options>) {
     this.packageCache = new MovablePackageCache(MacrosConfig.for(oldApp));
     this.app = V1App.create(oldApp, this.packageCache);
+    this.orderIdx = 0;
 
     // no reason to do this on demand because oldApp already eagerly loaded
     // all descendants
@@ -56,8 +58,9 @@ export default class V1InstanceCache {
   }
 
   private addAddon(addonInstance: any) {
+    this.orderIdx += 1;
     let Klass = this.adapterClass(addonInstance.pkg.name);
-    let v1Addon = new Klass(addonInstance, this.options, this.app, this.packageCache);
+    let v1Addon = new Klass(addonInstance, this.options, this.app, this.packageCache, this.orderIdx);
     let pkgs = getOrCreate(this.addons, v1Addon.root, () => []);
     pkgs.push(v1Addon);
     (addonInstance.addons as any[]).forEach(a => this.addAddon(a));

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -1,5 +1,5 @@
 import { Project, BuildResult, ExpectFile, expectFilesAt } from '@embroider/test-support';
-
+import { BuildParams } from '@embroider/test-support/build';
 import { throwOnWarnings } from '@embroider/core';
 import Options from '../src/options';
 import { join } from 'path';
@@ -8,35 +8,11 @@ import merge from 'lodash/merge';
 
 describe('stage2 build', function() {
   jest.setTimeout(120000);
+  throwOnWarnings();
 
-  describe('appTree merge order should be identical to ember-cli', function() {
-    let expectFile: ExpectFile;
-    let build: BuildResult;
-    let app: Project;
-
-    throwOnWarnings();
-
-    beforeAll(async function() {
-      app = Project.emberNew();
-      let fastbootAddonNamespace = app.addAddon('bbb');
-      merge(fastbootAddonNamespace.files, {
-        app: {
-          service: {
-            'fastboot.js': `bbb`,
-          },
-        },
-      });
-
-      let fastbootAddon = app.addAddon('aaa');
-      merge(fastbootAddon.files, {
-        app: {
-          service: {
-            'fastboot.js': `aaa`,
-          },
-        },
-      });
-
-      build = await BuildResult.build(app, {
+  describe('addon ordering is preserved from ember-cli', function() {
+    it('addons are lexographically sorted by ember-cli and the last one wins', async function() {
+      let buildOptions: Partial<BuildParams> = {
         stage: 2,
         type: 'app',
         emberAppOptions: {
@@ -46,20 +22,76 @@ describe('stage2 build', function() {
           },
         },
         embroiderOptions: {},
-      });
-      expectFile = expectFilesAt(build.outputPath);
-    });
+      };
+      let app = Project.emberNew();
+      // even though the bAddon was added first since it will be sorted lexographically it should
+      // come after aAddon and thus win once the services are merged
+      let bAddon = app.addAddon('bbb');
+      let aAddon = app.addAddon('aaa');
 
-    afterAll(async function() {
+      merge(aAddon.files, { app: { service: { 'foo.js': 'aaa' } } });
+      merge(bAddon.files, { app: { service: { 'foo.js': 'bbb' } } });
+
+      let build = await BuildResult.build(app, buildOptions);
+      let expectFile = expectFilesAt(build.outputPath);
+
+      let assertFile = expectFile('./service/foo.js');
+      assertFile.matches(/bbb/);
       await build.cleanup();
     });
 
-    it('the correct service file gets merged into app code', function() {
-      // the reason why this file should win is because we lexicographically
-      // sort the addons by name then apply a last addon wins approach.
+    it('addons declared as dependencies should win over devDependencies', async function() {
+      let buildOptions: Partial<BuildParams> = {
+        stage: 2,
+        type: 'app',
+        emberAppOptions: {
+          tests: false,
+          babel: {
+            plugins: [],
+          },
+        },
+        embroiderOptions: {},
+      };
+      let app = Project.emberNew();
+      let aAddon = app.addAddon('aaa');
+      let bAddon = app.addDevAddon('bbb');
 
-      let assertFile = expectFile('./service/fastboot.js');
+      merge(aAddon.files, { app: { service: { 'foo.js': 'aaa' } } });
+      merge(bAddon.files, { app: { service: { 'foo.js': 'bbb' } } });
+
+      let build = await BuildResult.build(app, buildOptions);
+      let expectFile = expectFilesAt(build.outputPath);
+
+      let assertFile = expectFile('./service/foo.js');
+      assertFile.matches(/aaa/);
+
+      await build.cleanup();
+    });
+
+    it('in repo addons declared win over dependencies', async function() {
+      let buildOptions: Partial<BuildParams> = {
+        stage: 2,
+        type: 'app',
+        emberAppOptions: {
+          tests: false,
+          babel: {
+            plugins: [],
+          },
+        },
+        embroiderOptions: {},
+      };
+      let app = Project.emberNew();
+      let aAddon = app.addAddon('aaa');
+      app.addInRepoAddon('bbb', { app: { service: { 'foo.js': 'bbb' } } });
+
+      merge(aAddon.files, { app: { service: { 'foo.js': 'aaa' } } });
+
+      let build = await BuildResult.build(app, buildOptions);
+      let expectFile = expectFilesAt(build.outputPath);
+
+      let assertFile = expectFile('./service/foo.js');
       assertFile.matches(/bbb/);
+      await build.cleanup();
     });
   });
 
@@ -67,8 +99,6 @@ describe('stage2 build', function() {
     let expectFile: ExpectFile;
     let build: BuildResult;
     let app: Project;
-
-    throwOnWarnings();
 
     beforeAll(async function() {
       app = Project.emberNew();

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -27,6 +27,7 @@ export interface AppMeta {
 // addon.
 export interface AddonMeta {
   type: 'addon';
+  orderIdx?: number;
 
   'auto-upgraded'?: true;
   'app-js'?: filename;

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -27,7 +27,7 @@ export interface AppMeta {
 // addon.
 export interface AddonMeta {
   type: 'addon';
-  orderIdx?: number;
+  'order-index'?: number;
 
   'auto-upgraded'?: true;
   'app-js'?: filename;


### PR DESCRIPTION
Fixes: #410

Addon ordering matters as ember-cli is built around the concept of "last addon wins". This ordering from ember-cli is lost after the compat stage and can produce issues when trees are merged. The exact logic that ember-cli uses to sort addons comes from here: https://github.com/ember-cli/ember-cli/commit/098a9b304b551fe235bd42399ce6975af2a1bc48. Instead of bring over that logic we can simply track the order of addons with `orderIdx` and write that as meta data (such that it can be used in later stages).