### PR TITLE
Allow customization of Webpack's babel loader options

### DIFF
--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -1,6 +1,16 @@
 import { Configuration } from 'webpack';
 
-export default interface Options {
+// [babel-loader](https://webpack.js.org/loaders/babel-loader/#options) specific options.
+// This does not include the babel configuration, which is pulled from the app, only the
+// additional options that `babel-loader` supports.
+export interface BabelLoaderOptions {
+  cacheDirectory?: boolean | false;
+  cacheIdentifier?: string;
+  cacheCompression?: boolean;
+  customize?: string;
+}
+
+export interface Options {
   webpackConfig: Configuration;
 
   // the base public URL for your assets in production. Use this when you want
@@ -18,4 +28,6 @@ export default interface Options {
   // Note that setting `JOBS=1` in the environment will also disable
   // `thread-loader`.
   threadLoaderOptions?: object | false;
+
+  babelLoaderOptions?: BabelLoaderOptions;
 }

--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -4,7 +4,7 @@ import { Configuration } from 'webpack';
 // This does not include the babel configuration, which is pulled from the app, only the
 // additional options that `babel-loader` supports.
 export interface BabelLoaderOptions {
-  cacheDirectory?: boolean | false;
+  cacheDirectory?: boolean | string;
   cacheIdentifier?: string;
   cacheCompression?: boolean;
   customize?: string;


### PR DESCRIPTION
Info
-----
* In a similar vein to #795, it can be useful for an app to be able to override the additional options provided by [babel-loader](https://webpack.js.org/loaders/babel-loader/#options). Note: The app already controls the babel config itself, this is only looking at the loader-specific options.
* One specific use-case is turning off the persistent cache, which can improve build performance in some projects.

Changes
-----
* Added `babelLoaderOptions` to the `webpack` package's `Options` object, with a specification of which options are available.
    * I couldn't find any existing type definitions, so I copied the options from the documentation (happy to update it to use `object` instead if we'd prefer to avoid having to maintain the types).
* Included the extra options in the `babelLoaderOptions` function to make sure that they override anything provided by Embroider.