### PR TITLE
Improve error message when module cannot be found in webpack

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -460,6 +460,8 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
       error.line = (error.loc ? error.loc.line : null) || (error.location ? error.location.line : null);
     }
     if (typeof error.message === 'string') {
+      error.message = error.message.replace(error.module.context, error.module.userRequest);
+
       // the tmpdir on OSX is horribly long and makes error messages hard to
       // read. This is doing the same as String.prototype.replaceAll, which node
       // doesn't have yet.


### PR DESCRIPTION
This fixes the "full path" of the source file of the error which allows it to be easier to copy and paste so you can inspect the file that is importing the module which does not exist.

Before:
<img width="1523" alt="Screen Shot 2021-03-05 at 10 29 37 AM" src="https://user-images.githubusercontent.com/166909/110836582-0ef99200-8255-11eb-95db-ce8e4ba3f0bb.png">

After:
![Screen Shot 2021-03-11 at 10 32 01 AM](https://user-images.githubusercontent.com/166909/110836592-128d1900-8255-11eb-98c8-8fbf04a93306.png)

Notice how `schema-helpers.js` is missing in the first example so you would have to grep the whole directory to find out which file contained the bad import.