### PR TITLE
Do not try to insert source maps

### DIFF
--- a/packages/webpack/src/html-placeholder.ts
+++ b/packages/webpack/src/html-placeholder.ts
@@ -47,6 +47,9 @@ export default class Placeholder {
     if (url.endsWith('.css')) {
       return this.insertStyleLink(url);
     }
+    if (url.endsWith('.map')) {
+      return;
+    }
     throw new Error(`don't know how to insertURL ${url}`);
   }
 

--- a/test-packages/static-app/ember-cli-build.js
+++ b/test-packages/static-app/ember-cli-build.js
@@ -21,6 +21,13 @@ module.exports = function (defaults) {
     staticAddonTrees: true,
     staticComponents: true,
     staticHelpers: true,
+    packagerOptions: {
+      // Setting devtool to source-map to ensure a failure if there's a regression on
+      // https://github.com/embroider-build/embroider/issues/725
+      webpackConfig: {
+        devtool: 'source-map',
+      },
+    },
     packageRules: [
       {
         package: 'static-app',


### PR DESCRIPTION
This should resolve https://github.com/embroider-build/embroider/issues/725, which we recently ran into while trying out Embroider. The solution is to just ignore source maps, because those aren't included as tags in the HTML, and are just requested on demand by the browser.

## Replication

Create an Ember app with Embroider, and set this in your Embroider config in `ember-cli-build.js`:

```
        packagerOptions: {
            webpackConfig: {
                devtool: "source-map",
            },
        },
```

On master, running `ember serve` will error with `don't know how to insertURL <asset name>.js.map`. With these changes, it should build correctly (including the source maps).