### PR TITLE
Respect fingerprinting options during stage 3

### DIFF
--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -11,7 +11,7 @@ interface PipelineOptions<PackagerOptions> extends Options {
 }
 
 export default function defaultPipeline<PackagerOptions>(
-  emberApp: object,
+  emberApp: any,
   packager?: Packager<PackagerOptions>,
   options?: PipelineOptions<PackagerOptions>
 ): Node {
@@ -49,7 +49,7 @@ export default function defaultPipeline<PackagerOptions>(
 
   let BroccoliPackager = toBroccoliPlugin(packager);
   let variants = (options && options.variants) || defaultVariants(emberApp);
-  return new BroccoliPackager(embroiderApp, variants, options && options.packagerOptions);
+  return new BroccoliPackager(embroiderApp, variants, emberApp.options.fingerprint, options && options.packagerOptions);
 }
 
 function hasFastboot(emberApp: any) {

--- a/packages/core/src/packager.ts
+++ b/packages/core/src/packager.ts
@@ -2,8 +2,8 @@
 // are intended to be generic across Packagers, and it's up to Packager authors
 
 export interface FingerprintOptions {
-  enabled?: boolean;
-  exclude?: any[];
+  enabled: boolean;
+  exclude: any[];
 }
 
 // to support each option (or not).

--- a/packages/core/src/packager.ts
+++ b/packages/core/src/packager.ts
@@ -2,8 +2,8 @@
 // are intended to be generic across Packagers, and it's up to Packager authors
 
 export interface FingerprintOptions {
-  enabled: boolean;
-  exclude: any[];
+  enabled?: boolean;
+  exclude?: string[];
 }
 
 // to support each option (or not).

--- a/packages/core/src/packager.ts
+++ b/packages/core/src/packager.ts
@@ -1,5 +1,11 @@
 // This is a collection of flags that convey what kind of build you want. They
 // are intended to be generic across Packagers, and it's up to Packager authors
+
+export interface FingerprintOptions {
+  enabled?: boolean;
+  exclude?: any[];
+}
+
 // to support each option (or not).
 export interface Variant {
   // descriptive name that can be used by the packager to label which output
@@ -50,6 +56,10 @@ export interface Packager<Options> {
     // if possible, the packager should direct its console output through this
     // hook.
     consoleWrite: (message: string) => void,
+    // options instructing the 3rd stage if it should fingerprint
+    // assets or not. primarly used for testem to make sure that it
+    // is not being fingerprinted as it is expected to be testem.js
+    fingerprint: FingerprintOptions,
     // A packager can have whatever custom options type it wants here. If the
     // packager is based on a third-party tool, this is where that tool's
     // configuration can go.

--- a/packages/core/src/to-broccoli-plugin.ts
+++ b/packages/core/src/to-broccoli-plugin.ts
@@ -1,15 +1,20 @@
 import Plugin from 'broccoli-plugin';
-import { Packager, PackagerInstance, Variant } from './packager';
+import { Packager, PackagerInstance, Variant, FingerprintOptions } from './packager';
 import Stage from './stage';
 
 interface BroccoliPackager<Options> {
-  new (stage: Stage, variants: Variant[], options?: Options): Plugin;
+  new (stage: Stage, variants: Variant[], fingerprint: FingerprintOptions, options?: Options): Plugin;
 }
 
 export default function toBroccoliPlugin<Options>(packagerClass: Packager<Options>): BroccoliPackager<Options> {
   class PackagerRunner extends Plugin {
     private packager: PackagerInstance | undefined;
-    constructor(private stage: Stage, private variants: Variant[], private options?: Options) {
+    constructor(
+      private stage: Stage,
+      private variants: Variant[],
+      private fingerprintOptions: FingerprintOptions,
+      private options?: Options
+    ) {
       super([stage.tree], {
         persistentOutput: true,
         needsCache: false,
@@ -30,6 +35,7 @@ export default function toBroccoliPlugin<Options>(packagerClass: Packager<Option
           this.outputPath,
           this.variants,
           msg => console.log(msg),
+          this.fingerprintOptions,
           this.options
         );
       }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -36,6 +36,7 @@
     "jsdom": "^16.4.0",
     "lodash": "^4.17.10",
     "mini-css-extract-plugin": "^0.4.3",
+    "minimatch": "^3.0.4",
     "pkg-up": "^3.1.0",
     "source-map-url": "^0.4.0",
     "style-loader": "^1.1.4",

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -34,7 +34,7 @@ const debug = makeDebug('embroider:debug');
 // terser lazily so it's only loaded for production builds that use it. Don't
 // add any non-type-only imports here.
 import type { MinifyOptions } from 'terser';
-import { FingerprintOptions } from '@embroider/core/src/packager';
+import type { FingerprintOptions } from '@embroider/core/src/packager';
 
 interface AppInfo {
   entrypoints: HTMLEntrypoint[];

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -108,11 +108,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     this.publicAssetURL = options?.publicAssetURL;
     this.fingerprint = Object.assign({ enabled: true, exclude: [] }, fingerprintOptions);
 
-    if (!fingerprintOptions.exclude) {
-      fingerprintOptions.exclude = [];
-    }
-
-    fingerprintOptions.exclude = ensureDefaultExcludedFingerprints(fingerprintOptions.exclude);
+    this.fingerprint.exclude = ensureDefaultExcludedFingerprints(this.fingerprint.exclude);
     this.fingerprint.exclude = fingerprintOptions.exclude.map(glob => {
       return new Minimatch(glob);
     });

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -94,7 +94,7 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     this.publicAssetURL = options?.publicAssetURL;
     this.fingerprint = Object.assign({ enabled: true, exclude: [] }, fingerprint);
 
-    if (fingerprint.exclude) {
+    if (fingerprint?.exclude) {
       this.fingerprint.exclude = fingerprint.exclude.map(glob => {
         return new Minimatch(glob);
       });

--- a/test-packages/static-app/ember-cli-build.js
+++ b/test-packages/static-app/ember-cli-build.js
@@ -24,7 +24,6 @@ module.exports = function (defaults) {
     skipBabel: [
       {
         package: 'qunit',
-        semver: '*',
       },
     ],
     packageRules: [

--- a/test-packages/static-app/ember-cli-build.js
+++ b/test-packages/static-app/ember-cli-build.js
@@ -21,6 +21,11 @@ module.exports = function (defaults) {
     staticAddonTrees: true,
     staticComponents: true,
     staticHelpers: true,
+    skipBabel: [
+      {
+        package: 'qunit',
+      },
+    ],
     packageRules: [
       {
         package: 'static-app',

--- a/test-packages/static-app/ember-cli-build.js
+++ b/test-packages/static-app/ember-cli-build.js
@@ -24,6 +24,7 @@ module.exports = function (defaults) {
     skipBabel: [
       {
         package: 'qunit',
+        semver: '*',
       },
     ],
     packageRules: [

--- a/test-packages/static-app/package.json
+++ b/test-packages/static-app/package.json
@@ -20,7 +20,8 @@
     "test:ember": "ember test --test-port=0",
     "test:ember-classic": "CLASSIC=true ember test --test-port=0",
     "test:custom-root": "CUSTOM_ROOT_URL=/custom/ ember test --test-port=0",
-    "test:custom-relative-root": "CUSTOM_ROOT_URL=custom-relative-root-url/ ember test --test-port=0"
+    "test:custom-relative-root": "CUSTOM_ROOT_URL=custom-relative-root-url/ ember test --test-port=0",
+    "test:production": "ember test --test-port=0 --environment=production"
   },
   "devDependencies": {
     "@ember/jquery": "^0.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5414,7 +5414,15 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^3.2.6, browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.0, browserslist@^4.4.1, browserslist@^4.8.5:
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
+
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.4.1, browserslist@^4.8.5:
   version "4.14.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.7.tgz#c071c1b3622c1c2e790799a37bb09473a4351cb6"
   integrity sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==
@@ -5677,6 +5685,11 @@ caniuse-lite@^1.0.0:
   version "1.0.30001135"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz#995b1eb94404a3c9a0d7600c113c9bb27f2cd8aa"
   integrity sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==
+
+caniuse-lite@^1.0.30000844:
+  version "1.0.30001202"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz#4cb3bd5e8a808e8cd89e4e66c549989bc8137201"
+  integrity sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==
 
 caniuse-lite@^1.0.30001157:
   version "1.0.30001157"
@@ -7008,6 +7021,11 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
+electron-to-chromium@^1.3.47:
+  version "1.3.690"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz#54df63ec42fba6b8e9e05fe4be52caeeedb6e634"
+  integrity sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==
+
 electron-to-chromium@^1.3.591:
   version "1.3.593"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.593.tgz#947ccf6dc8e013e2b053d2463ecd1043c164fcef"
@@ -7247,6 +7265,7 @@ ember-cli-get-component-path-option@^1.0.0:
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
 "ember-cli-htmlbars-3@npm:ember-cli-htmlbars@3", ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1, ember-cli-htmlbars@^3.1.0:
+  name ember-cli-htmlbars-3
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-3.1.0.tgz#87806c2a0bca2ab52d4fb8af8e2215c1ca718a99"
   integrity sha512-cgvRJM73IT0aePUG7oQ/afB7vSRBV3N0wu9BrWhHX2zkR7A7cUBI7KC9VPk6tbctCXoM7BRGsCC4aIjF7yrfXA==
@@ -9740,7 +9759,21 @@ fastboot-transform@^0.1.3:
     broccoli-stew "^1.5.0"
     convert-source-map "^1.5.1"
 
-fastboot@^2.0.0, fastboot@^2.0.1, fastboot@^3.1.0:
+fastboot@^2.0.0, fastboot@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-2.0.3.tgz#0b712e6c590f1b463dc5b12138893bcbbafa2459"
+  integrity sha512-NNH/o+XhITAQUnW2CC9IDXlcnI74W2BONjtRSRmc01N3uJl/7pcvX9iWTUWu2PYQbQZUBu8HzVFt7GmQ9qw9JQ==
+  dependencies:
+    chalk "^2.0.1"
+    cookie "^0.4.0"
+    debug "^4.1.0"
+    najax "^1.0.3"
+    resolve "^1.8.1"
+    rsvp "^4.8.0"
+    simple-dom "^1.4.0"
+    source-map-support "^0.5.0"
+
+fastboot@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-3.1.0.tgz#e71a2d45c9b034f8a5909562a125888325100843"
   integrity sha512-1GyX0seImE0l4Di/LVwTzL1XqXKECQvvDeEZmReNwMUDbsQxETGz3j7XUq/eWSxl1o4R/vZomvxOXdtae6kpfA==
@@ -15741,7 +15774,7 @@ rsvp@^3.0.14, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
   integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
 
-rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.1, rsvp@^4.8.2, rsvp@^4.8.3, rsvp@^4.8.4, rsvp@^4.8.5:
+rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.0, rsvp@^4.8.1, rsvp@^4.8.2, rsvp@^4.8.3, rsvp@^4.8.4, rsvp@^4.8.5:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
@@ -16282,7 +16315,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12, source-map-support@~0.5.19:
+source-map-support@^0.5.0, source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
We currently were fingerprinting all assets when in production mode which would break testing as testem.js would become fingerprinted and thus cause problems loading (ie if you did: `ember t --environment=production`). This threads through the fingerprinting options from the app and then determines if it should fingerprint or not from that. This makes the behavior inline with how classic builds work.

Fixes: #724 