### PR TITLE
Update thread-loader to get RegExp serialization

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -43,7 +43,7 @@
     "source-map-url": "^0.4.0",
     "style-loader": "^2.0.0",
     "terser": "^5.5.1",
-    "thread-loader": "^3.0.1"
+    "thread-loader": "^3.0.4"
   },
   "devDependencies": {
     "@types/csso": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17779,14 +17779,16 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-thread-loader@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-3.0.1.tgz#059752d5c3e223ec58fad5868fe6405e8375d480"
-  integrity sha512-c8Mr7jooXEAochk72XoQ1vPauwFToz9GVwqevqQShAypCUW0nRzYIbkzZo3KErNhhYf/+ga5cUQWxVXQteJj/g==
+thread-loader@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-3.0.4.tgz#c392e4c0241fbc80430eb680e4886819b504a31b"
+  integrity sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==
   dependencies:
+    json-parse-better-errors "^1.0.2"
     loader-runner "^4.1.0"
     loader-utils "^2.0.0"
     neo-async "^2.6.2"
+    schema-utils "^3.0.0"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Update to the latest thread-loader, mainly so we can [use RegExps](https://github.com/webpack-contrib/thread-loader/pull/102) in plugin options (which was release in v3.0.2).