### PR TITLE
Update custom package rules for ember-basic-dropdown

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-basic-dropdown.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-basic-dropdown.ts
@@ -20,7 +20,7 @@ let rulesForV1: PackageRules = {
 
 let rulesForV2: PackageRules = {
   package: 'ember-basic-dropdown',
-  semverRange: '>=2.0.0',
+  semverRange: '>=2.0.0 <=3.0.18',
   addonModules: {
     'components/basic-dropdown.js': {
       dependsOnComponents: ['{{basic-dropdown-trigger}}', '{{basic-dropdown-content}}'],


### PR DESCRIPTION
Based on https://github.com/embroider-build/embroider/issues/921#issuecomment-901186594, we do not need the custom rules anymore, since ember-basic-dropdown has wrapped everything in `ensure-safe-component` now anyhow (https://github.com/cibernox/ember-basic-dropdown/blob/master/CHANGELOG.md)