### PR TITLE
Add allowEmpty to __COMPILED_STYLES__ funnel

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -760,6 +760,7 @@ export default class V1Addon {
         addonStylesTree = buildFunnel(addonStylesTree, {
           srcDir: `${this.name}/__COMPILED_STYLES__`,
           destDir: '/',
+          allowEmpty: true
         });
       }
 

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -760,7 +760,7 @@ export default class V1Addon {
         addonStylesTree = buildFunnel(addonStylesTree, {
           srcDir: `${this.name}/__COMPILED_STYLES__`,
           destDir: '/',
-          allowEmpty: true
+          allowEmpty: true,
         });
       }
 


### PR DESCRIPTION
After upgrading to 0.44.0 received the following error:

```
You specified a `"srcDir": @linkedin/ember-vector-images/__COMPILED_STYLES__` which does not exist and did not specify `"allowEmpty": true`.
```