### PR TITLE
Allow compat adapter's to expose shouldApplyAdapter

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -1010,7 +1010,7 @@ export interface V1AddonConstructor {
     orderIdx: number
   ): V1Addon;
 
-  isEnabled?(addonInstance: any): boolean;
+  shouldApplyAdapter?(addonInstance: any): boolean;
 }
 
 class IntermediateBuild {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -1009,6 +1009,8 @@ export interface V1AddonConstructor {
     packageCache: PackageCache,
     orderIdx: number
   ): V1Addon;
+
+  isEnabled?(addonInstance: any): boolean;
 }
 
 class IntermediateBuild {

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -65,8 +65,8 @@ export default class V1InstanceCache {
       return V1Addon;
     }
 
-    if (AdapterClass.isEnabled) {
-      return AdapterClass.isEnabled(addonInstance) ? AdapterClass : V1Addon;
+    if (AdapterClass.shouldApplyAdapter) {
+      return AdapterClass.shouldApplyAdapter(addonInstance) ? AdapterClass : V1Addon;
     }
 
     return AdapterClass;


### PR DESCRIPTION
The use case is that if a compat adapter is found (either the built-in ones or custom ones) they will always be used. This method allows the compat adapters to opt out if say a newer version of a package fixes the issue.