### PR TITLE
[DOC] Update macroCondition template helper example

### DIFF
--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -92,7 +92,7 @@ Macros can also be used inside of templates:
 Starting with Ember 3.25 you can also use it to conditionally apply modifiers:
 
 ```hbs
-<button {{(if (macroCondition true) on) "click" this.something}}>Submit</button>
+<button {{(if (macroCondition true) (on "click" this.something)}}>Submit</button>
 ```
 
 However, in all cases the argument to `macroCondition` must be statically analyzable:


### PR DESCRIPTION
The `macroCondition` template example doesn't look correct. I think this fixes it.