### PR TITLE
[Discussion] Experiment with improving debugging of workers.

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -37,6 +37,7 @@ import crypto from 'crypto';
 import type { HbsLoaderConfig } from '@embroider/hbs-loader';
 import semverSatisfies from 'semver/functions/satisfies';
 import supportsColor from 'supports-color';
+import inspector from 'inspector';
 
 const debug = makeDebug('embroider:debug');
 
@@ -524,6 +525,8 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
 };
 
 const threadLoaderOptions = {
+  workerNodeArgs: inspector.url() !== undefined ? ['--inspect-brk=0'] : [],
+  workers: 'JOBS' in process.env && Number(process.env.JOBS),
   // poolTimeout shuts down idle workers. The problem is, for
   // interactive rebuilds that means your startup cost for the
   // next rebuild is at least 600ms worse. So we insist on


### PR DESCRIPTION
While debugging some stuff with parallel builds I've noticed several things, and have some ideas on how to possible improve the situation. 

1) we could make it easier to attach a debugger to one of the child-processes

One approach would be to automatically detect that the parent node process is in debug mode, and do the same with the children. This works alright, with the downside of needing more careful shutdown of the process.

Another approach would be to provide a separate environment variable to accomplish this.

2) when attempted to debug an issue that only appears only in parallel mode i noticed that JOBS=<N> doesn't correspond to the number of JOBS, rather it is any value but JOBS=1 will result in the number of available CPUs. This makes it both difficult to limit the number of JOBS based on available resources AND it was tricky to debug just 1 worker node scenarios.

One approach is to respect the number of JOBS if specified.

Another quirk is the inability to specify 1 single job, most of this time this likely doesn't matter, but it was a little odd.
Rather than JOBS=1 meaning use the primary process. We could instead have

* JOBS=false === use the primary process
* JOBS=<count> === explicitly set the worker count to <count>
* default experience is to let webpack decide.