### PR TITLE
apply rules to colocated templates

### DIFF
--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -986,6 +986,22 @@ describe('compat-resolver', function () {
     );
   });
 
+  test('acceptsComponentArguments matches co-located template', function () {
+    let packageRules = [
+      {
+        package: 'the-app',
+        components: {
+          '<FormBuilder />': {
+            acceptsComponentArguments: ['title'],
+          },
+        },
+      },
+    ];
+    let findDependencies = configure({ staticComponents: true, packageRules });
+    givenFile('components/form-builder.js');
+    expect(findDependencies('components/form-builder.hbs', `{{component title}}`)).toEqual([]);
+  });
+
   test(`element block params are not in scope for element's own attributes`, function () {
     let packageRules = [
       {


### PR DESCRIPTION
Before, component rules about the component itself were not getting applied to co-located templates unless you explicitly set a layout on the rule.