### PR TITLE
docs: for setting publicAssetUrl in non-production environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We are rapidly nearing a 1.0 release, and several large, heavily-tested Ember ap
 - you're likely to discover some Ember addons don't work or break your build
 - Embroider's own configuration options are subject to change, so you'll need
   to read the CHANGELOG.md when updating the Embroider packages.
-  
+
 Alternatively, it is totally safe to stick with the traditional build pipeline and wait for the official cutover point when EmberCLI starts generating new apps with Embroider by default.
 
 ## For Addon Authors
@@ -108,7 +108,7 @@ this was accomplished by configuring the `fingerprint: { prepend: ... }` option 
 ```js
 return require('@embroider/compat').compatBuild(app, Webpack, {
   packagerOptions: {
-    publicAssetURL: 'https://your-cdn-here.com/', // This should be a URL ending in "/"
+    publicAssetURL: EmberApp.env() === 'production' ? 'https://your-cdn-here.com/' : '/', // This should be a URL ending in "/"
   },
 });
 ```


### PR DESCRIPTION
This PR updates the `README.md` section for setting `publicAssetURL`, so the default example works for `development` and `test` builds.

This is a follow-up action for https://github.com/embroider-build/embroider/issues/780, which ended up being caused by using the default example in the current `README.md`.