### PR TITLE
unify matrix + linting jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ on:
     branches: [master]
 
 jobs:
-  linting:
+  preflight:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
       - uses: actions/checkout@v1
@@ -34,38 +36,19 @@ jobs:
       - run: yarn --frozen-lockfile
       - name: lint
         run: yarn lint
-
-  discover_matrix:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v1
-      - uses: volta-cli/action@v1
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - run: yarn --frozen-lockfile
       - id: set-matrix
         run: echo "::set-output name=matrix::$(node ./test-packages/support/suite-setup-util.js --matrix)"
 
   test:
-    needs: ["discover_matrix", "linting"]
+    needs: ["preflight"]
     name: ${{ matrix.name }}
     runs-on: '${{ matrix.os }}-latest'
     timeout-minutes: 15
 
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.discover_matrix.outputs.matrix)}}
+      matrix: ${{fromJson(needs.preflight.outputs.matrix)}}
+
     steps:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1


### PR DESCRIPTION
Matrix generation is nearly instant, no need to spin up a whole job job
where 99.9% of the time is spent installing & building