### PR TITLE
fix unnecessary inclusion of co-located templates

### DIFF
--- a/packages/core/src/app-files.ts
+++ b/packages/core/src/app-files.ts
@@ -45,8 +45,10 @@ export class AppFiles {
 
       // hbs files are resolvable, but not when they're inside the components
       // directory (where they are used for colocation only)
-      if (relativePath.startsWith('components/') && !relativePath.endsWith('.hbs')) {
-        components.push(relativePath);
+      if (relativePath.startsWith('components/')) {
+        if (!relativePath.endsWith('.hbs')) {
+          components.push(relativePath);
+        }
         continue;
       }
 


### PR DESCRIPTION
Fixes #589.

The hbs files of co-located templates in the app were being treated as `otherAppFiles`, meaning uncategorized and therefore unsafe to leave out of the build.

Really we just want to always leave them out here -- they are not, by themselves, resolvable. They're directly references by their corresponding JS (which we will have already synthesized if they are template-only).