### PR TITLE
Refactor suite-setup-util to avoid knock on errors.

### DIFF
--- a/test-packages/support/suite-setup-util.ts
+++ b/test-packages/support/suite-setup-util.ts
@@ -152,33 +152,29 @@ export async function emitDynamicSuites() {
   }
 }
 
+async function main() {
+  try {
+    if (process.argv.includes('--list')) {
+      const result = await allSuites();
+
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    }
+
+    if (process.argv.includes('--matrix')) {
+      const result = await githubMatrix();
+
+      process.stdout.write(JSON.stringify(result));
+    }
+
+    if (process.argv.includes('--emit')) {
+      await emitDynamicSuites();
+    }
+  } catch (error) {
+    console.error(error);
+    process.exitCode = -1;
+  }
+}
+
 if (require.main === module) {
-  if (process.argv.includes('--list')) {
-    allSuites()
-      .then(result => {
-        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
-      })
-      .catch(err => {
-        process.stderr.write(err);
-        process.exit(-1);
-      });
-  }
-
-  if (process.argv.includes('--matrix')) {
-    githubMatrix()
-      .then(result => {
-        process.stdout.write(JSON.stringify(result));
-      })
-      .catch(err => {
-        process.stderr.write(err);
-        process.exit(-1);
-      });
-  }
-
-  if (process.argv.includes('--emit')) {
-    emitDynamicSuites().catch(err => {
-      console.log(err);
-      process.exit(-1);
-    });
-  }
+  main();
 }


### PR DESCRIPTION
This is a small refactor that does a few things:

* migrate the manual promise chaining to async/await
* unify the error handling (so that it is all done in the same way)
* migrate from `process.stderr.write` to `console.error` (`process.stderr.write` only accepts a string or buffer, if you pass it an instance of `Error` you get an error that actually masks the _real_ error)
* migrate to `process.exitCode` instead of `process.exit` (forcing exit with `process.exit()` _in general_ should be avoided, and doesn't seem required in this context)
