### PR TITLE
Avoid running CI jobs on both push and pull_request events.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'v*' # prior release branches (e.g. `v0.30.x` branch)
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ master ]
 
 jobs:
   discover_matrix:


### PR DESCRIPTION
When pushing changes to a branch, CI would run **double** the jobs (one set of CI jobs for the branch push event, and another set of jobs for the `pull_request` event).

This change tweaks the CI hooks to only run for pull requests **targeting** `master` and branches named `master` (also allow `v*` style release branches, just in case we wanted them in the future).

Compare #703's (90 CI jobs) CI runs vs #694's (41 CI jobs).