### PR TITLE
Handle disabled in-repo addons

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -10,7 +10,7 @@ import EmptyPackageTree from './empty-package-tree';
 
 export default function cachedBuildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): Node {
   let tree = buildCompatAddon(originalPackage, v1Cache);
-  if (!originalPackage.mayRebuild) {
+  if (!originalPackage.mayRebuild && !(tree instanceof EmptyPackageTree)) {
     tree = new OneShot(tree);
   }
   return tree;

--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -181,6 +181,13 @@ export default class CompatAddons implements Stage {
         if (moved) {
           dep = moved;
         }
+
+        // if an in-repo addon is disabled/excluded, it has no name here
+        // we can skip this addon in that case
+        if (!dep.name) {
+          continue;
+        }
+
         let target = join(this.appDestDir, 'node_modules', dep.name);
         ensureDirSync(dirname(target));
         ensureSymlinkSync(dep.root, target, 'dir');

--- a/packages/compat/src/empty-package-tree.ts
+++ b/packages/compat/src/empty-package-tree.ts
@@ -2,7 +2,7 @@ import Plugin from 'broccoli-plugin';
 import { writeJSONSync } from 'fs-extra';
 import { join } from 'path';
 
-export default class extends Plugin {
+export default class EmptyPackageTree extends Plugin {
   private built = false;
 
   constructor() {


### PR DESCRIPTION
This fixes https://github.com/embroider-build/embroider/issues/568 and https://github.com/embroider-build/embroider/issues/302.

The change might be a bit simplistic, but it works. Not sure if that is acceptable, I tried it in our app and the build worked fine.
Only in-repo addons seem to be affected, it seems to be fine with regular disabled addons.