### PR TITLE
Moving cache busting tests to separate CI job

### DIFF
--- a/tests/scenarios/scenarios.ts
+++ b/tests/scenarios/scenarios.ts
@@ -57,4 +57,12 @@ export function supportMatrix(scenarios: Scenarios) {
   });
 }
 
+export function onlyRunRelease(scenarios: Scenarios) {
+  return scenarios.expand({ release });
+}
+
 export const appScenarios = supportMatrix(Scenarios.fromDir(dirname(require.resolve('../app-template/package.json'))));
+
+export const appReleaseScenario = onlyRunRelease(
+  Scenarios.fromDir(dirname(require.resolve('../app-template/package.json')))
+);


### PR DESCRIPTION
This reduces the time cost on macro-tests runs in CI.