### PR TITLE
Remove `ember-cli-htmlbars` dependency in `@embroider/compat`.

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -47,8 +47,6 @@
     "broccoli-source": "^3.0.0",
     "chalk": "^4.1.0",
     "debug": "^3.1.0",
-    "ember-cli-htmlbars": "^4.0.9",
-    "ember-cli-htmlbars-3": "npm:ember-cli-htmlbars@3",
     "fs-extra": "^7.0.0",
     "fs-tree-diff": "^2.0.0",
     "jsdom": "^16.4.0",
@@ -80,6 +78,7 @@
     "@types/semver": "^7.3.4",
     "@types/strip-bom": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
+    "ember-cli-htmlbars-3": "npm:ember-cli-htmlbars@3",
     "typescript": "~4.0.0"
   },
   "peerDependencies": {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -15,7 +15,7 @@ import { AddonMeta, TemplateCompiler, debug, PackageCache, Resolver, extensionsP
 import Options from './options';
 import walkSync from 'walk-sync';
 import ObserveTree from './observe-tree';
-import { Options as HTMLBarsOptions } from 'ember-cli-htmlbars';
+import type { Options as HTMLBarsOptions } from 'ember-cli-htmlbars';
 import { isEmbroiderMacrosPlugin } from '@embroider/macros/src/node';
 import { TransformOptions, PluginItem } from '@babel/core';
 import V1App from './v1-app';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7247,7 +7247,6 @@ ember-cli-get-component-path-option@^1.0.0:
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
 "ember-cli-htmlbars-3@npm:ember-cli-htmlbars@3", ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1, ember-cli-htmlbars@^3.1.0:
-  name ember-cli-htmlbars-3
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-3.1.0.tgz#87806c2a0bca2ab52d4fb8af8e2215c1ca718a99"
   integrity sha512-cgvRJM73IT0aePUG7oQ/afB7vSRBV3N0wu9BrWhHX2zkR7A7cUBI7KC9VPk6tbctCXoM7BRGsCC4aIjF7yrfXA==
@@ -7268,7 +7267,7 @@ ember-cli-htmlbars-inline-precompile@^2.1.0:
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^4.0.0, ember-cli-htmlbars@^4.0.8, ember-cli-htmlbars@^4.0.9, ember-cli-htmlbars@^4.2.0, ember-cli-htmlbars@^4.2.2, ember-cli-htmlbars@^4.2.3, ember-cli-htmlbars@^4.3.1:
+ember-cli-htmlbars@^4.0.0, ember-cli-htmlbars@^4.0.8, ember-cli-htmlbars@^4.2.0, ember-cli-htmlbars@^4.2.2, ember-cli-htmlbars@^4.2.3, ember-cli-htmlbars@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.3.1.tgz#4af8adc21ab3c4953f768956b7f7d207782cb175"
   integrity sha512-CW6AY/yzjeVqoRtItOKj3hcYzc5dWPRETmeCzr2Iqjt5vxiVtpl0z5VTqHqIlT5fsFx6sGWBQXNHIe+ivYsxXQ==


### PR DESCRIPTION
When introduced in 48fc86baff4cca03935435856468b318f4146724 this dependency was used (by `packages/compat/src/apply-ast-transforms.ts`) to import and re-use the broccoli plugin, but that code was removed in 07d3c461.

The only import we had for it was specifically for types, which we define internally (in `types/ember-cli-htmlbars/index.d.ts`).

These dependencies do not seem to be needed anymore.
