### PR TITLE
Fix case where autoRun = false

### DIFF
--- a/packages/compat/src/v1-appboot.ts
+++ b/packages/compat/src/v1-appboot.ts
@@ -32,9 +32,8 @@ export class ReadV1AppBoot extends Plugin {
   }
 
   readAppBoot() {
-    if (!this.appBoot) {
-      throw new Error(`AppBoot not available until after the build`);
+    if (this.appBoot) {
+      return this.appBoot;
     }
-    return this.appBoot;
   }
 }

--- a/packages/compat/src/v1-appboot.ts
+++ b/packages/compat/src/v1-appboot.ts
@@ -22,6 +22,7 @@ export class WriteV1AppBoot extends Plugin {
 
 export class ReadV1AppBoot extends Plugin {
   private appBoot: string | undefined;
+  private hasBuilt = false;
   constructor(appBootTree: Node) {
     super([appBootTree], {
       persistentOutput: true,
@@ -29,11 +30,13 @@ export class ReadV1AppBoot extends Plugin {
   }
   build() {
     this.appBoot = readFileSync(join(this.inputPaths[0], `config/app-boot.js`), 'utf8');
+    this.hasBuilt = true;
   }
 
   readAppBoot() {
-    if (this.appBoot) {
-      return this.appBoot;
+    if (!this.hasBuilt) {
+      throw new Error(`AppBoot not available until after the build`);
     }
+    return this.appBoot;
   }
 }


### PR DESCRIPTION
When `this.appBoot` is an empty string this would result in a falsy condition when instead it should be considered truthy. This code path is uncovered when autoRun is set to false due to: https://github.com/embroider-build/embroider/blob/9d13424943e9023537ac6ddc330c6f0d0fb26f1c/packages/core/src/app.ts#L1017