### PR TITLE
Handle dynamic import or importSync of missing module

### DIFF
--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -225,6 +225,7 @@ describe('stage2 build', function() {
 
     beforeAll(async function() {
       app = Project.emberNew();
+      app.addDependency('some-library', '1.0.0');
       app.linkPackage('ember-auto-import');
       app.linkPackage('@embroider/sample-transforms');
 

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -343,11 +343,6 @@ export class AppBuilder<TreeNames> {
       )
     );
 
-    babel.plugins.push(this.adjustImportsPlugin(appFiles));
-
-    // this is @embroider/macros configured for full stage3 resolution
-    babel.plugins.push(this.macrosConfig.babelPluginConfig());
-
     // this is our built-in support for the inline hbs macro
     babel.plugins.push([
       join(__dirname, 'babel-plugin-inline-hbs.js'),
@@ -356,6 +351,11 @@ export class AppBuilder<TreeNames> {
         stage: 3,
       },
     ]);
+
+    babel.plugins.push(this.adjustImportsPlugin(appFiles));
+
+    // this is @embroider/macros configured for full stage3 resolution
+    babel.plugins.push(this.macrosConfig.babelPluginConfig());
 
     babel.plugins.push([require.resolve('./template-colocation-plugin')]);
 

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -343,6 +343,8 @@ export class AppBuilder<TreeNames> {
       )
     );
 
+    babel.plugins.push(this.adjustImportsPlugin(appFiles));
+
     // this is @embroider/macros configured for full stage3 resolution
     babel.plugins.push(this.macrosConfig.babelPluginConfig());
 
@@ -355,7 +357,6 @@ export class AppBuilder<TreeNames> {
       },
     ]);
 
-    babel.plugins.push(this.adjustImportsPlugin(appFiles));
     babel.plugins.push([require.resolve('./template-colocation-plugin')]);
 
     return new PortableBabelConfig(babel, { basedir: this.root });
@@ -394,6 +395,7 @@ export class AppBuilder<TreeNames> {
       // up as a side-effect of babel transpilation, and babel is subject to
       // persistent caching.
       externalsDir: join(tmpdir(), 'embroider', 'externals'),
+      dynamicImports: [],
     };
     return [require.resolve('./babel-plugin-adjust-imports'), adjustOptions];
   }

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -395,7 +395,6 @@ export class AppBuilder<TreeNames> {
       // up as a side-effect of babel transpilation, and babel is subject to
       // persistent caching.
       externalsDir: join(tmpdir(), 'embroider', 'externals'),
-      dynamicImports: [],
     };
     return [require.resolve('./babel-plugin-adjust-imports'), adjustOptions];
   }

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -66,7 +66,12 @@ type DefineExpressionPath = NodePath<CallExpression> & {
 };
 
 export function isImportSyncExpression(path: NodePath<any>) {
-  if (!path.isCallExpression() || path.node.callee.type !== 'Identifier' || path.node.callee.name !== 'importSync') {
+  if (
+    !path ||
+    !path.isCallExpression() ||
+    path.node.callee.type !== 'Identifier' ||
+    path.node.callee.name !== 'importSync'
+  ) {
     return false;
   }
 
@@ -75,7 +80,7 @@ export function isImportSyncExpression(path: NodePath<any>) {
 }
 
 export function isDynamicImportExpression(path: NodePath<any>) {
-  if (!path.isCallExpression() || path.node.callee.type !== 'Import') {
+  if (!path || !path.isCallExpression() || path.node.callee.type !== 'Import') {
     return false;
   }
 
@@ -284,20 +289,25 @@ function handleRelocation(specifier: string, sourceFile: AdjustFile) {
 }
 
 export default function main() {
+  //debugger;
   return {
     visitor: {
       Program: {
         enter(path: NodePath<Program>, state: State) {
+          debugger;
           state.emberCLIVanillaJobs = [];
           state.adjustFile = new AdjustFile(path.hub.file.opts.filename, state.opts.relocatedFiles);
           addExtraImports(path, state.opts.extraImports);
         },
         exit(_: any, state: State) {
+          debugger;
           state.emberCLIVanillaJobs.forEach(job => job());
         },
       },
       CallExpression(path: NodePath<CallExpression>, state: State) {
+        //debugger;
         if (isImportSyncExpression(path) || isDynamicImportExpression(path)) {
+          debugger;
           const [source] = path.get('arguments');
           let { opts } = state;
           opts.dynamicImports.push((source.node as any).value);
@@ -310,6 +320,8 @@ export default function main() {
         if (!isDefineExpression(path)) {
           return;
         }
+
+        //debugger;
 
         let pkg = state.adjustFile.owningPackage();
         if (pkg && pkg.isV2Ember() && !pkg.meta['auto-upgraded']) {
@@ -352,11 +364,14 @@ export default function main() {
         path: NodePath<ImportDeclaration | ExportNamedDeclaration | ExportAllDeclaration>,
         state: State
       ) {
+        //debugger;
         let { opts, emberCLIVanillaJobs } = state;
         const { source } = path.node;
         if (source === null) {
           return;
         }
+
+        //debugger;
 
         let specifier = adjustSpecifier(source.value, state.adjustFile, opts);
         if (specifier !== source.value) {

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -289,25 +289,20 @@ function handleRelocation(specifier: string, sourceFile: AdjustFile) {
 }
 
 export default function main() {
-  //debugger;
   return {
     visitor: {
       Program: {
         enter(path: NodePath<Program>, state: State) {
-          debugger;
           state.emberCLIVanillaJobs = [];
           state.adjustFile = new AdjustFile(path.hub.file.opts.filename, state.opts.relocatedFiles);
           addExtraImports(path, state.opts.extraImports);
         },
         exit(_: any, state: State) {
-          debugger;
           state.emberCLIVanillaJobs.forEach(job => job());
         },
       },
       CallExpression(path: NodePath<CallExpression>, state: State) {
-        //debugger;
         if (isImportSyncExpression(path) || isDynamicImportExpression(path)) {
-          debugger;
           const [source] = path.get('arguments');
           let { opts } = state;
           opts.dynamicImports.push((source.node as any).value);
@@ -320,8 +315,6 @@ export default function main() {
         if (!isDefineExpression(path)) {
           return;
         }
-
-        //debugger;
 
         let pkg = state.adjustFile.owningPackage();
         if (pkg && pkg.isV2Ember() && !pkg.meta['auto-upgraded']) {
@@ -364,14 +357,11 @@ export default function main() {
         path: NodePath<ImportDeclaration | ExportNamedDeclaration | ExportAllDeclaration>,
         state: State
       ) {
-        //debugger;
         let { opts, emberCLIVanillaJobs } = state;
         const { source } = path.node;
         if (source === null) {
           return;
         }
-
-        //debugger;
 
         let specifier = adjustSpecifier(source.value, state.adjustFile, opts);
         if (specifier !== source.value) {

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -107,6 +107,14 @@ export function isDefineExpression(path: NodePath<any>): path is DefineExpressio
 }
 
 function adjustSpecifier(specifier: string, file: AdjustFile, opts: Options) {
+  if (specifier === '@embroider/macros') {
+    // the macros package is always handled directly within babel (not
+    // necessarily as a real resolvable package), so we should not mess with it.
+    // It might not get compiled away until *after* our plugin has run, which is
+    // why we need to know about it.
+    return specifier;
+  }
+
   specifier = handleRenaming(specifier, file, opts);
   specifier = handleExternal(specifier, file, opts);
   if (file.isRelocated) {

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -169,7 +169,7 @@ function isResolvable(packageName: string, fromPkg: V2Package): boolean {
 }
 
 const dynamicMissingModule = compile(`
-  throw new Error('Could not find module: {{{js-string-escape moduleName}}}.');
+  throw new Error('Could not find module \`{{{js-string-escape moduleName}}}\`');
 `) as (params: { moduleName: string }) => string;
 
 const externalTemplate = compile(`

--- a/packages/core/tests/babel-plugin-adjust-imports.test.ts
+++ b/packages/core/tests/babel-plugin-adjust-imports.test.ts
@@ -52,8 +52,30 @@ describe('babel-plugin-adjust-imports', function() {
   });
 
   test('isImportSyncExpression works', function() {
-    expect(isImportSyncExpressionFromSource(`importSync('foo');`)).toBe(true);
-    expect(isImportSyncExpressionFromSource(`var t = "importSync";`)).toBe(false);
+    expect(
+      isImportSyncExpressionFromSource(`
+      import { importSync } from '@embroider/macros';
+      importSync('foo');
+    `)
+    ).toBe(true);
+    expect(
+      isImportSyncExpressionFromSource(`
+      import { importSync as i } from '@embroider/macros';
+      i('foo');
+    `)
+    ).toBe(true);
+    expect(
+      isImportSyncExpressionFromSource(`
+      import { foo as importSync } from 'foobar';
+      importSync('foo');
+    `)
+    ).toBe(false);
+    expect(
+      isImportSyncExpressionFromSource(`
+      import { foo as i } from 'foobar';
+      i('foo');
+    `)
+    ).toBe(false);
   });
 
   test('isDynamicImportExpression works', function() {

--- a/packages/core/tests/babel-plugin-adjust-imports.test.ts
+++ b/packages/core/tests/babel-plugin-adjust-imports.test.ts
@@ -1,4 +1,9 @@
-import main, { isDefineExpression, Options as AdjustImportsOptions } from '../src/babel-plugin-adjust-imports';
+import main, {
+  isDefineExpression,
+  isDynamicImportExpression,
+  isImportSyncExpression,
+  Options as AdjustImportsOptions,
+} from '../src/babel-plugin-adjust-imports';
 import { transformSync } from '@babel/core';
 import { parse } from '@babel/parser';
 import traverse from '@babel/traverse';
@@ -24,6 +29,13 @@ describe('babel-plugin-adjust-imports', function() {
     return isDefineExpression(getFirstCallExpresssionPath(source));
   }
 
+  function isImportSyncExpressionFromSource(source: string) {
+    return isImportSyncExpression(getFirstCallExpresssionPath(source));
+  }
+  function isDynamicImportExpressionFromSource(source: string) {
+    return isDynamicImportExpression(getFirstCallExpresssionPath(source));
+  }
+
   test('isDefineExpression works', function() {
     expect(isDefineExpressionFromSource(`apple()`)).toBe(false);
     expect(isDefineExpressionFromSource(`(apple())`)).toBe(false);
@@ -37,6 +49,17 @@ describe('babel-plugin-adjust-imports', function() {
     expect(isDefineExpressionFromSource(`define;define('b/a/c', ['a', 'b', 'c'], function() { });`)).toBe(true);
     expect(isDefineExpressionFromSource(`import foo from 'foo'; define('apple')`)).toBe(false);
     expect(isDefineExpressionFromSource(`define('apple'); import foo from 'foo'`)).toBe(false);
+  });
+
+  test('isImportSyncExpression works', function() {
+    expect(isImportSyncExpressionFromSource(`importSync('foo');`)).toBe(true);
+    expect(isImportSyncExpressionFromSource(`var t = "importSync";`)).toBe(false);
+  });
+
+  test('isDynamicImportExpression works', function() {
+    expect(isDynamicImportExpressionFromSource(`import('foo');`)).toBe(true);
+    expect(isDynamicImportExpressionFromSource(`async () => { await import('foo'); }`)).toBe(true);
+    expect(isDynamicImportExpressionFromSource(`import foo from 'foo';`)).toBe(false);
   });
 
   test('main', function() {

--- a/packages/core/tests/babel-plugin-adjust-imports.test.ts
+++ b/packages/core/tests/babel-plugin-adjust-imports.test.ts
@@ -48,6 +48,7 @@ describe('babel-plugin-adjust-imports', function() {
       relocatedFiles: {},
       externalsDir: 'test',
       resolvableExtensions: ['.js', '.hbs'],
+      dynamicImports: [],
     };
 
     {

--- a/packages/core/tests/babel-plugin-adjust-imports.test.ts
+++ b/packages/core/tests/babel-plugin-adjust-imports.test.ts
@@ -71,7 +71,6 @@ describe('babel-plugin-adjust-imports', function() {
       relocatedFiles: {},
       externalsDir: 'test',
       resolvableExtensions: ['.js', '.hbs'],
-      dynamicImports: [],
     };
 
     {

--- a/test-packages/static-app/app/components/fancy-box.js
+++ b/test-packages/static-app/app/components/fancy-box.js
@@ -1,11 +1,5 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { dependencySatisfies, macroCondition, importSync } from '@embroider/macros';
-
-if (macroCondition(dependencySatisfies('ember-mocha', '9'))) {
-  //importSync('ember-mocha');
-  import('ember-websockets');
-}
 
 export default Component.extend({
   titleComponentWithDefault: computed('titleComponent', function() {

--- a/test-packages/static-app/app/components/fancy-box.js
+++ b/test-packages/static-app/app/components/fancy-box.js
@@ -4,5 +4,5 @@ import { computed } from '@ember/object';
 export default Component.extend({
   titleComponentWithDefault: computed('titleComponent', function() {
     return this.titleComponent || 'default-title';
-  }),
+  })
 });

--- a/test-packages/static-app/app/components/fancy-box.js
+++ b/test-packages/static-app/app/components/fancy-box.js
@@ -1,8 +1,14 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { dependencySatisfies, macroCondition, importSync } from '@embroider/macros';
+
+if (macroCondition(dependencySatisfies('ember-mocha', '9'))) {
+  //importSync('ember-mocha');
+  import('ember-websockets');
+}
 
 export default Component.extend({
   titleComponentWithDefault: computed('titleComponent', function() {
     return this.titleComponent || 'default-title';
-  })
+  }),
 });

--- a/test-packages/static-app/tests/unit/missing-import-sync-renamed-test.js
+++ b/test-packages/static-app/tests/unit/missing-import-sync-renamed-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { importSync as i } from '@embroider/macros';
+
+module('Unit | missing modules referenced by i which was renamed from importSync', function() {
+  test('it works', function(assert) {
+    assert.expect(2);
+
+    assert.throws(() => {
+      i('foobar');
+    }, /Error: Could not find module `foobar`/);
+
+    assert.throws(() => {
+      i('foobaz');
+    }, /Error: Could not find module `foobaz`/);
+  });
+});

--- a/test-packages/static-app/tests/unit/missing-imports-test.js
+++ b/test-packages/static-app/tests/unit/missing-imports-test.js
@@ -1,12 +1,16 @@
 import { module, test } from 'qunit';
 import { importSync } from '@embroider/macros';
 
-module('Unit | missing-imports', function() {
+module('Unit | missing modules referenced by importSync', function() {
   test('it works', function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     assert.throws(() => {
-      importSync('missingModule');
-    }, /Error: Could not find module `missingModule`/);
+      importSync('bar');
+    }, /Error: Could not find module `bar`/);
+
+    assert.throws(() => {
+      importSync('baz');
+    }, /Error: Could not find module `baz`/);
   });
 });

--- a/test-packages/static-app/tests/unit/missing-imports-test.js
+++ b/test-packages/static-app/tests/unit/missing-imports-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { importSync } from '@embroider/macros';
+
+module('Unit | missing-imports', function() {
+  test('it works', async function(assert) {
+    assert.expect(2);
+
+    assert.throws(() => {
+      importSync('missingModule');
+    }, /missing module/);
+
+    // assert.throws(async () => {
+    //   await import('missingModule');
+    // }, /missing module/);
+  });
+});

--- a/test-packages/static-app/tests/unit/missing-imports-test.js
+++ b/test-packages/static-app/tests/unit/missing-imports-test.js
@@ -2,15 +2,11 @@ import { module, test } from 'qunit';
 import { importSync } from '@embroider/macros';
 
 module('Unit | missing-imports', function() {
-  test('it works', async function(assert) {
-    assert.expect(2);
+  test('it works', function(assert) {
+    assert.expect(1);
 
     assert.throws(() => {
       importSync('missingModule');
     }, /missing module/);
-
-    // assert.throws(async () => {
-    //   await import('missingModule');
-    // }, /missing module/);
   });
 });

--- a/test-packages/static-app/tests/unit/missing-imports-test.js
+++ b/test-packages/static-app/tests/unit/missing-imports-test.js
@@ -7,6 +7,6 @@ module('Unit | missing-imports', function() {
 
     assert.throws(() => {
       importSync('missingModule');
-    }, /missing module/);
+    }, /Error: Could not find module: missingModule./);
   });
 });

--- a/test-packages/static-app/tests/unit/missing-imports-test.js
+++ b/test-packages/static-app/tests/unit/missing-imports-test.js
@@ -7,6 +7,6 @@ module('Unit | missing-imports', function() {
 
     assert.throws(() => {
       importSync('missingModule');
-    }, /Error: Could not find module: missingModule./);
+    }, /Error: Could not find module `missingModule`/);
   });
 });


### PR DESCRIPTION
If a module is imported via `import('foo')` or `importSync('foo')` but `foo` cannot be resolved, instead create a dummy module that throws a runtime error stating that the module could not be found. The reasoning behind this change is that it is acceptable to have "guarded imports". An example is take `ember-exam` which does not explicitly depend on either ember-qunit or ember-mocha but has code like the following:

```js
let emberTestFramework;

if (macroCondition(dependencySatisfies('ember-qunit', '*'))){
  emberTestFramework = importSync('ember-qunit');
} else if (macroCondition(dependencySatisfies('ember-mocha', '*'))) {
  emberTestFramework = importSync('ember-mocha');
}
```

During dev builds we do not strip out the conditionals that are falsy and thus when `macros-babel-plugin` runs it will try and resolve these imports (and cause a build-time error). This differs from 2 points of perspective: 1) classical system allow requiring a module that does not exist and you will not see any errors until that require is encountered at runtime (or if it is guarded it may never error). 2)  The behavior of the macro system in production mode would hide the fact that this module was not found since it striped out the import branch which is different from how it would behave under dev mode.

Additional background on ember-exam's change: https://github.com/ember-cli/ember-exam/pull/599

Fixes: #543
Fixes: #544