### PR TITLE
Fix the path to the on-disk styles file for in-repo engines

### DIFF
--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -719,7 +719,7 @@ describe('stage2 build', function () {
     test('lazy engine css is imported', function () {
       expectFile('assets/_engine_/lazy-engine.js')
         .matches(`  if (macroCondition(!getGlobalConfig().fastboot?.isRunning)) {
-i(\"../../../lazy-engine/lazy-engine.css\");
+i(\"../../node_modules/lazy-engine/lazy-engine.css\");
   }`);
     });
 
@@ -760,7 +760,7 @@ i(\"../../../lazy-engine/lazy-engine.css\");
     test('lazy engine css is not imported', function () {
       expectFile('assets/_engine_/lazy-engine.js')
         .doesNotMatch(`  if (macroCondition(!getGlobalConfig().fastboot?.isRunning)) {
-i(\"../../../lazy-engine/lazy-engine.css\");
+i(\"../../node_modules/lazy-engine/lazy-engine.css\");
   }`);
     });
   });

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -1081,7 +1081,7 @@ export class AppBuilder<TreeNames> {
       if (engineMeta && engineMeta['implicit-styles']) {
         for (let style of engineMeta['implicit-styles']) {
           styles.push({
-            path: explicitRelative(relativePath, join(engine.package.name, style)),
+            path: explicitRelative(dirname(relativePath), join(engine.appRelativePath, style)),
           });
         }
       }

--- a/test-packages/engines-host-app/app/router.js
+++ b/test-packages/engines-host-app/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('use-eager-engine');
   this.mount('lazy-engine', { path: '/use-lazy-engine', as: 'use-lazy-engine' });
   this.route('style-check');
+  this.mount('lazy-in-repo-engine', { path: '/use-lazy-in-repo-engine', as: 'use-lazy-in-repo-engine' });
 });
 
 export default Router;

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/engine.js
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from './resolver';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/helpers/duplicated-helper.js
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/helpers/duplicated-helper.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function duplicatedHelper() {
+  return 'from-lazy-in-repo-engine';
+}
+
+export default helper(duplicatedHelper);

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/resolver.js
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/routes.js
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/routes.js
@@ -1,0 +1,3 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function () {});

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/styles/addon.css
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/styles/addon.css
@@ -1,0 +1,6 @@
+.shared-style-target {
+  border-bottom-width: 2px;
+  border-bottom-style: solid;
+  border-bottom-color: blue;
+  content: 'lazy-in-repo-engine/addon/styles/addon.css';
+}

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/templates/application.hbs
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/addon/templates/application.hbs
@@ -1,0 +1,6 @@
+<div data-test-lazy-in-repo-engine-main>
+  <h1>Lazy In-Repo Engine</h1>
+  <div data-test-duplicated-helper>
+    {{duplicated-helper needAnArgumentHere="to force ember to consider this a helper"}}
+  </div>
+</div>

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/config/environment.js
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/config/environment.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'lazy-in-repo-engine',
+    environment
+  };
+
+  return ENV;
+};

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/index.js
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/index.js
@@ -1,0 +1,12 @@
+/* eslint-env node */
+'use strict';
+
+const EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'lazy-in-repo-engine',
+
+  lazyLoading: Object.freeze({
+    enabled: true,
+  }),
+});

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/package.json
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/package.json
@@ -6,7 +6,8 @@
   ],
   "dependencies": {
     "ember-cli-htmlbars": "*",
-    "ember-cli-babel": "*"
+    "ember-cli-babel": "*",
+    "ember-engines": "*"
   },
   "volta": {
     "extends": "../../package.json"

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/package.json
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/package.json
@@ -6,7 +6,9 @@
   ],
   "dependencies": {
     "ember-cli-htmlbars": "*",
-    "ember-cli-babel": "*",
+    "ember-cli-babel": "*"
+  },
+  "devDependencies": {
     "ember-engines": "*"
   },
   "volta": {

--- a/test-packages/engines-host-app/lib/lazy-in-repo-engine/package.json
+++ b/test-packages/engines-host-app/lib/lazy-in-repo-engine/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "lazy-in-repo-engine",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/test-packages/engines-host-app/package.json
+++ b/test-packages/engines-host-app/package.json
@@ -63,5 +63,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/lazy-in-repo-engine"
+    ]
   }
 }


### PR DESCRIPTION
Info
-----
* When using in-repo engines, the path generated to the engine's styles is malformed, resulting in an error like:
```
Can't resolve '../../../account-engine/account-engine/__COMPILED_STYLES__/account-engine.css' in '$TMPDIR/embroider/8840c8/assets/_engine_'
```
* There appear to be two issues: First, by passing the _filename_ into `explicitRelative`, the path has one too many `../` elements at the beginning (since it treats the file as a directory as well).
* Second, assuming that the engine will be in a top-level directory with the name equal to it's package name is wrong, as in-repo engines are contained in `lib/{package-name}`.

Changes
-----
* Updated the `implicit-styles` code to call `dirname` on the underlying `relativePath` (stripping off the filename from the path)
* Updated the `implicit-styles` code to use `engine.appRelativePath`, instead of hard-coding it to be the package name for the engine, making sure it includes the `lib/` if necessary.

Tested
-----
* Ran a build with an in-repo engine to confirm that the styles can be located by Webpack.
* Updated the test scenarios to include an in-repo addon and confirm that it builds and works as expected.