### PR TITLE
Fixup types for newer @babel/types.

### DIFF
--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -397,7 +397,7 @@ export default function main() {
       ) {
         let { opts, emberCLIVanillaJobs } = state;
         const { source } = path.node;
-        if (source === null) {
+        if (source === null || source === undefined) {
           return;
         }
 

--- a/packages/macros/tests/babel/eval.test.ts
+++ b/packages/macros/tests/babel/eval.test.ts
@@ -110,7 +110,7 @@ describe('evaluation', function () {
   });
 });
 
-function nodePathNotNull(path: NodePath<Expression | null>): path is NodePath<Expression> {
+function isNodePathPresent(path: NodePath<Expression | null | undefined>): path is NodePath<Expression> {
   return path.node != null;
 }
 
@@ -120,7 +120,7 @@ function testEval() {
       exit(path: NodePath<VariableDeclarator>) {
         let id = path.get('id').node;
         let value = path.get('init');
-        if (isIdentifier(id) && id.name === 'result' && nodePathNotNull(value)) {
+        if (isIdentifier(id) && id.name === 'result' && isNodePathPresent(value)) {
           let evaluator = new Evaluator({
             locals: {
               knownValue: 2,


### PR DESCRIPTION
Since `ExportNamedDeclaration`'s have an optional `source` field (see [here](https://github.com/babel/babel/blob/e498bee10f0123bb208baa228ce6417542a2c3c4/packages/babel-types/src/definitions/es2015.js#L351)), we have to check for both `null` and `undefined`. An update to `@babel/types` shows this as failing (it likely would have failed prior to @babel/types@7.8.0 also but in 7.8.0 they made most of the types `any` on accident see https://github.com/babel/babel/issues/11474).
