### PR TITLE
new staticAppPaths options

### DIFF
--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -259,6 +259,16 @@ describe('stage2 build', function () {
           helpers: {
             'embroider-sample-transforms-module.js': 'export default function() {}',
           },
+          'static-dir': {
+            'my-library.js': '',
+          },
+          'static-dir-not-really': {
+            'something.js': '',
+          },
+          'non-static-dir': {
+            'another-library.js': '',
+          },
+          'top-level-static.js': '',
         },
         public: {
           'public-file-1.txt': `initial state`,
@@ -362,6 +372,7 @@ describe('stage2 build', function () {
             semverRange: '^2.0.0',
           },
         ],
+        staticAppPaths: ['static-dir', 'top-level-static.js'],
         packageRules: [
           {
             package: 'my-addon',
@@ -573,6 +584,22 @@ describe('stage2 build', function () {
         '"my-app/templates/components/module-name-check/index.hbs"',
         'our sample transform injected the expected moduleName into the compiled template'
       );
+    });
+
+    test('non-static other paths are included in the entrypoint', function () {
+      expectFile('assets/my-app.js').matches(/i\("..\/non-static-dir\/another-library"\)/);
+    });
+
+    test('static other paths are not included in the entrypoint', function () {
+      expectFile('assets/my-app.js').doesNotMatch(/i\("..\/static-dir\/my-library"\)/);
+    });
+
+    test('top-level static other paths are not included in the entrypoint', function () {
+      expectFile('assets/my-app.js').doesNotMatch(/i\("..\/top-level-static"\)/);
+    });
+
+    test('staticAppPaths do not match partial path segments', function () {
+      expectFile('assets/my-app.js').matches(/i\("..\/static-dir-not-really\/something"\)/);
     });
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "broccoli-plugin": "^4.0.1",
     "broccoli-source": "^3.0.0",
     "debug": "^3.1.0",
+    "escape-string-regexp": "^4.0.0",
     "fast-sourcemap-concat": "^1.4.0",
     "filesize": "^4.1.2",
     "fs-extra": "^7.0.1",

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -30,6 +30,7 @@ import mergeWith from 'lodash/mergeWith';
 import cloneDeep from 'lodash/cloneDeep';
 import type { Params as InlineBabelParams } from './babel-plugin-inline-hbs';
 import { PortableHint } from './portable';
+import escapeRegExp from 'escape-string-regexp';
 
 export type EmberENV = unknown;
 
@@ -1019,6 +1020,30 @@ export class AppBuilder<TreeNames> {
     });
   }
 
+  @Memoize()
+  private get staticAppPathsPattern(): RegExp | undefined {
+    if (this.options.staticAppPaths.length > 0) {
+      return new RegExp(
+        '^(?:' +
+          this.options.staticAppPaths.map(staticAppPath => escapeRegExp(staticAppPath.replace(/\//g, sep))).join('|') +
+          ')(?:$|' +
+          sep +
+          ')'
+      );
+    }
+  }
+
+  private requiredOtherFiles(appFiles: AppFiles): readonly string[] {
+    let pattern = this.staticAppPathsPattern;
+    if (pattern) {
+      return appFiles.otherAppFiles.filter(f => {
+        return !pattern!.test(f);
+      });
+    } else {
+      return appFiles.otherAppFiles;
+    }
+  }
+
   private appJSAsset(
     relativePath: string,
     engine: Engine,
@@ -1033,7 +1058,7 @@ export class AppBuilder<TreeNames> {
     }
 
     let eagerModules = [];
-    let requiredAppFiles = [appFiles.otherAppFiles];
+    let requiredAppFiles = [this.requiredOtherFiles(appFiles)];
     if (!this.options.staticComponents) {
       requiredAppFiles.push(appFiles.components);
     }

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -25,6 +25,30 @@ export default interface Options {
   // README](https://github.com/embroider-build/embroider/blob/master/packages/router/README.md)
   splitAtRoutes?: (RegExp | string)[];
 
+  // Every file within your application's `app` directory is categorized as a
+  // component, helper, route, route template, controller, or "other".
+  //
+  // This option lets you decide which "other" files should be loaded
+  // statically. By default, all "other" files will be included in the build and
+  // registered with Ember's runtime loader, because we can't know if somebody
+  // is going to try to access them dynamically via Ember's resolver or AMD
+  // runtime `require`.
+  //
+  // If you know that your files are only ever imported, you can list them here
+  // and then they will only be included exactly where they're needed.
+  //
+  // Provide a list of directories or files relative to `/app`. For example
+  //
+  //     staticAppPaths: ['lib']
+  //
+  // means that everything under your-project/app/lib will be loaded statically.
+  //
+  // This option has no effect on components (which are governed by
+  // staticComponents), helpers (which are governed by staticHelpers), or the
+  // route-specific files (routes, route templates, and controllers which are
+  // governed by splitAtRoutes).
+  staticAppPaths?: string[];
+
   // By default, all modules that get imported into the app go through Babel, so
   // that all code will conform with your Babel targets. This option allows you
   // to turn Babel off for a particular package. You might need this to work
@@ -55,6 +79,7 @@ export function optionsWithDefaults(options?: Options): Required<Options> {
     splitAtRoutes: [],
     splitControllers: false,
     splitRouteClasses: false,
+    staticAppPaths: [],
     skipBabel: [],
     pluginHints: [],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,7 +5083,15 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^3.2.6, browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.0, browserslist@^4.4.1, browserslist@^4.8.5:
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
+
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.4.1, browserslist@^4.8.5:
   version "4.14.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.7.tgz#c071c1b3622c1c2e790799a37bb09473a4351cb6"
   integrity sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==
@@ -5277,6 +5285,11 @@ caniuse-lite@^1.0.0:
   version "1.0.30001135"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz#995b1eb94404a3c9a0d7600c113c9bb27f2cd8aa"
   integrity sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==
+
+caniuse-lite@^1.0.30000844:
+  version "1.0.30001161"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz#64f7ffe79ee780b8c92843ff34feb36cea4651e0"
+  integrity sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==
 
 caniuse-lite@^1.0.30001157:
   version "1.0.30001157"
@@ -6512,6 +6525,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+electron-to-chromium@^1.3.47:
+  version "1.3.607"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.607.tgz#1bff13f1cf89f2fee0d244b8c64a7138f80f3a3b"
+  integrity sha512-h2SYNaBnlplGS0YyXl8oJWokfcNxVjJANQfMCsQefG6OSuAuNIeW+A8yGT/ci+xRoBb3k2zq1FrOvkgoKBol8g==
 
 electron-to-chromium@^1.3.591:
   version "1.3.593"
@@ -8392,6 +8410,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@^1.11.0, escodegen@^1.14.1, escodegen@^1.9.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
@@ -9151,7 +9174,21 @@ fastboot-transform@^0.1.3:
     broccoli-stew "^1.5.0"
     convert-source-map "^1.5.1"
 
-fastboot@^2.0.0, fastboot@^2.0.1, fastboot@^3.1.0:
+fastboot@^2.0.0, fastboot@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-2.0.3.tgz#0b712e6c590f1b463dc5b12138893bcbbafa2459"
+  integrity sha512-NNH/o+XhITAQUnW2CC9IDXlcnI74W2BONjtRSRmc01N3uJl/7pcvX9iWTUWu2PYQbQZUBu8HzVFt7GmQ9qw9JQ==
+  dependencies:
+    chalk "^2.0.1"
+    cookie "^0.4.0"
+    debug "^4.1.0"
+    najax "^1.0.3"
+    resolve "^1.8.1"
+    rsvp "^4.8.0"
+    simple-dom "^1.4.0"
+    source-map-support "^0.5.0"
+
+fastboot@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-3.1.0.tgz#e71a2d45c9b034f8a5909562a125888325100843"
   integrity sha512-1GyX0seImE0l4Di/LVwTzL1XqXKECQvvDeEZmReNwMUDbsQxETGz3j7XUq/eWSxl1o4R/vZomvxOXdtae6kpfA==
@@ -14388,7 +14425,7 @@ rsvp@^3.0.14, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
   integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
 
-rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.1, rsvp@^4.8.2, rsvp@^4.8.3, rsvp@^4.8.4, rsvp@^4.8.5:
+rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.0, rsvp@^4.8.1, rsvp@^4.8.2, rsvp@^4.8.3, rsvp@^4.8.4, rsvp@^4.8.5:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
@@ -14885,7 +14922,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12, source-map-support@~0.5.19:
+source-map-support@^0.5.0, source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
This adds a new staticAppPaths option.

```
  // Every file within your application's `app` directory is categorized as a
  // component, helper, route, route template, controller, or "other".
  //
  // This option lets you decide which "other" files should be loaded
  // statically. By default, all "other" files will be included in the build and
  // registered with Ember's runtime loader, because we can't know if somebody
  // is going to try to access them dynamically via Ember's resolver or AMD
  // runtime `require`.
  //
  // If you know that your files are only ever imported, you can list them here
  // and then they will only be included exactly where they're needed.
  //
  // Provide a list of directories or files relative to `/app`. For example
  //
  //     staticAppPaths: ['lib']
  //
  // means that everything under your-project/app/lib will be loaded statically.
  //
  // This option has no effect on components (which are governed by
  // staticComponents), helpers (which are governed by staticHelpers), or the
  // route-specific files (routes, route templates, and controllers which are
  // governed by splitAtRoutes).
```