### PR TITLE
Remove babel-core dependency from @embroider/compat.

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -28,7 +28,6 @@
     "@babel/types": "^7.8.7",
     "@embroider/macros": "0.27.0",
     "assert-never": "^1.1.0",
-    "babel-core": "^6.26.3",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babylon": "^6.18.0",
     "bind-decorator": "^1.0.11",


### PR DESCRIPTION
This dependency seems unused within the `@embroider/compat` package, and causes a number of installation warnings.

Related to https://github.com/embroider-build/embroider/issues/577