### PR TITLE
Drop support for Node 10, 11, 13, and 15.

### DIFF
--- a/packages/addon-shim/package.json
+++ b/packages/addon-shim/package.json
@@ -29,7 +29,7 @@
     "@types/semver": "^7.3.6"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || 14.* || >= 16"
   },
   "ember-addon": {
     "main": "addon-main.js"

--- a/packages/babel-loader-7/package.json
+++ b/packages/babel-loader-7/package.json
@@ -12,6 +12,9 @@
     "babel-core": "^6.26.3",
     "babel-loader": "7"
   },
+  "engines": {
+    "node": "12.* || 14.* || >= 16"
+  },
   "volta": {
     "extends": "../../package.json"
   }

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -85,7 +85,7 @@
     "@embroider/core": "0.41.0"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14"
+    "node": "12.* || 14.* || >= 16"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,7 @@
     "typescript": "~4.0.0"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14"
+    "node": "12.* || 14.* || >= 16"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/hbs-loader/package.json
+++ b/packages/hbs-loader/package.json
@@ -32,7 +32,7 @@
     "webpack": "^4 || ^5"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14"
+    "node": "12.* || 14.* || >= 16"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -46,7 +46,7 @@
     "typescript": "~4.0.0"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14"
+    "node": "12.* || 14.* || >= 16"
   },
   "ember-addon": {
     "main": "src/ember-addon-main.js"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -78,7 +78,7 @@
     }
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14"
+    "node": "12.* || 14.* || >= 16"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -43,7 +43,7 @@
     "typescript": "~4.0.0"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14"
+    "node": "12.* || 14.* || >= 16"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/test-setup/package.json
+++ b/packages/test-setup/package.json
@@ -18,6 +18,9 @@
   "devDependencies": {
     "@embroider/compat": "0.41.0"
   },
+  "engines": {
+    "node": "12.* || 14.* || >= 16"
+  },
   "volta": {
     "extends": "../../package.json"
   }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -77,7 +77,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || 14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -59,7 +59,7 @@
     "webpack": "^5.0.0"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14"
+    "node": "12.* || 14.* || >= 16"
   },
   "volta": {
     "extends": "../../package.json"


### PR DESCRIPTION
This unifies the `engines` property across all of our packages (they didn't agree with each other, some were missing `engines` completely, etc) to support:

* Node 12.*
* Node 14.*
* Node 16 or higher

This matches the [currently supported releases](https://nodejs.org/en/about/releases/) by Node itself:

![image](https://user-images.githubusercontent.com/12637/122108226-f2d43680-cde9-11eb-9dfc-7b3c315ac170.png)
