### PR TITLE
Restructure workspaceDir logic

### DIFF
--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -25,8 +25,8 @@ export default function defaultPipeline<PackagerOptions>(
   packager?: PackagerConstructor<PackagerOptions>,
   options: PipelineOptions<PackagerOptions> = {}
 ): Node {
+  let outputPath: string;
   let addons;
-  let appDestDir: string;
 
   if (process.env.REUSE_WORKSPACE) {
     addons = new PrebuiltAddons(emberApp, options, process.env.REUSE_WORKSPACE);
@@ -40,18 +40,18 @@ export default function defaultPipeline<PackagerOptions>(
     emberApp.project.ui.write(`Building into ${options.workspaceDir}\n`);
     addons = new CompatAddons(emberApp, options);
     addons.ready().then(result => {
-      appDestDir = result.outputPath;
+      outputPath = result.outputPath;
     });
   }
 
   if (process.env.STAGE1_ONLY) {
-    return mergeTrees([addons.tree, writeFile('.stage1-output', () => appDestDir)]);
+    return mergeTrees([addons.tree, writeFile('.stage1-output', () => outputPath)]);
   }
 
   let embroiderApp = new App(emberApp, addons, options);
 
   if (process.env.STAGE2_ONLY || !packager) {
-    return mergeTrees([embroiderApp.tree, writeFile('.stage2-output', () => appDestDir)]);
+    return mergeTrees([embroiderApp.tree, writeFile('.stage2-output', () => outputPath)]);
   }
 
   let BroccoliPackager = toBroccoliPlugin(packager);

--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -38,10 +38,6 @@ export default function defaultPipeline<PackagerOptions>(
 
     emberApp.project.ui.write(`Building into ${options.workspaceDir}\n`);
     addons = new CompatAddons(emberApp, options);
-
-    if (options && options.onOutputPath) {
-      options.onOutputPath(options.workspaceDir);
-    }
   }
 
   if (process.env.STAGE1_ONLY) {

--- a/test-packages/support/build.ts
+++ b/test-packages/support/build.ts
@@ -14,6 +14,7 @@ import { Options } from '../../packages/compat/src';
 import { BoundExpectFile } from './file-assertions';
 import { TemplateCompiler, AppMeta } from '@embroider/core';
 import { Memoize } from 'typescript-memoize';
+import { stableWorkspaceDir } from '@embroider/compat/src/default-pipeline';
 
 export interface BuildParams {
   stage: 1 | 2;
@@ -48,6 +49,9 @@ export default class BuildResult {
       } else {
         instance = emberApp(project.baseDir, params.emberAppOptions);
       }
+
+      params.embroiderOptions.workspaceDir = stableWorkspaceDir(instance.project.root);
+
       let addons = new Addons(instance, params.embroiderOptions);
       let tree;
       if (params.stage === 1) {


### PR DESCRIPTION
Consolidate the logic for workspaceDir (the tmp location used for stage3) so that a proper `Building into ...` message can be displayed (it is currently displayed in the middle of other console.ui writes and can be lost / looks incorrect). This also standardizes the actual outputted "Building into ..." location and our internal workspaceDir. 

Building into now appears at the top of stdout:

![Screen Shot 2021-09-21 at 4 57 06 PM](https://user-images.githubusercontent.com/166909/134262746-8419834b-e99c-4589-9477-89f54e0eb9f8.png)