### PR TITLE
Run linting in CI before running the full matrix of jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,30 @@ on:
     branches: [master]
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: volta-cli/action@v1
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn --frozen-lockfile
+      - name: lint
+        run: yarn lint
+
   discover_matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -33,11 +55,11 @@ jobs:
         run: echo "::set-output name=matrix::$(node ./test-packages/support/suite-setup-util.js --matrix)"
 
   test:
-    needs: discover_matrix
+    needs: ["discover_matrix", "linting"]
     name: ${{ matrix.name }}
     runs-on: '${{ matrix.os }}-latest'
     timeout-minutes: 30
-    
+
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.discover_matrix.outputs.matrix)}}

--- a/test-packages/support/suite-setup-util.ts
+++ b/test-packages/support/suite-setup-util.ts
@@ -117,13 +117,6 @@ export async function githubMatrix() {
   });
 
   let include = [
-    // add our eslint
-    {
-      name: 'lint',
-      os: 'ubuntu',
-      command: 'yarn lint',
-      dir: resolve(__dirname, '..', '..'),
-    },
     ...suites.map(s => ({
       name: `${s.name} ubuntu`,
       os: 'ubuntu',


### PR DESCRIPTION
Right now we end up kicking off > 80 jobs repeatedly (as we fix simple linting issues), and since GH actions does not auto-cancel prior jobs we end up getting pretty backed up in the CI queue. This tweaks things to run linting prior to even starting the expanded list of matrix jobs.
