### PR TITLE
Fix webpack.run callback

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -463,7 +463,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
             this.consoleWrite(stats.toString());
           }
           resolve(stats.toJson());
-        } catch(e) {
+        } catch (e) {
           reject(e);
         }
       });

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -443,27 +443,29 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
   private runWebpack(webpack: webpack.MultiCompiler): Promise<webpack.StatsCompilation> {
     return new Promise((resolve, reject) => {
       webpack.run((err, stats) => {
-        if (err) {
-          if (stats) {
+        try {
+          if (err) {
+            if (stats) {
+              this.consoleWrite(stats.toString());
+            }
+            throw err;
+          }
+          if (!stats) {
+            // this doesn't really happen, but webpack's types imply that it
+            // could, so we just satisfy typescript here
+            throw new Error('bug: no stats and no err');
+          }
+          if (stats.hasErrors()) {
+            // the typing for MultiCompiler are all foobared.
+            throw this.findBestError(flatMap((stats as any).stats, s => s.compilation.errors));
+          }
+          if (stats.hasWarnings() || process.env.VANILLA_VERBOSE) {
             this.consoleWrite(stats.toString());
           }
-          reject(err);
-          return;
+          resolve(stats.toJson());
+        } catch(e) {
+          reject(e);
         }
-        if (!stats) {
-          // this doesn't really happen, but webpack's types imply that it
-          // could, so we just satisfy typescript here
-          throw new Error('bug: no stats and no err');
-        }
-        if (stats.hasErrors()) {
-          // the typing for MultiCompiler are all foobared.
-          reject(this.findBestError(flatMap((stats as any).stats, s => s.compilation.errors)));
-          return;
-        }
-        if (stats.hasWarnings() || process.env.VANILLA_VERBOSE) {
-          this.consoleWrite(stats.toString());
-        }
-        resolve(stats.toJson());
       });
     });
   }


### PR DESCRIPTION
Ensure all `throws`, including the explicit throw, correctly reject the wrapping promise.

---

As far as I can tell, this isn't the root cause of any posted issues, but something I noticed while debugging a different issue.