### PR TITLE
Upgrade ember-qunit to address canary deprecations

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
     "qunit": "^2.14.1",
-    "qunit-dom": "^0.8.4"
+    "qunit-dom": "^1.6.0"
   },
   "peerDependencies": {
     "@embroider/core": "0.43.1",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "@ember/test-helpers": "^2.2.5",
     "@ember/string": "^1.0.0",
     "@embroider/compat": "0.43.1",
     "@embroider/core": "0.43.1",
@@ -42,6 +43,7 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "cross-env": "^7.0.3",
+    "ember-auto-import": "^1.11.2",
     "ember-cli": "~3.10.1",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
@@ -55,7 +57,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^4.4.1",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.16.0",
     "ember-source-channel-url": "^1.1.0",
@@ -63,6 +65,7 @@
     "eslint-plugin-ember": "^7.0.0",
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^0.8.4"
   },
   "peerDependencies": {

--- a/packages/router/tests/index.html
+++ b/packages/router/tests/index.html
@@ -21,6 +21,13 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>

--- a/packages/router/tests/test-helper.js
+++ b/packages/router/tests/test-helper.js
@@ -1,8 +1,12 @@
 import Application from '../app';
 import config from '../config/environment';
+import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
+import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
+
+setup(QUnit.assert);
 
 start();

--- a/test-packages/fastboot-addon/package.json
+++ b/test-packages/fastboot-addon/package.json
@@ -54,7 +54,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit": "^2.14.1",
-    "qunit-dom": "^1.1.0"
+    "qunit-dom": "^1.6.0"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/test-packages/fastboot-addon/package.json
+++ b/test-packages/fastboot-addon/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
+    "@ember/test-helpers": "^2.2.5",
     "@embroider/test-support": "0.36.0",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
@@ -41,7 +42,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^4.6.0",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^7.0.0",
     "ember-source": "~3.17.0",
     "ember-source-channel-url": "^2.0.1",
@@ -52,6 +53,7 @@
     "eslint-plugin-node": "^9.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
+    "qunit": "^2.14.1",
     "qunit-dom": "^1.1.0"
   },
   "engines": {

--- a/test-packages/fastboot-addon/tests/index.html
+++ b/test-packages/fastboot-addon/tests/index.html
@@ -21,6 +21,13 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>

--- a/test-packages/fastboot-addon/tests/test-helper.js
+++ b/test-packages/fastboot-addon/tests/test-helper.js
@@ -1,8 +1,12 @@
-import Application from '../app';
-import config from '../config/environment';
+import Application from 'dummy/app';
+import config from 'dummy/config/environment';
+import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
+import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
+
+setup(QUnit.assert);
 
 start();

--- a/test-packages/macro-sample-addon/package.json
+++ b/test-packages/macro-sample-addon/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
     "qunit": "^2.14.1",
-    "qunit-dom": "^0.8.4"
+    "qunit-dom": "^1.6.0"
   },
   "engines": {
     "node": "8.* || >= 10.*"

--- a/test-packages/macro-sample-addon/package.json
+++ b/test-packages/macro-sample-addon/package.json
@@ -30,12 +30,14 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "@ember/test-helpers": "^2.2.5",
     "@ember/string": "^1.0.0",
     "@embroider/compat": "0.43.1",
     "@embroider/core": "0.43.1",
     "@embroider/test-support": "0.36.0",
     "@embroider/webpack": "0.43.1",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.11.2",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli": "~3.26.1",
     "ember-cli-eslint": "^5.1.0",
@@ -47,7 +49,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^4.4.1",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.10.0",
     "ember-source-channel-url": "^1.1.0",
@@ -56,6 +58,7 @@
     "eslint-plugin-ember": "^7.0.0",
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^0.8.4"
   },
   "engines": {

--- a/test-packages/macro-sample-addon/tests/index.html
+++ b/test-packages/macro-sample-addon/tests/index.html
@@ -21,6 +21,13 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>

--- a/test-packages/macro-sample-addon/tests/test-helper.js
+++ b/test-packages/macro-sample-addon/tests/test-helper.js
@@ -1,8 +1,12 @@
-import Application from '../app';
-import config from '../config/environment';
+import Application from 'dummy/app';
+import config from 'dummy/config/environment';
+import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
+import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
+
+setup(QUnit.assert);
 
 start();

--- a/test-packages/sample-transforms/package.json
+++ b/test-packages/sample-transforms/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
     "qunit": "^2.14.1",
-    "qunit-dom": "^0.8.4"
+    "qunit-dom": "^1.6.0"
   },
   "engines": {
     "node": "8.* || >= 10.*"

--- a/test-packages/sample-transforms/package.json
+++ b/test-packages/sample-transforms/package.json
@@ -24,8 +24,10 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "@ember/test-helpers": "^2.2.5",
     "@embroider/test-support": "0.36.0",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.11.2",
     "ember-cli": "~3.10.1",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
@@ -39,7 +41,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^4.4.1",
+    "ember-qunit": "^5.1.4",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.10.0",
     "ember-source-channel-url": "^1.1.0",
@@ -47,6 +49,7 @@
     "eslint-plugin-ember": "^7.0.0",
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
+    "qunit": "^2.14.1",
     "qunit-dom": "^0.8.4"
   },
   "engines": {

--- a/test-packages/sample-transforms/tests/index.html
+++ b/test-packages/sample-transforms/tests/index.html
@@ -21,6 +21,13 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>

--- a/test-packages/sample-transforms/tests/test-helper.js
+++ b/test-packages/sample-transforms/tests/test-helper.js
@@ -1,8 +1,12 @@
-import Application from '../app';
-import config from '../config/environment';
+import Application from 'dummy/app';
+import config from 'dummy/config/environment';
+import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
+import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
+
+setup(QUnit.assert);
 
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -15207,15 +15207,7 @@ quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit-dom@^0.8.4:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-0.8.5.tgz#34b7cffb338e631c39955b21bdbe4d774090124e"
-  integrity sha512-I4GSy22ESUkoZYDSYsqFJoMvqhpmgd2iCYlrN7aWLEOdmumUkao3qz24/qVNZd1PAnoOQA78FefzNPRHePFx1A==
-  dependencies:
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.1"
-
-qunit-dom@^1.1.0, qunit-dom@^1.6.0:
+qunit-dom@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-1.6.0.tgz#a4bea6a46329d221e4a317d712cb40709107b977"
   integrity sha512-YwSqcLjQcRI0fUFpaSWwU10KIJPFW5Qh+d3cT5DOgx81dypRuUSiPkKFmBY/CDs/R1KdHRadthkcXg2rqAon8Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,18 +1210,6 @@
   dependencies:
     ember-cli-babel "^7.4.0"
 
-"@ember/test-helpers@^1.7.1":
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-1.7.3.tgz#d06b36cb579b172186b11b236b90f0a1aba15ab0"
-  integrity sha512-0NwxM9rtl/vD/Zqv8cHefLxojL3l2xuRs6pEppff/Fe39ybXz5H7hm5ZvnpRO/lpSsIeX7tivht9ko6/V+sShw==
-  dependencies:
-    broccoli-debug "^0.6.5"
-    broccoli-funnel "^2.0.2"
-    ember-assign-polyfill "^2.6.0"
-    ember-cli-babel "^7.26.2"
-    ember-cli-htmlbars-inline-precompile "^2.1.0"
-    ember-test-waiters "^1.1.1"
-
 "@ember/test-helpers@^2.2.0", "@ember/test-helpers@^2.2.5":
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.2.6.tgz#48a5dd6f871dd531c81edfee8094991fd932dc12"
@@ -5904,7 +5892,7 @@ commander@^6.2.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
-common-tags@^1.4.0, common-tags@^1.8.0:
+common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
   integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
@@ -6789,14 +6777,6 @@ ember-asset-loader@^0.6.1:
     object-assign "^4.1.0"
     walk-sync "^1.1.3"
 
-ember-assign-polyfill@^2.6.0:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.7.2.tgz#58f6f60235126cb23df248c846008fa9a3245fc1"
-  integrity sha512-hDSaKIZyFS0WRQsWzxUgO6pJPFfmcpfdM7CbGoMgYGriYbvkKn+k8zTXSKpTFVGehhSmsLE9YPqisQ9QpPisfA==
-  dependencies:
-    ember-cli-babel "^7.20.5"
-    ember-cli-version-checker "^2.0.0"
-
 ember-auto-import@^1.10.1, ember-auto-import@^1.11.2, ember-auto-import@^1.2.21, ember-auto-import@^1.5.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.11.3.tgz#6e3384a7fbb163384a34546f2e902cd297b0e683"
@@ -7221,7 +7201,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -7240,7 +7220,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, 
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.6, ember-cli-babel@^7.4.0, ember-cli-babel@^7.4.1, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.6, ember-cli-babel@^7.4.0, ember-cli-babel@^7.4.1, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -7701,13 +7681,6 @@ ember-cli-test-info@^1.0.0:
   dependencies:
     ember-cli-string-utils "^1.0.0"
 
-ember-cli-test-loader@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz#3fb8d5d1357e4460d3f0a092f5375e71b6f7c243"
-  integrity sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==
-  dependencies:
-    ember-cli-babel "^6.8.1"
-
 ember-cli-test-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-3.0.0.tgz#1c036fc48de36155355fcda3266af63f977826f1"
@@ -7802,7 +7775,7 @@ ember-cli-uglify@^3.0.0:
     broccoli-uglify-sourcemap "^3.1.0"
     lodash.defaultsdeep "^4.6.0"
 
-ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
   integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
@@ -8500,19 +8473,6 @@ ember-popper@^0.11.3:
     fastboot-transform "^0.1.0"
     popper.js "^1.14.1"
 
-ember-qunit@^4.4.1, ember-qunit@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-4.6.0.tgz#ad79fd3ff00073a8779400cc5a4b44829517590f"
-  integrity sha512-i5VOGn0RP8XH+5qkYDOZshbqAvO6lHgF65D0gz8vRx4DszCIvJMJO+bbftBTfYMxp6rqG85etAA6pfNxE0DqsQ==
-  dependencies:
-    "@ember/test-helpers" "^1.7.1"
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.2"
-    common-tags "^1.4.0"
-    ember-cli-babel "^7.12.0"
-    ember-cli-test-loader "^2.2.0"
-    qunit "^2.9.3"
-
 ember-qunit@^5.1.2, ember-qunit@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-5.1.4.tgz#bc69f963a0f5409ce33bee1e4d8146b1407147bf"
@@ -8999,14 +8959,6 @@ ember-template-recast@^5.0.1:
     slash "^3.0.0"
     tmp "^0.2.1"
     workerpool "^6.1.4"
-
-ember-test-waiters@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-1.2.0.tgz#c12ead4313934c24cff41857020cacdbf8e6effe"
-  integrity sha512-aEw7YuutLuJT4NUuPTNiGFwgTYl23ThqmBxSkfFimQAn+keWjAftykk3dlFELuhsJhYW/S8YoVjN0bSAQRLNtw==
-  dependencies:
-    ember-cli-babel "^7.11.0"
-    semver "^6.3.0"
 
 ember-truth-helpers@^3.0.0:
   version "3.0.0"
@@ -15273,7 +15225,7 @@ qunit-dom@^1.1.0, qunit-dom@^1.6.0:
     ember-cli-babel "^7.23.0"
     ember-cli-version-checker "^5.1.1"
 
-qunit@^2.14.1, qunit@^2.6.1, qunit@^2.9.3:
+qunit@^2.14.1, qunit@^2.6.1:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.16.0.tgz#b8ed63d512e5d4eaada5afc0c6c9e8b844181ba1"
   integrity sha512-88x9t+rRMbB6IrCIUZvYU4pJy7NiBEv7SX8jD4LZAsIj+dV+kwGnFStOmPNvqa6HM96VZMD8CIIFKH2+3qvluA==


### PR DESCRIPTION
Based off https://github.com/embroider-build/embroider/pull/903, but avoiding latest conflicts with master and handling the breaking changes in all packages.