### PR TITLE
Support static apps using @embroider/macros

### DIFF
--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -285,19 +285,20 @@ export default class TemplateCompiler {
     }
 
     let opts = this.syntax.defaultOptions({ contents, moduleName });
-    if (this.params.resolver) {
-      let transform = this.params.resolver.astTransformer(this);
-      if (transform) {
-        this.params.plugins.ast!.push(transform);
-      }
-    }
-    opts.plugins!.ast = [...this.getReversedASTPlugins(this.params.plugins.ast!), ...opts.plugins!.ast!];
+    let plugins: Plugins = {
+      ...opts.plugins,
+      ast: [
+        ...this.getReversedASTPlugins(this.params.plugins.ast!),
+        this.params.resolver && this.params.resolver.astTransformer(this),
+        ...opts.plugins!.ast!,
+      ].filter(Boolean),
+    };
 
     let compiled = this.syntax.precompile(stripBom(contents), {
       contents,
       moduleName: runtimeName,
       filename: moduleName,
-      plugins: opts.plugins,
+      plugins,
     });
 
     if (this.params.resolver) {

--- a/test-packages/static-app/app/router.js
+++ b/test-packages/static-app/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('helpers-example');
   this.route('components-example');
   this.route('static-component-rules-example');
+  this.route('macros-example');
 });
 
 export default Router;

--- a/test-packages/static-app/app/templates/macros-example.hbs
+++ b/test-packages/static-app/app/templates/macros-example.hbs
@@ -1,0 +1,1 @@
+<h1 data-macro>Welcome to this {{#if (macroCondition (macroGetOwnConfig "isClassic"))}}classic{{else}}embroider{{/if}} app!</h1>

--- a/test-packages/static-app/tests/acceptance/macros-example-test.js
+++ b/test-packages/static-app/tests/acceptance/macros-example-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { getOwnConfig } from '@embroider/macros';
+
+module('Acceptance | macros-example', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('macros work', async function(assert) {
+    await visit('/macros-example');
+
+    if (getOwnConfig().isClassic) {
+      assert.dom('[data-macro]').hasText('Welcome to this classic app!');
+    } else {
+      assert.dom('[data-macro]').hasText('Welcome to this embroider app!');
+    }
+  });
+});


### PR DESCRIPTION
Spike to fix #476.

The first commit adds a test, that fails in the way described in #476.

The second seems to fix the problem by ignoring the embroider macros in the resolver just like Ember's built-ins. Though as stated in https://github.com/embroider-build/embroider/issues/476#issuecomment-691524287, I am not sure if that's the preferred way to do it...