### PR TITLE
Allow thread-loader configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ return require('@embroider/compat').compatBuild(app, Webpack, {
 });
 ```
 
-The options are documented in detail in [Core Options](https://github.com/embroider-build/embroider/blob/master/packages/core/src/options.ts) and [Compat Options](https://github.com/embroider-build/embroider/blob/master/packages/compat/src/options.ts).
+The options are documented in detail in [Core Options](https://github.com/embroider-build/embroider/blob/master/packages/core/src/options.ts), [Compat Options](https://github.com/embroider-build/embroider/blob/master/packages/compat/src/options.ts), and [Webpack Options](https://github.com/embroider-build/embroider/blob/master/packages/webpack/src/options.ts).
 
 The recommended steps when introducing Embroider into an existing app are:
 

--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -1,0 +1,21 @@
+import { Configuration } from 'webpack';
+
+export default interface Options {
+  webpackConfig: Configuration;
+
+  // the base public URL for your assets in production. Use this when you want
+  // to serve all your assets from a different origin (like a CDN) than your
+  // actual index.html will be served on.
+  //
+  // This should be a URL ending in "/".
+  publicAssetURL?: string;
+
+  // [thread-loader](https://github.com/webpack-contrib/thread-loader) options.
+  // If set to false, `thread-loader` will not be used. If set to an object, it
+  // will be used to configure `thread-loader`. If not specified,
+  // `thread-loader` will be used with a default configuration.
+  //
+  // Note that setting `JOBS=1` in the environment will also disable
+  // `thread-loader`.
+  threadLoaderOptions?: object | false;
+}


### PR DESCRIPTION
Currently `thread-loader` is not configurable, meaning that in some CI environments where the OS reports a very large number of CPUs, `thread-loader` will create a very large worker pool.

The only configuration that is currently available is setting `JOBS=1`, but the pool warmup call doesn't check `JOBS`, so always spawns the full number of workers.

So this commit:

* Skips warming the worker pool if `JOBS=1` and we know we won't be using `thread-loader`
* Adds a `thread-loader` configuration object to the options interface that allows applications to pass their own `thread-loader` configuration, or `false` to disable the use of `thread-loader` entirely.