### PR TITLE
Ensure components + helpers can work from `this` paths with `staticComponents = true` & `staticHelpers = true`

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -64,9 +64,6 @@ export function makeResolverTransform(resolver: Resolver) {
           if (node.path.type !== 'PathExpression') {
             return;
           }
-          if (node.path.original.includes('liquidif')) {
-            debugger;
-          }
           if (node.path.this === true) {
             return;
           }
@@ -82,9 +79,6 @@ export function makeResolverTransform(resolver: Resolver) {
         MustacheStatement(node: ASTv1.MustacheStatement) {
           if (node.path.type !== 'PathExpression') {
             return;
-          }
-          if (node.path.original.includes('liquidif')) {
-            debugger;
           }
           if (scopeStack.inScope(node.path.parts[0])) {
             return;

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -28,6 +28,9 @@ export function makeResolverTransform(resolver: Resolver) {
           if (scopeStack.inScope(node.path.parts[0])) {
             return;
           }
+          if (node.path.head.type === 'ThisHead') {
+            return;
+          }
           if (node.path.parts.length > 1) {
             // paths with a dot in them (which therefore split into more than
             // one "part") are classically understood by ember to be contextual
@@ -61,6 +64,9 @@ export function makeResolverTransform(resolver: Resolver) {
           if (node.path.type !== 'PathExpression') {
             return;
           }
+          if (node.path.original.includes('liquidif')) {
+            debugger;
+          }
           if (node.path.this === true) {
             return;
           }
@@ -76,6 +82,9 @@ export function makeResolverTransform(resolver: Resolver) {
         MustacheStatement(node: ASTv1.MustacheStatement) {
           if (node.path.type !== 'PathExpression') {
             return;
+          }
+          if (node.path.original.includes('liquidif')) {
+            debugger;
           }
           if (scopeStack.inScope(node.path.parts[0])) {
             return;

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -28,7 +28,7 @@ export function makeResolverTransform(resolver: Resolver) {
           if (scopeStack.inScope(node.path.parts[0])) {
             return;
           }
-          if (node.path.head.type === 'ThisHead') {
+          if (node.path.head && node.path.head.type === 'ThisHead') {
             return;
           }
           if (node.path.parts.length > 1) {

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -28,7 +28,7 @@ export function makeResolverTransform(resolver: Resolver) {
           if (scopeStack.inScope(node.path.parts[0])) {
             return;
           }
-          if (node.path.head && node.path.head.type === 'ThisHead') {
+          if (node.path.this === true) {
             return;
           }
           if (node.path.parts.length > 1) {
@@ -81,6 +81,9 @@ export function makeResolverTransform(resolver: Resolver) {
             return;
           }
           if (scopeStack.inScope(node.path.parts[0])) {
+            return;
+          }
+          if (node.path.this === true) {
             return;
           }
           if (node.path.parts.length > 1) {

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -476,9 +476,9 @@ describe('compat-resolver', function () {
     let findDependencies = configure({ staticHelpers: true });
     expect(findDependencies('templates/application.hbs', `{{(this.myHelper 42)}}`)).toEqual([]);
   });
-  test('class defined component not failing if there is no arguments', function () {
+  test('helper defined in component not failing if there is no arguments', function () {
     let findDependencies = configure({ staticComponents: true, staticHelpers: true });
-    expect(findDependencies('templates/application.hbs', `{{this.myComponent}}`)).toEqual([]);
+    expect(findDependencies('templates/application.hbs', `{{#if (this.myHelper)}}{{/if}}`)).toEqual([]);
   });
   test('class defined component not failing if there is a block', function () {
     let findDependencies = configure({ staticComponents: true, staticHelpers: true });

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -476,6 +476,20 @@ describe('compat-resolver', function () {
     let findDependencies = configure({ staticHelpers: true });
     expect(findDependencies('templates/application.hbs', `{{(this.myHelper 42)}}`)).toEqual([]);
   });
+  test('class defined component not failing if there is no arguments', function () {
+    let findDependencies = configure({ staticComponents: true, staticHelpers: true });
+    expect(findDependencies('templates/application.hbs', `{{this.myComponent}}`)).toEqual([]);
+  });
+  test('class defined component not failing if there is a block', function () {
+    let findDependencies = configure({ staticComponents: true, staticHelpers: true });
+    expect(findDependencies('templates/application.hbs', `{{#this.myComponent}}hello{{/this.myComponent}}`)).toEqual(
+      []
+    );
+  });
+  test('class defined component not failing with arguments', function () {
+    let findDependencies = configure({ staticComponents: true, staticHelpers: true });
+    expect(findDependencies('templates/application.hbs', `{{#this.myComponent 42}}{{/this.myComponent}}`)).toEqual([]);
+  });
   test('mustache missing, no args', function () {
     let findDependencies = configure({
       staticComponents: true,


### PR DESCRIPTION
Allow components from `{{#this.foobar}}baz{{/this.foobar}}` to be static. Needed for: adopted-ember-addons/ember-collapsible-panel#87