### PR TITLE
Use renamed package for the template meta moduleName

### DIFF
--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -289,7 +289,19 @@ export default class CompatResolver implements Resolver {
   absPathToRuntimeName(absPath: string) {
     let pkg = PackageCache.shared('embroider-stage3').ownerOfFile(absPath);
     if (pkg) {
-      return join(pkg.name, relative(pkg.root, absPath))
+      let moduleName = pkg.name;
+      if (pkg.isV2Addon()) {
+        let renamedMeta = pkg.meta['renamed-packages'];
+        if (renamedMeta) {
+          Object.entries(renamedMeta).forEach(([key, value]) => {
+            if (value === pkg!.name) {
+              moduleName = key;
+            }
+          });
+        }
+      }
+
+      return join(moduleName, relative(pkg.root, absPath))
         .replace(this.resolvableExtensionsPattern, '')
         .split(sep)
         .join('/');


### PR DESCRIPTION
If an addon specifies a different moduleName other than that of its package.name we should respect that before compiling the templates. This really isn't recommended but achieves backwards compatibility with classical builds.