### PR TITLE
Better error message with webpack v4 installed

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.10",
     "mini-css-extract-plugin": "^1.3.2",
     "pkg-up": "^3.1.0",
+    "semver": "^7.3.5",
     "source-map-url": "^0.4.0",
     "style-loader": "^2.0.0",
     "terser": "^5.5.1",

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -26,6 +26,7 @@ import { HTMLEntrypoint } from './html-entrypoint';
 import { StatSummary } from './stat-summary';
 import crypto from 'crypto';
 import type { HbsLoaderConfig } from '@embroider/hbs-loader';
+import semverSatisfies from 'semver/functions/satisfies';
 
 const debug = makeDebug('embroider:debug');
 
@@ -83,6 +84,10 @@ const Webpack: Packager<Options> = class Webpack implements PackagerInstance {
     private consoleWrite: (msg: string) => void,
     options?: Options
   ) {
+    if (!semverSatisfies(webpack.version, '^5.0.0')) {
+      throw new Error(`@embroider/webpack requires webpack@^5.0.0, but found version ${webpack.version}`);
+    }
+
     this.pathToVanillaApp = realpathSync(pathToVanillaApp);
     this.extraConfig = options?.webpackConfig;
     this.publicAssetURL = options?.publicAssetURL;


### PR DESCRIPTION
Detect when a too-old version of webpack is installed up front and provide an explicit error message, rather than a more cryptic failure later.

For google-ability, the current error that occurs with webpack v4 installed instead of v5 is:

```
broccoliBuilderErrorStack: Error: don't know how to insertURL /assets/undefined
    at Placeholder.insertURL (/home/bent/Projekter/Loadbalancer/node_modules/@embroider/webpack/src/html-placeholder.js:43:15)
    at HTMLEntrypoint.render (/home/bent/Projekter/Loadbalancer/node_modules/@embroider/webpack/src/html-entrypoint.js:101:41)
    at Webpack.writeFiles (/home/bent/Projekter/Loadbalancer/node_modules/@embroider/webpack/src/ember-webpack.js:299:105)
  - code: [undefined]
  - codeFrame: don't know how to insertURL /assets/undefined
  - errorMessage: don't know how to insertURL /assets/undefined
        at PackagerRunner (@embroider/webpack)
```