### PR TITLE
[WIP] Allow staticOptions via packageRules

### DIFF
--- a/packages/compat/src/dependency-rules.ts
+++ b/packages/compat/src/dependency-rules.ts
@@ -9,7 +9,7 @@ export interface PackageRules {
   package: string;
   semverRange?: string;
 
-  components: {
+  components?: {
     // I would prefer to write the key type here as `ComponentSnippet` to aid
     // documentation, but Typescript won't allow it. See ComponentSnippet below.
     [key: string]: ComponentRules;
@@ -25,6 +25,13 @@ export interface PackageRules {
     // `filename` is relative to the app's root, and it assumes v2 package
     // format. Like "templates/components/foo.hbs".
     [filename: string]: ModuleRules;
+  };
+
+  options?: {
+    staticAddonTestSupportTrees?: boolean;
+    staticAddonTrees?: boolean;
+    staticHelpers?: boolean;
+    staticComponents?: boolean;
   };
 }
 
@@ -163,6 +170,20 @@ export function preprocessComponentRule(componentRules: ComponentRules): Preproc
     yieldsSafeComponents: componentRules.yieldsSafeComponents || [],
     yieldsArguments: componentRules.yieldsArguments || [],
   };
+}
+
+export function ruleForPackageName(
+  packageRules: PackageRules[],
+  packageName: string,
+  packageVersion: string
+): PackageRules | undefined {
+  // rule order implies precedence. The first rule that matches a given package
+  // applies to that package, and no other rule does.
+  for (let rule of packageRules) {
+    if (rule.package === packageName && (!rule.semverRange || satisfies(packageVersion, rule.semverRange))) {
+      return rule;
+    }
+  }
 }
 
 export function activePackageRules(packageRules: PackageRules[], activePackages: Package[]): ActivePackageRules[] {

--- a/packages/compat/src/dependency-rules.ts
+++ b/packages/compat/src/dependency-rules.ts
@@ -30,8 +30,6 @@ export interface PackageRules {
   options?: {
     staticAddonTestSupportTrees?: boolean;
     staticAddonTrees?: boolean;
-    staticHelpers?: boolean;
-    staticComponents?: boolean;
   };
 }
 

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -609,7 +609,7 @@ export default class V1Addon {
 
     // TODO: this should be perf optimized
     let rule = ruleForPackageName(
-      this.options.packageRules.concat(defaultAddonPackageRules()),
+      this.addonOptions.packageRules.concat(defaultAddonPackageRules()),
       this.packageJSON.name,
       this.packageJSON.version
     );

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -600,14 +600,7 @@ export default class V1Addon {
     }
   }
 
-  private buildTreeForAddon(built: IntermediateBuild) {
-    let tree = this.treeForAddon(built);
-    if (!tree) {
-      return;
-    }
-    let templateOnlyComponents: Tree = new SynthesizeTemplateOnlyComponents(tree, ['components']);
-
-    // TODO: this should be perf optimized
+  private get isStaticAddonTrees() {
     let rule = ruleForPackageName(
       this.addonOptions.packageRules.concat(defaultAddonPackageRules()),
       this.packageJSON.name,
@@ -615,7 +608,28 @@ export default class V1Addon {
     );
 
     let ruleStaticAddonTree = !rule?.options?.staticAddonTrees || true;
-    if (!this.addonOptions.staticAddonTrees || ruleStaticAddonTree) {
+    return !this.addonOptions.staticAddonTrees || ruleStaticAddonTree;
+  }
+
+  private get isStaticAddonTestSupportTrees() {
+    let rule = ruleForPackageName(
+      this.addonOptions.packageRules.concat(defaultAddonPackageRules()),
+      this.packageJSON.name,
+      this.packageJSON.version
+    );
+
+    let ruleStaticAddonTestSupportTrees = !rule?.options?.staticAddonTestSupportTrees || true;
+    return !this.addonOptions.staticAddonTestSupportTrees || ruleStaticAddonTestSupportTrees;
+  }
+
+  private buildTreeForAddon(built: IntermediateBuild) {
+    let tree = this.treeForAddon(built);
+    if (!tree) {
+      return;
+    }
+    let templateOnlyComponents: Tree = new SynthesizeTemplateOnlyComponents(tree, ['components']);
+
+    if (!this.isStaticAddonTrees) {
       let filenames: string[] = [];
       let templateOnlyComponentNames: string[] = [];
 
@@ -690,7 +704,7 @@ export default class V1Addon {
       addonTestSupportTree = this.transpile(this.stockTree('addon-test-support'));
     }
     if (addonTestSupportTree) {
-      if (!this.addonOptions.staticAddonTestSupportTrees) {
+      if (!this.isStaticAddonTestSupportTrees) {
         let filenames: string[] = [];
         addonTestSupportTree = new ObserveTree(addonTestSupportTree, outputPath => {
           filenames = walkSync(outputPath, { globs: ['**/*.js', '**/*.hbs'] }).map(f => `./${f.replace(/.js$/i, '')}`);


### PR DESCRIPTION
This enables all of the static flags to be individually changed on a per package basis via the packageRules option. This will greatly help with apps onboarding to embroider as it will give them the flexibility to "opt out" of an optimization for a bad addon.