### PR TITLE
add note on route splitting with pods in readme

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -24,6 +24,10 @@ In your `router.js` file, import our router instead of the stock one:
 +import EmberRouter from '@embroider/router';
 ```
 
+## Notes on usage with pods
+
+If you use the pod file layout for your routes, you have to make sure to set a non-undefined `podModulePrefix` in your `config/environment.js`. `podModulePrefix: ''` is also allowed. Otherwise, your pod routes will not be picked up by Embroider.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE.md).


### PR DESCRIPTION
After spending some time trying to figure out why route splitting did not work, I finally found out that it was because I am using pod layout for my routes, but had no `podModulePrefix` defined - which does work normally as far as I can tell, but Embroider has some code checking for `podModulePrefix !== undefined` which is not triggered in this case.

I figured it might make sense to add this to the readme of @embroider/router, as others might also run into this issue!