### PR TITLE
easier stage2-only config

### DIFF
--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -12,7 +12,7 @@ interface PipelineOptions<PackagerOptions> extends Options {
 
 export default function defaultPipeline<PackagerOptions>(
   emberApp: object,
-  packager: Packager<PackagerOptions>,
+  packager?: Packager<PackagerOptions>,
   options?: PipelineOptions<PackagerOptions>
 ): Node {
   let outputPath: string;
@@ -43,7 +43,7 @@ export default function defaultPipeline<PackagerOptions>(
 
   let embroiderApp = new App(emberApp, addons, options);
 
-  if (process.env.STAGE2_ONLY) {
+  if (process.env.STAGE2_ONLY || !packager) {
     return mergeTrees([embroiderApp.tree, writeFile('.stage2-output', () => outputPath)]);
   }
 


### PR DESCRIPTION
This allows you to not pass a stage3 packager to compatBuild, which is an easier way of saying you want embroider to stop at stage 2.