### PR TITLE
guard against stringly broccoli trees

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -37,7 +37,7 @@ import { pathExistsSync } from 'fs-extra';
 interface TreeNames {
   appJS: Tree;
   htmlTree: Tree;
-  publicTree: Tree;
+  publicTree: Tree | undefined;
   configTree: Tree;
 }
 
@@ -54,7 +54,7 @@ function setup(legacyEmberAppInstance: object, options: Required<Options>) {
   let appBootTree = oldPackage.appBoot;
 
   if (options.extraPublicTrees.length > 0) {
-    publicTree = mergeTrees([publicTree, ...options.extraPublicTrees].filter(Boolean));
+    publicTree = mergeTrees([publicTree, ...options.extraPublicTrees].filter(Boolean) as Tree[]);
   }
 
   let inTrees = {
@@ -292,7 +292,7 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
   }
 
   mainModule(): string {
-    return this.oldPackage.isModuleUnification ? 'src/main' : 'app';
+    return 'app';
   }
 
   mainModuleConfig(): unknown {

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -86,12 +86,6 @@ export default class V1App {
   }
 
   @Memoize()
-  get isModuleUnification() {
-    let experiments = this.requireFromEmberCLI('./lib/experiments');
-    return experiments.MODULE_UNIFICATION && !!this.app.trees.src;
-  }
-
-  @Memoize()
   private get emberCLILocation() {
     const emberCLIPackage = resolvePackagePath('ember-cli', this.root);
 
@@ -176,7 +170,6 @@ export default class V1App {
       addons: this.app.project.addons,
       autoRun: this.autoRun,
       storeConfigInMeta: this.storeConfigInMeta,
-      isModuleUnification: this.isModuleUnification,
     });
   }
 
@@ -594,8 +587,8 @@ export default class V1App {
     }
   }
 
-  get vendorTree(): Tree {
-    return this.app.trees.vendor;
+  get vendorTree(): Tree | undefined {
+    return ensureTree(this.app.trees.vendor);
   }
 
   @Memoize()
@@ -603,8 +596,8 @@ export default class V1App {
     return this.requireFromEmberCLI('ember-cli-preprocess-registry/preprocessors');
   }
 
-  get publicTree(): Tree {
-    return this.app.trees.public;
+  get publicTree(): Tree | undefined {
+    return ensureTree(this.app.trees.public);
   }
 
   processAppJS(): { appJS: Tree } {
@@ -698,4 +691,11 @@ class V1DummyApp extends V1App {
 interface Preprocessors {
   preprocessJs(tree: Tree, a: string, b: string, options: object): Tree;
   preprocessCss(tree: Tree, a: string, b: string, options: object): Tree;
+}
+
+function ensureTree(maybeTree: string | Tree | undefined): Tree | undefined {
+  if (typeof maybeTree === 'string') {
+    return new WatchedDir(maybeTree);
+  }
+  return maybeTree;
 }

--- a/packages/compat/tests/dummy-app.test.ts
+++ b/packages/compat/tests/dummy-app.test.ts
@@ -99,6 +99,9 @@ describe('dummy app tests', function () {
               return ENV;
             };`,
           },
+          public: {
+            'robots.txt': 'go away bots',
+          },
         },
       },
     });
@@ -122,5 +125,10 @@ describe('dummy app tests', function () {
     writeFileSync(join(project.baseDir, 'addon/components/example.hbs'), 'goodbye');
     await build.rebuild();
     expectFile('../../components/example.hbs').matches(/goodbye/);
+  });
+
+  test('contains public assets from dummy app', async function () {
+    expectFile('robots.txt').exists();
+    expectFile('package.json').json().get('ember-addon.assets').includes('robots.txt');
   });
 });

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -585,9 +585,6 @@ describe('stage2 build', function () {
                   console.log(isDevelopingThisPackage());`,
               },
             },
-            public: {
-              'robots.txt': '',
-            },
           },
         },
       });

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -585,6 +585,9 @@ describe('stage2 build', function () {
                   console.log(isDevelopingThisPackage());`,
               },
             },
+            public: {
+              'robots.txt': '',
+            },
           },
         },
       });

--- a/packages/core/src/wait-for-trees.ts
+++ b/packages/core/src/wait-for-trees.ts
@@ -72,11 +72,15 @@ function isTree(x: any): x is Tree {
 function* findTrees<NamedTrees>(trees: NamedTrees): IterableIterator<{ name: string; single?: Tree; multi?: Tree[] }> {
   for (let [name, value] of Object.entries(trees)) {
     if (Array.isArray(value)) {
-      yield { name, multi: value.filter(isTree) };
-    } else {
-      if (isTree(value)) {
-        yield { name, single: value };
+      let stringTrees = value.filter(t => typeof t === 'string');
+      if (stringTrees.length > 0) {
+        throw new Error(`found strings instead of broccoli trees for ${name}: ${value}`);
       }
+      yield { name, multi: value.filter(isTree) };
+    } else if (isTree(value)) {
+      yield { name, single: value };
+    } else if (typeof value === 'string') {
+      throw new Error(`found a string when we expected a broccoli tree for ${name}: ${value}`);
     }
   }
 }


### PR DESCRIPTION
We need to make sure all the broccoli trees we're passing out of v1-app are actually Trees and not strings. Previously, we were just passing vendor and public trees through to the output, which could let strings escape. And it turns out, dummy apps all use a string by default for their public tree, which meant we were dropping their public assets.