### PR TITLE
support EMBROIDER_REBUILD_ADDONS for pure v2 addons

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -5,7 +5,7 @@ import broccoliMergeTrees from 'broccoli-merge-trees';
 import { Node } from 'broccoli-node-api';
 import OneShot from './one-shot';
 import Funnel from 'broccoli-funnel';
-import { UnwatchedDir } from 'broccoli-source';
+import { UnwatchedDir, WatchedDir } from 'broccoli-source';
 import EmptyPackageTree from './empty-package-tree';
 
 export default function cachedBuildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): Node {
@@ -22,7 +22,7 @@ function buildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): N
     // non-native-v2 addon. (The non-native one will get rewritten and
     // therefore moved, so to continue depending on it the native one needs to
     // move too.)
-    return withoutNodeModules(originalPackage.root);
+    return withoutNodeModules(originalPackage);
   }
 
   let oldPackages = v1Cache.getAddons(originalPackage.root);
@@ -49,8 +49,9 @@ function buildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): N
   }
 }
 
-function withoutNodeModules(root: string): Node {
-  return new Funnel(new UnwatchedDir(root), {
+function withoutNodeModules(originalPackage: Package): Node {
+  let Klass = originalPackage.mayRebuild ? WatchedDir : UnwatchedDir;
+  return new Funnel(new Klass(originalPackage.root), {
     exclude: ['node_modules'],
   });
 }

--- a/packages/compat/src/moved-package-cache.ts
+++ b/packages/compat/src/moved-package-cache.ts
@@ -33,6 +33,7 @@ export class MovedPackageCache extends PackageCache {
   readonly appDestDir: string;
   private commonSegmentCount: number;
   readonly moved: Map<Package, Package> = new Map();
+  readonly unmovedAddons: Set<Package>;
 
   constructor(
     rootCache: PackageCache['rootCache'],
@@ -82,6 +83,7 @@ export class MovedPackageCache extends PackageCache {
     }
     this.rootCache = rootCache;
     this.resolutionCache = resolutionCache;
+    this.unmovedAddons = movedSet.unmovedAddons;
   }
 
   private movedPackage(originalPkg: Package): Package {
@@ -215,6 +217,7 @@ function pathSegments(filename: string) {
 
 class MovedSet {
   private mustMove: Map<Package, boolean> = new Map();
+  unmovedAddons: Set<Package> = new Set();
 
   constructor(private app: Package) {
     this.check(app);
@@ -256,6 +259,11 @@ class MovedSet {
       mustMove = this.check(dep) || mustMove;
     }
     this.mustMove.set(pkg, mustMove);
+
+    if (!mustMove) {
+      this.unmovedAddons.add(pkg);
+    }
+
     return mustMove;
   }
 


### PR DESCRIPTION
This extends the EMBROIDER_REBUILD_ADDONS env var to cover native v2 addons.

They go down different code paths depending on whether they have any non-v2 addon dependencies, and this covers both cases.