### PR TITLE
Use `require` for retrieving the adjust imports info

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -338,12 +338,12 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
       podModulePrefix: this.podModulePrefix(),
       options: this.options,
       activePackageRules: this.activeRules(),
-      adjustImportsOptionsFile: this.adjustImportsOptionsFile(),
+      adjustImportsOptionsPath: this.adjustImportsOptionsPath(),
     });
   }
 
   @Memoize()
-  adjustImportsOptionsFile(): string {
+  adjustImportsOptionsPath(): string {
     let file = join(this.root, '_adjust_imports.json');
     writeFileSync(file, JSON.stringify(this.adjustImportsOptions()));
     return file;

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -22,7 +22,7 @@ import Options from './options';
 import { ResolvedDep } from '@embroider/core/src/resolver';
 import { dasherize } from './dasherize-component-name';
 import { makeResolverTransform } from './resolver-transform';
-import { pathExistsSync, readFileSync } from 'fs-extra';
+import { pathExistsSync } from 'fs-extra';
 import resolve from 'resolve';
 
 export interface ComponentResolution {
@@ -119,7 +119,7 @@ interface RehydrationParamsBase {
 }
 
 interface RehydrationParamsWithFile extends RehydrationParamsBase {
-  adjustImportsOptionsFile: string;
+  adjustImportsOptionsPath: string;
 }
 
 interface RehydrationParamsWithOptions extends RehydrationParamsBase {
@@ -201,8 +201,9 @@ export default class CompatResolver implements Resolver {
   @Memoize()
   get adjustImportsOptions(): AdjustImportsOptions {
     const { params } = this;
-    return 'adjustImportsOptionsFile' in params
-      ? JSON.parse(readFileSync(params.adjustImportsOptionsFile, 'utf8'))
+    return 'adjustImportsOptionsPath' in params
+      ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require(params.adjustImportsOptionsPath)
       : params.adjustImportsOptions;
   }
 

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -111,7 +111,7 @@ export interface AppAdapter<TreeNames> {
   // compatibility
   adjustImportsOptions(): AdjustImportsOptions;
 
-  adjustImportsOptionsFile(): string;
+  adjustImportsOptionsPath(): string;
 
   // The template preprocessor plugins that are configured in the app.
   htmlbarsPlugins(): TemplateCompilerPlugins;
@@ -417,9 +417,14 @@ export class AppBuilder<TreeNames> {
         relocatedFiles[join(destPath, relativePath).split(sep).join('/')] = originalPath;
       }
     }
+    let relocatedFilesPath = join(this.root, '_relocated_files.json');
+    writeFileSync(relocatedFilesPath, JSON.stringify({ relocatedFiles }));
     return [
       require.resolve('./babel-plugin-adjust-imports'),
-      { adjustImportsOptionsFile: this.adapter.adjustImportsOptionsFile(), relocatedFiles },
+      {
+        adjustImportsOptionsPath: this.adapter.adjustImportsOptionsPath(),
+        relocatedFilesPath,
+      },
     ];
   }
 


### PR DESCRIPTION
Moving this to use `require` means that we get to take advantage of the per-worker require cache (and don't needlessly re-read the file over and over again).