### PR TITLE
Use configPath to locate the configuration file, instead of assuming a fixed path

### DIFF
--- a/packages/compat/src/compat-adapters/ember-get-config.ts
+++ b/packages/compat/src/compat-adapters/ember-get-config.ts
@@ -1,6 +1,5 @@
 import V1Addon from '../v1-addon';
 import writeFile from 'broccoli-file-creator';
-import { join } from 'path';
 
 function createIndexContents(config: any): string {
   return `export default ${JSON.stringify(config)};`;
@@ -19,9 +18,8 @@ function createIndexContents(config: any): string {
  */
 export default class extends V1Addon {
   get v2Tree() {
-    const configModulePath = join(this.app.root, 'config/environment.js');
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const configModule = require(configModulePath);
+    const configModule = require(this.app.configPath());
     const appEnvironmentConfig = configModule(this.app.env);
 
     return writeFile('index.js', createIndexContents(appEnvironmentConfig));

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -127,8 +127,12 @@ export default class V1App {
     return this.app.tests || false;
   }
 
+  configPath(): string {
+    return this.app.project.configPath();
+  }
+
   private get configTree() {
-    return new this.configLoader(dirname(this.app.project.configPath()), {
+    return new this.configLoader(dirname(this.configPath()), {
       env: this.app.env,
       tests: this.app.tests || false,
       project: this.app.project,


### PR DESCRIPTION
Info
-----
The `compatAdapter` for `ember-get-config` currently assumes that the configuration file is always in `config/environment.js`. However, it is possible to change the config directory with a setting in `package.json`. If that is done, the compat adapter will fail when it tries to require a file that doesn't exist.

Changes
-----
* Updated `V1App` to provide access to Ember's method of locating the `environment` file.
* Updated the `ember-get-config` adapter to use the above, instead of assuming that it's always at `config/environment.js`