### PR TITLE
Add compatibility for ember-element-helper

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-element-helper.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-element-helper.ts
@@ -1,0 +1,13 @@
+import { PackageRules } from '..';
+
+let rules: PackageRules = {
+  package: 'ember-element-helper',
+  addonModules: {
+    'helpers/-element.js': {
+      dependsOnComponents: ['{{-dynamic-element}}', '{{-dynamic-element-alt}}'],
+    },
+  },
+  components: {},
+};
+
+export default [rules];


### PR DESCRIPTION
It does some dynamic component magic that Embroider is not able to understand. Specifically it is returning the component name (`-dynamic-element` or `-dynamic-element-alt`) from the [`-element` helper](https://github.com/tildeio/ember-element-helper/blob/main/addon/helpers/-element.js), that is passed to `{{component}}`, all after its own AST transformation. This rule should make Embroider aware of the dependencies, to pull those two components in.

I tested this rule successfully in a local Embroider-build addon (adding it to the Embroider setup in `ember-cli-build.js`). I didn't see test coverage for other compat adapters here, so do we need tests for this here?

/cc @chancancode