### PR TITLE
fix: check if addon has enableTypeScriptTransform set

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -211,6 +211,16 @@ export default class V1Addon {
       return true;
     }
 
+    if (
+      this.addonInstance.options &&
+      this.addonInstance.options['ember-cli-babel'] &&
+      this.addonInstance.options['ember-cli-babel'].enableTypeScriptTransform
+    ) {
+      // This addon has explicitly configured ember-cli-babel to add the
+      // TypeScript transform Babel plugin.
+      return true;
+    }
+
     let babelConfig = this.options.babel as TransformOptions | undefined;
     if (babelConfig && babelConfig.plugins && babelConfig.plugins.length > 0) {
       // this addon has custom babel plugins, so we need to run them here in


### PR DESCRIPTION
In addition to #529, we need to check if an addon has set [`enableTypeScriptTransform`](https://github.com/babel/ember-cli-babel#enabling-typescript-transpilation).