### PR TITLE
Make extraImports lazy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-v1
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn --frozen-lockfile
@@ -63,7 +63,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-v1
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn --frozen-lockfile

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -460,9 +460,9 @@ describe('stage2 build', function () {
 
     test('addon/hello-world.js', function () {
       let assertFile = expectFile('node_modules/my-addon/components/hello-world.js').transform(build.transpile);
-      assertFile.matches(/import \* as a. from ["']\.\.\/synthetic-import-1/);
+      assertFile.matches(/import \* as a\d? from ["']\.\.\/synthetic-import-1/);
       assertFile.matches(/window\.define\(["']\my-addon\/synthetic-import-1["']/);
-      assertFile.matches(/import \* as a. from ["']\.\.\/\.\.\/\.\.\/templates\/components\/second-choice\.hbs["']/);
+      assertFile.matches(/import \* as a\d? from ["']\.\.\/\.\.\/\.\.\/templates\/components\/second-choice\.hbs["']/);
       assertFile.matches(/window\.define\(["']my-app\/templates\/components\/second-choice["']/);
       assertFile.matches(
         /import somethingExternal from ["'].*\/externals\/not-a-resolvable-package["']/,
@@ -472,7 +472,7 @@ describe('stage2 build', function () {
 
     test('app/hello-world.js', function () {
       let assertFile = expectFile('./components/hello-world.js').transform(build.transpile);
-      assertFile.matches(/import \* as a. from ["']\.\.\/node_modules\/my-addon\/synthetic-import-1/);
+      assertFile.matches(/import \* as a\d? from ["']\.\.\/node_modules\/my-addon\/synthetic-import-1/);
       assertFile.matches(/window\.define\(["']my-addon\/synthetic-import-1["']/);
       assertFile.matches(
         /export \{ default \} from ['"]\.\.\/node_modules\/my-addon\/components\/hello-world['"]/,
@@ -490,7 +490,7 @@ describe('stage2 build', function () {
 
     test('uses-inline-template.js', function () {
       let assertFile = expectFile('./components/uses-inline-template.js').transform(build.transpile);
-      assertFile.matches(/import a. from ["']\.\.\/templates\/components\/first-choice.hbs/);
+      assertFile.matches(/import a\d? from ["']\.\.\/templates\/components\/first-choice.hbs/);
       assertFile.matches(/window\.define\(["']\my-app\/templates\/components\/first-choice["']/);
     });
 

--- a/packages/compat/tests/stage2.test.ts
+++ b/packages/compat/tests/stage2.test.ts
@@ -460,10 +460,12 @@ describe('stage2 build', function () {
 
     test('addon/hello-world.js', function () {
       let assertFile = expectFile('node_modules/my-addon/components/hello-world.js').transform(build.transpile);
-      assertFile.matches(/import \* as a\d? from ["']\.\.\/synthetic-import-1/);
-      assertFile.matches(/window\.define\(["']\my-addon\/synthetic-import-1["']/);
-      assertFile.matches(/import \* as a\d? from ["']\.\.\/\.\.\/\.\.\/templates\/components\/second-choice\.hbs["']/);
-      assertFile.matches(/window\.define\(["']my-app\/templates\/components\/second-choice["']/);
+      assertFile.matches(
+        /window\.define\(["']\my-addon\/synthetic-import-1["'],\s*function\s\(\)\s*\{\s*return\s+require\(["']\.\.\/synthetic-import-1/
+      );
+      assertFile.matches(
+        /window\.define\(["']my-app\/templates\/components\/second-choice["'],\s*function\s\(\)\s*\{\s*return\s+require\(["']\.\.\/\.\.\/\.\.\/templates\/components\/second-choice\.hbs["']/
+      );
       assertFile.matches(
         /import somethingExternal from ["'].*\/externals\/not-a-resolvable-package["']/,
         'externals are handled correctly'
@@ -472,8 +474,9 @@ describe('stage2 build', function () {
 
     test('app/hello-world.js', function () {
       let assertFile = expectFile('./components/hello-world.js').transform(build.transpile);
-      assertFile.matches(/import \* as a\d? from ["']\.\.\/node_modules\/my-addon\/synthetic-import-1/);
-      assertFile.matches(/window\.define\(["']my-addon\/synthetic-import-1["']/);
+      assertFile.matches(
+        /window\.define\(["']\my-addon\/synthetic-import-1["'],\s*function\s\(\)\s*\{\s*return\s+require\(["']\.\.\/node_modules\/my-addon\/synthetic-import-1/
+      );
       assertFile.matches(
         /export \{ default \} from ['"]\.\.\/node_modules\/my-addon\/components\/hello-world['"]/,
         'remapped to precise copy of my-addon'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "@embroider/macros": "0.48.0",
     "@embroider/shared-internals": "0.48.0",
     "assert-never": "^1.2.1",
-    "babel-import-util": "^0.2.0",
+    "babel-import-util": "^1.1.0",
     "babel-plugin-ember-template-compilation": "^1.0.0",
     "broccoli-node-api": "^1.7.0",
     "broccoli-persistent-filter": "^3.1.2",

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -8,6 +8,7 @@ import { outputFileSync } from 'fs-extra';
 import { Memoize } from 'typescript-memoize';
 import { compile } from './js-handlebars';
 import { handleImportDeclaration } from './mini-modules-polyfill';
+import { ImportUtil } from 'babel-import-util';
 
 interface State {
   adjustFile: AdjustFile;
@@ -350,7 +351,8 @@ export default function main(babel: typeof Babel) {
         enter(path: NodePath<t.Program>, state: State) {
           let opts = ensureOpts(state);
           state.adjustFile = new AdjustFile(path.hub.file.opts.filename, opts.relocatedFiles);
-          addExtraImports(t, path, opts.extraImports);
+          let adder = new ImportUtil(t, path);
+          addExtraImports(adder, t, path, opts.extraImports);
         },
         exit(path: NodePath<t.Program>, state: State) {
           for (let child of path.get('body')) {
@@ -442,27 +444,28 @@ function rewriteTopLevelImport(
   return join(__dirname, '..');
 };
 
-function addExtraImports(t: BabelTypes, path: NodePath<t.Program>, extraImports: Required<Options>['extraImports']) {
-  let counter = 0;
+function addExtraImports(
+  adder: ImportUtil,
+  t: BabelTypes,
+  path: NodePath<t.Program>,
+  extraImports: Required<Options>['extraImports']
+) {
   for (let { absPath, target, runtimeName } of extraImports) {
     if (absPath === path.hub.file.opts.filename) {
       if (runtimeName) {
-        path.node.body.unshift(amdDefine(t, runtimeName, counter));
-        path.node.body.unshift(
-          t.importDeclaration([t.importNamespaceSpecifier(t.identifier(`a${counter++}`))], t.stringLiteral(target))
-        );
+        path.node.body.unshift(amdDefine(t, adder, path, target, runtimeName));
       } else {
-        path.node.body.unshift(t.importDeclaration([], t.stringLiteral(target)));
+        adder.importForSideEffect(target);
       }
     }
   }
 }
 
-function amdDefine(t: BabelTypes, runtimeName: string, importCounter: number) {
+function amdDefine(t: BabelTypes, adder: ImportUtil, path: NodePath<t.Program>, target: string, runtimeName: string) {
   return t.expressionStatement(
     t.callExpression(t.memberExpression(t.identifier('window'), t.identifier('define')), [
       t.stringLiteral(runtimeName),
-      t.functionExpression(null, [], t.blockStatement([t.returnStatement(t.identifier(`a${importCounter}`))])),
+      t.functionExpression(null, [], t.blockStatement([t.returnStatement(adder.import(path, target, '*', 'a'))])),
     ])
   );
 }

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -462,10 +462,11 @@ function addExtraImports(
 }
 
 function amdDefine(t: BabelTypes, adder: ImportUtil, path: NodePath<t.Program>, target: string, runtimeName: string) {
+  let value = t.callExpression(adder.import(path, '@embroider/macros', 'importSync'), [t.stringLiteral(target)]);
   return t.expressionStatement(
     t.callExpression(t.memberExpression(t.identifier('window'), t.identifier('define')), [
       t.stringLiteral(runtimeName),
-      t.functionExpression(null, [], t.blockStatement([t.returnStatement(adder.import(path, target, '*', 'a'))])),
+      t.functionExpression(null, [], t.blockStatement([t.returnStatement(value)])),
     ])
   );
 }

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -29,7 +29,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "babel-import-util": "^0.2.0",
+    "babel-import-util": "^1.1.0",
     "ember-rfc176-data": "^0.3.17",
     "resolve-package-path": "^4.0.1",
     "typescript-memoize": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,6 +4066,11 @@ babel-import-util@^0.2.0:
   resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-0.2.0.tgz#b468bb679919601a3570f9e317536c54f2862e23"
   integrity sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==
 
+babel-import-util@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-1.1.0.tgz#4156b16ef090c4f0d3cdb869ff799202f24aeb93"
+  integrity sha512-sfzgAiJsUT1es9yrHAuJZuJfBkkOE7Og6rovAIwK/gNJX6MjDfWTprbPngdJZTd5ye4F3FvpvpQmvKXObRzVYA==
+
 babel-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"


### PR DESCRIPTION
The `PackageRules` system can account for undeclared dependencies between third-party modules.

Right now it generates top-level static imports for those things. But this can make them eager where they weren't before, which can run afoul of module cycles.

This PR is attempting to make them lazy by using `importSync` instead. 

Note that not all environments support a lazy `importSync`, but the default webpack one does. It's still helpful as a compatibility path, as the ecosystem refactors away from needing `PackageRules`.