### PR TITLE
accidental duplication of babel plugin list

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -335,7 +335,7 @@ export class AppBuilder<TreeNames> {
 
   @Memoize()
   private babelConfig(templateCompilerParams: TemplateCompilerParams, appFiles: Engine[]) {
-    let babel = this.adapter.babelConfig();
+    let babel = cloneDeep(this.adapter.babelConfig());
 
     if (!babel.plugins) {
       babel.plugins = [];


### PR DESCRIPTION
On rebuilds, the list of babel plugins was getting longer.

It's easy not to notice if your stage3 packager doesn't try reloading the babel config every time. 