### PR TITLE
Avoid `Testem.hookIntoTestFramework` unless `QUnit` or `Mocha` are defined.

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -253,8 +253,8 @@ export class AppBuilder<TreeNames> {
         relativePath: '_testing_suffix_.js',
         source: `
         var runningTests=true;
-        if (window.Testem) {
-          window.Testem.hookIntoTestFramework();
+        if (typeof Testem !== 'undefined' && (typeof QUnit !== 'undefined' || typeof Mocha !== 'undefined')) {
+          Testem.hookIntoTestFramework();
         }`,
       });
 


### PR DESCRIPTION
Fixes https://github.com/embroider-build/embroider/issues/530