### PR TITLE
Continuing to extend and improve audit

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "name": "Run tests",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "cwd": "${workspaceFolder}/packages/compat",
-      "args": ["--runInBand", "--testPathPattern", "tests/audit.test.js"], //, "--test-name-pattern", "traverse"],
+      "args": ["--runInBand", "--testPathPattern", "tests/audit.test.js", "--test-name-pattern", "re-export"],
       "outputCapture": "std"
     },
     {

--- a/packages/compat/src/audit-cli.ts
+++ b/packages/compat/src/audit-cli.ts
@@ -65,7 +65,9 @@ function runCLI() {
       yargs => yargs,
       async () => {
         let results = new AuditResults();
-        Object.assign(results, JSON.parse(readFileSync(process.stdin.fd, 'utf8')));
+        // process.stdin.fd is a documented public API. The Node typings don't
+        // seem to know about it.
+        Object.assign(results, JSON.parse(readFileSync((process.stdin as any).fd, 'utf8')));
         process.stdout.write(results.humanReadable());
         process.exit(0);
       }

--- a/packages/compat/src/audit-cli.ts
+++ b/packages/compat/src/audit-cli.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'fs-extra';
 import yargs from 'yargs/yargs';
-import { Audit, isBuildError } from './audit';
+import { Audit, AuditResults, isBuildError } from './audit';
 
 // slightly wacky because yargs types don't cover this, but you can't access the
 // other documented place to find `hideBin` on node < 12.17
@@ -10,53 +11,65 @@ const { hideBin } = (yargs as any) as {
 };
 
 function runCLI() {
-  return yargs(hideBin(process.argv)).command(
-    '$0',
-    'audit your app for embroider compatibility problems',
-    yargs => {
-      return yargs
-        .option('debug', {
-          alias: 'd',
-          type: 'boolean',
-          description: 'Add debug logging about the audit itself',
-          default: false,
-        })
-        .option('json', {
-          alias: 'j',
-          type: 'boolean',
-          description: 'Print results in JSON format',
-          default: false,
-        })
-        .option('reuse-build', {
-          alias: 'r',
-          type: 'boolean',
-          description: 'Reuse previous build',
-          default: false,
-        })
-        .option('app', {
-          type: 'string',
-          description: 'Path to your app',
-          default: process.cwd(),
-        })
-        .fail(function (_, err, _yargs) {
-          if (isBuildError(err)) {
-            process.stderr.write(err.message + '\n');
-          } else {
-            console.error(err);
-          }
-          process.exit(1);
-        });
-    },
-    async options => {
-      let results = await Audit.run(options);
-      if (options.json) {
-        process.stdout.write(JSON.stringify(results, null, 2) + '\n');
-      } else {
-        process.stdout.write(results.humanReadable());
+  return yargs(hideBin(process.argv))
+    .command(
+      '$0',
+      'audit your app for embroider compatibility problems',
+      yargs => {
+        return yargs
+          .option('debug', {
+            alias: 'd',
+            type: 'boolean',
+            description: 'Add debug logging about the audit itself',
+            default: false,
+          })
+          .option('json', {
+            alias: 'j',
+            type: 'boolean',
+            description: 'Print results in JSON format',
+            default: false,
+          })
+          .option('reuse-build', {
+            alias: 'r',
+            type: 'boolean',
+            description: 'Reuse previous build',
+            default: false,
+          })
+          .option('app', {
+            type: 'string',
+            description: 'Path to your app',
+            default: process.cwd(),
+          })
+          .fail(function (_, err, _yargs) {
+            if (isBuildError(err)) {
+              process.stderr.write(err.message + '\n');
+            } else {
+              console.error(err);
+            }
+            process.exit(1);
+          });
+      },
+      async options => {
+        let results = await Audit.run(options);
+        if (options.json) {
+          process.stdout.write(JSON.stringify(results, null, 2) + '\n');
+        } else {
+          process.stdout.write(results.humanReadable());
+        }
+        process.exit(results.perfect ? 0 : 1);
       }
-      process.exit(results.perfect ? 0 : 1);
-    }
-  ).argv;
+    )
+    .command(
+      'pretty',
+      'format JSON audit results as pretty human-readable results',
+      yargs => yargs,
+      async () => {
+        let results = new AuditResults();
+        Object.assign(results, JSON.parse(readFileSync(process.stdin.fd, 'utf8')));
+        process.stdout.write(results.humanReadable());
+        process.exit(0);
+      }
+    ).argv;
 }
 
 if (require.main === module) {

--- a/packages/compat/src/audit-cli.ts
+++ b/packages/compat/src/audit-cli.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'fs-extra';
+import { readFileSync, readJSONSync, writeFileSync } from 'fs-extra';
+import { resolve } from 'path';
 import yargs from 'yargs/yargs';
-import { Audit, AuditResults, isBuildError } from './audit';
+import { Audit, AuditResults, Finding, isBuildError } from './audit';
 
 // slightly wacky because yargs types don't cover this, but you can't access the
 // other documented place to find `hideBin` on node < 12.17
@@ -35,10 +36,30 @@ function runCLI() {
             description: 'Reuse previous build',
             default: false,
           })
+          .option('load', {
+            alias: 'l',
+            type: 'string',
+            description: 'Load previous audit results from a JSON file instead of running a new audit',
+          })
+          .option('save', {
+            alias: 's',
+            type: 'string',
+            description: 'Save audit results as a JSON file.',
+          })
           .option('app', {
             type: 'string',
             description: 'Path to your app',
             default: process.cwd(),
+          })
+          .option('filter', {
+            type: 'string',
+            description:
+              'Path to a JS file that describes which findings to silence. Generate the initial file using `--create-filter`.',
+          })
+          .option('create-filter', {
+            type: 'string',
+            description:
+              'Path to a JS file where we will create a filter that will silence all your current findings. Pass it back into future audits via --filter',
           })
           .fail(function (_, err, _yargs) {
             if (isBuildError(err)) {
@@ -50,11 +71,25 @@ function runCLI() {
           });
       },
       async options => {
-        let results = await Audit.run(options);
+        let filter = loadFilter(options);
+        let results: AuditResults;
+        if (options.load) {
+          results = new AuditResults();
+          Object.assign(results, readJSONSync(options.load));
+        } else {
+          results = await Audit.run(options);
+        }
+        if (options.save) {
+          writeFileSync(options.save, JSON.stringify(results, null, 2));
+        }
+        applyFilter(filter, results);
         if (options.json) {
           process.stdout.write(JSON.stringify(results, null, 2) + '\n');
         } else {
           process.stdout.write(results.humanReadable());
+        }
+        if (options['create-filter']) {
+          createFilter(options['create-filter'], results);
         }
         process.exit(results.perfect ? 0 : 1);
       }
@@ -62,13 +97,39 @@ function runCLI() {
     .command(
       'pretty',
       'format JSON audit results as pretty human-readable results',
+      yargs => {
+        return yargs.option('filter', {
+          type: 'string',
+          description:
+            'Path to a JS file that describes which findings to silence. Generate the file using `embroider-compat-audit acknowledge`',
+        });
+      },
+      async options => {
+        let filter = loadFilter(options);
+        let results = new AuditResults();
+        // process.stdin.fd is a documented public API. The Node typings don't
+        // seem to know about it.
+        Object.assign(results, JSON.parse(readFileSync((process.stdin as any).fd, 'utf8')));
+        applyFilter(filter, results);
+        process.stdout.write(results.humanReadable());
+        process.exit(0);
+      }
+    )
+    .command(
+      'acknowledge',
+      'Pipe your audit JSON to this command to generate a filter file that will silence the current issues. Pass the filter file into your next audit via --filter. Delete findings out of the filter file as you address them.',
       yargs => yargs,
       async () => {
         let results = new AuditResults();
         // process.stdin.fd is a documented public API. The Node typings don't
         // seem to know about it.
         Object.assign(results, JSON.parse(readFileSync((process.stdin as any).fd, 'utf8')));
-        process.stdout.write(results.humanReadable());
+        let findings = results.findings.map(f => ({
+          filename: f.filename,
+          message: f.message,
+          detail: f.detail,
+        }));
+        process.stdout.write(`module.exports = ${JSON.stringify({ findings }, null, 2)};\n`);
         process.exit(0);
       }
     ).argv;
@@ -76,4 +137,36 @@ function runCLI() {
 
 if (require.main === module) {
   runCLI();
+}
+
+type Filter = { findings: Omit<Finding, 'codeFrame'>[] };
+
+function loadFilter(options: { filter: string | undefined }): Filter | undefined {
+  if (options.filter) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(resolve(options.filter));
+  }
+}
+
+function applyFilter(filter: Filter | undefined, results: AuditResults) {
+  if (filter) {
+    results.findings = results.findings.filter(finding => {
+      return !filter!.findings.find(filtered => {
+        return (
+          filtered.message === finding.message &&
+          filtered.detail === finding.detail &&
+          filtered.filename === finding.filename
+        );
+      });
+    });
+  }
+}
+
+function createFilter(filename: string, results: AuditResults) {
+  let findings = results.findings.map(f => ({
+    filename: f.filename,
+    message: f.message,
+    detail: f.detail,
+  }));
+  writeFileSync(filename, `module.exports = ${JSON.stringify({ findings }, null, 2)};\n`);
 }

--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -377,6 +377,14 @@ export class Audit {
       module.imports = result.imports;
       module.isCJS = result.isCJS;
       module.isAMD = result.isAMD;
+      for (let problem of result.problems) {
+        this.pushFinding({
+          filename,
+          message: problem.message,
+          detail: problem.detail,
+          codeFrame: this.frames.render(problem.codeFrameIndex),
+        });
+      }
       return result.imports.map(i => i.source);
     } catch (err) {
       if (err.code === 'BABEL_PARSE_ERROR') {

--- a/packages/compat/src/audit/babel-visitor.ts
+++ b/packages/compat/src/audit/babel-visitor.ts
@@ -78,7 +78,7 @@ export function auditJS(rawSource: string, filename: string, babelConfig: Transf
           });
         } else {
           problems.push({
-            message: `audit tool is unable to understand this usage of importSync`,
+            message: `audit tool is unable to understand this usage of ${isImport(callee) ? 'import' : 'importSync'}`,
             detail: arg.type,
             codeFrameIndex: saveCodeFrame(arg),
           });

--- a/packages/compat/src/audit/babel-visitor.ts
+++ b/packages/compat/src/audit/babel-visitor.ts
@@ -25,7 +25,7 @@ export interface InternalImport {
   codeFrameIndex: number | undefined;
   specifiers: {
     name: string | NamespaceMarker;
-    local: string;
+    local: string | null; // can be null when re-exporting, because in that case we import `name` from `source` but don't create any local binding for it
     codeFrameIndex: number | undefined;
   }[];
 }
@@ -125,16 +125,36 @@ export function auditJS(rawSource: string, filename: string, babelConfig: Transf
     },
     ExportSpecifier(path: NodePath<ExportSpecifier>) {
       exports.add(name(path.node.exported));
+      if (path.parent.type === 'ExportNamedDeclaration' && path.parent.source) {
+        imports[imports.length - 1].specifiers.push({
+          name: name(path.node.local),
+          local: null, // re-exports don't create local bindings
+          codeFrameIndex: saveCodeFrame(path.node),
+        });
+      }
     },
     ExportNamespaceSpecifier(path: NodePath<ExportNamespaceSpecifier>) {
       exports.add(name(path.node.exported));
+      if (path.parent.type === 'ExportNamedDeclaration' && path.parent.source) {
+        imports[imports.length - 1].specifiers.push({
+          name: { isNamespace: true },
+          local: null, // re-exports don't create local bindings
+          codeFrameIndex: saveCodeFrame(path.node),
+        });
+      }
     },
     ExportAllDeclaration(path: NodePath<ExportAllDeclaration>) {
       exports.add({ all: path.node.source.value });
       imports.push({
         source: path.node.source.value,
         codeFrameIndex: saveCodeFrame(path.node.source),
-        specifiers: [],
+        specifiers: [
+          {
+            name: { isNamespace: true },
+            local: null,
+            codeFrameIndex: saveCodeFrame(path.node),
+          },
+        ],
       });
     },
     ExportNamedDeclaration(path: NodePath<ExportNamedDeclaration>) {

--- a/packages/compat/tests/audit.test.ts
+++ b/packages/compat/tests/audit.test.ts
@@ -1,6 +1,7 @@
 import { emberTemplateCompilerPath, Project } from '@embroider/test-support';
 import { AppMeta, TemplateCompiler, throwOnWarnings } from '@embroider/core';
 import merge from 'lodash/merge';
+import fromPairs from 'lodash/fromPairs';
 import { Audit, Finding } from '../src/audit';
 import CompatResolver from '../src/resolver';
 
@@ -185,6 +186,7 @@ describe('audit', function () {
       `,
     });
     let result = await audit();
+    expect(result.findings).toEqual([]);
     let exports = result.modules['./app.js'].exports;
     expect(exports).toContain('a');
     expect(exports).toContain('b');
@@ -207,6 +209,46 @@ describe('audit', function () {
     expect(exports).not.toContain('interior2');
     expect(exports).not.toContain('interior3');
     expect(exports).not.toContain('thing1');
+  });
+
+  test(`finds all re-exports`, async function () {
+    merge(app.files, {
+      'app.js': `
+        export { default as a, b, thing as c } from './lib-a';
+        export * from './lib-b';
+        export * as libC from './lib-c';
+      `,
+      'lib-a.js': `
+        export default function() {}
+        export function b() {}
+        export function thing() {}
+      `,
+      'lib-b.js': `
+        export const alpha = 1;
+        export class beta {}
+      `,
+      'lib-c.js': `
+        export function whatever() {}
+      `,
+    });
+
+    let result = await audit();
+    expect(result.findings).toEqual([]);
+    let exports = result.modules['./app.js'].exports;
+    expect(exports).toContain('a');
+    expect(exports).toContain('b');
+    expect(exports).not.toContain('thing');
+    expect(exports).toContain('c');
+    expect(exports).toContain('alpha');
+    expect(exports).toContain('beta');
+    expect(exports).toContain('libC');
+    expect(result.modules['./app.js'].imports.length).toBe(3);
+    let imports = fromPairs(result.modules['./app.js'].imports.map(imp => [imp.source, imp.specifiers]));
+    expect(imports).toEqual({
+      './lib-a': ['a', 'b', 'thing'],
+      './lib-b': [{ isNamespaceMarker: true }],
+      './lib-c': [{ isNamespaceMarker: true }],
+    });
   });
 
   test(`tolerates CJS`, async function () {


### PR DESCRIPTION
 - [x] don't crash on unimplemented TemplateLiteral importSync
 - [x] add new `pretty` subcommand
 - [x] traverse reexports
 - [ ] ~implement TemplateLiteral import() and importSync()~ (moving this to new issue https://github.com/embroider-build/embroider/issues/599)