### PR TITLE
Add Compat Adapter for `@html-next/vertical-collection`

### DIFF
--- a/packages/compat/src/compat-adapters/@html-next/vertical-collection.ts
+++ b/packages/compat/src/compat-adapters/@html-next/vertical-collection.ts
@@ -1,0 +1,8 @@
+import V1Addon from '../../v1-addon';
+
+export default class VerticalCollection extends V1Addon {
+  // `@html-next/vertical-collection` does some custom Babel stuff, so we'll let it do it's own thing
+  customizes(...names: string[]) {
+    return super.customizes(...names.filter(n => n !== 'treeForAddon'));
+  }
+}


### PR DESCRIPTION
As suggested by @ef4, this change allows the Vertical Collection addon to opt out of the `treeForAddon` hook since it does a bunch of custom stuff in there.