### PR TITLE
Do not try to import package.json files that do not exist

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -42,7 +42,7 @@ function buildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): N
   let needsSmooshing = oldPackages[0].hasAnyTrees();
   if (needsSmooshing) {
     let trees = oldPackages.map(pkg => pkg.v2Tree).reverse();
-    let smoosher = new SmooshPackageJSON(trees);
+    let smoosher = new SmooshPackageJSON(trees, { annotation: originalPackage.name });
     return broccoliMergeTrees([...trees, smoosher], { overwrite: true });
   } else {
     return oldPackages[0].v2Tree;

--- a/packages/compat/src/smoosh-package-json.ts
+++ b/packages/compat/src/smoosh-package-json.ts
@@ -5,9 +5,9 @@ import { join } from 'path';
 import { mergeWithUniq } from './merges';
 
 export default class SmooshPackageJSON extends Plugin {
-  constructor(inputTrees: Node[]) {
+  constructor(inputTrees: Node[], opts: { annotation?: string } = {}) {
     super(inputTrees, {
-      annotation: 'embroider:core:smoosh-package-json',
+      annotation: `embroider:core:smoosh-package-json:${opts?.annotation}`,
     });
   }
 

--- a/packages/compat/src/smoosh-package-json.ts
+++ b/packages/compat/src/smoosh-package-json.ts
@@ -1,6 +1,6 @@
 import Plugin from 'broccoli-plugin';
 import { Node } from 'broccoli-node-api';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { mergeWithUniq } from './merges';
 
@@ -12,7 +12,12 @@ export default class SmooshPackageJSON extends Plugin {
   }
 
   build() {
-    let pkgs = this.inputPaths.map(p => JSON.parse(readFileSync(join(p, 'package.json'), 'utf8')));
+    let pkgs = this.inputPaths.map(p => {
+      let pkgPath = join(p, 'package.json');
+      if (existsSync(pkgPath)) {
+        return JSON.parse(readFileSync(pkgPath, 'utf8'));
+      }
+    });
     let pkg = mergeWithUniq({}, ...pkgs);
     writeFileSync(join(this.outputPath, 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
   }


### PR DESCRIPTION
Originally discovered when trying to transition an app with a dependency on @ember/test-waiters. The build would fail with 

```
ENOENT: no such file or directory, open '/var/folders/f8/xfnrq0_13ps4cr_dmy07306m0000gn/T/broccoli-67108qWW7v8FiITOw/out-16-broccoli_merge_trees/package.json'
        at SmooshPackageJSON (embroider:core:smoosh-package-json)
-~- created here: -~-
    at new Plugin (/Users/matt/p/boxel/node_modules/@embroider/compat/node_modules/broccoli-plugin/dist/index.js:45:33)
    at new SmooshPackageJSON (/Users/matt/p/boxel/node_modules/@embroider/compat/src/smoosh-package-json.js:12:9)
    at buildCompatAddon (/Users/matt/p/boxel/node_modules/@embroider/compat/src/build-compat-addon.js:43:24)
    at Object.cachedBuildCompatAddon [as default] (/Users/matt/p/boxel/node_modules/@embroider/compat/src/build-compat-addon.js:13:16)
    at /Users/matt/p/boxel/node_modules/@embroider/compat/src/compat-addons.js:45:105
    at Array.map (<anonymous>)
    at CompatAddons.get tree [as tree] (/Users/matt/p/boxel/node_modules/@embroider/compat/src/compat-addons.js:45:63)
    at CompatApp.augment (/Users/matt/p/boxel/node_modules/@embroider/core/src/build-stage.js:57:64)
    at CompatApp.get tree (/Users/matt/p/boxel/node_modules/@embroider/core/src/build-stage.js:26:50)
    at CompatApp.<anonymous> (/Users/matt/p/boxel/node_modules/typescript-memoize/dist/memoize-decorator.js:67:52)
    at new PackagerRunner (/Users/matt/p/boxel/node_modules/@embroider/core/src/to-broccoli-plugin.js:10:26)
    at Object.defaultPipeline (/Users/matt/p/boxel/node_modules/@embroider/compat/src/default-pipeline.js:43:12)
    at module.exports (/Users/matt/p/boxel/ember-cli-build.js:31:39)
    at Builder.readBuildFile (/Users/matt/p/boxel/node_modules/ember-cli/lib/models/builder.js:49:14)
    at Builder.setupBroccoliBuilder (/Users/matt/p/boxel/node_modules/ember-cli/lib/models/builder.js:63:22)
    at new Builder (/Users/matt/p/boxel/node_modules/ember-cli/lib/models/builder.js:29:10)
-~- (end) -~-


Stack Trace and Error Report: /var/folders/f8/xfnrq0_13ps4cr_dmy07306m0000gn/T/error.dump.72fd66c5af95b4ddee1fb9f04acbe7a6.log
```

@ef4 noticed that it's was doing something hacky to ensure a single version of the addons "won" [(discord link)](https://discord.com/channels/480462759797063690/568935504288940056/796825997735362610)

