### PR TITLE
[Experiment] Skip yarn —frozen-lockfile if we had a cache hit.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,13 @@ jobs:
       - uses: actions/cache@v2
         id: yarn-cache
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          path: '**'
+          key: ${{ runner.os }}-yarn-v2-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-v1
+            ${{ runner.os }}-yarn-v2
       - name: yarn --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
-      - name: yarn prepare
-        if: steps.yarn-cache.outputs.cache-hit == 'true'
-        run: yarn prepare
       - name: lint
         run: yarn lint
 
@@ -48,16 +45,13 @@ jobs:
       - uses: actions/cache@v2
         id: yarn-cache
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          path: '**'
+          key: ${{ runner.os }}-yarn-v2-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-v1
+            ${{ runner.os }}-yarn-v2
       - name: yarn --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: yarn prepare
-        if: steps.yarn-cache.outputs.cache-hit == 'true'
-        run: yarn prepare
       - id: set-matrix
         run: echo "::set-output name=matrix::$(node ./test-packages/support/suite-setup-util.js --matrix)"
 
@@ -77,16 +71,13 @@ jobs:
         if: runner.os != 'Windows'
         id: yarn-cache
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          path: '**'
+          key: ${{ runner.os }}-yarn-v2-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-v1
+            ${{ runner.os }}-yarn-v2
       - name: yarn --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
-      - name: yarn prepare
-        if: steps.yarn-cache.outputs.cache-hit == 'true'
-        run: yarn prepare
       - name: suite
         run: ${{ matrix.command }}
         working-directory: ${{ matrix.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2
         id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: '**/node_modules'
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - run: yarn --frozen-lockfile
+      - name: yarn --frozen-lockfile
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile
+      - name: yarn prepare
+        if: steps.yarn-cache.outputs.cache-hit == 'true'
+        run: yarn prepare
       - name: lint
         run: yarn lint
 
@@ -43,17 +45,19 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2
         id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: '**/node_modules'
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - run: yarn --frozen-lockfile
+      - name: yarn --frozen-lockfile
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: yarn prepare
+        if: steps.yarn-cache.outputs.cache-hit == 'true'
+        run: yarn prepare
       - id: set-matrix
         run: echo "::set-output name=matrix::$(node ./test-packages/support/suite-setup-util.js --matrix)"
 
@@ -69,17 +73,19 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2
         id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: '**/node_modules'
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - run: yarn --frozen-lockfile
+      - name: yarn --frozen-lockfile
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile
+      - name: yarn prepare
+        if: steps.yarn-cache.outputs.cache-hit == 'true'
+        run: yarn prepare
       - name: suite
         run: ${{ matrix.command }}
         working-directory: ${{ matrix.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         id: yarn-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-yarn-v1
       - name: yarn --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
@@ -49,9 +49,9 @@ jobs:
         id: yarn-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-yarn-v1
       - name: yarn --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -74,12 +74,13 @@ jobs:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1
       - uses: actions/cache@v2
+        if: runner.os != 'Windows'
         id: yarn-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-yarn-v1
       - name: yarn --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile


### PR DESCRIPTION
In theory this should be safe, as our cache key is based: `os + hashFile(**/yarn.lock)`.

This would reduce our install times by 40s -> 1.5minutes or up to about 100 GH-Action minutes or so.