### PR TITLE
fixing a regression with ast transforms

### DIFF
--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -353,7 +353,7 @@ export default class CompatResolver implements Resolver {
     return extensionsPattern(this.params.adjustImportsOptions.resolvableExtensions);
   }
 
-  absPathToRuntimeName(absPath: string, owningPackage?: { root: string; name: string }) {
+  absPathToRuntimePath(absPath: string, owningPackage?: { root: string; name: string }) {
     let pkg = owningPackage || PackageCache.shared('embroider-stage3').ownerOfFile(absPath);
     if (pkg) {
       let packageRuntimeName = pkg.name;
@@ -363,20 +363,18 @@ export default class CompatResolver implements Resolver {
           break;
         }
       }
-      return join(packageRuntimeName, relative(pkg.root, absPath))
-        .replace(this.resolvableExtensionsPattern, '')
-        .split(sep)
-        .join('/')
-        .replace(/\/index$/, '');
+      return join(packageRuntimeName, relative(pkg.root, absPath)).split(sep).join('/');
     } else if (absPath.startsWith(this.params.root)) {
-      return join(this.params.modulePrefix, relative(this.params.root, absPath))
-        .replace(this.resolvableExtensionsPattern, '')
-        .split(sep)
-        .join('/')
-        .replace(/\/index$/, '');
+      return join(this.params.modulePrefix, relative(this.params.root, absPath)).split(sep).join('/');
     } else {
       throw new Error(`bug: can't figure out the runtime name for ${absPath}`);
     }
+  }
+
+  absPathToRuntimeName(absPath: string, owningPackage?: { root: string; name: string }) {
+    return this.absPathToRuntimePath(absPath, owningPackage)
+      .replace(this.resolvableExtensionsPattern, '')
+      .replace(/\/index$/, '');
   }
 
   private get staticComponentsEnabled(): boolean {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -11,7 +11,7 @@ import mergeTrees from 'broccoli-merge-trees';
 import semver from 'semver';
 import rewriteAddonTree from './rewrite-addon-tree';
 import { mergeWithAppend } from './merges';
-import { AddonMeta, TemplateCompiler, debug, PackageCache, Resolver } from '@embroider/core';
+import { AddonMeta, TemplateCompiler, debug, PackageCache, Resolver, extensionsPattern } from '@embroider/core';
 import Options from './options';
 import walkSync from 'walk-sync';
 import ObserveTree from './observe-tree';
@@ -72,11 +72,16 @@ class V1AddonCompatResolver implements Resolver {
   dependenciesOf(_moduleName: string): ResolvedDep[] {
     return [];
   }
-  absPathToRuntimeName(moduleName: string) {
-    if (isAbsolute(moduleName)) {
-      return moduleName;
+  absPathToRuntimePath(absPath: string) {
+    if (isAbsolute(absPath)) {
+      return absPath;
     }
-    return join(this.params.modulePrefix, moduleName);
+    return join(this.params.modulePrefix, absPath);
+  }
+  absPathToRuntimeName(absPath: string) {
+    return this.absPathToRuntimePath(absPath)
+      .replace(extensionsPattern(['.js', '.hbs']), '')
+      .replace(/\/index$/, '');
   }
 }
 

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -236,6 +236,7 @@ describe('stage2 build', function () {
               'first-choice.hbs': 'first',
               'second-choice.hbs': 'second',
               'third-choice.hbs': 'third',
+              'module-name.hbs': '<div class={{embroider-sample-transforms-module}}>hello world</div>',
             },
           },
           components: {
@@ -253,6 +254,9 @@ describe('stage2 build', function () {
             return import('some-library');
           }
         `,
+          helpers: {
+            'embroider-sample-transforms-module.js': 'export default function() {}',
+          },
         },
         public: {
           'public-file-1.txt': `initial state`,
@@ -559,6 +563,14 @@ describe('stage2 build', function () {
       expectFile('./does-dynamic-import.js')
         .transform(build.transpile)
         .matches(/return import\(['"]some-library['"]\)/);
+    });
+
+    test('hbs transform sees expected module name', function () {
+      let assertFile = expectFile('templates/components/module-name.hbs').transform(build.transpile);
+      assertFile.matches(
+        '"my-app/templates/components/module-name.hbs"',
+        'our sample transform injected the expected moduleName into the compiled template'
+      );
     });
   });
 

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -236,7 +236,9 @@ describe('stage2 build', function () {
               'first-choice.hbs': 'first',
               'second-choice.hbs': 'second',
               'third-choice.hbs': 'third',
-              'module-name.hbs': '<div class={{embroider-sample-transforms-module}}>hello world</div>',
+              'module-name-check': {
+                'index.hbs': '<div class={{embroider-sample-transforms-module}}>hello world</div>',
+              },
             },
           },
           components: {
@@ -566,9 +568,9 @@ describe('stage2 build', function () {
     });
 
     test('hbs transform sees expected module name', function () {
-      let assertFile = expectFile('templates/components/module-name.hbs').transform(build.transpile);
+      let assertFile = expectFile('templates/components/module-name-check/index.hbs').transform(build.transpile);
       assertFile.matches(
-        '"my-app/templates/components/module-name.hbs"',
+        '"my-app/templates/components/module-name-check/index.hbs"',
         'our sample transform injected the expected moduleName into the compiled template'
       );
     });

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -9,5 +9,14 @@ export interface ResolvedDep {
 export interface Resolver {
   astTransformer(templateCompiler: TemplateCompiler): unknown;
   dependenciesOf(moduleName: string): ResolvedDep[];
-  absPathToRuntimeName(absPath: string): string | undefined;
+
+  // this takes an absolute path to a file and gives back a path like
+  // "the-package-name/path/to/the-file.js", while taking into account any
+  // backward-compatible runtime name of the package. It's used by the template
+  // compiler, because this is the kind of path AST plugins expect to see.
+  absPathToRuntimePath(absPath: string): string;
+
+  // this takes an absolute path to a file and gives back the runtime name of
+  // that module, as it would tradtionally be named within loader.js.
+  absPathToRuntimeName(absPath: string): string;
 }

--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -7,7 +7,7 @@ import Filter from 'broccoli-persistent-filter';
 import stringify from 'json-stable-stringify';
 import { createHash } from 'crypto';
 import { compile } from './js-handlebars';
-import { join, sep, extname } from 'path';
+import { join, sep } from 'path';
 import { PluginItem } from '@babel/core';
 import { Memoize } from 'typescript-memoize';
 import wrapLegacyHbsPluginIfNeeded from 'wrap-legacy-hbs-plugin-if-needed';
@@ -277,7 +277,7 @@ export default class TemplateCompiler {
     let runtimeName: string;
 
     if (this.params.resolver) {
-      runtimeName = `${this.params.resolver.absPathToRuntimeName(moduleName)}${extname(moduleName)}` || moduleName;
+      runtimeName = this.params.resolver.absPathToRuntimePath(moduleName);
     } else {
       runtimeName = moduleName;
     }

--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -343,7 +343,7 @@ export default class TemplateCompiler {
 
     opts.filename = moduleName;
     opts.moduleName = this.params.resolver
-      ? this.params.resolver.absPathToRuntimeName(moduleName) || moduleName
+      ? this.params.resolver.absPathToRuntimePath(moduleName) || moduleName
       : moduleName;
     let ast = this.syntax.preprocess(contents, opts);
     return this.syntax.print(ast);

--- a/test-packages/sample-transforms/lib/glimmer-plugin.js
+++ b/test-packages/sample-transforms/lib/glimmer-plugin.js
@@ -13,7 +13,7 @@ function sampleTransform(env) {
             type: 'StringLiteral',
             value: env.moduleName,
             original: env.moduleName,
-            loc: {}
+            loc: node.path.loc,
           });
           return node;
         }


### PR DESCRIPTION
We regressed recently by changing the paths seen by ast transforms.

It turns out we really need to resolve two difference concepts: runtime paths, which include the file extension and include any trailing `index` path segment, and runtime names, which don't include the file extension and always omit a trailing `index` segment.

Most runtime stuff in ember uses runtime names, but AST transforms traditionally see the runtime path.