### PR TITLE
Add windows scenarios to CI matrix generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
   test:
     needs: discover_matrix
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.os }}-latest"
+
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.discover_matrix.outputs.matrix)}}

--- a/test-packages/support/suite-setup-util.ts
+++ b/test-packages/support/suite-setup-util.ts
@@ -1,5 +1,5 @@
 import { tmpdir } from 'os';
-import { basename, join, resolve } from 'path';
+import { basename, join, relative, resolve } from 'path';
 import { readdirSync, statSync, unlinkSync, writeFileSync } from 'fs-extra';
 
 // we sometimes run our various Ember app's test suites in parallel, and
@@ -81,6 +81,12 @@ export async function allSuites({ includeEmberTry } = { includeEmberTry: true })
   return suites;
 }
 
+function relativeToEmbroiderRoot(absolutePath: string): string {
+  let embroiderRoot = resolve(__dirname, '../..');
+
+  return relative(embroiderRoot, absolutePath);
+}
+
 export async function githubMatrix() {
   let suites = await allSuites();
 
@@ -110,7 +116,7 @@ export async function githubMatrix() {
       name: `${s.name} windows`,
       os: 'windows',
       command: `${s.command} ${s.args.join(' ')}`,
-      dir: s.dir,
+      dir: relativeToEmbroiderRoot(s.dir),
     })),
   ];
 

--- a/test-packages/support/suite-setup-util.ts
+++ b/test-packages/support/suite-setup-util.ts
@@ -92,21 +92,31 @@ export async function githubMatrix() {
     dir: resolve(__dirname, '..', '..'),
   });
 
-  // add our eslint
-  suites.unshift({
-    name: 'lint',
-    command: 'yarn',
-    args: ['lint'],
-    dir: resolve(__dirname, '..', '..'),
-  });
-
-  return {
-    name: suites.map(s => s.name),
-    include: suites.map(s => ({
-      name: s.name,
+  let include = [
+    // add our eslint
+    {
+      name: 'lint',
+      os: 'ubuntu',
+      command: 'yarn lint',
+      dir: resolve(__dirname, '..', '..'),
+    },
+    ...suites.map(s => ({
+      name: `${s.name} ubuntu`,
+      os: 'ubuntu',
       command: `${s.command} ${s.args.join(' ')}`,
       dir: s.dir,
     })),
+    ...suites.map(s => ({
+      name: `${s.name} windows`,
+      os: 'windows',
+      command: `${s.command} ${s.args.join(' ')}`,
+      dir: s.dir,
+    })),
+  ];
+
+  return {
+    name: include.map(s => s.name),
+    include,
   };
 }
 


### PR DESCRIPTION
This runs out test suites for both Ubuntu and Windows (with the exception of linting).

This replicates the reported failures in https://github.com/embroider-build/embroider/issues/681 and https://github.com/embroider-build/embroider/issues/676.
