### PR TITLE
Fix missing hostWhitelist in FastBoot's package.json manifest

### DIFF
--- a/packages/compat/src/compat-adapters/ember-cli-fastboot.ts
+++ b/packages/compat/src/compat-adapters/ember-cli-fastboot.ts
@@ -119,6 +119,7 @@ class RewriteManifest extends Plugin {
       schemaVersion: 5,
       htmlEntrypoint: 'index.html',
       moduleWhitelist: json.fastboot.moduleWhitelist,
+      hostWhitelist: json.fastboot.hostWhitelist,
     };
 
     // this is a message to Embroider stage2 (in app.ts), because we need it to

--- a/test-packages/fastboot-app/app/routes/index.js
+++ b/test-packages/fastboot-app/app/routes/index.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class IndexRoute extends Route {
+  @service
+  fastboot;
+
+  beforeModel() {
+    // This is only to to make sure we can correctly access the request's host, which fails if FastBoot's `hostWhitelist`
+    // is not correctly set up. This is the case when the changes added to /dist/package.json by FastBoot are not correctly
+    // merged by Embroider. So this serves as a reproduction of https://github.com/embroider-build/embroider/issues/160
+    return this.fastboot.isFastBoot ? this.fastboot.request.host : null;
+  }
+}

--- a/test-packages/fastboot-app/config/environment.js
+++ b/test-packages/fastboot-app/config/environment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(environment) {
+module.exports = function (environment) {
   let ENV = {
     modulePrefix: 'fastboot-app',
     environment,
@@ -13,14 +13,17 @@ module.exports = function(environment) {
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.
-        Date: false
-      }
+        Date: false,
+      },
+    },
+    fastboot: {
+      hostWhitelist: [/^localhost:\d+$/],
     },
 
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-    }
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
Adds accessing `request.host` to `fastboot-app` that reproduces the missing FastBoot package.json data (here `hostWhitelist`) ~reported in #160~. This triggers the `You must provide a hostWhitelist to retrieve the host` error making the app's FastBoot tests fail. 

The second commit adds a fix, exposing the `hostWhitelist` manifest field, that got lost in the custom compat adapter, but still seems to be required and expected by `fastBoot` [here](https://github.com/ember-fastboot/fastboot/blob/429eb1d1c3d9353f3085196e71cfde416f154cba/src/fastboot-schema.js#L94).