### PR TITLE
Add support for ember-cli addon proxy (bundle caching)

### DIFF
--- a/packages/compat/src/get-real-addon.ts
+++ b/packages/compat/src/get-real-addon.ts
@@ -1,0 +1,32 @@
+// As of ember-cli@3.28, addon instances _may_ be proxied. This can become a
+// problem when patching (setting/restoring) methods on the addon instance or
+// comparing with the addon `__proto__`. The purpose of this util method is to
+// correctly return the _real_ (original) addon instance and not the proxy.
+// @see https://github.com/ember-cli/ember-cli/pull/9487
+
+let TARGET_INSTANCE_SYMBOL: any;
+
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const targetInstanceModule = require('ember-cli/lib/models/per-bundle-addon-cache/target-instance');
+
+  if (targetInstanceModule) {
+    TARGET_INSTANCE_SYMBOL = targetInstanceModule.TARGET_INSTANCE;
+  }
+} catch (e) {
+  // we only want to handle the error when this module isn't found; i.e.,
+  // when a consumer of `ember-engines` is using an old version of `ember-cli`
+  // (less than `ember-cli` 3.28)
+  if (!e || e.code !== 'MODULE_NOT_FOUND') {
+    throw e;
+  }
+}
+
+/**
+ * Given an addon instance, gets the _real_ addon instance
+ * @param maybeProxyAddon - the addon instance, which may be a proxy
+ * @returns the _real_ (not proxied) addon instance
+ */
+export default function getRealAddon(maybeProxyAddon: any): any {
+  return (TARGET_INSTANCE_SYMBOL && maybeProxyAddon[TARGET_INSTANCE_SYMBOL]) || maybeProxyAddon;
+}


### PR DESCRIPTION
As of ember-cli@3.28, addon instances _may_ be proxied (see https://github.com/ember-cli/ember-cli/pull/9487). This can become a problem when patching (setting/restoring) methods on the addon instance or comparing with the addon `__proto__`.

There was an initial workaround for setting/restoring the `preprocessJs` method (see https://github.com/ember-cli/ember-cli/pull/9562). This has proven to be unsustainable as other similar issues were uncovered.

For example, when an addon is proxied, this comparison will _always_ be `true`:
```js
(this.addonInstance.__proto__ && this.addonInstance[treeName] !== this.addonInstance.__proto__[treeName])
```
... as the methods on the `__proto__` are the original method, while on the (proxied) addon are proxy methods. This particular scenario manifests in empty addon trees for proxied addons.

The fix here is to get a reference to the _real_ addon whenever patching methods or comparing to the `__proto__`.
A similar solution was implemented in `ember-engines` (see https://github.com/ember-engines/ember-engines/pull/769).