### PR TITLE
Reproduce issue https://github.com/embroider-build/embroider/issues/1038

### DIFF
--- a/packages/macros/tests/babel/dependency-satisfies.test.ts
+++ b/packages/macros/tests/babel/dependency-satisfies.test.ts
@@ -123,5 +123,24 @@ describe(`dependencySatisfies`, function () {
       );
       expect(runDefault(code)).toBe(true);
     });
+
+    test('it considers alpha releases as allowed', () => {
+      project = new Project('test-app', '1.0.0');
+      project.addDevDependency('ember-source', '4.2.0-alpha.2');
+      project.writeSync();
+
+      process.chdir(project.baseDir);
+
+      let code = transform(
+        `
+          import { dependencySatisfies } from '@embroider/macros';
+          export default function() {
+            return dependencySatisfies('ember-source', '>= 3.27.0-canary || >= 3.27.0-beta');
+          }
+        `,
+        { filename: path.join(project.baseDir, 'foo.js') }
+      );
+      expect(runDefault(code)).toBe(true);
+    });
   });
 });

--- a/packages/macros/tests/babel/macro-condition.test.ts
+++ b/packages/macros/tests/babel/macro-condition.test.ts
@@ -1,4 +1,4 @@
-import { makeRunner, makeBabelConfig, allModes } from './helpers';
+import { Project, makeRunner, makeBabelConfig, allModes } from './helpers';
 import { allBabelVersions } from '@embroider/test-support';
 import { MacrosConfig } from '../../src/node';
 
@@ -339,6 +339,28 @@ describe('macroCondition', function () {
       `);
         expect(run(code)).toBe('alpha');
         expect(code).not.toMatch(/beta/);
+      });
+
+      buildTimeTest('can evaluate pre-release dependency expressions', () => {
+        let project = new Project('test-app', '1.0.0');
+        project.addDevDependency('ember-source', '4.2.0-alpha.2');
+        project.writeSync();
+
+        process.chdir(project.baseDir);
+
+        let code = transform(`
+          import { macroCondition, dependencySatisfies } from '@embroider/macros';
+          export default function() {
+            return macroCondition(
+              dependencySatisfies('ember-source', '>=3.27.0-canary || >=3.27.0-beta')
+            )
+              ? 'success'
+              : 'failure'
+          }
+        `);
+
+        expect(run(code)).toBe('success');
+        expect(code).not.toMatch(/failure/);
       });
 
       buildTimeTest('can see booleans inside getConfig', () => {


### PR DESCRIPTION
Things left to do:
 - the macroConditions tests are super thrown off by the project logic copied from dependencySatisfies tests.
 
 the tldr is that ember >= 4.1 doesn't work with @embroider/macros;