### PR TITLE
package.json: Add missing `repository` fields

### DIFF
--- a/packages/babel-loader-7/package.json
+++ b/packages/babel-loader-7/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@embroider/babel-loader-7",
   "version": "0.23.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/babel-loader-7"
+  },
   "license": "MIT",
   "main": "index.js",
   "dependencies": {

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -3,6 +3,11 @@
   "version": "0.23.0",
   "private": false,
   "description": "Backward compatibility layer for the Embroider build system.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/compat"
+  },
   "license": "MIT",
   "author": "Edward Faulkner",
   "main": "src/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,11 @@
   "version": "0.23.0",
   "private": false,
   "description": "A build system for EmberJS applications.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/core"
+  },
   "license": "MIT",
   "author": "Edward Faulkner",
   "main": "src/index.js",

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -6,6 +6,11 @@
   "keywords": [
     "ember-addon"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/macros"
+  },
   "license": "MIT",
   "author": "Edward Faulkner",
   "main": "src/index.js",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -5,7 +5,11 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "https://github.com/embroider/build/embroider",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/router"
+  },
   "license": "MIT",
   "author": "Edward Faulkner <edward@eaf4.com>",
   "directories": {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -3,6 +3,11 @@
   "version": "0.23.0",
   "private": false,
   "description": "Builds EmberJS apps with Webpack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/webpack"
+  },
   "license": "MIT",
   "author": "Edward Faulkner",
   "main": "src/ember-webpack.js",


### PR DESCRIPTION
This should allow tools like https://github.com/renovatebot/renovate to find the changelog in this repo.