### PR TITLE
allow publicAssetURL to differ from rootURL

### DIFF
--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -74,7 +74,7 @@ function defaultVariants(emberApp: any): Variant[] {
   } else {
     variants.push({
       name: 'dev',
-      runtime: 'all',
+      runtime: hasFastboot(emberApp) ? 'all' : 'browser',
       optimizeForProduction: false,
     });
   }


### PR DESCRIPTION
This serves as a replacement for the classic `prepend` in broccoli-asset-rev.