### PR TITLE
Fix ember-test-selectors compat adapter for v6

### DIFF
--- a/packages/compat/src/compat-adapters/ember-test-selectors.ts
+++ b/packages/compat/src/compat-adapters/ember-test-selectors.ts
@@ -1,9 +1,10 @@
+import semver from 'semver';
 import V1Addon from '../v1-addon';
 import { forceIncludeModule } from '../compat-utils';
 
 export default class extends V1Addon {
   get packageMeta() {
-    if (this.addonInstance._stripTestSelectors) {
+    if (this.addonInstance._stripTestSelectors || semver.satisfies(this.packageJSON.version, '>=6.0.0')) {
       return super.packageMeta;
     } else {
       return forceIncludeModule(super.packageMeta, './utils/bind-data-test-attributes');


### PR DESCRIPTION
Version 6 of ember-test-selectors removed the ability to bind attrs, therefore the file that was being included is not existing anymore.