### PR TITLE
Add `this` param to `ensureSafeComponent` import example

### DIFF
--- a/REPLACING-COMPONENT-HELPER.md
+++ b/REPLACING-COMPONENT-HELPER.md
@@ -198,7 +198,7 @@ import { ensureSafeComponent } from '@embroider/util';
 export default class extends Component {
   get whichComponent() {
     let module = importSync(`./feed-items/${this.args.model.type}`);
-    return ensureSafeComponent(module.default);
+    return ensureSafeComponent(module.default, this);
   }
 }
 ```


### PR DESCRIPTION
I was trying out this exact example myself and as written, it was throwing the following error: `Cannot read property 'Symbol(OWNER)' of undefined`. 

Adding `this` as a second param, similar to the examples above, makes it work.