### PR TITLE
Improve Webpack logging output

### DIFF
--- a/packages/core/src/to-broccoli-plugin.ts
+++ b/packages/core/src/to-broccoli-plugin.ts
@@ -1,6 +1,7 @@
 import Plugin from 'broccoli-plugin';
 import { Packager, PackagerConstructor, Variant } from './packager';
 import Stage from './stage';
+import { tmpdir } from '@embroider/shared-internals';
 
 interface BroccoliPackager<Options> {
   new (stage: Stage, variants: Variant[], options?: Options): Plugin;
@@ -31,7 +32,7 @@ export default function toBroccoliPlugin<Options>(
           outputPath,
           this.outputPath,
           this.variants,
-          msg => console.log(msg),
+          msg => console.log(msg.split(tmpdir).join('$TMPDIR')),
           this.options
         );
       }


### PR DESCRIPTION
TL;DR temporary directories can be quite long, so let’s emulate our [webpack error processing](https://github.com/embroider-build/embroider/blob/b525bd5d93a7e99de1194022edfde041cf79e309/packages/webpack/src/ember-webpack.ts#L520) for all webpack logging. This ensures redundant path prefixes are shortened to `$TMPDIR`