### PR TITLE
Limit linting and matrix discovery CI jobs to 5 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   linting:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v1
@@ -37,7 +37,7 @@ jobs:
 
   discover_matrix:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
We should lock this down, as these taking more then 5 minutes isn't
acceptable.

Chatting with @thoov, we believe we can reduce these to sub 1 minute
with a little effort.

Once our GH Actions concurrency is increased, we may want to explore
that