### PR TITLE
Fix loader.js issue by disabling makeDefaultExport option

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -244,6 +244,12 @@ export class AppBuilder<TreeNames> {
         relativePath: '_ember_env_.js',
         source: `window.EmberENV=${JSON.stringify(emberENV, null, 2)};`,
       });
+
+      result.push({
+        kind: 'in-memory',
+        relativePath: '_loader_.js',
+        source: `loader.makeDefaultExport=false;`,
+      });
     }
 
     if (type === 'implicit-test-scripts') {


### PR DESCRIPTION
This is just a quick PoC, which seems to fix #539 for me. ~However that seems to be more like a dirty workaround tbh. Just wanted to post this here to discuss future directions for how to fix this more properly.~

Unfortunately there seems to be no way to tell loader.js to not set makeDefaultExport by default. We could extend the addon, but then we don't have control over the version the user's app uses, as it's the app's dependency, and not ours. Or maybe we can tell Webpack somehow to export a `default` key as a classic build does? (see #539)