### PR TITLE
Deflate AdjustImportsOptions

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -22,7 +22,7 @@ import walkSync from 'walk-sync';
 import { join } from 'path';
 import { JSDOM } from 'jsdom';
 import { V1Config } from './v1-config';
-import { statSync, readdirSync } from 'fs';
+import { statSync, readdirSync, writeFileSync } from 'fs';
 import Options, { optionsWithDefaults } from './options';
 import CompatResolver from './resolver';
 import { activePackageRules, PackageRules, expandModuleRules } from './dependency-rules';
@@ -36,6 +36,7 @@ import { pathExistsSync } from 'fs-extra';
 import { tmpdir } from '@embroider/shared-internals';
 import { Options as AdjustImportsOptions } from '@embroider/core/src/babel-plugin-adjust-imports';
 import { getEmberExports } from '@embroider/core/src/load-ember-template-compiler';
+
 import semver from 'semver';
 
 interface TreeNames {
@@ -337,8 +338,15 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
       podModulePrefix: this.podModulePrefix(),
       options: this.options,
       activePackageRules: this.activeRules(),
-      adjustImportsOptions: this.adjustImportsOptions(),
+      adjustImportsOptionsFile: this.adjustImportsOptionsFile(),
     });
+  }
+
+  @Memoize()
+  adjustImportsOptionsFile(): string {
+    let file = join(this.root, '_adjust_imports.json');
+    writeFileSync(file, JSON.stringify(this.adjustImportsOptions()));
+    return file;
   }
 
   @Memoize()
@@ -346,6 +354,7 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     return this.makeAdjustImportOptions(true);
   }
 
+  // this gets serialized out by babel plugin and ast plugin
   private makeAdjustImportOptions(outer: boolean): AdjustImportsOptions {
     let renamePackages = Object.assign({}, ...this.allActiveAddons.map(dep => dep.meta['renamed-packages']));
     let renameModules = Object.assign({}, ...this.allActiveAddons.map(dep => dep.meta['renamed-modules']));

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -22,7 +22,7 @@ import Options from './options';
 import { ResolvedDep } from '@embroider/core/src/resolver';
 import { dasherize } from './dasherize-component-name';
 import { makeResolverTransform } from './resolver-transform';
-import { pathExistsSync } from 'fs-extra';
+import { pathExistsSync, readFileSync } from 'fs-extra';
 import resolve from 'resolve';
 
 export interface ComponentResolution {
@@ -110,14 +110,23 @@ function extractOptions(options: Required<Options> | ResolverOptions): ResolverO
   };
 }
 
-interface RehydrationParams {
+interface RehydrationParamsBase {
   root: string;
   modulePrefix: string;
   podModulePrefix?: string;
   options: ResolverOptions;
   activePackageRules: ActivePackageRules[];
+}
+
+interface RehydrationParamsWithFile extends RehydrationParamsBase {
+  adjustImportsOptionsFile: string;
+}
+
+interface RehydrationParamsWithOptions extends RehydrationParamsBase {
   adjustImportsOptions: AdjustImportsOptions;
 }
+
+type RehydrationParams = RehydrationParamsWithFile | RehydrationParamsWithOptions;
 
 export function rehydrate(params: RehydrationParams) {
   return new CompatResolver(params);
@@ -173,7 +182,7 @@ export default class CompatResolver implements Resolver {
     // "inherit" the rules that are attached to their corresonding JS module.
     if (absPath.endsWith('.hbs')) {
       let stem = absPath.slice(0, -4);
-      for (let ext of this.params.adjustImportsOptions.resolvableExtensions) {
+      for (let ext of this.adjustImportsOptions.resolvableExtensions) {
         if (ext !== '.hbs') {
           let rules = this.rules.components.get(stem + ext);
           if (rules) {
@@ -187,6 +196,14 @@ export default class CompatResolver implements Resolver {
 
   private isIgnoredComponent(dasherizedName: string) {
     return this.rules.ignoredComponents.includes(dasherizedName);
+  }
+
+  @Memoize()
+  get adjustImportsOptions(): AdjustImportsOptions {
+    const { params } = this;
+    return 'adjustImportsOptionsFile' in params
+      ? JSON.parse(readFileSync(params.adjustImportsOptionsFile, 'utf8'))
+      : params.adjustImportsOptions;
   }
 
   @Memoize()
@@ -357,7 +374,7 @@ export default class CompatResolver implements Resolver {
     try {
       absPath = resolve.sync(path, {
         basedir: dirname(from),
-        extensions: this.params.adjustImportsOptions.resolvableExtensions,
+        extensions: this.adjustImportsOptions.resolvableExtensions,
       });
     } catch (err) {
       return;
@@ -372,14 +389,14 @@ export default class CompatResolver implements Resolver {
 
   @Memoize()
   private get resolvableExtensionsPattern() {
-    return extensionsPattern(this.params.adjustImportsOptions.resolvableExtensions);
+    return extensionsPattern(this.adjustImportsOptions.resolvableExtensions);
   }
 
   absPathToRuntimePath(absPath: string, owningPackage?: { root: string; name: string }) {
     let pkg = owningPackage || PackageCache.shared('embroider-stage3').ownerOfFile(absPath);
     if (pkg) {
       let packageRuntimeName = pkg.name;
-      for (let [runtimeName, realName] of Object.entries(this.params.adjustImportsOptions.renamePackages)) {
+      for (let [runtimeName, realName] of Object.entries(this.adjustImportsOptions.renamePackages)) {
         if (realName === packageRuntimeName) {
           packageRuntimeName = runtimeName;
           break;
@@ -408,7 +425,7 @@ export default class CompatResolver implements Resolver {
   }
 
   private tryHelper(path: string, from: string): Resolution | null {
-    for (let extension of this.params.adjustImportsOptions.resolvableExtensions) {
+    for (let extension of this.adjustImportsOptions.resolvableExtensions) {
       let absPath = join(this.params.root, 'helpers', path) + extension;
       if (pathExistsSync(absPath)) {
         return {
@@ -426,10 +443,6 @@ export default class CompatResolver implements Resolver {
     return null;
   }
 
-  get adjustImportsOptions() {
-    return this.params.adjustImportsOptions;
-  }
-
   @Memoize()
   private get appPackage(): AppPackagePlaceholder {
     return { root: this.params.root, name: this.params.modulePrefix };
@@ -440,7 +453,7 @@ export default class CompatResolver implements Resolver {
     if (parts.length > 1 && parts[0].length > 0) {
       let cache = PackageCache.shared('embroider-stage3');
       let packageName = parts[0];
-      let renamed = this.params.adjustImportsOptions.renamePackages[packageName];
+      let renamed = this.adjustImportsOptions.renamePackages[packageName];
       if (renamed) {
         packageName = renamed;
       }
@@ -462,7 +475,7 @@ export default class CompatResolver implements Resolver {
     // as a key into the rules, and we want to be able to find our rules when
     // checking from our own template (among other times).
 
-    let extensions = ['.hbs', ...this.params.adjustImportsOptions.resolvableExtensions.filter(e => e !== '.hbs')];
+    let extensions = ['.hbs', ...this.adjustImportsOptions.resolvableExtensions.filter(e => e !== '.hbs')];
 
     let componentModules = [] as string[];
 

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -111,6 +111,8 @@ export interface AppAdapter<TreeNames> {
   // compatibility
   adjustImportsOptions(): AdjustImportsOptions;
 
+  adjustImportsOptionsFile(): string;
+
   // The template preprocessor plugins that are configured in the app.
   htmlbarsPlugins(): TemplateCompilerPlugins;
 
@@ -417,7 +419,7 @@ export class AppBuilder<TreeNames> {
     }
     return [
       require.resolve('./babel-plugin-adjust-imports'),
-      Object.assign({}, this.adapter.adjustImportsOptions(), { relocatedFiles }),
+      { adjustImportsOptionsFile: this.adapter.adjustImportsOptionsFile(), relocatedFiles },
     ];
   }
 


### PR DESCRIPTION
The babel-loader cache key hashes babel options which has the AdjustImportsOptions used multiple times and is very large.

This PR moves this into a file ignoring caching for now since everything it moves is already memoized and only thing this affects is in-repo-addons and isDevelopingAddon true which is currently an issue.

This doesn't address relocatedFiles which is very large because it is outside the spot that is memoized.