### PR TITLE
clear main fields from v1 addons when rewriting them

### DIFF
--- a/packages/compat/src/rewrite-package-json.ts
+++ b/packages/compat/src/rewrite-package-json.ts
@@ -26,6 +26,13 @@ export default class RewritePackageJSON extends Plugin {
       this.getMeta()
     );
     pkg['ember-addon'] = meta;
+
+    // classic addons don't get to customize their entrypoints like this. We
+    // always rewrite them so their entrypoint is index.js, so whatever was here
+    // is just misleading to stage3 packagers that might look (rollup does).
+    delete pkg.main;
+    delete pkg.module;
+
     writeFileSync(join(this.outputPath, 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
   }
 }


### PR DESCRIPTION
v1 addons don't get to customize `main` in package.json. When rewriting them to v2, we always rewrite them to put their main at `index.js` anyway. The presence of these fields can confuse stage3 packagers.