### PR TITLE
Tighten CI job timeout down to 15min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     needs: ["discover_matrix", "linting"]
     name: ${{ matrix.name }}
     runs-on: '${{ matrix.os }}-latest'
-    timeout-minutes: 30
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Speaking with the team, we would love to reach a 10 minute Commit -> CI
feedback loop goal. (Assuming the GH Actions queue depth isn't too deep)

We have spoken with  GH to increase our concurrency, but in-order to
reach our goal each of our jobs cannot exceed 5->8minutes.

This is a first step in locking that in.

---

Note: I will wait until everyone is around to chat about this more.