### PR TITLE
Update to released version of fixturify-project.

### DIFF
--- a/test-packages/support/package.json
+++ b/test-packages/support/package.json
@@ -21,7 +21,7 @@
     "ember-resolver": "^7.0.0",
     "ember-source": "3.17.0",
     "execa": "^4.0.3",
-    "fixturify-project": "git+https://github.com/ef4/node-fixturify-project#e52e2e7724ae1da8dc57a231d74a8ccfdffc119a",
+    "fixturify-project": "^2.1.0",
     "fs-extra": "^7.0.0",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.10",

--- a/test-packages/support/project.ts
+++ b/test-packages/support/project.ts
@@ -120,6 +120,9 @@ export default App;
 }
 
 export class Project extends FixturifyProject {
+  // FIXME: update fixturify-project to allow easier customization of `pkg`
+  declare pkg: any;
+
   static emberNew(name = 'my-app'): Project {
     let app = new Project(name);
     app.files = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9237,13 +9237,6 @@ fixturify-project@^2.1.0:
     tmp "^0.0.33"
     type-fest "^0.11.0"
 
-"fixturify-project@git+https://github.com/ef4/node-fixturify-project#e52e2e7724ae1da8dc57a231d74a8ccfdffc119a":
-  version "1.9.1"
-  resolved "git+https://github.com/ef4/node-fixturify-project#e52e2e7724ae1da8dc57a231d74a8ccfdffc119a"
-  dependencies:
-    fixturify "^1.2.0"
-    tmp "^0.0.33"
-
 fixturify@^0.3.2:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-0.3.4.tgz#c676de404a7f8ee8e64d0b76118e62ec95ab7b25"


### PR DESCRIPTION
The original fork was done in order to support scoped packages (https://github.com/stefanpenner/node-fixturify-project/pull/25), and that PR has landed.
