### PR TITLE
Support CSS from lazy engines

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -1034,9 +1034,16 @@ export class AppBuilder<TreeNames> {
     }
 
     let styles = [];
-    // only import styles from engines with a parent (this excludeds the parent application)
-    // as their styles will be inserted via a direct <link> tag.
+    // only import styles from engines with a parent (this excludeds the parent application) as their styles
+    // will be inserted via a direct <link> tag.
     if (engine.parent) {
+      let implicitStyles = this.impliedAssets('implicit-styles', engine);
+      for (let style of implicitStyles) {
+        styles.push({
+          path: explicitRelative('assets/_engine_', style.relativePath),
+        });
+      }
+
       styles.push({
         path: explicitRelative(relativePath, engine.package.name + '/' + engine.package.name + '.css'),
       });

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -434,9 +434,9 @@ export class AppBuilder<TreeNames> {
       }
     }
 
-    //html.insertStyleLink(html.styles, `assets/${this.app.name}.css`);
+    html.insertStyleLink(html.styles, `assets/${this.app.name}.css`);
 
-    const parentEngine = this.getParentEngine(appFiles) as Engine;
+    const parentEngine = appFiles.find(e => !e.parent) as Engine;
     let vendorJS = this.implicitScriptsAsset(prepared, parentEngine, emberENV);
     if (vendorJS) {
       html.insertScriptTag(html.implicitScripts, vendorJS.relativePath);
@@ -474,10 +474,6 @@ export class AppBuilder<TreeNames> {
     if (implicitTestStylesAsset) {
       html.insertStyleLink(html.implicitTestStyles, implicitTestStylesAsset.relativePath);
     }
-  }
-
-  private getParentEngine(engines: Engine[]) {
-    return engines.find(e => !e.parent);
   }
 
   private implicitScriptsAsset(
@@ -1038,31 +1034,13 @@ export class AppBuilder<TreeNames> {
     }
 
     let styles = [];
-    if (!engine.parent) {
-      styles.push({
-        path: `${engine.package.name}/assets/${engine.package.name}.css`,
-      });
-    } else {
-      let implicitStyles = this.impliedAssets('implicit-styles', engine);
-
-      for (let style of implicitStyles) {
-        styles.push({
-          path: '../../' + style.relativePath, // TODO: make better
-        });
-      }
-
+    // only import styles from engines with a parent (this excludeds the parent application)
+    // as their styles will be inserted via a direct <link> tag.
+    if (engine.parent) {
       styles.push({
         path: explicitRelative(relativePath, engine.package.name + '/' + engine.package.name + '.css'),
       });
     }
-
-    // only import styles from engines with a parent (this excludeds the parent application) as their styles
-    // will be inserted via a direct <link> tag.
-    // if (engine.parent) {
-    //   styles.push({
-    //     path: explicitRelative(relativePath, engine.package.name + '/' + engine.package.name + '.css'),
-    //   });
-    // }
 
     let lazyEngines: { names: string[]; path: string }[] = [];
     for (let childEngine of childEngines) {

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -431,7 +431,7 @@ export class AppBuilder<TreeNames> {
       }
     }
 
-    html.insertStyleLink(html.styles, `assets/${this.app.name}.css`);
+    //html.insertStyleLink(html.styles, `assets/${this.app.name}.css`);
 
     const parentEngine = this.getParentEngine(appFiles) as Engine;
     let vendorJS = this.implicitScriptsAsset(prepared, parentEngine, emberENV);
@@ -1035,23 +1035,31 @@ export class AppBuilder<TreeNames> {
     }
 
     let styles = [];
-    // if (!engine.parent) {
-    //   styles.push({
-    //     path: `${engine.package.name}/assets/${engine.package.name}.css`,
-    //   });
-    // } else {
-    //   styles.push({
-    //     path: explicitRelative(relativePath, engine.package.name + '/' + engine.package.name + '.css'),
-    //   });
-    // }
+    if (!engine.parent) {
+      styles.push({
+        path: `${engine.package.name}/assets/${engine.package.name}.css`,
+      });
+    } else {
+      let implicitStyles = this.impliedAssets('implicit-styles', engine);
 
-    // only import styles from engines with a parent (this excludeds the parent application) as their styles
-    // will be inserted via a direct <link> tag.
-    if (engine.parent) {
+      for (let style of implicitStyles) {
+        styles.push({
+          path: '../../' + style.relativePath, // TODO: make better
+        });
+      }
+
       styles.push({
         path: explicitRelative(relativePath, engine.package.name + '/' + engine.package.name + '.css'),
       });
     }
+
+    // only import styles from engines with a parent (this excludeds the parent application) as their styles
+    // will be inserted via a direct <link> tag.
+    // if (engine.parent) {
+    //   styles.push({
+    //     path: explicitRelative(relativePath, engine.package.name + '/' + engine.package.name + '.css'),
+    //   });
+    // }
 
     let lazyEngines: { names: string[]; path: string }[] = [];
     for (let childEngine of childEngines) {

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -294,7 +294,10 @@ export class AppBuilder<TreeNames> {
         let options = { basedir: addon.root };
         for (let mod of implicitScripts) {
           if (type === 'implicit-styles') {
-            styles.push(resolve.sync(mod, options));
+            // exclude engines because they will handle their own css importation
+            if (!addon.isEngine()) {
+              styles.push(resolve.sync(mod, options));
+            }
           } else {
             result.push(resolve.sync(mod, options));
           }

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -1234,8 +1234,7 @@ let w = window;
 let d = w.define;
 
 {{#if styles}}
-  if (macroCondition(getGlobalConfig().fastboot?.isRunning)) {}
-  else {
+  if (macroCondition(!getGlobalConfig().fastboot?.isRunning)) {
     {{#each styles as |stylePath| ~}}
       i("{{stylePath.path}}");
     {{/each}}

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -283,7 +283,6 @@ export class AppBuilder<TreeNames> {
 
   private impliedAddonAssets(type: keyof ImplicitAssetPaths): string[] {
     let result: Array<string> = [];
-
     for (let addon of sortBy(this.adapter.allActiveAddons, this.scriptPriority.bind(this))) {
       let implicitScripts = addon.meta[type];
       if (implicitScripts) {
@@ -1212,9 +1211,8 @@ let w = window;
 let d = w.define;
 
 {{#if styles}}
-  if (macroCondition(getGlobalConfig().fastboot?.isRunning)) {
-    console.log('todo');
-  } else {
+  if (macroCondition(getGlobalConfig().fastboot?.isRunning)) {}
+  else {
     {{#each styles as |stylePath| ~}}
       i("{{stylePath.path}}");
     {{/each}}

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -295,7 +295,7 @@ export class AppBuilder<TreeNames> {
         for (let mod of implicitScripts) {
           if (type === 'implicit-styles') {
             // exclude engines because they will handle their own css importation
-            if (!addon.isEngine()) {
+            if (!addon.isLazyEngine()) {
               styles.push(resolve.sync(mod, options));
             }
           } else {
@@ -497,7 +497,8 @@ export class AppBuilder<TreeNames> {
     if (!asset) {
       let implicitStyles = this.impliedAssets('implicit-styles', application);
       if (implicitStyles.length > 0) {
-        asset = new ConcatenatedAsset('assets/vendor.css', implicitStyles, this.resolvableExtensionsPattern);
+        // we reverse because we want the synthetic vendor style at the top
+        asset = new ConcatenatedAsset('assets/vendor.css', implicitStyles.reverse(), this.resolvableExtensionsPattern);
         prepared.set(asset.relativePath, asset);
       }
     }
@@ -1036,7 +1037,7 @@ export class AppBuilder<TreeNames> {
     let styles = [];
     // only import styles from engines with a parent (this excludeds the parent application) as their styles
     // will be inserted via a direct <link> tag.
-    if (engine.parent) {
+    if (engine.parent && engine.package.isLazyEngine()) {
       let implicitStyles = this.impliedAssets('implicit-styles', engine);
       for (let style of implicitStyles) {
         styles.push({

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -37,7 +37,7 @@
     "mini-css-extract-plugin": "^0.4.3",
     "pkg-up": "^2.0.0",
     "source-map-url": "^0.4.0",
-    "style-loader": "^0.23.0",
+    "style-loader": "^1.1.4",
     "terser": "^3.16.1",
     "thread-loader": "^1.2.0",
     "webpack": "^4.43.0"

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -399,7 +399,9 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
 
   private makeCSSRule(variant: Variant) {
     return [
-      variant.optimizeForProduction ? MiniCssExtractPlugin.loader : 'style-loader',
+      variant.optimizeForProduction
+        ? MiniCssExtractPlugin.loader
+        : { loader: 'style-loader', options: { injectType: 'styleTag' } },
       {
         loader: 'css-loader',
         options: {

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -407,7 +407,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
         options: {
           url: true,
           import: true,
-          modules: true,
+          modules: 'global',
         },
       },
     ];

--- a/test-packages/eager-engine/addon/styles/addon.css
+++ b/test-packages/eager-engine/addon/styles/addon.css
@@ -1,3 +1,4 @@
+/* eager-engine/addon/styles/addon.css */
 .shared-style-target {
   border-left-width: 2px;
   border-left-style: solid;

--- a/test-packages/eager-engine/addon/styles/addon.css
+++ b/test-packages/eager-engine/addon/styles/addon.css
@@ -1,6 +1,6 @@
-/* eager-engine/addon/styles/addon.css */
 .shared-style-target {
   border-left-width: 2px;
   border-left-style: solid;
   border-left-color: blue;
+  content: 'eager-engine/addon/styles/addon.css';
 }

--- a/test-packages/engines-host-app/app/styles/app.css
+++ b/test-packages/engines-host-app/app/styles/app.css
@@ -1,3 +1,4 @@
+/* engines-host-app/app/styles/app.css */
 .shared-style-target {
   width: 100px;
   height: 100px;

--- a/test-packages/engines-host-app/app/styles/app.css
+++ b/test-packages/engines-host-app/app/styles/app.css
@@ -1,6 +1,6 @@
-/* engines-host-app/app/styles/app.css */
 .shared-style-target {
   width: 100px;
   height: 100px;
   background-color: gray;
+  content: 'engines-host-app/app/styles/app.css';
 }

--- a/test-packages/engines-host-app/ember-cli-build.js
+++ b/test-packages/engines-host-app/ember-cli-build.js
@@ -2,7 +2,7 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-module.exports = function(defaults) {
+module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     // Add options here
   });
@@ -19,6 +19,8 @@ module.exports = function(defaults) {
   // modules that you would like to import into your application
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
+
+  app.import('vendor/styles.css');
 
   if (process.env.CLASSIC) {
     return app.toTree();

--- a/test-packages/engines-host-app/tests/acceptance/basics-test.js
+++ b/test-packages/engines-host-app/tests/acceptance/basics-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest, skip } from 'ember-qunit';
 
-module('Acceptance | basics', function(hooks) {
+module('Acceptance | basics', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('host-app', async function(assert) {
+  test('host-app', async function (assert) {
     await visit('/');
     assert.equal(currentURL(), '/');
     assert.dom('[data-test-duplicated-helper]').containsText('from-engines-host-app');
@@ -14,34 +14,10 @@ module('Acceptance | basics', function(hooks) {
   // this test must be the first test that loads the use-lazy-engine engine
   // as after it has loaded it will not "unload" and we are checking that these
   // modules are entering require.entries for the first time.
-  test('lazy-engine', async function(assert) {
+  test('lazy-engine', async function (assert) {
     await visit('/');
     let entriesBefore = Object.entries(window.require.entries).length;
 
-    // TODO: uncomment once we fix this appearing too eagerly
-    // assert.notOk(!!window.require.entries['lazy-engine/helpers/duplicated-helper']);
-
-    await visit('/use-lazy-engine');
-    let entriesAfter = Object.entries(window.require.entries).length;
-    assert.ok(!!window.require.entries['lazy-engine/helpers/duplicated-helper']);
-    assert.ok(entriesAfter > entriesBefore);
-    assert.equal(currentURL(), '/use-lazy-engine');
-    assert.dom('[data-test-lazy-engine-main] > h1').containsText('Lazy engine');
-    assert.dom('[data-test-duplicated-helper]').containsText('from-lazy-engine');
-  });
-
-  // See TODO comment in above test
-  skip('lazy engines own app tree is lazy', function() {});
-
-  test('eager-engine', async function(assert) {
-    await visit('/use-eager-engine');
-    assert.equal(currentURL(), '/use-eager-engine');
-    assert.dom('[data-test-eager-engine-main] > h1').containsText('Eager engine');
-    assert.dom('[data-test-truth-helpers-ok]').exists();
-    assert.dom('[data-test-duplicated-helper]').containsText('from-eager-engine-helper');
-  });
-
-  test('styles', async function(assert) {
     await visit('/style-check');
     assert.dom('.shared-style-target').exists();
 
@@ -51,16 +27,23 @@ module('Acceptance | basics', function(hooks) {
       'eager-engine styles are present'
     );
 
-    // TODO: uncomment this after implement lazy styles. See skipped test below
-    // that I left as a reminder.
-    //
-    // assert.equal(
-    //   getComputedStyle(document.querySelector('.shared-style-target'))['border-right-width'],
-    //   '0px',
-    //   'lazy-engine styles are not present'
-    // );
+    assert.equal(
+      getComputedStyle(document.querySelector('.shared-style-target'))['border-right-width'],
+      '0px',
+      'lazy-engine styles are not present'
+    );
+
+    // TODO: uncomment once we fix this appearing too eagerly
+    //assert.notOk(!!window.require.entries['lazy-engine/helpers/duplicated-helper']);
 
     await visit('/use-lazy-engine');
+    let entriesAfter = Object.entries(window.require.entries).length;
+    assert.ok(!!window.require.entries['lazy-engine/helpers/duplicated-helper']);
+    assert.ok(entriesAfter > entriesBefore);
+    assert.equal(currentURL(), '/use-lazy-engine');
+    assert.dom('[data-test-lazy-engine-main] > h1').containsText('Lazy engine');
+    assert.dom('[data-test-duplicated-helper]').containsText('from-lazy-engine');
+
     await visit('/style-check');
 
     assert.equal(
@@ -76,7 +59,14 @@ module('Acceptance | basics', function(hooks) {
     );
   });
 
-  skip('lazy styles are not present until after lazy engine loads', function() {
-    // See commented assertion in previous test.
+  // See TODO comment in above test
+  skip('lazy engines own app tree is lazy', function () {});
+
+  test('eager-engine', async function (assert) {
+    await visit('/use-eager-engine');
+    assert.equal(currentURL(), '/use-eager-engine');
+    assert.dom('[data-test-eager-engine-main] > h1').containsText('Eager engine');
+    assert.dom('[data-test-truth-helpers-ok]').exists();
+    assert.dom('[data-test-duplicated-helper]').containsText('from-eager-engine-helper');
   });
 });

--- a/test-packages/engines-host-app/tests/acceptance/basics-test.js
+++ b/test-packages/engines-host-app/tests/acceptance/basics-test.js
@@ -33,6 +33,12 @@ module('Acceptance | basics', function (hooks) {
       'lazy-engine styles are not present'
     );
 
+    assert.equal(
+      getComputedStyle(document.querySelector('.shared-style-target'))['border-right-color'],
+      'rgb(0, 0, 128)',
+      'lazy-engine vendor styles are not present'
+    );
+
     // TODO: uncomment once we fix this appearing too eagerly
     //assert.notOk(!!window.require.entries['lazy-engine/helpers/duplicated-helper']);
 
@@ -56,6 +62,12 @@ module('Acceptance | basics', function (hooks) {
       getComputedStyle(document.querySelector('.shared-style-target'))['border-right-width'],
       '2px',
       'now lazy-engine styles are present'
+    );
+
+    assert.equal(
+      getComputedStyle(document.querySelector('.shared-style-target'))['border-right-color'],
+      'rgb(0, 128, 0)',
+      'lazy-engine vendor styles are present'
     );
   });
 

--- a/test-packages/engines-host-app/tests/acceptance/basics-test.js
+++ b/test-packages/engines-host-app/tests/acceptance/basics-test.js
@@ -30,12 +30,12 @@ module('Acceptance | basics', function (hooks) {
     assert.equal(
       getComputedStyle(document.querySelector('.shared-style-target'))['border-right-width'],
       '0px',
-      'lazy-engine styles are not present'
+      'lazy-engine addon styles are not present'
     );
 
     assert.equal(
-      getComputedStyle(document.querySelector('.shared-style-target'))['border-right-color'],
-      'rgb(0, 0, 128)',
+      getComputedStyle(document.querySelector('.shared-style-target'))['border-top-width'],
+      '0px',
       'lazy-engine vendor styles are not present'
     );
 
@@ -65,8 +65,8 @@ module('Acceptance | basics', function (hooks) {
     );
 
     assert.equal(
-      getComputedStyle(document.querySelector('.shared-style-target'))['border-right-color'],
-      'rgb(0, 128, 0)',
+      getComputedStyle(document.querySelector('.shared-style-target'))['border-top-width'],
+      '2px',
       'lazy-engine vendor styles are present'
     );
   });

--- a/test-packages/engines-host-app/vendor/styles.css
+++ b/test-packages/engines-host-app/vendor/styles.css
@@ -1,0 +1,3 @@
+.shared-style-target {
+  content: 'engines-host-app/vendor/styles.css';
+}

--- a/test-packages/lazy-engine/addon/styles/addon.css
+++ b/test-packages/lazy-engine/addon/styles/addon.css
@@ -1,6 +1,6 @@
-/* lazy-engine/addon/styles/addon.css */
 .shared-style-target {
   border-right-width: 2px;
   border-right-style: solid;
   border-right-color: blue;
+  content: 'lazy-engine/addon/styles/addon.css';
 }

--- a/test-packages/lazy-engine/addon/styles/addon.css
+++ b/test-packages/lazy-engine/addon/styles/addon.css
@@ -1,3 +1,4 @@
+/* lazy-engine/addon/styles/addon.css */
 .shared-style-target {
   border-right-width: 2px;
   border-right-style: solid;

--- a/test-packages/lazy-engine/package.json
+++ b/test-packages/lazy-engine/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.20.5",
-    "ember-cli-htmlbars": "^4.3.1"
+    "ember-cli-htmlbars": "^4.3.1",
+    "macro-sample-addon": "*"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/test-packages/macro-sample-addon/addon/styles/addon.css
+++ b/test-packages/macro-sample-addon/addon/styles/addon.css
@@ -1,3 +1,4 @@
+/* macro-sample-addon/addon/styles/addon.css */
 .shared-style-target {
   border-right-color: green;
 }

--- a/test-packages/macro-sample-addon/addon/styles/addon.css
+++ b/test-packages/macro-sample-addon/addon/styles/addon.css
@@ -1,4 +1,6 @@
 /* macro-sample-addon/addon/styles/addon.css */
 .shared-style-target {
-  border-right-color: green;
+  border-top-width: 2px;
+  border-top-style: solid;
+  border-top-color: green;
 }

--- a/test-packages/macro-sample-addon/addon/styles/addon.css
+++ b/test-packages/macro-sample-addon/addon/styles/addon.css
@@ -1,6 +1,6 @@
-/* macro-sample-addon/addon/styles/addon.css */
 .shared-style-target {
   border-top-width: 2px;
   border-top-style: solid;
   border-top-color: green;
+  content: 'macro-sample-addon/addon/styles/addon.css';
 }

--- a/test-packages/macro-sample-addon/addon/styles/basic.css
+++ b/test-packages/macro-sample-addon/addon/styles/basic.css
@@ -1,0 +1,3 @@
+.shared-style-target {
+  border-right-color: green;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,6 +1936,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/json-schema@^7.0.5":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
+  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
@@ -2624,6 +2629,11 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
+
+ajv-keywords@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.4, ajv@^6.5.5, ajv@^6.9.1:
   version "6.12.5"
@@ -11591,6 +11601,15 @@ loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loader-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 loader.js@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.7.0.tgz#a1a52902001c83631efde9688b8ab3799325ef1f"
@@ -14379,6 +14398,15 @@ schema-utils@^2.6.5:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
+schema-utils@^2.7.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
+  integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
+  dependencies:
+    "@types/json-schema" "^7.0.5"
+    ajv "^6.12.4"
+    ajv-keywords "^3.5.2"
+
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -15119,13 +15147,13 @@ strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-style-loader@^0.23.0:
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
-  integrity sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==
+style-loader@^1.1.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e"
+  integrity sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==
   dependencies:
-    loader-utils "^1.1.0"
-    schema-utils "^1.0.0"
+    loader-utils "^2.0.0"
+    schema-utils "^2.7.0"
 
 styled_string@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
Lazy engine CSS is now imported via their own entry javascript file. Given the work that was done for #434 we now get as a by-product lazy CSS (for non lazy engines their styles will not be lazy). The fundamental change here is that CSS is able to be imported into javascript via webpack's style loader plugin and now during construction of each lazy engine's entry file we stick CSS imports at the top.

An example of what a lazy engine's entry file looks like after this change is:

```js
import { importSync as i, macroCondition, getGlobalConfig } from '@embroider/macros';
let w = window;
let d = w.define;

if (macroCondition(getGlobalConfig().fastboot?.isRunning)) {}
else {
  // STYLES ARE NOW IMPORTED HERE
  i("../../../lazy-engine/lazy-engine.css");
}

d("lazy-engine/_app_/helpers/duplicated-helper", function(){ return i("../../../lazy-engine/_app_/helpers/duplicated-helper");});
d("lazy-engine/config/_environment_browser_", function(){ return i("../../../lazy-engine/config/_environment_browser_");});
// ...
```

Here is the corresponding app's entry file (we can see how the above lazy entry file is not loaded until invoked by embroider's router):

```js
import { importSync as i, macroCondition, getGlobalConfig } from '@embroider/macros';
let w = window;
let d = w.define;


d("engines-host-app/app", function(){ return i("../app");});
d("engines-host-app/config/asset-manifest", function(){ return i("../config/asset-manifest");});
//...
d("ember-test-waiters/wait-for-promise", function(){ return i("../../../node_modules/ember-test-waiters/wait-for-promise");});
d("ember-test-waiters/waiter-manager", function(){ return i("../../../node_modules/ember-test-waiters/waiter-manager");});

i("./_engine_/eager-engine.js");


w._embroiderEngineBundles_ = [
  {
    names: ["lazy-engine"],
    load: function() {
      return import("./_engine_/lazy-engine.js");
    }
  },
]


if (typeof FastBoot === 'undefined') {
  if (!runningTests) {
    require('engines-host-app/app')['default'].create({"name":"engines-host-app","version":"0.0.0+f34a4df5"});
  }
}
```