### PR TITLE
Resolve the template compiler from ember-source instead of project root

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -34,7 +34,6 @@ import { MacrosConfig } from '@embroider/macros/src/node';
 import bind from 'bind-decorator';
 import { pathExistsSync } from 'fs-extra';
 import { tmpdir } from 'os';
-import { dirname } from 'path';
 import { Options as AdjustImportsOptions } from '@embroider/core/src/babel-plugin-adjust-imports';
 
 interface TreeNames {
@@ -318,10 +317,6 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     return this.configTree.readConfig().rootURL;
   }
 
-  private templateCompilerPath(): string {
-    return 'ember-source/vendor/ember/ember-template-compiler';
-  }
-
   strictV2Format() {
     return false;
   }
@@ -380,15 +375,9 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
 
   @Memoize()
   resolveTemplateCompilerPath() {
-    // we cannot assume this will be resolvable from the project root as it might be
-    // symlinked. Instead we should the package location and grab the template
-    // compiler from it.
-    let emberSourcePkg = this.allActiveAddons.find(p => p.name === 'ember-source');
-    if (emberSourcePkg) {
-      return resolveSync(this.templateCompilerPath(), { basedir: dirname(dirname(emberSourcePkg.root)) });
-    }
-
-    return resolveSync(this.templateCompilerPath(), { basedir: this.root });
+    let emberSource = this.oldPackage.app.project.findAddonByName('ember-source');
+    let templateCompilerPath = emberSource.absolutePaths.templateCompiler;
+    return templateCompilerPath;
   }
 
   // unlike `templateResolver`, this one brings its own simple TemplateCompiler

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -384,9 +384,8 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     // symlinked. Instead we should the package location and grab the template
     // compiler from it.
     let emberSourcePkg = this.allActiveAddons.find(p => p.name === 'ember-source');
-
     if (emberSourcePkg) {
-      return join(dirname(emberSourcePkg.root), this.templateCompilerPath());
+      return resolveSync(this.templateCompilerPath(), { basedir: dirname(dirname(emberSourcePkg.root)) });
     }
 
     return resolveSync(this.templateCompilerPath(), { basedir: this.root });

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -34,6 +34,7 @@ import { MacrosConfig } from '@embroider/macros/src/node';
 import bind from 'bind-decorator';
 import { pathExistsSync } from 'fs-extra';
 import { tmpdir } from 'os';
+import { dirname } from 'path';
 import { Options as AdjustImportsOptions } from '@embroider/core/src/babel-plugin-adjust-imports';
 
 interface TreeNames {
@@ -385,7 +386,7 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     let emberSourcePkg = this.allActiveAddons.find(p => p.name === 'ember-source');
 
     if (emberSourcePkg) {
-      return join(emberSourcePkg.root, this.templateCompilerPath());
+      return join(dirname(emberSourcePkg.root), this.templateCompilerPath());
     }
 
     return resolveSync(this.templateCompilerPath(), { basedir: this.root });

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -68,7 +68,7 @@ export default class V1App {
   private _implicitScripts: string[] = [];
   private _implicitStyles: string[] = [];
 
-  protected constructor(protected app: EmberApp, protected packageCache: PackageCache) {}
+  protected constructor(public app: EmberApp, protected packageCache: PackageCache) {}
 
   // always the name from package.json. Not the one that apps may have weirdly
   // customized.

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -94,7 +94,7 @@ export interface AppAdapter<TreeNames> {
   rootURL(): string;
 
   // The path to ember's template compiler source
-  templateCompilerPath(): string;
+  resolveTemplateCompilerPath(): string;
 
   // Path to a build-time Resolver module to be used during template
   // compilation.
@@ -891,7 +891,7 @@ export class AppBuilder<TreeNames> {
 
     return {
       plugins,
-      compilerPath: resolve.sync(this.adapter.templateCompilerPath(), { basedir: this.root }),
+      compilerPath: this.adapter.resolveTemplateCompilerPath(),
       resolver: this.adapter.templateResolver(),
       EmberENV: config,
     };


### PR DESCRIPTION
We cannot assume this will be resolvable from the project root as it might be symlinked. Instead we should get the addon instance and grab the template compiler location directly from it. This is technically a more stable location of the compiler instead of hard coding a location.

This becomes relevant in ember-cli's test suite as they symlink the entire node_modules directory into a per test tmp directory and looking for a hard coded location fails.