### PR TITLE
Add 3.20 and 3.24 to list of matrix tests.

### DIFF
--- a/packages/router/config/ember-try.js
+++ b/packages/router/config/ember-try.js
@@ -16,6 +16,22 @@ module.exports = function () {
           },
         },
         {
+          name: 'ember-lts-3.20',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.20.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.24',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.24.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {

--- a/packages/util/config/ember-try.js
+++ b/packages/util/config/ember-try.js
@@ -32,6 +32,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/test-packages/macro-sample-addon/config/ember-try.js
+++ b/test-packages/macro-sample-addon/config/ember-try.js
@@ -16,6 +16,22 @@ module.exports = function () {
           },
         },
         {
+          name: 'ember-lts-3.20',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.20.5',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.24',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.24.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {


### PR DESCRIPTION
Not all of our internal (or test) packages run `ember-try` scenarios, but this updates the ones that do to include ember-source@3.20 and ember-source@3.24.
