### PR TITLE
allow custom treeForAddonStyles

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -499,7 +499,7 @@ export default class V1Addon implements V1Package {
 
   protected addonStylesTree(): Tree | undefined {
     if (this.customizes('treeForAddonStyles')) {
-      todo(`${this.name} may have customized the addon style tree`);
+      return this.invokeOriginalTreeFor('addon-styles');
     } else if (this.hasStockTree('addon-styles')) {
       return this.addonInstance.compileStyles(this.stockTree('addon-styles'));
     }


### PR DESCRIPTION
This seems low-risk because we haven't heavily customizes much of the CSS pipeline. We mostly just let the existing ember-cli code do its thing.