### PR TITLE
Exclude 'babel-plugin-compact-reexports' during Stage 1 build

### DIFF
--- a/packages/compat/src/detect-compact-reexports.ts
+++ b/packages/compat/src/detect-compact-reexports.ts
@@ -1,0 +1,13 @@
+import { PluginItem } from '@babel/core';
+
+export function isCompactReexports(item: PluginItem): boolean {
+  let pluginPath: string;
+  if (typeof item === 'string') {
+    pluginPath = item;
+  } else if (Array.isArray(item) && item.length > 0 && typeof item[0] === 'string') {
+    pluginPath = item[0];
+  } else {
+    return false;
+  }
+  return /(^|\/)babel-plugin-compact-reexports\//.test(pluginPath);
+}

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -23,6 +23,7 @@ import modulesCompat from './modules-compat';
 import writeFile from 'broccoli-file-creator';
 import SynthesizeTemplateOnlyComponents from './synthesize-template-only-components';
 import { isEmberAutoImportDynamic } from './detect-ember-auto-import';
+import { isCompactReexports } from './detect-compact-reexports';
 import { ResolvedDep } from '@embroider/core/src/resolver';
 
 const stockTreeNames = Object.freeze([
@@ -1003,6 +1004,12 @@ function babelPluginAllowedInStage1(plugin: PluginItem) {
   if (isEmberAutoImportDynamic(plugin)) {
     // We replace ember-auto-import's implementation of dynamic import(), so we
     // need to stop its plugin from rewriting those.
+    return false;
+  }
+
+  if (isCompactReexports(plugin)) {
+    // We don't want to replace re-exports at this stage, since that will turn
+    // an `export` statement into a `define`, which is handled in Stage 3
     return false;
   }
 


### PR DESCRIPTION
Info
-----
* The plugin `babel-plugin-compact-reexports`, included by `ember-engines`, translates an ES Modules re-export statement (`export { foo } from './bar'`) into a single-line AMD declaration, which saves space compared to the multiple lines an explicit import & export would use.
* However, during the Stage 1 Embroider build, we want to leave the ES Modules exports as they are, so that they can be properly parsed during Stage 3.

Changes
-----
* Analogous to the existing code that removes other invalid plugins during Stage 1, added a section to detect and exclude `babel-plugin-compact-reexports` during a stage 1 build.

Tested
-----
* Performed a `STAGE1_ONLY` build and confirmed that the reexport statements are _not_ translated and are left as-is