### PR TITLE
tolerate missing rootURL on asset references

### DIFF
--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -652,12 +652,14 @@ export default class V1App {
 
   private withoutRootURL(src: string) {
     let rootURL = this.config.readConfig().rootURL;
+    // remove the leading slash for now
+    src = src.replace(/^\//, '');
+    // only remove the rootURL if the src startsWith it
     if (src.startsWith(rootURL)) {
-      src = '/' + src.slice(rootURL.length);
-    } else if (src.startsWith('/' + rootURL)) {
-      src = src.slice(rootURL.length);
+      src = src.replace(rootURL, '');
     }
-    return src;
+    // always add a leading slash
+    return '/' + src;
   }
 
   findAppScript(scripts: HTMLScriptElement[], entrypoint: string): HTMLScriptElement {

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -764,4 +764,36 @@ i(\"../../node_modules/lazy-engine/lazy-engine.css\");
   }`);
     });
   });
+
+  describe('asset paths without rootURL', function () {
+    let build: BuildResult;
+    let expectFile: ExpectFile;
+
+    beforeAll(async function () {
+      // setting `assetPrefix: ''` here will remove the `{{rootURL}}` from the generated `index.html`
+      let app = Project.emberNew(undefined, { assetPrefix: '' });
+      let buildOptions: Partial<BuildParams> = {
+        stage: 2,
+        type: 'app',
+        emberAppOptions: {
+          tests: false,
+          babel: {
+            plugins: [],
+          },
+        },
+        embroiderOptions: {},
+      };
+
+      build = await BuildResult.build(app, buildOptions);
+      expectFile = expectFilesAt(build.outputPath);
+    });
+
+    afterAll(async function () {
+      await build.cleanup();
+    });
+
+    test('should find app js correctly', function () {
+      expectFile('index.html').matches('<script src="/assets/my-app.js" type="module"></script>');
+    });
+  });
 });

--- a/packages/core/src/html-entrypoint.ts
+++ b/packages/core/src/html-entrypoint.ts
@@ -51,7 +51,10 @@ export class HTMLEntrypoint {
   }
 
   private relativeToApp(rootRelativeURL: string) {
-    return rootRelativeURL.replace(this.rootURL, '');
+    // Check that the rootRelativeURL startsWith the rootURL before stripping it.
+    // If rootRelativeURL = 'assets/foo.js', and rootURL = '/', we do not want to
+    // incorrectly produce 'assetsfoo.js'
+    return rootRelativeURL.startsWith(this.rootURL) ? rootRelativeURL.replace(this.rootURL, '') : rootRelativeURL;
   }
 
   private handledScripts() {

--- a/test-packages/support/project.ts
+++ b/test-packages/support/project.ts
@@ -70,7 +70,7 @@ function addonEnvironmentFile() {
   };`;
 }
 
-function indexFile(appName: string) {
+function indexFile(appName: string, assetPrefix = '{{rootURL}}') {
   return `
 <!DOCTYPE html>
 <html>
@@ -83,16 +83,16 @@ function indexFile(appName: string) {
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/${appName}.css">
+    <link integrity="" rel="stylesheet" href="${assetPrefix}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="${assetPrefix}assets/${appName}.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/${appName}.js"></script>
+    <script src="${assetPrefix}assets/vendor.js"></script>
+    <script src="${assetPrefix}assets/${appName}.js"></script>
 
     {{content-for "body-footer"}}
   </body>
@@ -167,7 +167,7 @@ export class Project extends FixturifyProject {
   // FIXME: update fixturify-project to allow easier customization of `pkg`
   declare pkg: any;
 
-  static emberNew(name = 'my-app'): Project {
+  static emberNew(name = 'my-app', options?: any): Project {
     let app = new Project(name);
     app.files = {
       // you might think you want to pass params to customize cliBuildFile, but
@@ -179,7 +179,7 @@ export class Project extends FixturifyProject {
         'environment.js': environmentFile(name),
       },
       app: {
-        'index.html': indexFile(name),
+        'index.html': indexFile(name, options?.assetPrefix),
         styles: {
           'app.css': '',
         },


### PR DESCRIPTION
Currently, if `{{rootURL}}` is not present on the app js entrypoint in `index.html`, the build fails in stage 2 with:
```
could not find app javascript in index.html
```

The fix here (see `v1-app.ts`) is to be more forgiving when "finding" the app js entrypoint by making the `rootURL` prefix optional.
That is, `<script src="assets/app.js">` and `<script src="{{rootURL}}assets/app.js">` are both acceptable.

The primary argument for making `{{rootURL}}` optional is that prefixing the asset path with `{{rootURL}}` is not currently required in classic build, and this behavior is strictly being introduced in the `@embroider/compat` layer.

Additionally, `HTMLEntrypoint#relativeToApp` can currently result in inaccurate warnings for asset paths that contain the `rootURL` within the path. e.g. given, `rootURL = '/'`:
```
<link href="assets/foo/bar.css"/>
<script src="assets/fiz/buzz.js"></script>
```
... results in (note the first missing `/` in the paths):
```
warning: in index.html  <link rel="stylesheet" href="assetsfoo/bar.css"> does not exist on disk. If this is intentional, use a data-embroider-ignore attribute.
warning: in index.html  <script src="assetsfiz/buzz.js"> does not exist on disk. If this is intentional, use a data-embroider-ignore attribute.
```
The fix here (see `html-entrypoint.ts`) is to only strip the `rootURL` if the path `startsWith(rootURL)`. This ensures we surface accurate warnings.

## Alternate solutions
The above may be controversial as prefixing with `{{rootURL}}` is probably the _correct_ fix. However, we currently have an app that cannot successfully run with `{{rootURL}}` prefix (this is an issue of our own doing and not a compelling argument).

An alternate approach would be to look for a `data-*` attribute to find the entrypoint. 