### PR TITLE
Build variants

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "**/tmp/**": true
   },
   "eslint.validate": ["javascript", "typescript"],
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,10 @@
-export { Packager, PackagerInstance } from './packager';
+export {
+  Packager,
+  PackagerInstance,
+  Variant,
+  applyVariantToBabelConfig,
+  applyVariantToTemplateCompiler,
+} from './packager';
 export { Resolver } from './resolver';
 export { AppMeta, AddonMeta } from './metadata';
 export { default as Package, V2AddonPackage as AddonPackage, V2AppPackage as AppPackage, V2Package } from './package';

--- a/packages/core/src/packager.ts
+++ b/packages/core/src/packager.ts
@@ -1,3 +1,28 @@
+// This is a collection of flags that convey what kind of build you want. They
+// are intended to be generic across Packagers, and it's up to Packager authors
+// to support each option (or not).
+export interface Variant {
+  // descriptive name that can be used by the packager to label which output
+  // goes with which variant.
+  name: string;
+
+  // Which runtime should this build work in? Dev builds will typically be "all"
+  // because we produce a single build that works in browser and fastboot. But
+  // production builds can be divided into a browser-only variant and a
+  // fastboot-only variant so that each can be separately optimized.
+  //
+  // Note that if you build *only* a fastboot variant, you're unlikely to end up
+  // with any assets that can boot and run in the browser too, so the typical
+  // thing to do is to have to two variants and for the packager to use the
+  // assets from the browser build to generate browser-facing <script> tags in
+  // the output of the fastboot build.
+  runtime: 'all' | 'browser' | 'fastboot';
+
+  // true if this build should be optimized for production, at the cost of
+  // slower builds and/or worse debuggability
+  optimizeForProduction: boolean;
+}
+
 export interface Packager<Options> {
   new (
     // where on disk the packager will find the app it's supposed to build. The
@@ -7,6 +32,21 @@ export interface Packager<Options> {
     inputPath: string,
     // where the packager should write the packaged app.
     outputPath: string,
+    // list of active build variants. There is always at least one variant, but
+    // there can be many.
+    //
+    // The main requirement for correctness is that the Packager is required to
+    // apply each variant to the babel and template-compiler configs that it
+    // finds in the app in order to build that variant.
+    //
+    // It is up to each Packager to decide how to combine the output from the
+    // multiple variants. It might choose to just put them in separate
+    // subdirectories of `outputPath`, or it might know how to combine them
+    // correctly into one build that will run each variant under the appropriate
+    // conditions.
+    //
+    // Not all packagers will support all arbitrary combinations of variants.
+    variants: Variant[],
     // if possible, the packager should direct its console output through this
     // hook.
     consoleWrite: (message: string) => void,
@@ -22,4 +62,28 @@ export interface Packager<Options> {
 
 export interface PackagerInstance {
   build(): Promise<void>;
+}
+
+export function applyVariantToBabelConfig(variant: Variant, babelConfig: any) {
+  if (variant.runtime === 'fastboot') {
+    babelConfig = Object.assign({}, babelConfig);
+    if (babelConfig.plugins) {
+      babelConfig.plugins = babelConfig.plugins.slice();
+    } else {
+      babelConfig.plugins = [];
+    }
+    let macroPlugin = babelConfig.plugins.find(
+      (p: any) => Array.isArray(p) && p[1] && p[1].embroiderMacrosConfigMarker
+    );
+    if (macroPlugin) {
+      macroPlugin[1].globalConfig.fastboot = { isRunning: true };
+    }
+  }
+  return babelConfig;
+}
+
+export function applyVariantToTemplateCompiler(_variant: Variant, templateCompiler: any) {
+  // TODO: we don't actually consume the variant in the template macros yet, but
+  // Packagers must call this function anyway because we will.
+  return templateCompiler;
 }

--- a/packages/core/src/to-broccoli-plugin.ts
+++ b/packages/core/src/to-broccoli-plugin.ts
@@ -1,15 +1,15 @@
 import Plugin from 'broccoli-plugin';
-import { Packager, PackagerInstance } from './packager';
+import { Packager, PackagerInstance, Variant } from './packager';
 import Stage from './stage';
 
 interface BroccoliPackager<Options> {
-  new (stage: Stage, options?: Options): Plugin;
+  new (stage: Stage, variants: Variant[], options?: Options): Plugin;
 }
 
 export default function toBroccoliPlugin<Options>(packagerClass: Packager<Options>): BroccoliPackager<Options> {
   class PackagerRunner extends Plugin {
     private packager: PackagerInstance | undefined;
-    constructor(private stage: Stage, private options?: Options) {
+    constructor(private stage: Stage, private variants: Variant[], private options?: Options) {
       super([stage.tree], {
         persistentOutput: true,
         needsCache: false,
@@ -25,7 +25,13 @@ export default function toBroccoliPlugin<Options>(packagerClass: Packager<Option
         if (packageCache) {
           packageCache.shareAs('embroider-stage3');
         }
-        this.packager = new packagerClass(outputPath, this.outputPath, msg => console.log(msg), this.options);
+        this.packager = new packagerClass(
+          outputPath,
+          this.outputPath,
+          this.variants,
+          msg => console.log(msg),
+          this.options
+        );
       }
       return this.packager.build();
     }

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -9,7 +9,7 @@
   getting script vs module context correct).
 */
 
-import { PackagerInstance, AppMeta, Packager, getOrCreate } from '@embroider/core';
+import { PackagerInstance, AppMeta, Packager } from '@embroider/core';
 import webpack, { Configuration } from 'webpack';
 import {
   readFileSync,
@@ -22,16 +22,14 @@ import {
   readJsonSync,
 } from 'fs-extra';
 import { join, dirname, relative, sep } from 'path';
-import { JSDOM } from 'jsdom';
 import isEqual from 'lodash/isEqual';
 import mergeWith from 'lodash/mergeWith';
-import partition from 'lodash/partition';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import Placeholder from './html-placeholder';
 import makeDebug from 'debug';
 import { format } from 'util';
 import { tmpdir } from 'os';
 import { warmup as threadLoaderWarmup } from 'thread-loader';
+import { HTMLEntrypoint } from './html-entrypoint';
 
 const debug = makeDebug('embroider:debug');
 
@@ -39,115 +37,6 @@ const debug = makeDebug('embroider:debug');
 // terser lazily so it's only loaded for production builds that use it. Don't
 // add any non-type-only imports here.
 import { MinifyOptions } from 'terser';
-
-class HTMLEntrypoint {
-  private dom: JSDOM;
-  private placeholders: Map<string, Placeholder[]> = new Map();
-  modules: string[] = [];
-  scripts: string[] = [];
-  styles: string[] = [];
-
-  constructor(private pathToVanillaApp: string, private rootURL: string, public filename: string) {
-    this.dom = new JSDOM(readFileSync(join(this.pathToVanillaApp, this.filename), 'utf8'));
-
-    for (let tag of this.handledStyles()) {
-      let styleTag = tag as HTMLLinkElement;
-      let href = styleTag.href;
-      if (!isAbsoluteURL(href)) {
-        let url = this.relativeToApp(href);
-        this.styles.push(url);
-        let placeholder = new Placeholder(styleTag);
-        let list = getOrCreate(this.placeholders, url, () => []);
-        list.push(placeholder);
-      }
-    }
-
-    for (let scriptTag of this.handledScripts()) {
-      // scriptTag.src include rootURL. Convert it to be relative to the app.
-      let src = this.relativeToApp(scriptTag.src);
-
-      if (scriptTag.type === 'module') {
-        this.modules.push(src);
-      } else {
-        this.scripts.push(src);
-      }
-
-      let placeholder = new Placeholder(scriptTag);
-      let list = getOrCreate(this.placeholders, src, () => []);
-      list.push(placeholder);
-    }
-  }
-
-  private relativeToApp(rootRelativeURL: string) {
-    return rootRelativeURL.replace(this.rootURL, '');
-  }
-
-  private handledScripts() {
-    let scriptTags = [...this.dom.window.document.querySelectorAll('script')] as HTMLScriptElement[];
-    let [ignoredScriptTags, handledScriptTags] = partition(scriptTags, scriptTag => {
-      return !scriptTag.src || scriptTag.hasAttribute('data-embroider-ignore') || isAbsoluteURL(scriptTag.src);
-    });
-    for (let scriptTag of ignoredScriptTags) {
-      scriptTag.removeAttribute('data-embroider-ignore');
-    }
-    return handledScriptTags;
-  }
-
-  private handledStyles() {
-    let styleTags = [...this.dom.window.document.querySelectorAll('link[rel="stylesheet"]')] as HTMLLinkElement[];
-    let [ignoredStyleTags, handledStyleTags] = partition(styleTags, styleTag => {
-      return !styleTag.href || styleTag.hasAttribute('data-embroider-ignore') || isAbsoluteURL(styleTag.href);
-    });
-    for (let styleTag of ignoredStyleTags) {
-      styleTag.removeAttribute('data-embroider-ignore');
-    }
-    return handledStyleTags;
-  }
-
-  render(bundles: Map<string, string[]>, lazyBundles: Set<string>, rootURL: string): string {
-    let insertedLazy = false;
-
-    for (let [src, placeholders] of this.placeholders) {
-      let matchingBundles = bundles.get(src);
-      if (matchingBundles) {
-        for (let placeholder of placeholders) {
-          insertedLazy = maybeInsertLazyBundles(insertedLazy, lazyBundles, placeholder, rootURL);
-          for (let matchingBundle of matchingBundles) {
-            let src = rootURL + matchingBundle;
-            placeholder.insertURL(src);
-          }
-        }
-      } else {
-        // no match means keep the original HTML content for this placeholder.
-        // (If we really wanted it empty instead, there would be matchingBundles
-        // and it would be an empty list.)
-        for (let placeholder of placeholders) {
-          placeholder.reset();
-        }
-      }
-    }
-    return this.dom.serialize();
-  }
-}
-
-// we (somewhat arbitrarily) decide to put the lazy bundles before the very
-// first <script> that we have rewritten
-function maybeInsertLazyBundles(
-  insertedLazy: boolean,
-  lazyBundles: Set<string>,
-  placeholder: Placeholder,
-  rootURL: string
-): boolean {
-  if (!insertedLazy && placeholder.isScript()) {
-    for (let bundle of lazyBundles) {
-      let element = placeholder.start.ownerDocument.createElement('fastboot-script');
-      element.setAttribute('src', rootURL + bundle);
-      placeholder.insert(element);
-    }
-    return true;
-  }
-  return insertedLazy;
-}
 
 interface AppInfo {
   entrypoints: HTMLEntrypoint[];
@@ -565,10 +454,6 @@ function appendArrays(objValue: any, srcValue: any) {
   if (Array.isArray(objValue)) {
     return objValue.concat(srcValue);
   }
-}
-
-function isAbsoluteURL(url: string) {
-  return /^(?:[a-z]+:)?\/\//i.test(url);
 }
 
 function isCSS(filename: string) {

--- a/packages/webpack/src/html-entrypoint.ts
+++ b/packages/webpack/src/html-entrypoint.ts
@@ -1,0 +1,119 @@
+import { getOrCreate } from '@embroider/core';
+import { readFileSync } from 'fs-extra';
+import { join } from 'path';
+import { JSDOM } from 'jsdom';
+import partition from 'lodash/partition';
+import Placeholder from './html-placeholder';
+
+export class HTMLEntrypoint {
+  private dom: JSDOM;
+  private placeholders: Map<string, Placeholder[]> = new Map();
+  modules: string[] = [];
+  scripts: string[] = [];
+  styles: string[] = [];
+
+  constructor(private pathToVanillaApp: string, private rootURL: string, public filename: string) {
+    this.dom = new JSDOM(readFileSync(join(this.pathToVanillaApp, this.filename), 'utf8'));
+
+    for (let tag of this.handledStyles()) {
+      let styleTag = tag as HTMLLinkElement;
+      let href = styleTag.href;
+      if (!isAbsoluteURL(href)) {
+        let url = this.relativeToApp(href);
+        this.styles.push(url);
+        let placeholder = new Placeholder(styleTag);
+        let list = getOrCreate(this.placeholders, url, () => []);
+        list.push(placeholder);
+      }
+    }
+
+    for (let scriptTag of this.handledScripts()) {
+      // scriptTag.src include rootURL. Convert it to be relative to the app.
+      let src = this.relativeToApp(scriptTag.src);
+
+      if (scriptTag.type === 'module') {
+        this.modules.push(src);
+      } else {
+        this.scripts.push(src);
+      }
+
+      let placeholder = new Placeholder(scriptTag);
+      let list = getOrCreate(this.placeholders, src, () => []);
+      list.push(placeholder);
+    }
+  }
+
+  private relativeToApp(rootRelativeURL: string) {
+    return rootRelativeURL.replace(this.rootURL, '');
+  }
+
+  private handledScripts() {
+    let scriptTags = [...this.dom.window.document.querySelectorAll('script')] as HTMLScriptElement[];
+    let [ignoredScriptTags, handledScriptTags] = partition(scriptTags, scriptTag => {
+      return !scriptTag.src || scriptTag.hasAttribute('data-embroider-ignore') || isAbsoluteURL(scriptTag.src);
+    });
+    for (let scriptTag of ignoredScriptTags) {
+      scriptTag.removeAttribute('data-embroider-ignore');
+    }
+    return handledScriptTags;
+  }
+
+  private handledStyles() {
+    let styleTags = [...this.dom.window.document.querySelectorAll('link[rel="stylesheet"]')] as HTMLLinkElement[];
+    let [ignoredStyleTags, handledStyleTags] = partition(styleTags, styleTag => {
+      return !styleTag.href || styleTag.hasAttribute('data-embroider-ignore') || isAbsoluteURL(styleTag.href);
+    });
+    for (let styleTag of ignoredStyleTags) {
+      styleTag.removeAttribute('data-embroider-ignore');
+    }
+    return handledStyleTags;
+  }
+
+  render(bundles: Map<string, string[]>, lazyBundles: Set<string>, rootURL: string): string {
+    let insertedLazy = false;
+
+    for (let [src, placeholders] of this.placeholders) {
+      let matchingBundles = bundles.get(src);
+      if (matchingBundles) {
+        for (let placeholder of placeholders) {
+          insertedLazy = maybeInsertLazyBundles(insertedLazy, lazyBundles, placeholder, rootURL);
+          for (let matchingBundle of matchingBundles) {
+            let src = rootURL + matchingBundle;
+            placeholder.insertURL(src);
+          }
+        }
+      } else {
+        // no match means keep the original HTML content for this placeholder.
+        // (If we really wanted it empty instead, there would be matchingBundles
+        // and it would be an empty list.)
+        for (let placeholder of placeholders) {
+          placeholder.reset();
+        }
+      }
+    }
+    return this.dom.serialize();
+  }
+}
+
+function isAbsoluteURL(url: string) {
+  return /^(?:[a-z]+:)?\/\//i.test(url);
+}
+
+// we (somewhat arbitrarily) decide to put the lazy bundles before the very
+// first <script> that we have rewritten
+function maybeInsertLazyBundles(
+  insertedLazy: boolean,
+  lazyBundles: Set<string>,
+  placeholder: Placeholder,
+  rootURL: string
+): boolean {
+  if (!insertedLazy && placeholder.isScript()) {
+    for (let bundle of lazyBundles) {
+      let element = placeholder.start.ownerDocument.createElement('fastboot-script');
+      element.setAttribute('src', rootURL + bundle);
+      placeholder.insert(element);
+    }
+    return true;
+  }
+  return insertedLazy;
+}

--- a/packages/webpack/src/html-placeholder.ts
+++ b/packages/webpack/src/html-placeholder.ts
@@ -66,6 +66,7 @@ export default class Placeholder {
     newTag.src = src;
     this.insert(newTag);
     this.insertNewline();
+    return newTag;
   }
 
   insertStyleLink(href: string) {

--- a/packages/webpack/src/stat-summary.ts
+++ b/packages/webpack/src/stat-summary.ts
@@ -1,0 +1,12 @@
+import { Variant } from '@embroider/core';
+
+export interface StatSummary {
+  // entrypoints.get(inputAsset).get(variantIndex) === outputAssets
+  entrypoints: Map<string, Map<number, string[]>>;
+
+  // lazyBundles are tracked specifically for fastboot, so these always come
+  // from the fastboot variant, if any
+  lazyBundles: Set<string>;
+
+  variants: Variant[];
+}

--- a/packages/webpack/src/webpack-hbs-loader.ts
+++ b/packages/webpack/src/webpack-hbs-loader.ts
@@ -1,11 +1,12 @@
 import { loader } from 'webpack';
 import { getOptions } from 'loader-utils';
+import { applyVariantToTemplateCompiler } from '@embroider/core';
 
 export default function hbsLoader(this: loader.LoaderContext, templateContent: string) {
-  let { templateCompilerFile } = getOptions(this);
+  let { templateCompilerFile, variant } = getOptions(this);
 
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  let templateCompiler = require(templateCompilerFile).compile;
+  let templateCompiler = applyVariantToTemplateCompiler(variant, require(templateCompilerFile)).compile;
 
   try {
     return templateCompiler(this.resourcePath, templateContent);

--- a/test-packages/fastboot-app.test.js
+++ b/test-packages/fastboot-app.test.js
@@ -1,7 +1,7 @@
 const execa = require('execa');
 
 test('fastboot-app embroider', async () => {
-  jest.setTimeout(120000);
+  jest.setTimeout(480000);
 
   await execa('yarn', ['test'], {
     cwd: `${__dirname}/fastboot-app`,
@@ -9,7 +9,7 @@ test('fastboot-app embroider', async () => {
 });
 
 test('fastboot-app classic', async () => {
-  jest.setTimeout(120000);
+  jest.setTimeout(480000);
   await execa('yarn', ['test'], {
     cwd: `${__dirname}/fastboot-app`,
     env: { CLASSIC: 'true' },

--- a/test-packages/fastboot-app/fastboot-tests/fastboot-basic-tests.js
+++ b/test-packages/fastboot-app/fastboot-tests/fastboot-basic-tests.js
@@ -4,7 +4,7 @@ const { module: Qmodule, test } = require('qunit');
 const setup = require('./util');
 
 Qmodule('fastboot basics', function(hooks) {
-  setup(hooks);
+  setup(hooks, process.env.FASTBOOT_APP_PROD === 'true' ? ['--environment', 'production'] : undefined);
 
   let doc;
 

--- a/test-packages/fastboot-app/fastboot-tests/util.js
+++ b/test-packages/fastboot-app/fastboot-tests/util.js
@@ -5,7 +5,7 @@ const { execFileSync } = require('child_process');
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
 
-module.exports = function setup(hooks) {
+module.exports = function setup(hooks, buildArgs = []) {
   let fastboot;
 
   async function visit(assert, url, { expectStatus } = {}) {
@@ -24,7 +24,7 @@ module.exports = function setup(hooks) {
 
   hooks.before(async function(assert) {
     if (!process.env.REUSE_FASTBOOT_BUILD) {
-      execFileSync('node', ['./node_modules/.bin/ember', 'build']);
+      execFileSync('node', ['./node_modules/.bin/ember', 'build', ...buildArgs]);
       process.env.REUSE_FASTBOOT_BUILD = 'true';
     }
     fastboot = new FastBoot({

--- a/test-packages/fastboot-app/package.json
+++ b/test-packages/fastboot-app/package.json
@@ -18,7 +18,9 @@
     "start": "ember serve",
     "test": "npm-run-all lint:* test:*",
     "test:ember": "ember test --test-port=0",
-    "test:fastboot": "qunit fastboot-tests"
+    "test:ember-production": "ember test --test-port=0 --environment=production",
+    "test:fastboot": "qunit fastboot-tests",
+    "test:fastboot-production": "FASTBOOT_APP_PROD=true qunit fastboot-tests"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",


### PR DESCRIPTION
This creates an API for third-stage packagers to support multiple simultaneous build variants. The immediate motivation is to produce fastboot- and browser-optimized production builds. It should also be able to grow to allow the targeting of different sets of browsers.