### PR TITLE
fix renamed-modules when used with languages that transpile to js

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -488,11 +488,9 @@ export default class V1Addon implements V1Package {
 
         // this captures addons that are trying to escape their own package's
         // namespace
-        let result = rewriteAddonTree(tree, this.name, this.moduleName);
-        tree = result.tree;
+        let result = rewriteAddonTree(this.transpile(tree), this.name, this.moduleName);
         built.dynamicMeta.push(result.getMeta);
-
-        return this.transpile(tree);
+        return result.tree;
       }
     } else if (this.hasStockTree('addon')) {
       return this.transpile(this.stockTree('addon'));


### PR DESCRIPTION
The `rewriteAddonTree` transformation captures any modules that are trying to escape their own package namespace and records their names as our `renamed-modules` in the addon metadata. But if you are using typescript or another preprocessor that changes the file extensions, we currently save the renamed-modules and then transpile, which results in the names in the metadata not matching the actual files.

This switches the order so we preprocessor first and then record the renamed-modules.