### PR TITLE
Add link:all script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,5 +34,4 @@ In the tests directory we derive our tests off of base app and addon templates (
 
 1. Clone this repo.
 2. Run `yarn compile` (or `yarn compile --watch`).
-3. In each of the `./packages/*` directories, run `yarn link`.
-4. In your app, `yarn link @embroider/core` and any other embroider packages that appear in your package.json.
+3. From the root of this repo, run `yarn link:all ../path/to/your/project`

--- a/link-all.sh
+++ b/link-all.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# requires
+#   - jq, https://stedolan.github.io/jq/
+#
+# optionally takes one argument
+#   the path to link up
+#
+# example (in the embroider root directory)
+#   yarn link:all ../my-other-project/sub-directory
+#
+#   the project, my-other-project/sub-directory will be linked up locally to embroider
+
+function get_workspaces() {
+  yarn workspaces --json info --json | jq '.data' -r | jq 'map(.location) | .[]' -r
+}
+
+embroider_packages=$(get_workspaces | grep ^packages)
+
+target_project=$1
+
+for path in $embroider_packages
+do
+  name=$(cd $path && cat package.json | jq '.name' -r)
+
+  if  [ -z "$target_project" ]; then
+    echo "Linking everything"
+
+    ( cd $path && yarn link )
+  else
+    if [ -z "$(cat $target_project/package.json | grep $name)" ]; then
+      echo "Skipping $name. Not present in target project."
+    else
+      echo "Linking $name"
+      ( cd $path && yarn link )
+      ( cd $target_project && yarn link $name )
+    fi
+  fi
+done
+

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clean": "git clean -x -f",
     "compile": "tsc",
     "lint": "eslint . --cache",
+    "link:all": "./link-all.sh",
     "prepare": "tsc",
     "test": "node ./test-packages/support/suite-setup-util.js --emit && jest"
   },


### PR DESCRIPTION
I added this because I find linking monorepos to be tedious. 

sample output
```bash
❯ yarn link:all ../limber/frontend/
yarn run v1.22.11
$ ./link-all.sh ../limber/frontend/
Skipping @embroider/addon-shim. Not present in target project.
Skipping @embroider/babel-loader-8. Not present in target project.
Linking @embroider/compat
warning There's already a package called "@embroider/compat" registered. This command has had no effect. If this command was run in another folder with the same name, the other folder is still linked. Please run yarn unlink in the other folder if you want to register this folder.
success Using linked package for "@embroider/compat".
Linking @embroider/core
warning There's already a package called "@embroider/core" registered. This command has had no effect. If this command was run in another folder with the same name, the other folder is still linked. Please run yarn unlink in the other folder if you want to register this folder.
success Using linked package for "@embroider/core".
Skipping @embroider/hbs-loader. Not present in target project.
Skipping @embroider/macros. Not present in target project.
Skipping @embroider/router. Not present in target project.
Skipping @embroider/shared-internals. Not present in target project.
Skipping @embroider/test-setup. Not present in target project.
Skipping @embroider/util. Not present in target project.
Linking @embroider/webpack
warning There's already a package called "@embroider/webpack" registered. This command has had no effect. If this command was run in another folder with the same name, the other folder is still linked. Please run yarn unlink in the other folder if you want to register this folder.
success Using linked package for "@embroider/webpack".
Done in 1.82s.

```