### PR TITLE
Add missing typescript devDependency

### DIFF
--- a/packages/addon-shim/package.json
+++ b/packages/addon-shim/package.json
@@ -26,7 +26,8 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "@types/semver": "^7.3.6"
+    "@types/semver": "^7.3.6",
+    "typescript": "~4.0.0"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -74,7 +74,8 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
     "qunit": "^2.14.1",
-    "qunit-dom": "^1.6.0"
+    "qunit-dom": "^1.6.0",
+    "typescript": "~4.0.0"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"


### PR DESCRIPTION
Depending on `yarn` on disk layout details, the packages would not be guaranteed to have a `tsc` script available to them (which caused an error during `npm publish` since we call `tsc` in `prepare` script).

This was causing a failure when publishing.
