### PR TITLE
fix(test-setup): install `webpack` alongside `@embroider/webpack`

### DIFF
--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -54,6 +54,9 @@ export function embroiderSafe(extension?: object) {
           '@embroider/core': currentEmbroiderVersion,
           '@embroider/webpack': currentEmbroiderVersion,
           '@embroider/compat': currentEmbroiderVersion,
+
+          // Webpack is a peer dependency of `@embroider/webpack`
+          webpack: '^5.0.0',
         },
       },
       env: {
@@ -73,6 +76,9 @@ export function embroiderOptimized(extension?: object) {
           '@embroider/core': currentEmbroiderVersion,
           '@embroider/webpack': currentEmbroiderVersion,
           '@embroider/compat': currentEmbroiderVersion,
+
+          // Webpack is a peer dependency of `@embroider/webpack`
+          webpack: '^5.0.0',
         },
       },
       env: {


### PR DESCRIPTION
Since `webpack` is a peer dependency to `@embroider/webpack` now, the `@embroider/test-setup` package should also install that as part of the "Ember Try" configuration that it generates.