### PR TITLE
Add compat adapter for `ember-get-config`

### DIFF
--- a/packages/compat/src/compat-adapters/ember-get-config.ts
+++ b/packages/compat/src/compat-adapters/ember-get-config.ts
@@ -1,0 +1,29 @@
+import V1Addon from '../v1-addon';
+import writeFile from 'broccoli-file-creator';
+import { join } from 'path';
+
+function createIndexContents(config: any): string {
+  return `export default ${JSON.stringify(config)};`;
+}
+
+/**
+ * The `ember-get-config` addon conceptually does just one thing: re-exports the `config/environment` runtime module
+ * from the host app so that addons can import it themseles. It handles the "hard part" of knowing what the host app's
+ * module name is, since that's not something an addon can normally know ahead of time.
+ *
+ * From a dependency graph perspective though, declaring all of the dependencies correctly would require a circular
+ * dependency from the addon back to the host app itself, which we don't want to introduce.
+ *
+ * We need to basically re-implement the entire addon's behavior so that it still exports the app's
+ * `config/environment` runtime value, but without needing it to actually export from the host app's module.
+ */
+export default class extends V1Addon {
+  get v2Tree() {
+    const configModulePath = join(this.app.root, 'config/environment.js');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const configModule = require(configModulePath);
+    const appEnvironmentConfig = configModule(this.app.env);
+
+    return writeFile('index.js', createIndexContents(appEnvironmentConfig));
+  }
+}

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -113,7 +113,7 @@ export default class V1Addon {
   constructor(
     protected addonInstance: any,
     protected addonOptions: Required<Options>,
-    public app: V1App,
+    protected app: V1App,
     private packageCache: PackageCache,
     private orderIdx: number
   ) {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -113,7 +113,7 @@ export default class V1Addon {
   constructor(
     protected addonInstance: any,
     protected addonOptions: Required<Options>,
-    private app: V1App,
+    public app: V1App,
     private packageCache: PackageCache,
     private orderIdx: number
   ) {


### PR DESCRIPTION
I've been struggling to get `ember-get-config` to work with the Vite packager due to the fact that it's desired behavior is to re-export a module from the host app.

At @ef4's suggestion I totally replaced the original way of doing this with a new approach that is Embroider-compatible. We can look up the host app's config at build-time and serialize it into the module's `index.js`; this maintains the add-on's API without having the export from the host app.

One drawback is that the `config/environment` contents are now serialized twice in the payload, but I don't think that's necessarily a huge deal.

One other approach I had tried was using the `setOwnConfig`/`getOwnConfig` API from the `macros` package but

1. I couldn't get it working; I overrode the `options` getter and added the `@embroider/macros` property but `getOwnConfig` introduced into the module's `index.js` would return `undefined`
2. It ultimately was just extra steps; the approach taken here is simpler by cutting out that whole step