### PR TITLE
avoid interactions with patched require

### DIFF
--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -151,7 +151,7 @@ function isResolvable(packageName: string, fromPkg: V2Package): boolean {
 
 const externalTemplate = compile(`
 {{#if (eq runtimeName "require")}}
-const m = window.require;
+const m = window.requirejs;
 {{else}}
 const m = window.require("{{{js-string-escape runtimeName}}}");
 {{/if}}


### PR DESCRIPTION
Addons like ember-classic-decorator manipulate window.require such that it changes over time. But require is also available as an import, and once imported its value is cached. This can cause us to cache the temporary value, which lacks features like `require.has`, breaking other code.

This change avoids the problem by always using requirejs instead of require when people `import require from "require"`.