### PR TITLE
Add nodeReslove, because otherwise, sibling files cannot be imported?

### DIFF
--- a/packages/addon-dev/sample-rollup.config.js
+++ b/packages/addon-dev/sample-rollup.config.js
@@ -1,5 +1,6 @@
 import babel from '@rollup/plugin-babel';
 import { Addon } from '@embroider/addon-dev/rollup';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const addon = new Addon({
   srcDir: 'src',
@@ -12,6 +13,8 @@ export default {
   output: addon.output(),
 
   plugins: [
+    nodeResolve({ resolveOnly: ['./'] }),
+
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
     addon.publicEntrypoints(['components/**/*.js', 'index.js']),


### PR DESCRIPTION
Related: https://github.com/NullVoxPopuli/ember-resources/pull/284/files

<details><summary>Given, this config</summary>

```js
import path from 'path';
import { nodeResolve } from '@rollup/plugin-node-resolve';

import { babel } from '@rollup/plugin-babel';

import { Addon } from '@embroider/addon-dev/rollup';

const addon = new Addon({
  srcDir: 'src',
  destDir: 'dist',
});

const extensions = ['.js', '.ts'];

const rollupConfig = {
  input: path.join('src', 'index.ts'),

  // This provides defaults that work well alongside `publicEntrypoints` below.
  // You can augment this if you need to.
  output: { ...addon.output(), entryFileNames: '[name].js' },

  plugins: [
    // this is needed so we can have files that import other files...
     nodeResolve({ resolveOnly: ['./'], extensions }),

    // These are the modules that users should be able to import from your
    // addon. Anything not listed here may get optimized away.
    addon.publicEntrypoints(['index.js']),

    // These are the modules that should get reexported into the traditional
    // "app" tree. Things in here should also be in publicEntrypoints above, but
    // not everything in publicEntrypoints necessarily needs to go here.
    // addon.appReexports(['components/**/*.js', 'services/**/*.js']),

    // This babel config should *not* apply presets or compile away ES modules.
    // It exists only to provide development niceties for you, like automatic
    // template colocation.
    // See `babel.config.json` for the actual Babel configuration!
    babel({ babelHelpers: 'bundled', extensions }),

    // Follow the V2 Addon rules about dependencies. Your code can import from
    // `dependencies` and `peerDependencies` as well as standard Ember-provided
    // package names.
    addon.dependencies(),

    // addons are allowed to contain imports of .css files, which we want rollup
    // to leave alone and keep in the published output.
    // addon.keepAssets(['**/*.css']),

    // Remove leftover build artifacts when starting a new build.
    addon.clean(),
  ],
};

export default rollupConfig;
```

</details>

I have successful compile:
```
rollup v2.60.0
bundles src/index.ts → dist...
created dist in 294ms

[2021-11-16 16:08:30] waiting for changes...
```
but, if I comment out the nodeResolve line, I get this error:

```
rollup v2.60.0
bundles src/index.ts → dist...
[!] Error: Could not resolve './-private/resources/lifecycle' from src/index.ts
Error: Could not resolve './-private/resources/lifecycle' from src/index.ts
    at error (:scissors:/ember-resources/node_modules/rollup/dist/shared/rollup.js:158:30)
    at ModuleLoader.handleResolveId (:scissors:/ember-resources/node_modules/rollup/dist/shared/rollup.js:22336:24)
    at :scissors:/ember-resources/node_modules/rollup/dist/shared/rollup.js:22310:26


[2021-11-16 16:11:28] waiting for changes...


```