### PR TITLE
move node-only types out of macros default entrypoint

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -30,7 +30,7 @@ import flatMap from 'lodash/flatMap';
 import { Memoize } from 'typescript-memoize';
 import flatten from 'lodash/flatten';
 import { sync as resolveSync } from 'resolve';
-import { MacrosConfig } from '@embroider/macros';
+import { MacrosConfig } from '@embroider/macros/src/node';
 import bind from 'bind-decorator';
 import { pathExistsSync } from 'fs-extra';
 import { tmpdir } from 'os';

--- a/packages/compat/src/moved-package-cache.ts
+++ b/packages/compat/src/moved-package-cache.ts
@@ -2,7 +2,7 @@ import { join, dirname, resolve, sep, isAbsolute } from 'path';
 import { ensureSymlinkSync, readdirSync, readlinkSync, realpathSync, lstatSync } from 'fs-extra';
 import { Memoize } from 'typescript-memoize';
 import { PackageCache, Package, getOrCreate } from '@embroider/core';
-import { MacrosConfig } from '@embroider/macros';
+import { MacrosConfig } from '@embroider/macros/src/node';
 
 function assertNoTildeExpansion(source: string, target: string) {
   if (target.includes('~')) {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -16,7 +16,7 @@ import Options from './options';
 import walkSync from 'walk-sync';
 import ObserveTree from './observe-tree';
 import { Options as HTMLBarsOptions } from 'ember-cli-htmlbars';
-import { isEmbroiderMacrosPlugin } from '@embroider/macros';
+import { isEmbroiderMacrosPlugin } from '@embroider/macros/src/node';
 import { TransformOptions, PluginItem } from '@babel/core';
 import V1App from './v1-app';
 import modulesCompat from './modules-compat';

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -13,7 +13,7 @@ import { writeJSONSync, ensureDirSync, copySync, readdirSync, pathExistsSync, ex
 import AddToTree from './add-to-tree';
 import DummyPackage, { OwningAddon } from './dummy-package';
 import { TransformOptions } from '@babel/core';
-import { isEmbroiderMacrosPlugin } from '@embroider/macros';
+import { isEmbroiderMacrosPlugin } from '@embroider/macros/src/node';
 import resolvePackagePath from 'resolve-package-path';
 import Concat from 'broccoli-concat';
 import mapKeys from 'lodash/mapKeys';

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -9,7 +9,7 @@ import { getOrCreate } from '@embroider/core';
 import { MovablePackageCache } from './moved-package-cache';
 import Options from './options';
 import isEqual from 'lodash/isEqual';
-import { MacrosConfig } from '@embroider/macros';
+import { MacrosConfig } from '@embroider/macros/src/node';
 
 export default class V1InstanceCache {
   static caches: WeakMap<object, V1InstanceCache> = new WeakMap();

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -15,7 +15,7 @@ import { Asset, EmberAsset, ImplicitAssetPaths, InMemoryAsset, OnDiskAsset } fro
 import assertNever from 'assert-never';
 import SourceMapConcat from 'fast-sourcemap-concat';
 import Options from './options';
-import { MacrosConfig } from '@embroider/macros';
+import { MacrosConfig } from '@embroider/macros/src/node';
 import { PluginItem, TransformOptions } from '@babel/core';
 import { makePortable } from './portable-babel-config';
 import { TemplateCompilerPlugins } from '.';

--- a/packages/macros/src/ember-addon-main.ts
+++ b/packages/macros/src/ember-addon-main.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { MacrosConfig, isEmbroiderMacrosPlugin } from '.';
+import { MacrosConfig, isEmbroiderMacrosPlugin } from './node';
 
 export = {
   name: '@embroider/macros',

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -72,19 +72,3 @@ class Oops extends Error {
     this.params = params;
   }
 }
-
-// Entrypoint for managing the macro config within Node.
-export { default as MacrosConfig, Merger } from './macros-config';
-
-// Utility for detecting our babel and AST plugins.
-import { PluginItem } from '@babel/core';
-export function isEmbroiderMacrosPlugin(item: PluginItem) {
-  return (
-    (Array.isArray(item) &&
-      item.length > 1 &&
-      item[1] &&
-      typeof item[1] === 'object' &&
-      (item[1] as any).embroiderMacrosConfigMarker) ||
-    (item && typeof item === 'function' && (item as any).embroiderMacrosASTMarker)
-  );
-}

--- a/packages/macros/src/node.ts
+++ b/packages/macros/src/node.ts
@@ -1,0 +1,18 @@
+// this is the public entrypoint for Node-side code, as opposed to index.ts
+// which is our browser-visible public entrypoint
+
+// Entrypoint for managing the macro config within Node.
+export { default as MacrosConfig, Merger } from './macros-config';
+
+// Utility for detecting our babel and AST plugins.
+import { PluginItem } from '@babel/core';
+export function isEmbroiderMacrosPlugin(item: PluginItem) {
+  return (
+    (Array.isArray(item) &&
+      item.length > 1 &&
+      item[1] &&
+      typeof item[1] === 'object' &&
+      (item[1] as any).embroiderMacrosConfigMarker) ||
+    (item && typeof item === 'function' && (item as any).embroiderMacrosASTMarker)
+  );
+}

--- a/packages/macros/tests/babel/each.test.ts
+++ b/packages/macros/tests/babel/each.test.ts
@@ -1,6 +1,6 @@
 import { allBabelVersions } from '@embroider/test-support';
 import { makeBabelConfig, allModes, makeRunner } from './helpers';
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 
 describe('each', function () {
   let macrosConfig: MacrosConfig;

--- a/packages/macros/tests/babel/env-macros.test.ts
+++ b/packages/macros/tests/babel/env-macros.test.ts
@@ -1,7 +1,7 @@
 import { allBabelVersions } from '@embroider/test-support';
 import { makeBabelConfig, allModes, makeRunner } from './helpers';
 import { PackageCache } from '@embroider/core';
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 
 describe(`env macros`, function () {
   let macrosConfig: MacrosConfig;

--- a/packages/macros/tests/babel/fail-build.test.ts
+++ b/packages/macros/tests/babel/fail-build.test.ts
@@ -1,5 +1,5 @@
 import { allBabelVersions, runDefault } from './helpers';
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 
 describe(`fail build macro`, function () {
   allBabelVersions(function (transform: (code: string) => string, config: MacrosConfig) {

--- a/packages/macros/tests/babel/get-config.test.ts
+++ b/packages/macros/tests/babel/get-config.test.ts
@@ -1,6 +1,6 @@
 import { allBabelVersions } from '@embroider/test-support';
 import { makeBabelConfig, allModes, makeRunner } from './helpers';
-import { MacrosConfig } from '../../src';
+import { MacrosConfig } from '../../src/node';
 import { dirname } from 'path';
 
 describe(`getConfig`, function () {

--- a/packages/macros/tests/babel/helpers.ts
+++ b/packages/macros/tests/babel/helpers.ts
@@ -1,4 +1,4 @@
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 import { join, dirname } from 'path';
 import { allBabelVersions as allBabel, Project, runDefault, Transform, toCJS } from '@embroider/test-support';
 import { readFileSync } from 'fs';

--- a/packages/macros/tests/babel/import-sync.test.ts
+++ b/packages/macros/tests/babel/import-sync.test.ts
@@ -1,5 +1,5 @@
 import { allBabelVersions } from './helpers';
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 
 describe('importSync', function () {
   allBabelVersions(function createTests(transform: (code: string) => string, config: MacrosConfig) {

--- a/packages/macros/tests/babel/macro-condition.test.ts
+++ b/packages/macros/tests/babel/macro-condition.test.ts
@@ -1,6 +1,6 @@
 import { makeRunner, makeBabelConfig, allModes } from './helpers';
 import { allBabelVersions } from '@embroider/test-support';
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 
 describe('macroCondition', function () {
   let config: MacrosConfig;

--- a/packages/macros/tests/glimmer/fail-build.test.ts
+++ b/packages/macros/tests/glimmer/fail-build.test.ts
@@ -1,5 +1,5 @@
 import { templateTests } from './helpers';
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 
 describe(`macroFailBuild`, function () {
   templateTests(function (transform: (code: string) => string, config: MacrosConfig) {

--- a/packages/macros/tests/glimmer/get-config.test.ts
+++ b/packages/macros/tests/glimmer/get-config.test.ts
@@ -1,5 +1,5 @@
 import { templateTests } from './helpers';
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 
 describe(`macroGetConfig`, function () {
   templateTests(function (transform: (code: string) => string, config: MacrosConfig) {

--- a/packages/macros/tests/glimmer/helpers.ts
+++ b/packages/macros/tests/glimmer/helpers.ts
@@ -1,6 +1,6 @@
 import { TemplateCompiler } from '@embroider/core';
 import { emberTemplateCompilerPath, Project } from '@embroider/test-support';
-import { MacrosConfig } from '../..';
+import { MacrosConfig } from '../../src/node';
 import { join } from 'path';
 const compilerPath = emberTemplateCompilerPath();
 

--- a/test-packages/static-app/ember-cli-build.js
+++ b/test-packages/static-app/ember-cli-build.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-const { MacrosConfig } = require('@embroider/macros');
+const { MacrosConfig } = require('@embroider/macros/src/node');
 
-module.exports = function(defaults) {
+module.exports = function (defaults) {
   let app = new EmberApp(defaults, {});
 
   MacrosConfig.for(app).setOwnConfig(__filename, {


### PR DESCRIPTION
They unnecessarily confuse typescript apps.