### PR TITLE
Improve semver checks for the modules polyfill

### DIFF
--- a/packages/compat/src/compat-adapters/ember-source.ts
+++ b/packages/compat/src/compat-adapters/ember-source.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
 import semver from 'semver';
 
 export default class extends V1Addon {
-  private useRealModules = semver.satisfies(this.packageJSON.version, '>=3.27.0', { includePrerelease: true });
+  private useRealModules = semver.satisfies(this.packageJSON.version, '>=3.27.0-beta.0', { includePrerelease: true });
 
   get v2Tree() {
     return mergeTrees([super.v2Tree, new Funnel(this.rootTree, { include: ['dist/ember-template-compiler.js'] })]);

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -365,7 +365,9 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     }
 
     let emberSource = this.activeAddonChildren().find(a => a.name === 'ember-source')!;
-    let emberNeedsModulesPolyfill = semver.satisfies(emberSource.version, '<3.27.0', { includePrerelease: true });
+    let emberNeedsModulesPolyfill = semver.satisfies(emberSource.version, '<3.27.0-beta.0', {
+      includePrerelease: true,
+    });
 
     return {
       activeAddons,


### PR DESCRIPTION
This improves the semver checks to enable the following features for the beta versions of the `3.27` release:

- Use real Ember modules
- Disable module polyfills. These also happen to use the Ember global, which throws deprecation notices in `3.27+`.

Fixes #781.
Fixes #787.
Fixes #794.

I think that’s all of ’em!