### PR TITLE
Enable tests to run from the browser with ember s command

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -455,6 +455,16 @@ export class AppBuilder<TreeNames> {
 
       let implicitTestScripts = this.impliedAssets('implicit-test-scripts');
       if (implicitTestScripts.length > 0) {
+        // this is the traditional test-support-suffix.js, it should go to test-support
+        implicitTestScripts.push({
+          kind: 'in-memory',
+          relativePath: '_testing_suffix_.js',
+          source: `
+          var runningTests=true;
+          if (window.Testem) {
+            window.Testem.hookIntoTestFramework();
+          }`,
+        });
         let testSupportJS = new ConcatenatedAsset(
           'assets/test-support.js',
           implicitTestScripts,
@@ -1018,7 +1028,7 @@ let d = w.define;
 {{/if}}
 
 {{#if autoRun ~}}
-  if (typeof EMBER_DISABLE_AUTO_BOOT === 'undefined' || !EMBER_DISABLE_AUTO_BOOT) {
+  if (!runningTests) {
     i("{{js-string-escape mainModule}}").default.create({{{json-stringify appConfig}}});
   }
 {{else  if appBoot ~}}
@@ -1029,11 +1039,6 @@ let d = w.define;
   {{!- TODO: both of these suffixes should get dynamically generated so they incorporate
        any content-for added by addons. -}}
 
-  {{!- this is the traditional test-support-suffix.js -}}
-  runningTests = true;
-  if (window.Testem) {
-    window.Testem.hookIntoTestFramework();
-  }
 
   {{!- this is the traditional tests-suffix.js -}}
   i('../tests/test-helper');


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli/blob/627934f91b2aa0e19b041fdb1b547873c1855793/lib/broccoli/default-packager.js#L994-L1013

ember-cli adds all these to `test-support.js`, not to `tests.js` file. Moving the code fixes issue #113 