### PR TITLE
Only patch `ember-cli-deprecation-workflow` releases before `2.0.0`

### DIFF
--- a/packages/compat/src/compat-adapters/ember-cli-deprecation-workflow.ts
+++ b/packages/compat/src/compat-adapters/ember-cli-deprecation-workflow.ts
@@ -4,8 +4,15 @@ import { UnwatchedDir } from 'broccoli-source';
 import resolve from 'resolve';
 import { Memoize } from 'typescript-memoize';
 import buildFunnel from 'broccoli-funnel';
+import semver from 'semver';
 
 export default class extends V1Addon {
+  // v2.0.0 removes the usage of `ember-debug-handlers-polyfill`, so we only need to apply the adapter if we're working
+  // with a version that is older than that
+  static shouldApplyAdapter(addonInstance: any) {
+    return semver.lt(addonInstance.pkg.version, '2.0.0');
+  }
+
   @Memoize()
   get v2Trees() {
     // ember-cli-deprecation-workflow does `app.import` of a file that isn't in


### PR DESCRIPTION
I ran into an error when trying out Embroider in my main Ember app.

The compat adapter for `ember-cli-deprecation-workflow` resolves an error with `ember-debug-handlers-polyfill` which is no longer present in version `2.0.0`. Because it's not installed, Node is unable to resolve the location of the package.

We should opt out of the patch if the installed version is `2.0.0` or greater.