### PR TITLE
allowUnsafeDynamicComponents flag

### DIFF
--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -83,6 +83,11 @@ export default interface Options extends CoreOptions {
   //
   // Follow to the definition of PackageRules for more info.
   packageRules?: PackageRules[];
+
+  // This turns build errors into runtime errors. It is not a good idea to keep
+  // it on in production. But it can be helpful when testing how much of your
+  // app is able to work with staticComponents enabled.
+  allowUnsafeDynamicComponents?: boolean;
 }
 
 const defaults = Object.assign(coreWithDefaults(), {
@@ -93,6 +98,7 @@ const defaults = Object.assign(coreWithDefaults(), {
   workspaceDir: null,
   optionalComponents: [],
   packageRules: [],
+  allowUnsafeDynamicComponents: false,
 });
 
 export function optionsWithDefaults(options?: Options): Required<Options> {
@@ -110,5 +116,6 @@ export const recommendedOptions: { [name: string]: Options } = Object.freeze({
     staticAddonTestSupportTrees: true,
     staticHelpers: true,
     staticComponents: true,
+    allowUnsafeDynamicComponents: false,
   }),
 });

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -100,12 +100,13 @@ const builtInComponents = ['input', 'link-to', 'textarea'];
 // this is a subset of the full Options. We care about serializability, and we
 // only needs parts that are easily serializable, which is why we don't keep the
 // whole thing.
-type ResolverOptions = Pick<Required<Options>, 'staticHelpers' | 'staticComponents'>;
+type ResolverOptions = Pick<Required<Options>, 'staticHelpers' | 'staticComponents' | 'allowUnsafeDynamicComponents'>;
 
 function extractOptions(options: Required<Options> | ResolverOptions): ResolverOptions {
   return {
     staticHelpers: options.staticHelpers,
     staticComponents: options.staticComponents,
+    allowUnsafeDynamicComponents: options.allowUnsafeDynamicComponents,
   };
 }
 
@@ -310,7 +311,7 @@ export default class CompatResolver implements Resolver {
     if (deps) {
       for (let dep of deps) {
         if (dep.type === 'error') {
-          if (!this.auditMode) {
+          if (!this.auditMode && !this.params.options.allowUnsafeDynamicComponents) {
             let e = new Error(
               `${dep.message}: ${dep.detail} in ${humanReadableFile(this.params.root, moduleName)}`
             ) as any;

--- a/packages/compat/tests/audit.test.ts
+++ b/packages/compat/tests/audit.test.ts
@@ -29,7 +29,7 @@ describe('audit', function () {
         resolver: new CompatResolver({
           root: app.baseDir,
           modulePrefix: 'audit-this-app',
-          options: { staticComponents: false, staticHelpers: false },
+          options: { staticComponents: false, staticHelpers: false, allowUnsafeDynamicComponents: false },
           activePackageRules: [],
           adjustImportsOptions: {
             renamePackages: {},


### PR DESCRIPTION
This can be helpful while testing, because instead of stopping your build at the first potentially-missing component, you can get a complete build and see how much of your app is working in the browser.

It is not recommended to be on in production, because it makes it easy to accidentally ship runtime errors.