### PR TITLE
Support pods layout for route-based code splitting

### DIFF
--- a/packages/compat/tests/route-split.test.ts
+++ b/packages/compat/tests/route-split.test.ts
@@ -168,4 +168,183 @@ describe('splitAtRoutes', function () {
       });
     });
   });
+
+  describe('pods', function () {
+    let expectFile: ExpectFile;
+    let build: BuildResult;
+
+    beforeAll(async function () {
+      let buildOptions: Partial<BuildParams> = {
+        stage: 2,
+        type: 'app',
+        emberAppOptions: {
+          tests: false,
+          babel: {
+            plugins: [],
+          },
+        },
+        embroiderOptions: {
+          staticAddonTrees: true,
+          staticAddonTestSupportTrees: true,
+          staticHelpers: true,
+          staticComponents: true,
+          splitAtRoutes: ['people'],
+        },
+      };
+      let app = Project.emberNew('my-app');
+      merge(app.files, {
+        app: {
+          pods: {
+            index: {
+              'template.hbs': '<Welcome/>',
+              'controller.js': '',
+              'route.js': '',
+            },
+            people: {
+              'template.hbs': '<h1>People</h1>{{outlet}}',
+              'controller.js': '',
+              'route.js': '',
+              index: {
+                'template.hbs': '<AllPeople/>',
+              },
+              show: {
+                'template.hbs': '<OnePerson/>',
+                'controller.js': '',
+                'route.js': '',
+              },
+            },
+          },
+          components: {
+            'welcome.hbs': '',
+            'all-people.js': 'export default class {}',
+            'one-person.hbs': '{{capitalize @person.name}}',
+            'unused.hbs': '',
+          },
+          helpers: {
+            'capitalize.js': 'export default function(){}',
+          },
+        },
+        config: {
+          'environment.js': `module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'my-app',
+    podModulePrefix: 'my-app/pods',
+    environment,
+    rootURL: '/',
+    locationType: 'auto',
+    EmberENV: {
+      FEATURES: {
+      },
+      EXTEND_PROTOTYPES: {
+        Date: false
+      }
+    },
+    APP: {}
+  };
+  return ENV;
+};`,
+        },
+      });
+      build = await BuildResult.build(app, buildOptions);
+      expectFile = expectFilesAt(build.outputPath);
+    });
+
+    afterAll(async function () {
+      await build.cleanup();
+    });
+
+    it('has no components in main entrypoint', function () {
+      expectFile('./assets/my-app.js').doesNotMatch('all-people');
+      expectFile('./assets/my-app.js').doesNotMatch('welcome');
+      expectFile('./assets/my-app.js').doesNotMatch('unused');
+    });
+
+    it('has no helpers in main entrypoint', function () {
+      expectFile('./assets/my-app.js').doesNotMatch('capitalize');
+    });
+
+    it('has non-split controllers in main entrypoint', function () {
+      expectFile('./assets/my-app.js').matches('pods/index/controller');
+    });
+
+    it('has non-split route templates in main entrypoint', function () {
+      expectFile('./assets/my-app.js').matches('pods/index/template');
+    });
+
+    it('has non-split routes in main entrypoint', function () {
+      expectFile('./assets/my-app.js').matches('pods/index/route');
+    });
+
+    it('does not have split controllers in main entrypoint', function () {
+      expectFile('./assets/my-app.js').doesNotMatch('pods/people/controller');
+      expectFile('./assets/my-app.js').doesNotMatch('pods/people/show/controller');
+    });
+
+    it('does not have split route templates in main entrypoint', function () {
+      expectFile('./assets/my-app.js').doesNotMatch('pods/people/template');
+      expectFile('./assets/my-app.js').doesNotMatch('pods/people/index/template');
+      expectFile('./assets/my-app.js').doesNotMatch('pods/people/show/template');
+    });
+
+    it('does not have split routes in main entrypoint', function () {
+      expectFile('./assets/my-app.js').doesNotMatch('pods/people/route');
+      expectFile('./assets/my-app.js').doesNotMatch('pods/people/show/route');
+    });
+
+    it('dynamically imports the route entrypoint from the main entrypoint', function () {
+      expectFile('./assets/my-app.js').matches('import("./_route_/people")');
+    });
+
+    it('has split controllers in route entrypoint', function () {
+      expectFile('./assets/_route_/people.js').matches('pods/people/controller');
+      expectFile('./assets/_route_/people.js').matches('pods/people/show/controller');
+    });
+
+    it('has split route templates in route entrypoint', function () {
+      expectFile('./assets/_route_/people.js').matches('pods/people/template');
+      expectFile('./assets/_route_/people.js').matches('pods/people/index/template');
+      expectFile('./assets/_route_/people.js').matches('pods/people/show/template');
+    });
+
+    it('has split routes in route entrypoint', function () {
+      expectFile('./assets/_route_/people.js').matches('pods/people/route');
+      expectFile('./assets/_route_/people.js').matches('pods/people/show/route');
+    });
+
+    it('has no components in route entrypoint', function () {
+      expectFile('./assets/_route_/people.js').doesNotMatch('all-people');
+      expectFile('./assets/_route_/people.js').doesNotMatch('welcome');
+      expectFile('./assets/_route_/people.js').doesNotMatch('unused');
+    });
+
+    it('has no helpers in route entrypoint', function () {
+      expectFile('./assets/_route_/people.js').doesNotMatch('capitalize');
+    });
+
+    describe('audit', function () {
+      let auditResults: AuditResults;
+      beforeAll(async function () {
+        let audit = new Audit(build.outputPath);
+        auditResults = await audit.run();
+      });
+
+      it('has no issues', function () {
+        expect(auditResults.findings).toEqual([]);
+      });
+
+      it('helper is consumed only from the template that uses it', function () {
+        expect(auditResults.modules['./helpers/capitalize.js']?.consumedFrom).toEqual(['./components/one-person.hbs']);
+      });
+
+      it('component is consumed only from the template that uses it', function () {
+        expect(auditResults.modules['./components/one-person.js']?.consumedFrom).toEqual([
+          './pods/people/show/template.hbs',
+        ]);
+      });
+
+      it('does not include unused component', function () {
+        expect(auditResults.modules['./components/unused.hbs']).toBe(undefined);
+      });
+    });
+  });
 });

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -84,6 +84,9 @@ export interface AppAdapter<TreeNames> {
   // their modulePrefix.)
   modulePrefix(): string;
 
+  // The module prefix when pods file layout is used
+  podModulePrefix(): string | undefined;
+
   // The public URL at which your app will be served.
   rootURL(): string;
 
@@ -620,7 +623,7 @@ export class AppBuilder<TreeNames> {
       .forEach(a => a.differ.update());
     return this.appDiffers.map(a => {
       return Object.assign({}, a.engine, {
-        appFiles: new AppFiles(a.differ, this.resolvableExtensionsPattern),
+        appFiles: new AppFiles(a.differ, this.resolvableExtensionsPattern, this.adapter.podModulePrefix()),
       });
     });
   }


### PR DESCRIPTION
Fixes #602 

@ef4 I'll needs some assistance here, as I am not quite happy with this yet. I does work for me locally, however...
* to be able to understand the pod-based routes correctly, I need to know the app's `podModulePrefix`. Ideally we would just read this from `config/environment.js`, where it is defined, to have a single source of truth. However that's basically a runtime config, but we need this a build time. And AFAIU this still needs to be build, before we can read from it, or at least I haven't found an obvious and clean way to read this at build time. So the most effortless option was to duplicate the setting, by adding it to our existing options. But not sure if that approach is good!?
* there is no test coverage. Again, I have confirmed this to work locally, but found no trivial way to add some tests, either unit testing `AppFiles`, or having an integration test asserts that (classic or pods) routes get correctly splitted out. I didn't find existing similar tests, is there some prior art somewhere? 
