### PR TITLE
adding test-setup package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,8 @@
 /packages/webpack/**/*.d.ts
 /test-packages/support/**/*.js
 /test-packages/**/*.d.ts
+/packages/test-setup/**/*.js
+/packages/test-setup/**/*.d.ts
 
 # unconventional js
 /blueprints/*/files/

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -1,7 +1,7 @@
 export { default as App } from './compat-app';
 export { default as Addons } from './compat-addons';
 export { default as PrebuiltAddons } from './prebuilt-addons';
-export { default as Options } from './options';
+export { default as Options, recommendedOptions } from './options';
 export { default as V1Addon } from './v1-addon';
 export { default as compatBuild } from './default-pipeline';
 export { PackageRules, ModuleRules } from './dependency-rules';

--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -98,3 +98,17 @@ const defaults = Object.assign(coreWithDefaults(), {
 export function optionsWithDefaults(options?: Options): Required<Options> {
   return Object.assign({}, defaults, options);
 }
+
+// These are recommended configurations for addons to test themselves under. By
+// keeping them here, it's easier to do ecosystem-wide compatibility testing.
+// See the `@embroider/test-setup` package which can help consume these to test
+// them in CI.
+export const recommendedOptions: { [name: string]: Options } = Object.freeze({
+  safe: Object.freeze({}),
+  optimized: Object.freeze({
+    staticAddonTrees: true,
+    staticAddonTestSupportTrees: true,
+    staticHelpers: true,
+    staticComponents: true,
+  }),
+});

--- a/packages/test-setup/.gitignore
+++ b/packages/test-setup/.gitignore
@@ -1,0 +1,7 @@
+/node_modules
+/src/**/*.js
+/src/**/*.d.ts
+/src/**/*.map
+/tests/**/*.js
+/tests/**/*.d.ts
+/tests/**/*.map

--- a/packages/test-setup/README.md
+++ b/packages/test-setup/README.md
@@ -1,0 +1,112 @@
+# @embroider/test-setup
+
+This package exists to make it easier to add Embroider compatibility testing to your addon's or app's continuous integration (CI) matrix.
+
+It's small and and doesn't actually install Embroider. Instead, it gives you a utility that will cause your project to build using Embroider if Embroider happens to be present. This lets you conditionally add Embroider only when you want to test it (via [ember-try](https://github.com/ember-cli/ember-try), for example).
+
+## Should I use this in my addon?
+
+Yes. By testing under Embroider, you ensure that your addon won't block apps from working under Embroider.
+
+## Should I use this in my app?
+
+Maybe. **This package is intended for CI testing only**. If you're ready to switch completely to Embroider, you should not use `@embroider/test-setup`. You should directly depend on the Embroider packages so you can control what version you're getting and how it's configured.
+
+That said, adding Embroider to your app's CI matrix is a great way to help ensure Embroider will support your app well once it hits a stable release. We want to hear from you if it doesn't work, so we can figure out why. So using the package is a good idea, up until the point where you don't need it anymore because you're switching full-time to Embroider.
+
+# How to use it
+
+1. Add `@embroider/test-setup` as a devDependency of your app or addon.
+2. Modify your `ember-cli-build.js` file:
+
+   ```diff
+   - return app.toTree();
+   + const { maybeEmbroider } = require('@embroider/test-setup');
+   + return maybeEmbroider(app);
+   ```
+
+3. In `config/ember-try.js`, add one or more of the scenarios we provide
+
+   ```js
+   const getChannelURL = require('ember-source-channel-url');
+   const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
+   module.exports = async function () {
+     return {
+       scenarios: [
+         {
+           name: 'ember-release',
+           npm: {
+             devDependencies: {
+               'ember-source': await getChannelURL('release'),
+             },
+           },
+         },
+         embroiderSafe(),
+         embroiderOptimized(),
+       ],
+     };
+   };
+   ```
+
+4. If your CI system invokes ember-try scenarios one by one, make sure to add these new scenarios to your matrix (for example, in `.travis.yml` or `.github/workflows/ci.yml`). Their names are `embroider-safe` and `embroider-optimized`.
+
+# Understanding the scenarios
+
+The `embroiderSafe()` scenario configures Embroider with its most backward-compatible settings.
+
+The `embroiderOptimized()` scenario tests with Embroider with its most aggressive settings.
+
+It's important for addons to work correctly under both scenarios, because this gives app authors the widest range of options to use as they migrate. Working under `embroiderOptimized()` does not guarantee you work under `embroiderSafe()`, because the optimized builds can actually compile-out certain problematic behaviors (like broken-but-unused modules).
+
+It's less important for apps to work correctly under both -- you can pick one and just ensure you keep working under it. It's also OK to manage your own configuration directly, if you've achieved a level of support somewhere between these extremes.
+
+# API Docs
+
+### `maybeEmbroider(app, [embroiderOptions])`
+
+This function always accepts your `app` (the value returned from `new EmberApp` or `new EmberAddon` in `ember-cli-build.js`). It always returns a broccoli tree.
+
+When Embroider is not present in the app's dependencies, it does exactly the same thing as `app.toTree()`. But when Embroider is present, it uses Embroider and if it sees one of our pre-defined scenario names in the environment variable `EMBROIDER_TEST_SETUP_OPTIONS`, it will merge those pre-defined options into any options that you provided.
+
+For detailed documentation on what can go in `embroiderOptions`, see the comments in [Core Options](`https://github.com/embroider-build/embroider/blob/master/packages/core/src/options.ts`) and [Compat Options](https://github.com/embroider-build/embroider/blob/master/packages/compat/src/options.ts).
+
+If you normally pass extra broccoli trees to the `app.toTree()` method, you can still do so and should use the `extraPublicTrees` option:
+
+```diff
+-return app.toTree([icons, fonts]);
++return maybeEmbroider(app, { extraPublicTrees: [icons, fonts] });
+```
+
+### `embroiderSafe([emberTryConfig])`
+
+Returns an ember-try scenario that configures Embroider to use the most compatible options. You can optionally pass additional ember-try arguments that will be merged into the provided scenario, like:
+
+```js
+embroiderSafe({
+  npm: {
+    devDependencies: {
+      somethingExtra: '1.0.0',
+    },
+  },
+  env: {
+    WHATEVER: 'hi',
+  },
+});
+```
+
+### `embroiderOptimized([emberTryConfig])`
+
+Returns an ember-try scenario that configures Embroider to use the most aggressive options. You can optionally pass additional ember-try arguments that will be merged into the provided scenario, like:
+
+```js
+embroiderOptimized({
+  npm: {
+    devDependencies: {
+      somethingExtra: '1.0.0',
+    },
+  },
+  env: {
+    WHATEVER: 'hi',
+  },
+});
+```

--- a/packages/test-setup/package.json
+++ b/packages/test-setup/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@embroider/test-setup",
+  "version": "0.26.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/test-setup"
+  },
+  "license": "MIT",
+  "main": "src/index.js",
+  "files": [
+    "src/index.js"
+  ],
+  "dependencies": {
+    "lodash": "^4.17.20",
+    "resolve": "^1.17.0"
+  },
+  "devDependencies": {
+    "@embroider/compat": "0.26.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -1,0 +1,89 @@
+import type { Options } from '@embroider/compat';
+
+/*
+  Use this instead of `app.toTree()` in your ember-cli-build.js:
+
+    return maybeEmbroider(app);
+
+*/
+export function maybeEmbroider(app: any, opts: Options = {}) {
+  if (!('@embroider/core' in app.dependencies())) {
+    return app.toTree(opts?.extraPublicTrees);
+  }
+
+  // we're using `require` here on purpose because
+  //  - we don't want to load any of these things until they're actually needed;
+  //  - we can't use `await import()` because this function needs to be synchronous to go inside ember-cli-build.js
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  let resolve = require('resolve') as typeof import('resolve');
+  let { Webpack } = require(resolve.sync('@embroider/webpack', {
+    basedir: app.project.root,
+  })) as typeof import('@embroider/webpack');
+  let Compat = require(resolve.sync('@embroider/compat', {
+    basedir: app.project.root,
+  })) as typeof import('@embroider/compat');
+  let mergeWith = require('lodash/mergeWith') as typeof import('lodash/mergeWith');
+  /* eslint-enable @typescript-eslint/no-require-imports */
+
+  if (process.env.EMBROIDER_TEST_SETUP_OPTIONS) {
+    let scenario = Compat.recommendedOptions[process.env.EMBROIDER_TEST_SETUP_OPTIONS];
+    if (scenario) {
+      opts = mergeWith({}, scenario, opts, appendArrays);
+      console.log(`Successfully applied EMBROIDER_TEST_SETUP_OPTIONS=${process.env.EMBROIDER_TEST_SETUP_OPTIONS}`);
+    } else {
+      throw new Error(`No such scenario EMBROIDER_TEST_SETUP_OPTIONS=${process.env.EMBROIDER_TEST_SETUP_OPTIONS}`);
+    }
+  }
+
+  return Compat.compatBuild(app, Webpack, opts);
+}
+
+export function embroiderSafe(extension?: object) {
+  return extendScenario(
+    {
+      name: 'embroider-safe',
+      npm: {
+        devDependencies: {
+          '@embroider/core': '*',
+          '@embroider/webpack': '*',
+          '@embroider/compat': '*',
+        },
+      },
+      env: {
+        EMBROIDER_TEST_SETUP_OPTIONS: 'safe',
+      },
+    },
+    extension
+  );
+}
+
+export function embroiderOptimized(extension?: object) {
+  return extendScenario(
+    {
+      name: 'embroider-optimized',
+      npm: {
+        devDependencies: {
+          '@embroider/core': '*',
+          '@embroider/webpack': '*',
+          '@embroider/compat': '*',
+        },
+      },
+      env: {
+        EMBROIDER_TEST_SETUP_OPTIONS: 'optimized',
+      },
+    },
+    extension
+  );
+}
+
+function extendScenario(scenario: object, extension?: object) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  let mergeWith = require('lodash/mergeWith') as typeof import('lodash/mergeWith');
+  return mergeWith(scenario, extension, appendArrays);
+}
+
+function appendArrays(objValue: any, srcValue: any) {
+  if (Array.isArray(objValue)) {
+    return objValue.concat(srcValue);
+  }
+}


### PR DESCRIPTION
Adding a new `@embroider/test-setup` package that helps apps and addons test under Embroider in CI. See its readme.