### PR TITLE
Address misleading warnings from rollup about externals

### DIFF
--- a/packages/addon-dev/sample-rollup.config.js
+++ b/packages/addon-dev/sample-rollup.config.js
@@ -26,7 +26,13 @@ export default {
     // template colocation.
     babel({
       plugins: ['@embroider/addon-dev/template-colocation-plugin'],
+      babelHelpers: 'bundled',
     }),
+
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),

--- a/packages/addon-dev/src/rollup-addon-dependencies.ts
+++ b/packages/addon-dev/src/rollup-addon-dependencies.ts
@@ -1,0 +1,54 @@
+import type { Plugin } from 'rollup';
+import { readJsonSync } from 'fs-extra';
+import {
+  emberVirtualPackages,
+  emberVirtualPeerDeps,
+  packageName,
+  templateCompilationModules,
+} from '@embroider/shared-internals';
+
+const compilationModules = new Set(
+  templateCompilationModules.map((m) => m.module)
+);
+
+function resolvableDependencies() {
+  let deps = new Set();
+  let pkg = readJsonSync('package.json');
+  if (pkg.dependencies) {
+    for (let name of Object.keys(pkg.dependencies)) {
+      deps.add(name);
+    }
+  }
+  if (pkg.peerDependencies) {
+    for (let name of Object.keys(pkg.peerDependencies)) {
+      deps.add(name);
+    }
+  }
+  return deps;
+}
+
+export default function emberExternals(): Plugin {
+  let deps = resolvableDependencies();
+
+  return {
+    name: 'ember-externals',
+
+    async resolveId(source) {
+      let pkgName = packageName(source);
+      if (!pkgName) {
+        // No package name found means this is a relative import, which we don't
+        // need to deal with.
+        return;
+      }
+
+      if (
+        deps.has(pkgName) ||
+        emberVirtualPeerDeps.has(pkgName) ||
+        emberVirtualPackages.has(pkgName) ||
+        compilationModules.has(pkgName)
+      ) {
+        return { id: source, external: true };
+      }
+    },
+  };
+}

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -3,6 +3,7 @@ import { default as publicEntrypoints } from './rollup-public-entrypoints';
 import { default as appReexports } from './rollup-app-reexports';
 import { default as clean } from 'rollup-plugin-delete';
 import { default as keepAssets } from './rollup-keep-assets';
+import { default as dependencies } from './rollup-addon-dependencies';
 import type { Plugin } from 'rollup';
 
 export class Addon {
@@ -62,5 +63,9 @@ export class Addon {
   // above).
   output() {
     return { dir: this.#destDir, format: 'es', entryFileNames: '[name]' };
+  }
+
+  dependencies() {
+    return dependencies();
   }
 }


### PR DESCRIPTION
When building a v2 addon we deliberately *don't* want rollup to do anything with imports of our dependencies or the various ember-provided package names we might refer to. And that is what already happens, except rollup emits warnings about them.

This adds a plugin that handles these dependenices correctly, making them explicitly as external so there's no warning, while ensuring that if you stray from the allowed resolvable dependencies you will still see warnings.