### PR TITLE
Fix race condition finding the owning package of a given file when using multiple workers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,6 @@
     "js-string-escape": "^1.0.1",
     "jsdom": "^16.6.0",
     "lodash": "^4.17.21",
-    "pkg-up": "^3.1.0",
     "resolve": "^1.20.0",
     "resolve-package-path": "^4.0.1",
     "strip-bom": "^4.0.0",

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "ember-rfc176-data": "^0.3.17",
     "resolve-package-path": "^4.0.1",
-    "pkg-up": "^3.1.0",
     "typescript-memoize": "^1.0.1",
     "fs-extra": "^9.1.0",
     "lodash": "^4.17.21",

--- a/packages/shared-internals/src/package-cache.ts
+++ b/packages/shared-internals/src/package-cache.ts
@@ -1,9 +1,8 @@
 import Package from './package';
-import { realpathSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 import { getOrCreate } from './get-or-create';
 import resolvePackagePath from 'resolve-package-path';
 import { dirname, sep } from 'path';
-import { sync as pkgUpSync } from 'pkg-up';
 
 export default class PackageCache {
   resolve(packageName: string, fromPackage: Package): Package {
@@ -67,15 +66,15 @@ export default class PackageCache {
         // any higher caches don't apply to us
         break;
       }
-      let candidate = segments.slice(0, length).join(sep);
+
+      let usedSegments = segments.slice(0, length);
+      let candidate = usedSegments.join(sep);
       if (this.rootCache.has(candidate)) {
         return this.rootCache.get(candidate);
       }
-    }
-
-    let packageJSONPath = pkgUpSync({ cwd: filename });
-    if (packageJSONPath) {
-      return this.get(dirname(packageJSONPath));
+      if (existsSync([...usedSegments, 'package.json'].join(sep))) {
+        return this.get(candidate);
+      }
     }
   }
 

--- a/packages/shared-internals/src/package-cache.ts
+++ b/packages/shared-internals/src/package-cache.ts
@@ -60,7 +60,7 @@ export default class PackageCache {
 
     // first we look through our cached packages for any that are rooted right
     // at or above the file.
-    for (let length = segments.length - 1; length >= 0; length--) {
+    for (let length = segments.length; length >= 0; length--) {
       if (segments[length - 1] === 'node_modules') {
         // once we hit a node_modules, we're leaving the package we were in, so
         // any higher caches don't apply to us

--- a/packages/shared-internals/tests/package-cache.test.ts
+++ b/packages/shared-internals/tests/package-cache.test.ts
@@ -49,4 +49,45 @@ describe('package-cache', () => {
     packageCache.ownerOfFile(join(tmpLocation, 'index.js'));
     expect(packageCache.ownerOfFile(join(tmpLocation, 'inner', 'index.js'))!.root).toBe(join(tmpLocation, 'inner'));
   });
+  test('it handles nested in-repo packages', () => {
+    let { name: tmpLocation } = tmp.dirSync();
+    tmpLocation = realpathSync(tmpLocation);
+
+    let projectJSON = {
+      'package.json': JSON.stringify({
+        name: 'outer',
+      }),
+      'index.js': '',
+      inner: {
+        'package.json': JSON.stringify({
+          name: 'inner',
+        }),
+        'index.js': '',
+      },
+    };
+    fixturify.writeSync(tmpLocation, projectJSON);
+    let packageCache = new PackageCache();
+    expect(packageCache.ownerOfFile(join(tmpLocation, 'inner', 'index.js'))!.root).toBe(join(tmpLocation, 'inner'));
+  });
+
+  test('it considers the package dir owned by the package', () => {
+    let { name: tmpLocation } = tmp.dirSync();
+    tmpLocation = realpathSync(tmpLocation);
+
+    let projectJSON = {
+      'package.json': JSON.stringify({
+        name: 'outer',
+      }),
+      'index.js': '',
+      inner: {
+        'package.json': JSON.stringify({
+          name: 'inner',
+        }),
+        'index.js': '',
+      },
+    };
+    fixturify.writeSync(tmpLocation, projectJSON);
+    let packageCache = new PackageCache();
+    expect(packageCache.ownerOfFile(join(tmpLocation, 'inner'))!.root).toBe(join(tmpLocation, 'inner'));
+  });
 });

--- a/packages/shared-internals/tests/package-cache.test.ts
+++ b/packages/shared-internals/tests/package-cache.test.ts
@@ -1,0 +1,52 @@
+import PackageCache from '../src/package-cache';
+import tmp from 'tmp';
+import { join } from 'path';
+import fixturify from 'fixturify';
+import { realpathSync } from 'fs';
+
+tmp.setGracefulCleanup();
+
+describe('package-cache', () => {
+  test('it handles nested in-repo packages', () => {
+    let { name: tmpLocation } = tmp.dirSync();
+    tmpLocation = realpathSync(tmpLocation);
+
+    let projectJSON = {
+      'package.json': JSON.stringify({
+        name: 'outer',
+      }),
+      'index.js': '',
+      inner: {
+        'package.json': JSON.stringify({
+          name: 'inner',
+        }),
+        'index.js': '',
+      },
+    };
+    fixturify.writeSync(tmpLocation, projectJSON);
+    let packageCache = new PackageCache();
+    expect(packageCache.ownerOfFile(join(tmpLocation, 'inner', 'index.js'))!.root).toBe(join(tmpLocation, 'inner'));
+  });
+
+  test('it handles nested in-repo packages even when the parent is in cache', () => {
+    let { name: tmpLocation } = tmp.dirSync();
+    tmpLocation = realpathSync(tmpLocation);
+
+    let projectJSON = {
+      'package.json': JSON.stringify({
+        name: 'outer',
+      }),
+      'index.js': '',
+      inner: {
+        'package.json': JSON.stringify({
+          name: 'inner',
+        }),
+        'index.js': '',
+      },
+    };
+    fixturify.writeSync(tmpLocation, projectJSON);
+    let packageCache = new PackageCache();
+    packageCache.ownerOfFile(join(tmpLocation, 'index.js'));
+    expect(packageCache.ownerOfFile(join(tmpLocation, 'inner', 'index.js'))!.root).toBe(join(tmpLocation, 'inner'));
+  });
+});

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -42,7 +42,6 @@
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^1.6.0",
-    "pkg-up": "^3.1.0",
     "semver": "^7.3.5",
     "source-map-url": "^0.4.1",
     "style-loader": "^2.0.0",


### PR DESCRIPTION
`PackageCache`'s `ownerOfFile` can give the wrong result when dealing with in-repo nested package structures (like a dummy app, in-repo-addon, or runtime fastboot directory) such that there is no intervening `node_modules` folder between the parent and child packages.

It only happens if there's a request for the parent package before the files in the child package, which is why this was a sporadic race that only happened sometimes, when running with multiple parallel workers where the order is nondeterministic.