### PR TITLE
TemplateCompiler fixes / improvements (avoid monkey patch for Ember 3.27+)

### DIFF
--- a/packages/core/src/patch-template-compiler.ts
+++ b/packages/core/src/patch-template-compiler.ts
@@ -15,124 +15,178 @@ import {
 import { NodePath } from '@babel/traverse';
 import { transform } from '@babel/core';
 
-export function patch(source: string, templateCompilerPath: string) {
+function emberVersionGte(templateCompilerPath: string, source: string, major: number, minor: number): boolean {
+  // ember-template-compiler.js contains a comment that indicates what version it is for
+  // that looks like:
+
+  /*!
+   * @overview  Ember - JavaScript Application Framework
+   * @copyright Copyright 2011-2020 Tilde Inc. and contributors
+   *            Portions Copyright 2006-2011 Strobe Inc.
+   *            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
+   * @license   Licensed under MIT license
+   *            See https://raw.github.com/emberjs/ember.js/master/LICENSE
+   * @version   3.25.1
+   */
+
+  let version = source.match(/@version\s+([\d\.]+)/);
+  if (!version || !version[1]) {
+    throw new Error(
+      `Could not find version string in \`${templateCompilerPath}\`. Maybe we don't support your ember-source version?`
+    );
+  }
+
+  let numbers = version[1].split('.');
+  let actualMajor = parseInt(numbers[0], 10);
+  let actualMinor = parseInt(numbers[1], 10);
+
+  return actualMajor > major || (actualMajor === major && actualMinor >= minor);
+}
+
+export function patch(source: string, templateCompilerPath: string): string {
   let replacedVar = false;
+  let patchedSource;
 
-  // patch applies to ember 3.12 through 3.16. The template compiler contains a
-  // comment with the version.
-  let needsPatch = /@version\s+3\.1[23456][^\d]/.test(source);
+  let needsAngleBracketPrinterFix =
+    emberVersionGte(templateCompilerPath, source, 3, 12) && !emberVersionGte(templateCompilerPath, source, 3, 17);
 
-  // here we are stripping off the first `var Ember;`. That one small change
-  // lets us crack open the file and get access to its internal loader, because
-  // we can give it our own predefined `Ember` variable instead, which it will
-  // use and put `Ember.__loader` onto.
-  //
-  // on ember 3.12 through 3.16 (which use variants of glimmer-vm 0.38.5) we
-  // also apply a patch to the printer in @glimmer/syntax to fix
-  // https://github.com/glimmerjs/glimmer-vm/pull/941/files because it can
-  // really bork apps under embroider, and we'd like to support at least all
-  // active LTS versions of ember.
-  let patchedSource = transform(source, {
-    plugins: [
-      function () {
-        return {
-          visitor: {
-            VariableDeclarator(path: NodePath<VariableDeclarator>) {
-              let id = path.node.id;
-              if (id.type === 'Identifier' && id.name === 'Ember' && !replacedVar) {
-                replacedVar = true;
-                path.remove();
-              }
-            },
-            CallExpression: {
-              enter(path: NodePath<CallExpression>, state: BabelState) {
-                if (!needsPatch) {
-                  return;
-                }
-                let callee = path.get('callee');
-                if (!callee.isIdentifier() || callee.node.name !== 'define') {
-                  return;
-                }
-                let firstArg = path.get('arguments')[0];
-                if (!firstArg.isStringLiteral() || firstArg.node.value !== '@glimmer/syntax') {
-                  return;
-                }
-                state.definingGlimmerSyntax = path;
-              },
-              exit(path: NodePath<CallExpression>, state: BabelState) {
-                if (state.definingGlimmerSyntax === path) {
-                  state.definingGlimmerSyntax = false;
+  if (needsAngleBracketPrinterFix) {
+    // here we are stripping off the first `var Ember;`. That one small change
+    // lets us crack open the file and get access to its internal loader, because
+    // we can give it our own predefined `Ember` variable instead, which it will
+    // use and put `Ember.__loader` onto.
+    //
+    // on ember 3.12 through 3.16 (which use variants of glimmer-vm 0.38.5) we
+    // also apply a patch to the printer in @glimmer/syntax to fix
+    // https://github.com/glimmerjs/glimmer-vm/pull/941/files because it can
+    // really bork apps under embroider, and we'd like to support at least all
+    // active LTS versions of ember.
+    patchedSource = transform(source, {
+      plugins: [
+        function () {
+          return {
+            visitor: {
+              VariableDeclarator(path: NodePath<VariableDeclarator>) {
+                let id = path.node.id;
+                if (id.type === 'Identifier' && id.name === 'Ember' && !replacedVar) {
+                  replacedVar = true;
+                  path.remove();
                 }
               },
-            },
-            FunctionDeclaration: {
-              enter(path: NodePath<FunctionDeclaration>, state: BabelState) {
-                if (!state.definingGlimmerSyntax) {
-                  return;
-                }
-                let id = path.get('id');
-                if (id.isIdentifier() && id.node.name === 'build') {
-                  state.declaringBuildFunction = path;
-                }
+              CallExpression: {
+                enter(path: NodePath<CallExpression>, state: BabelState) {
+                  let callee = path.get('callee');
+                  if (!callee.isIdentifier() || callee.node.name !== 'define') {
+                    return;
+                  }
+                  let firstArg = path.get('arguments')[0];
+                  if (!firstArg.isStringLiteral() || firstArg.node.value !== '@glimmer/syntax') {
+                    return;
+                  }
+                  state.definingGlimmerSyntax = path;
+                },
+                exit(path: NodePath<CallExpression>, state: BabelState) {
+                  if (state.definingGlimmerSyntax === path) {
+                    state.definingGlimmerSyntax = false;
+                  }
+                },
               },
-              exit(path: NodePath<FunctionDeclaration>, state: BabelState) {
-                if (state.declaringBuildFunction === path) {
-                  state.declaringBuildFunction = false;
-                }
+              FunctionDeclaration: {
+                enter(path: NodePath<FunctionDeclaration>, state: BabelState) {
+                  if (!state.definingGlimmerSyntax) {
+                    return;
+                  }
+                  let id = path.get('id');
+                  if (id.isIdentifier() && id.node.name === 'build') {
+                    state.declaringBuildFunction = path;
+                  }
+                },
+                exit(path: NodePath<FunctionDeclaration>, state: BabelState) {
+                  if (state.declaringBuildFunction === path) {
+                    state.declaringBuildFunction = false;
+                  }
+                },
               },
-            },
-            SwitchCase: {
-              enter(path: NodePath<SwitchCase>, state: BabelState) {
-                if (!state.definingGlimmerSyntax) {
+              SwitchCase: {
+                enter(path: NodePath<SwitchCase>, state: BabelState) {
+                  if (!state.definingGlimmerSyntax) {
+                    return;
+                  }
+                  let test = path.get('test');
+                  if (test.isStringLiteral() && test.node.value === 'ElementNode') {
+                    state.caseElementNode = path;
+                  }
+                },
+                exit(path: NodePath<SwitchCase>, state: BabelState) {
+                  if (state.caseElementNode === path) {
+                    state.caseElementNode = false;
+                  }
+                },
+              },
+              IfStatement(path: NodePath<IfStatement>, state: BabelState) {
+                if (!state.caseElementNode) {
                   return;
                 }
                 let test = path.get('test');
-                if (test.isStringLiteral() && test.node.value === 'ElementNode') {
-                  state.caseElementNode = path;
-                }
-              },
-              exit(path: NodePath<SwitchCase>, state: BabelState) {
-                if (state.caseElementNode === path) {
-                  state.caseElementNode = false;
+                // the place we want is the only if with a computed member
+                // expression predicate.
+                if (test.isMemberExpression() && test.node.computed) {
+                  path.node.alternate = ifStatement(
+                    memberExpression(identifier('ast'), identifier('selfClosing')),
+                    blockStatement([
+                      expressionStatement(
+                        callExpression(memberExpression(identifier('output'), identifier('push')), [
+                          stringLiteral(' />'),
+                        ])
+                      ),
+                    ]),
+                    path.node.alternate
+                  );
                 }
               },
             },
-            IfStatement(path: NodePath<IfStatement>, state: BabelState) {
-              if (!state.caseElementNode) {
-                return;
-              }
-              let test = path.get('test');
-              // the place we want is the only if with a computed member
-              // expression predicate.
-              if (test.isMemberExpression() && test.node.computed) {
-                path.node.alternate = ifStatement(
-                  memberExpression(identifier('ast'), identifier('selfClosing')),
-                  blockStatement([
-                    expressionStatement(
-                      callExpression(memberExpression(identifier('output'), identifier('push')), [stringLiteral(' />')])
-                    ),
-                  ]),
-                  path.node.alternate
-                );
-              }
+          };
+        },
+      ],
+    })!.code!;
+  } else {
+    // applies to < 3.12 and >= 3.17
+    //
+    // here we are stripping off the first `var Ember;`. That one small change
+    // lets us crack open the file and get access to its internal loader, because
+    // we can give it our own predefined `Ember` variable instead, which it will
+    // use and put `Ember.__loader` onto.
+    patchedSource = transform(source, {
+      plugins: [
+        function () {
+          return {
+            visitor: {
+              VariableDeclarator(path: NodePath<VariableDeclarator>) {
+                let id = path.node.id;
+                if (id.type === 'Identifier' && id.name === 'Ember' && !replacedVar) {
+                  replacedVar = true;
+                  path.remove();
+                }
+              },
             },
-          },
-        };
-      },
-    ],
-  })!.code!;
+          };
+        },
+      ],
+    })!.code!;
+  }
 
   if (!replacedVar) {
     throw new Error(
       `didn't find expected source in ${templateCompilerPath}. Maybe we don't support your ember-source version?`
     );
   }
+
   return `
-  let module = { exports: {} };
-  let Ember = {};
-  ${patchedSource};
-  module.exports.Ember = Ember;
-  return module.exports
+      let module = { exports: {} };
+      let Ember = {};
+      ${patchedSource};
+      module.exports.Ember = Ember;
+      return module.exports
   `;
 }
 

--- a/packages/core/src/patch-template-compiler.ts
+++ b/packages/core/src/patch-template-compiler.ts
@@ -182,11 +182,9 @@ export function patch(source: string, templateCompilerPath: string): string {
   }
 
   return `
-      let module = { exports: {} };
       let Ember = {};
       ${patchedSource};
       module.exports.Ember = Ember;
-      return module.exports
   `;
 }
 

--- a/packages/core/src/patch-template-compiler.ts
+++ b/packages/core/src/patch-template-compiler.ts
@@ -44,6 +44,11 @@ function emberVersionGte(templateCompilerPath: string, source: string, major: nu
 }
 
 export function patch(source: string, templateCompilerPath: string): string {
+  if (emberVersionGte(templateCompilerPath, source, 3, 27)) {
+    // no modifications are needed after https://github.com/emberjs/ember.js/pull/19426
+    return source;
+  }
+
   let replacedVar = false;
   let patchedSource;
 

--- a/packages/core/src/template-compiler.ts
+++ b/packages/core/src/template-compiler.ts
@@ -36,7 +36,6 @@ interface GlimmerSyntax {
   preprocess(html: string, options?: PreprocessOptions): AST;
   print(ast: AST): string;
   defaultOptions(options: PreprocessOptions): PreprocessOptions;
-  registerPlugin(type: string, plugin: unknown): void;
   precompile(
     templateContents: string,
     options: {
@@ -137,7 +136,6 @@ function loadGlimmerSyntax(templateCompilerPath: string): GlimmerSyntax {
       print: theExports._print,
       preprocess: theExports._preprocess,
       defaultOptions: theExports.compileOptions,
-      registerPlugin: theExports.registerPlugin,
       precompile: theExports.precompile,
       _Ember: theExports._Ember,
       cacheKey,
@@ -158,7 +156,6 @@ function loadGlimmerSyntax(templateCompilerPath: string): GlimmerSyntax {
       print: syntax.print,
       preprocess: syntax.preprocess,
       defaultOptions: compilerOptions.default,
-      registerPlugin: compilerOptions.registerPlugin,
       precompile: theExports.precompile,
       _Ember: theExports._Ember,
       cacheKey,


### PR DESCRIPTION
At a high level this PR does a few things:

- Avoid monkey patch template compiler on Ember >= 3.27
- Refactor template compiler patches to simplify and make it clearer to know when we can remove each patch
- Use Node's builtin `vm.createContext` to prevent global mutation during template compiler evaluation
- Remove references to the deprecated `registerPlugin` template compiler API (we were not using it)
- Update `TemplateCompiler#applyTransforms` to be safer for source -> source transformations (e.g. preserving entity encoding)


