### PR TITLE
`undefined` does not serialize with broccoli-babel-transpiler

### DIFF
--- a/packages/macros/src/babel/state.ts
+++ b/packages/macros/src/babel/state.ts
@@ -40,7 +40,7 @@ export default interface State {
     // the package root directory of the app, if the app is under active
     // development. Needed so that we can get consistent answers to
     // `isDevelopingApp` and `isDeveopingThisPackage`
-    appPackageRoot: string | undefined;
+    appPackageRoot: string;
 
     embroiderMacrosConfigMarker: true;
 

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -245,7 +245,7 @@ export default class MacrosConfig {
       owningPackageRoot,
 
       isDevelopingPackageRoots: [...this.isDevelopingPackageRoots].map(root => this.moves.get(root) || root),
-      appPackageRoot: this.appPackageRoot ? this.moves.get(this.appPackageRoot) || this.appPackageRoot : undefined,
+      appPackageRoot: this.appPackageRoot ? this.moves.get(this.appPackageRoot) || this.appPackageRoot : '',
 
       // This is used as a signature so we can detect ourself among the plugins
       // emitted from v1 addons.

--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "ember build",
+    "build:production": "ember build -prod",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",

--- a/tests/scenarios/macro-test.ts
+++ b/tests/scenarios/macro-test.ts
@@ -43,6 +43,11 @@ appScenarios
         assert.equal(result.exitCode, 0, result.output);
       });
 
+      test(`yarn test production`, async function (assert) {
+        let result = await app.execute(`cross-env THROW_UNLESS_PARALLELIZABLE=1 EMBER_ENV='production' yarn test`);
+        assert.equal(result.exitCode, 0, result.output);
+      });
+
       test(`CLASSIC=true yarn test`, async function (assert) {
         // throw_unless_parallelizable is enabled to ensure that @embroider/macros is parallelizable
         let result = await app.execute(`cross-env THROW_UNLESS_PARALLELIZABLE=1 CLASSIC=true yarn test`);

--- a/tests/scenarios/macro-test.ts
+++ b/tests/scenarios/macro-test.ts
@@ -43,8 +43,8 @@ appScenarios
         assert.equal(result.exitCode, 0, result.output);
       });
 
-      test(`yarn test production`, async function (assert) {
-        let result = await app.execute(`cross-env THROW_UNLESS_PARALLELIZABLE=1 EMBER_ENV='production' yarn test`);
+      test(`yarn build production`, async function (assert) {
+        let result = await app.execute(`cross-env THROW_UNLESS_PARALLELIZABLE=1 yarn build:production`);
         assert.equal(result.exitCode, 0, result.output);
       });
 


### PR DESCRIPTION
When broccoli-babel-transpiler tries to determine if a plugin is serializable it checks for [certain types](https://github.com/babel/broccoli-babel-transpiler/blob/416732dd5d57b9f29dad7afd7f7cae76f0ac1606/lib/parallel-api.js#L45-L61).

If the value is undefined it is not serializable and thus not parallelizable. Since we are just checking for truthyness of the `appPackageRoot` value we can instead use an empty string. This also satisfies the babel type which is string | undefined.

This comes up in production builds as `appPackageRoot` does [not get set](https://github.com/embroider-build/embroider/blob/4af550f393b4770cb5f0a78ded29586a8db2d445/packages/macros/src/ember-addon-main.ts#L30)