### PR TITLE
Don't resolve built-in components when used with the component helper

### DIFF
--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -731,6 +731,11 @@ export default class CompatResolver implements Resolver {
         from
       );
     }
+
+    if (builtInComponents.includes(component.path)) {
+      return null;
+    }
+
     let found = this.tryComponent(component.path, from);
     if (found) {
       return this.add(found, from);

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -518,6 +518,21 @@ describe('compat-resolver', function () {
       },
     ]);
   });
+  test('built-in components are ignored when used with the component helper', function () {
+    let findDependencies = configure({
+      staticComponents: true,
+    });
+    expect(
+      findDependencies(
+        'templates/application.hbs',
+        `
+      {{component "input"}}
+      {{component "link-to"}}
+      {{component "textarea"}}
+    `
+      )
+    ).toEqual([]);
+  });
   test('component helper with direct addon package reference', function () {
     let findDependencies = configure({
       staticComponents: true,


### PR DESCRIPTION
It seems that the code that handles the component helper doesn't ignore the built-in components like the other [component resolving code does](https://github.com/embroider-build/embroider/blob/bec54e21af303b07a600c4c220ccb3032d5f4619/packages/compat/src/resolver.ts#L667-L669).

Closes #815 