### PR TITLE
Identify component in snippet rule when ast type is "Template"

### DIFF
--- a/packages/compat/src/dependency-rules.ts
+++ b/packages/compat/src/dependency-rules.ts
@@ -116,7 +116,7 @@ export type ArgumentMapping =
     };
 
 // A component snippet is a string containing valid HBS that is a single
-// component invocation. We use it to refer to compoanents in a way that doesn't
+// component invocation. We use it to refer to components in a way that doesn't
 // require any new syntax or rules, and that's necessarily supported by whatever
 // build-time template resolver is in use.
 //

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -221,7 +221,7 @@ export default class CompatResolver implements Resolver {
     } catch (err) {
       throw new Error(`unable to parse component snippet "${snippet}" from rule ${JSON.stringify(rule, null, 2)}`);
     }
-    if (ast.type === 'Program' && ast.body.length > 0) {
+    if ((ast.type === 'Program' || ast.type === 'Template') && ast.body.length > 0) {
       let first = ast.body[0];
       if (first.type === 'MustacheStatement' && first.path.type === 'PathExpression') {
         return first.path.original;

--- a/test-packages/support/package.json
+++ b/test-packages/support/package.json
@@ -19,7 +19,7 @@
     "ember-cli-babel": "^7.20.5",
     "ember-cli-htmlbars": "^4.2.0",
     "ember-resolver": "^7.0.0",
-    "ember-source": "~3.15.0",
+    "ember-source": "3.17.0",
     "fixturify-project": "git+https://github.com/ef4/node-fixturify-project#e52e2e7724ae1da8dc57a231d74a8ccfdffc119a",
     "fs-extra": "^7.0.0",
     "loader.js": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,6 +413,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
   integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
 
+"@babel/helper-plugin-utils@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz#ec5a5cf0eec925b66c60580328b122c01230a127"
+  integrity sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==
+
 "@babel/helper-regex@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.8.3.tgz#139772607d51b93f23effe72105b319d2a4c6965"
@@ -757,12 +762,20 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-block-scoping@^7.4.4", "@babel/plugin-transform-block-scoping@^7.6.2", "@babel/plugin-transform-block-scoping@^7.8.3":
+"@babel/plugin-transform-block-scoping@^7.4.4", "@babel/plugin-transform-block-scoping@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz#97d35dab66857a437c166358b91d09050c868f3a"
   integrity sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+    lodash "^4.17.13"
+
+"@babel/plugin-transform-block-scoping@^7.6.2":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.1.tgz#47092d89ca345811451cd0dc5d91605982705d5e"
+  integrity sha512-8bpWG6TtF5akdhIm/uWTyjHqENpy13Fx8chg7pFH875aNLwX8JxIxqm08gmAT+Whe6AOmaTeLPe7dpLbXt+xUw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.1"
     lodash "^4.17.13"
 
 "@babel/plugin-transform-classes@^7.8.6":
@@ -8205,6 +8218,36 @@ ember-source-channel-url@^2.0.1:
   dependencies:
     got "^8.0.1"
 
+ember-source@3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.17.0.tgz#6365b8e43f72d552f62e5d7ee4e841595ae70579"
+  integrity sha512-CfOi00tYGdwR12FuBMuiBzyC4cmabHtkL+LpORWavCRHN0UfBpBTj64rmKMD2HNJhYZFVX+8ZFTO27FX8D6Glg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/plugin-transform-block-scoping" "^7.6.2"
+    "@babel/plugin-transform-object-assign" "^7.2.0"
+    "@ember/edition-utils" "^1.2.0"
+    babel-plugin-debug-macros "^0.3.3"
+    babel-plugin-filter-imports "^4.0.0"
+    broccoli-concat "^3.7.4"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    chalk "^3.0.0"
+    ember-cli-babel "^7.13.2"
+    ember-cli-get-component-path-option "^1.0.0"
+    ember-cli-is-package-missing "^1.0.0"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-version-checker "^3.1.3"
+    ember-router-generator "^2.0.0"
+    inflection "^1.12.0"
+    jquery "^3.4.1"
+    resolve "^1.14.2"
+    semver "^6.1.1"
+    silent-error "^1.1.1"
+
 ember-source@~3.10.0:
   version "3.10.2"
   resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.10.2.tgz#17a0405f1e470698f601622b3383cce7f80e2d31"
@@ -8251,35 +8294,6 @@ ember-source@~3.13.0:
     inflection "^1.12.0"
     jquery "^3.4.1"
     resolve "^1.11.1"
-    silent-error "^1.1.1"
-
-ember-source@~3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.15.0.tgz#f6500c6d289ce58231bf1e6695c4974df2be7390"
-  integrity sha512-daTELJBDMGqAmQb/Puxdk1YR204/zs1DEiEMQWlqbtmhphAoDUbGi9ifJu20ajP/IcOCWw9Vp7aPzguTohWF7w==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/plugin-transform-block-scoping" "^7.6.2"
-    "@babel/plugin-transform-object-assign" "^7.2.0"
-    "@ember/edition-utils" "^1.1.1"
-    babel-plugin-debug-macros "^0.3.3"
-    babel-plugin-filter-imports "^3.0.0"
-    broccoli-concat "^3.7.4"
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.2"
-    chalk "^2.4.2"
-    ember-cli-babel "^7.11.0"
-    ember-cli-get-component-path-option "^1.0.0"
-    ember-cli-is-package-missing "^1.0.0"
-    ember-cli-normalize-entity-name "^1.0.0"
-    ember-cli-path-utils "^1.0.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-version-checker "^3.1.3"
-    ember-router-generator "^2.0.0"
-    inflection "^1.12.0"
-    jquery "^3.4.1"
-    resolve "^1.11.1"
-    semver "^6.1.1"
     silent-error "^1.1.1"
 
 ember-source@~3.17.0:


### PR DESCRIPTION
ember-source@3.17.0 introduced a change to `ember-source/vendor/ember/ember-template-compiler` that is parsing `{{foo-bar}}` AST type as a "Template".