### PR TITLE
Update app template dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - 'v*'
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   discover_matrix:
@@ -28,14 +28,14 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - run: yarn
+      - run: yarn --frozen-lockfile
       - id: set-matrix
         run: echo "::set-output name=matrix::$(node ./test-packages/support/suite-setup-util.js --matrix)"
 
   test:
     needs: discover_matrix
     name: ${{ matrix.name }}
-    runs-on: "${{ matrix.os }}-latest"
+    runs-on: '${{ matrix.os }}-latest'
 
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - run: yarn
+      - run: yarn --frozen-lockfile
       - name: suite
         run: ${{ matrix.command }}
         working-directory: ${{ matrix.dir }}

--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
-    "@embroider/compat": "0.39.1",
-    "@embroider/core": "0.39.1",
-    "@embroider/webpack": "0.39.1",
+    "@embroider/compat": "0.40.0",
+    "@embroider/core": "0.40.0",
+    "@embroider/webpack": "0.40.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,6 +1370,19 @@
 "@embroider/sample-lib@link:test-packages/sample-lib":
   version "0.0.0"
 
+"@embroider/shared-internals@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.39.1.tgz#33c88778fc7c42ba20dbe625b34abe51816dfc77"
+  integrity sha512-fpENfZqPWd/JUlmpAW1pN967rxSoUg7dTGmkgtAt+UZQh/d4XMeyUGGHTkRToboKa0W19xRu64RZ9LT94xUkeQ==
+  dependencies:
+    ember-rfc176-data "^0.3.17"
+    fs-extra "^7.0.1"
+    lodash "^4.17.10"
+    pkg-up "^3.1.0"
+    resolve-package-path "^1.2.2"
+    semver "^7.3.2"
+    typescript-memoize "^1.0.0-alpha.3"
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"


### PR DESCRIPTION
I noticed that `yarn.lock` is out-of-date and running `yarn` would update it to add `0.39.1` versions of the embroider packages plus a bunch of their dependencies. I'm guessing the issue here isn't an out-of-date `yarn.lock`, but a merge oversight (?) resulting in `app-template` pointing at the `0.39.1` versions rather than `0.40.0`, which I think means some of the tests weren't actually running against the latest version.

`@embroider/shared-internals@^0.39.1` was added to `yarn.lock`, I believe because it's a transitive dependency of `app-template`'s `ember-auto-import` dependency. I also updated the CI scripts to run `yarn` with `--frozen-lockfile` so `yarn.lock` being out-of-date will be caught by CI in the future.

I don't really know how `scenario-tester` works with workspaces, but I'm wondering if we should change `app-template`'s `@embroider/*` versions in `package.json` to `*`. Assuming `scenario-tester` handles workspaces correctly, this would ensure that they always match and run against the local `@embroider/*` packages, and never fetch them from the registry and run against probably-older code.

If that doesn't make sense/work, then I suspect we'd want to remove `app-template` from the package workspaces and treat it as a standalone test fixture so its dependencies aren't mixed with the workspace's. As it stands, it might run against the local packages or it might run against some code fetched from the registry depending on the specifics of the different version strings, and that seems kinda non-deterministic for an automated testing environment.