### PR TITLE
Migrate from rwjblue/setup-volta to volta-cli/action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v1
-      - uses: rwjblue/setup-volta@v1
-        with:
-          node-version: '12'
+      - uses: volta-cli/action@v1
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -43,9 +41,7 @@ jobs:
       matrix: ${{fromJson(needs.discover_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v1
-      - uses: rwjblue/setup-volta@v1
-        with:
-          node-version: '12'
+      - uses: volta-cli/action@v1
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/test-packages/eager-engine/package.json
+++ b/test-packages/eager-engine/package.json
@@ -64,6 +64,6 @@
     "ember-engines": "^0.8.2"
   },
   "volta": {
-    "extends": "../package.json"
+    "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
Same volta goodness, now from official source. :smile:

Additional changes:

* Removed manual `node-version` declaration so that we use whatever pinned node is specified in the top level `volta` config.
* Fixed test-packages/eager-engine's volta config (it was extending from a non-existent path).
