### PR TITLE
Adding rules for some common deps

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-data.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-data.ts
@@ -1,0 +1,14 @@
+import { PackageRules } from '..';
+
+let rules: PackageRules[] = [
+  {
+    package: '@ember-data/store',
+    addonModules: {
+      '-private.js': {
+        dependsOnModules: ['@ember-data/record-data/-private'],
+      },
+    },
+  },
+];
+
+export default rules;

--- a/packages/compat/src/addon-dependency-rules/ember-modal-dialog.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-modal-dialog.ts
@@ -1,0 +1,27 @@
+import { PackageRules } from '..';
+
+const rules: PackageRules[] = [
+  {
+    package: 'ember-modal-dialog',
+    components: {
+      '<ModalDialog/>': {
+        invokes: {
+          modalDialogComponentName: [
+            '{{ember-modal-dialog/-in-place-dialog}}',
+            '{{ember-modal-dialog/-liquid-tether-dialog}}',
+            '{{ember-modal-dialog/-tether-dialog}}',
+            '{{ember-modal-dialog/-liquid-dialog}}',
+            '{{ember-modal-dialog/-basic-dialog}}',
+          ],
+        },
+        layout: {
+          addonPath: 'templates/components/modal-dialog.hbs',
+        },
+      },
+      '<LiquidWormhole/>': { safeToIgnore: true },
+      '<LiquidTether/>': { safeToIgnore: true },
+    },
+  },
+];
+
+export default rules;

--- a/packages/compat/src/addon-dependency-rules/ember-power-select-with-create.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-power-select-with-create.ts
@@ -1,0 +1,22 @@
+import { PackageRules } from '..';
+
+const rules: PackageRules[] = [
+  {
+    package: 'ember-power-select-with-create',
+    components: {
+      '<PowerSelectWithCreate/>': {
+        acceptsComponentArguments: ['powerSelectComponentName', 'suggestedOptionComponent'],
+        layout: {
+          addonPath: 'templates/components/power-select-with-create.hbs',
+        },
+      },
+    },
+    addonModules: {
+      'components/power-select-with-create.js': {
+        dependsOnComponents: ['<PowerSelect/>', '<PowerSelectWithCreate::SuggestedOption/>'],
+      },
+    },
+  },
+];
+
+export default rules;

--- a/packages/compat/src/compat-adapters/@ember-data/model.ts
+++ b/packages/compat/src/compat-adapters/@ember-data/model.ts
@@ -1,0 +1,12 @@
+import V1Addon from '../../v1-addon';
+
+export default class EmberDataModel extends V1Addon {
+  get packageMeta() {
+    const meta = super.packageMeta;
+    if (!meta['implicit-modules']) {
+      meta['implicit-modules'] = [];
+    }
+    meta['implicit-modules'].push('./-private');
+    return meta;
+  }
+}


### PR DESCRIPTION
This adds packageRules for ember-modal-dialog, ember-power-select-with-create, and `@ember-data/store`, making each of them compatible with staticComponent mode.

This also adds a compat adapter for `@ember-data/model` because there's un-analyzable dynamic shenanigans there.