### PR TITLE
Support in-repo addons within other addons

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -8,21 +8,27 @@ import Funnel from 'broccoli-funnel';
 import { UnwatchedDir } from 'broccoli-source';
 import EmptyPackageTree from './empty-package-tree';
 
-export default function cachedBuildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): Tree {
-  let tree = buildCompatAddon(originalPackage, v1Cache);
+export default function cachedBuildCompatAddon(
+  originalPackage: Package,
+  v1Cache: V1InstanceCache
+): { tree: Tree; nonResolvableDeps: Package[] } {
+  let { tree, nonResolvableDeps } = buildCompatAddon(originalPackage, v1Cache);
   if (!originalPackage.mayRebuild) {
     tree = new OneShot(tree);
   }
-  return tree;
+  return { tree, nonResolvableDeps };
 }
 
-function buildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): Tree {
+function buildCompatAddon(
+  originalPackage: Package,
+  v1Cache: V1InstanceCache
+): { tree: Tree; nonResolvableDeps: Package[] } {
   if (originalPackage.isV2Addon()) {
     // this case is needed when a native-v2 addon depends on a
     // non-native-v2 addon. (The non-native one will get rewritten and
     // therefore moved, so to continue depending on it the native one needs to
     // move too.)
-    return withoutNodeModules(originalPackage.root);
+    return { tree: withoutNodeModules(originalPackage.root), nonResolvableDeps: [] };
   }
 
   let oldPackages = v1Cache.getAddons(originalPackage.root);
@@ -36,16 +42,19 @@ function buildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): T
     // because that whole process only depends on looking at all the
     // package.json files on disk -- it can't know which ones are going to end
     // up unused at this point.
-    return new EmptyPackageTree();
+    return { tree: new EmptyPackageTree(), nonResolvableDeps: [] };
   }
 
   let needsSmooshing = oldPackages[0].hasAnyTrees();
   if (needsSmooshing) {
     let trees = oldPackages.map(pkg => pkg.v2Tree).reverse();
     let smoosher = new SmooshPackageJSON(trees);
-    return broccoliMergeTrees([...trees, smoosher], { overwrite: true });
+    return {
+      tree: broccoliMergeTrees([...trees, smoosher], { overwrite: true }),
+      nonResolvableDeps: oldPackages[0].nonResolvableDependencies(), // TODO: combine nonResolvableDeps from all copies
+    };
   } else {
-    return oldPackages[0].v2Tree;
+    return { tree: oldPackages[0].v2Tree, nonResolvableDeps: oldPackages[0].nonResolvableDependencies() };
   }
 }
 

--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -45,16 +45,23 @@ function buildCompatAddon(
     return { tree: new EmptyPackageTree(), nonResolvableDeps: [] };
   }
 
+  let nonResolvableDependencies: Set<Package> = new Set();
+  for (let pkg of oldPackages) {
+    for (let dep of pkg.nonResolvableDependencies()) {
+      nonResolvableDependencies.add(dep);
+    }
+  }
+
   let needsSmooshing = oldPackages[0].hasAnyTrees();
   if (needsSmooshing) {
     let trees = oldPackages.map(pkg => pkg.v2Tree).reverse();
     let smoosher = new SmooshPackageJSON(trees);
     return {
       tree: broccoliMergeTrees([...trees, smoosher], { overwrite: true }),
-      nonResolvableDeps: oldPackages[0].nonResolvableDependencies(), // TODO: combine nonResolvableDeps from all copies
+      nonResolvableDeps: Array.from(nonResolvableDependencies),
     };
   } else {
-    return { tree: oldPackages[0].v2Tree, nonResolvableDeps: oldPackages[0].nonResolvableDependencies() };
+    return { tree: oldPackages[0].v2Tree, nonResolvableDeps: Array.from(nonResolvableDependencies) };
   }
 }
 

--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -47,11 +47,9 @@ export default class CompatAddons implements Stage {
   get tree(): Tree {
     let movedAddons = [...this.packageCache.moved.keys()].map(oldPkg => {
       let { tree, nonResolvableDeps } = buildCompatAddon(oldPkg, this.v1Cache);
-
       for (let dep of nonResolvableDeps) {
         this.nonResolvableDepsOfAddons.push({ pkg: oldPkg, dep });
       }
-
       return tree;
     });
     let { synthVendor, synthStyles } = this.getSyntheticPackages(this.v1Cache.app, movedAddons);

--- a/packages/compat/src/rewrite-package-json.ts
+++ b/packages/compat/src/rewrite-package-json.ts
@@ -46,6 +46,8 @@ export default class RewritePackageJSON extends Plugin {
       pkg.dependencies = {};
     }
 
+    // add in repo addons to dependencies as they will be symlinked
+    // into node_modules
     for (let dep of nonResolvableDependencies) {
       pkg.dependencies[dep.name] = '*';
     }

--- a/packages/compat/src/rewrite-package-json.ts
+++ b/packages/compat/src/rewrite-package-json.ts
@@ -1,12 +1,17 @@
 import Plugin, { Tree } from 'broccoli-plugin';
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { AddonMeta } from '@embroider/core';
+import { AddonMeta, Package } from '@embroider/core';
 
 type GetMeta = () => Partial<AddonMeta>;
+type GetNonResolvableDependencies = () => Package[];
 
 export default class RewritePackageJSON extends Plugin {
-  constructor(inputTree: Tree, private getMeta: GetMeta) {
+  constructor(
+    inputTree: Tree,
+    private getMeta: GetMeta,
+    private getNonResolvableDependencies: GetNonResolvableDependencies
+  ) {
     super([inputTree], {
       annotation: 'embroider:core:rewrite-package-json',
     });
@@ -35,6 +40,16 @@ export default class RewritePackageJSON extends Plugin {
     );
     this.cachedLast = pkg;
     pkg['ember-addon'] = meta;
+
+    let nonResolvableDependencies = this.getNonResolvableDependencies();
+    if (nonResolvableDependencies.length && !pkg.dependencies) {
+      pkg.dependencies = {};
+    }
+
+    for (let dep of nonResolvableDependencies) {
+      pkg.dependencies[dep.name] = '*';
+    }
+
     writeFileSync(join(this.outputPath, 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
   }
 }

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -30,6 +30,14 @@ describe('stage2 build', function() {
 
       let depA = app.addAddon('dep-a');
       let depB = app.addAddon('dep-b');
+      let depC = app.addAddon('dep-c');
+
+      depA.linkPackage('dep-c', depC.root);
+      depB.linkPackage('dep-c', depC.root);
+
+      depC.addInRepoAddon('in-repo-d', {
+        app: { service: { 'in-repo.js': 'in-repo-d' } },
+      });
 
       depA.addInRepoAddon('in-repo-a', {
         app: { service: { 'in-repo.js': 'in-repo-a' } },

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -37,6 +37,9 @@ describe('stage2 build', function() {
       depB.addInRepoAddon('in-repo-b', {
         app: { service: { 'in-repo.js': 'in-repo-b' } },
       });
+      depB.addInRepoAddon('in-repo-c', {
+        app: { service: { 'in-repo.js': 'in-repo-c' } },
+      });
 
       build = await BuildResult.build(app, buildOptions);
       expectFile = expectFilesAt(build.outputPath);
@@ -52,10 +55,19 @@ describe('stage2 build', function() {
         .json()
         .get('dependencies.in-repo-a')
         .equals('*');
+      expectFile('./node_modules/dep-b/package.json')
+        .json()
+        .get('dependencies.in-repo-b')
+        .equals('*');
+      expectFile('./node_modules/dep-b/package.json')
+        .json()
+        .get('dependencies.in-repo-c')
+        .equals('*');
 
-      // check that symlinks is correct
+      // check that symlinks are correct
       expectFile('./node_modules/dep-a/node_modules/in-repo-a/package.json');
       expectFile('./node_modules/dep-b/node_modules/in-repo-b/package.json');
+      expectFile('./node_modules/dep-b/node_modules/in-repo-c/package.json');
 
       // check that the in repo addons are correct upgraded
       expectFile('./node_modules/dep-a/node_modules/in-repo-a/package.json')
@@ -66,9 +78,13 @@ describe('stage2 build', function() {
         .json()
         .get('ember-addon.version')
         .equals(2);
+      expectFile('./node_modules/dep-b/node_modules/in-repo-c/package.json')
+        .json()
+        .get('ember-addon.version')
+        .equals(2);
 
       // check that the app trees with in repo addon are combined correctly
-      expectFile('./service/in-repo.js').matches(/in-repo-b/);
+      expectFile('./service/in-repo.js').matches(/in-repo-c/);
     });
   });
 

--- a/test-packages/support/project.ts
+++ b/test-packages/support/project.ts
@@ -292,10 +292,14 @@ export class Project extends FixturifyProject {
         lib: {
           [name]: {
             'index.js': addonIndexFile(''),
-            'package.json': JSON.stringify({
-              name,
-              keywords: ['ember-addon'],
-            }),
+            'package.json': JSON.stringify(
+              {
+                name,
+                keywords: ['ember-addon'],
+              },
+              null,
+              2
+            ),
           },
         },
       },


### PR DESCRIPTION
Fixes: #428 

This PR enables in-repo addons of addons to be supported. To achieve this the PR:

- enables V1Addons to be extended (just like V1App) such that their dependencies include in-repo addons

- rewrites the addon's package.json to include in-repo addons as direct dependencies instead of as ember-addon.paths (ie removes the "emberness" from them)

- Symlink the in-repo addons into the addons node_module such that they can be naturally discovered like normal dependencies 