### PR TITLE
bugfixes for production webpack-handled css

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -12,16 +12,7 @@
 import { getOrCreate, Variant, applyVariantToBabelConfig } from '@embroider/core';
 import { PackagerInstance, AppMeta, Packager } from '@embroider/core';
 import webpack, { Configuration } from 'webpack';
-import {
-  readFileSync,
-  writeFileSync,
-  copySync,
-  realpathSync,
-  ensureDirSync,
-  Stats,
-  statSync,
-  readJsonSync,
-} from 'fs-extra';
+import { readFileSync, outputFileSync, copySync, realpathSync, Stats, statSync, readJsonSync } from 'fs-extra';
 import { join, dirname, relative, sep } from 'path';
 import isEqual from 'lodash/isEqual';
 import mergeWith from 'lodash/mergeWith';
@@ -149,7 +140,12 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
       performance: {
         hints: false,
       },
-      plugins: [new MiniCssExtractPlugin()],
+      plugins: [
+        new MiniCssExtractPlugin({
+          filename: `chunk.[chunkhash].css`,
+          chunkFilename: `chunk.[chunkhash].css`,
+        }),
+      ],
       node: false,
       module: {
         rules: [
@@ -252,10 +248,10 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     }
     let { code: outCode, map: outMap } = await Terser.default.minify(inCode, terserOpts);
     let finalFilename = this.getFingerprintedFilename(script, outCode!);
-    writeFileSync(join(this.outputPath, finalFilename), outCode!);
+    outputFileSync(join(this.outputPath, finalFilename), outCode!);
     written.add(script);
     if (appRelativeSourceMapURL && outMap) {
-      writeFileSync(join(this.outputPath, appRelativeSourceMapURL), outMap);
+      outputFileSync(join(this.outputPath, appRelativeSourceMapURL), outMap);
       written.add(appRelativeSourceMapURL);
     }
     return finalFilename;
@@ -273,7 +269,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     const minifiedCss = csso.minify(cssContent).css;
 
     let finalFilename = this.getFingerprintedFilename(style, minifiedCss);
-    writeFileSync(join(this.outputPath, finalFilename), minifiedCss);
+    outputFileSync(join(this.outputPath, finalFilename), minifiedCss);
     written.add(style);
     return finalFilename;
   }
@@ -347,8 +343,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     }
 
     for (let entrypoint of entrypoints) {
-      ensureDirSync(dirname(join(this.outputPath, entrypoint.filename)));
-      writeFileSync(join(this.outputPath, entrypoint.filename), entrypoint.render(stats), 'utf8');
+      outputFileSync(join(this.outputPath, entrypoint.filename), entrypoint.render(stats), 'utf8');
       written.add(entrypoint.filename);
     }
 

--- a/packages/webpack/src/html-placeholder.ts
+++ b/packages/webpack/src/html-placeholder.ts
@@ -41,16 +41,13 @@ export default class Placeholder {
   }
 
   insertURL(url: string) {
-    switch (this.target.tagName) {
-      case 'SCRIPT':
-        return this.insertScriptTag(url);
-      case 'LINK':
-        if ((this.target as HTMLLinkElement).rel === 'stylesheet') {
-          return this.insertStyleLink(url);
-        }
-      default:
-        throw new Error(`don't know how to insertURL into this ${this.target}`);
+    if (url.endsWith('.js')) {
+      return this.insertScriptTag(url);
     }
+    if (url.endsWith('.css')) {
+      return this.insertStyleLink(url);
+    }
+    throw new Error(`don't know how to insertURL ${url}`);
   }
 
   insertScriptTag(src: string) {


### PR DESCRIPTION
 - MiniCssExtractPlugin emits css chunks from what were originally JS assets, so our placeholder rewriter needs to handle type switching
  - apps with NPM namespaces needed to created missing directories when writing production CSS.