### PR TITLE
Pin dependencies added through @embroider/test-setup

### DIFF
--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -1,5 +1,8 @@
 import type { Options } from '@embroider/compat';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const currentEmbroiderVersion = require('../package.json').version;
+
 /*
   Use this instead of `app.toTree()` in your ember-cli-build.js:
 
@@ -44,9 +47,9 @@ export function embroiderSafe(extension?: object) {
       name: 'embroider-safe',
       npm: {
         devDependencies: {
-          '@embroider/core': '*',
-          '@embroider/webpack': '*',
-          '@embroider/compat': '*',
+          '@embroider/core': currentEmbroiderVersion,
+          '@embroider/webpack': currentEmbroiderVersion,
+          '@embroider/compat': currentEmbroiderVersion,
         },
       },
       env: {
@@ -63,9 +66,9 @@ export function embroiderOptimized(extension?: object) {
       name: 'embroider-optimized',
       npm: {
         devDependencies: {
-          '@embroider/core': '*',
-          '@embroider/webpack': '*',
-          '@embroider/compat': '*',
+          '@embroider/core': currentEmbroiderVersion,
+          '@embroider/webpack': currentEmbroiderVersion,
+          '@embroider/compat': currentEmbroiderVersion,
         },
       },
       env: {


### PR DESCRIPTION
I tried to add the new test-setup to an addon here: https://github.com/albertjan/ember-cli-yadda/pull/87, but that failed with `core_1.applyVariantToBabelConfig is not a function`. Also npm complained about `@embroider/webpack@0.28.0 requires a peer of @embroider/core@0.28.0 but none is installed.`. See https://travis-ci.org/github/albertjan/ember-cli-yadda/jobs/738517154#L273

It turned out that `'@embroider/core': '*'` would not install the latest version when an older version of it was already installed. Which is more or less always the case when `ember-auto-import` is present, but that still depends on a very outdated version (0.4.3) -  *Note: I already updated it in https://github.com/ef4/ember-auto-import/pull/308, but it's still unreleased! (hint hint :wink:) But a release wouldn't help much here, as the old dependency will still be around for a long time...*

So in this PR I pin the dependencies to the latest published version. Tested this locally successfully. Note that this assumes that `@embroider/test-setup` and the other embroider dependencies are published in lockstep!

