### PR TITLE
Fix SourceMaps when debugging published embroider

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "sourceMap": true,
+    "inlineSources": true,
     "experimentalDecorators": true,
     "allowUnreachableCode": false,
     "strict": true,


### PR DESCRIPTION
Currently, our sourcemaps reference the corresponding and non existence source file via
the sourcemap sources property.

For example:

```json
{"version":3,"file":"add-to-tree.js","sourceRoot":"","sources":["add-to-tree.ts"] ...
```

Unfortunately, as we do not publish our `.ts` files, debugging tools get
confused. To address this debugging issue, we now configure TypeScript
to inline said sources in the sourcemap file.

Example picture prior to this PR: 

![image](https://user-images.githubusercontent.com/1377/130879001-1f0ff4f2-f880-483b-84c0-ce15bbe0468d.png)
