### PR TITLE
Fix missing exports in package key

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,8 @@
     },
     "./src/messages": "./src/messages.js",
     "./src/babel-plugin-inline-hbs": "./src/babel-plugin-inline-hbs.js",
-    "./src/mini-modules-polyfill": "./src/mini-modules-polyfill.js"
+    "./src/mini-modules-polyfill": "./src/mini-modules-polyfill.js",
+    "./src/load-ember-template-compiler": "./src/load-ember-template-compiler.js"
   },
   "files": [
     "src/**/*.js",


### PR DESCRIPTION
Error: 

```
Package subpath './src/load-ember-template-compiler' is not defined by "exports" in /.../embroider/node_modules/@embroider/core/package.json
```