### PR TITLE
Apply compileStyles to custom treeForAddonStyles

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -696,7 +696,10 @@ export default class V1Addon {
 
   protected addonStylesTree(): Node | undefined {
     if (this.customizes('treeForAddonStyles')) {
-      return this.invokeOriginalTreeFor('addon-styles');
+      let custom = this.invokeOriginalTreeFor('addon-styles');
+      if (custom) {
+        return this.addonInstance.compileStyles(custom);
+      }
     } else if (this.hasStockTree('addon-styles')) {
       return this.addonInstance.compileStyles(this.stockTree('addon-styles'));
     }


### PR DESCRIPTION
It looks to me as if this was always supposed to be present. I noticed because an addon with a customized `treeForAddonStyles` broke under embroider on ember-cli 3.18+, because its customized output was not getting wrapped in the `__COMPILED_STYES__` directory as expected.