### PR TITLE
moduleName must include the extension in precompile options

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -488,11 +488,9 @@ export default class V1Addon implements V1Package {
 
         // this captures addons that are trying to escape their own package's
         // namespace
-        let result = rewriteAddonTree(tree, this.name, this.moduleName);
-        tree = result.tree;
+        let result = rewriteAddonTree(this.transpile(tree), this.name, this.moduleName);
         built.dynamicMeta.push(result.getMeta);
-
-        return this.transpile(tree);
+        return result.tree;
       }
     } else if (this.hasStockTree('addon')) {
       return this.transpile(this.stockTree('addon'));

--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -7,7 +7,7 @@ import Filter from 'broccoli-persistent-filter';
 import stringify from 'json-stable-stringify';
 import { createHash } from 'crypto';
 import { compile } from './js-handlebars';
-import { join, sep } from 'path';
+import { join, sep, extname } from 'path';
 import { PluginItem, transform } from '@babel/core';
 import { Memoize } from 'typescript-memoize';
 import { NodePath } from '@babel/traverse';
@@ -321,7 +321,7 @@ export default class TemplateCompiler {
     let runtimeName: string;
 
     if (this.params.resolver) {
-      runtimeName = this.params.resolver.absPathToRuntimeName(moduleName) || moduleName;
+      runtimeName = `${this.params.resolver.absPathToRuntimeName(moduleName)}${extname(moduleName)}` || moduleName;
     } else {
       runtimeName = moduleName;
     }


### PR DESCRIPTION
moduleName in template.__meta previously included an extension of the compiled file.
Embroider build stripped it off during the build process. Adding it back again.