### PR TITLE
Fix broken style-loader dependency

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -37,7 +37,7 @@
     "mini-css-extract-plugin": "^0.4.3",
     "pkg-up": "^2.0.0",
     "source-map-url": "^0.4.0",
-    "style-loader": "^0.24.0",
+    "style-loader": "^0.23.0",
     "terser": "^3.16.1",
     "thread-loader": "^1.2.0",
     "webpack": "^4.43.0"


### PR DESCRIPTION
Seems the latest release commit (0.23.0 to 0.24.0) also accidentally bumped the version of this package, which coincidentally also had a version of 0.23.0, to a non-existing version of 0.24.0. (Is this a manual find/replace type operation, or automated?)

This broke CI on master. And will certainly break when folks install the latest release, so a quick follow up release of 0.24.1 seems required! @ef4 