### PR TITLE
Fix ember-test-selectors custom adapter for 6.x

### DIFF
--- a/packages/compat/src/compat-adapters/ember-test-selectors.ts
+++ b/packages/compat/src/compat-adapters/ember-test-selectors.ts
@@ -1,12 +1,14 @@
 import V1Addon from '../v1-addon';
 import { forceIncludeModule } from '../compat-utils';
+import semver from 'semver';
 
 export default class extends V1Addon {
+  // v6.0.0 of ember-test-selectors dropped the attribute binding for classic components
+  static shouldApplyAdapter(addonInstance: any) {
+    return semver.lt(addonInstance.pkg.version, '6.0.0') && !addonInstance._stripTestSelectors;
+  }
+
   get packageMeta() {
-    if (this.addonInstance._stripTestSelectors) {
-      return super.packageMeta;
-    } else {
-      return forceIncludeModule(super.packageMeta, './utils/bind-data-test-attributes');
-    }
+    return forceIncludeModule(super.packageMeta, './utils/bind-data-test-attributes');
   }
 }


### PR DESCRIPTION
The 6.x release of ember-test-selectors dropped the attribute binding for classic components. This leads to a build error due to the current compat-adapter of embroider:

```
module not found: Error: 
Can't resolve '../node_modules/ember-test-selectors/utils/bind-data-test-attributes' 
in '$TMPDIR/embroider/d7920e/assets/my-app.js'
```

This PR makes the compat adapter only run for ember-test-selector versions below 6. Not sure if there is a "nicer" way to check this than to take the version of the addon pkg info, but I guess it works well enough for this case!