### PR TITLE
Append styles imported in JS to end of `document.head`

### DIFF
--- a/packages/core/src/html-placeholder.ts
+++ b/packages/core/src/html-placeholder.ts
@@ -32,8 +32,12 @@ export default class Placeholder {
     }
   }
 
-  insert(node: Node) {
+  insert(node: Node): void {
     this.end.parentElement.insertBefore(node, this.end);
+  }
+
+  appendToHead(node: Node): void {
+    this.end.ownerDocument.head.appendChild(node);
   }
 
   isScript(): boolean {
@@ -70,12 +74,20 @@ export default class Placeholder {
     let newTag = this.end.ownerDocument.createElement('link');
     newTag.href = href;
     newTag.rel = 'stylesheet';
-    this.insert(newTag);
-    this.insertNewline();
+
+    if (this.isScript()) {
+      // Add dynamic styles from scripts to the bottom of the head, and not to where the script was,
+      // to prevent FOUC when pre-rendering (FastBoot)
+      this.appendToHead(newTag);
+    } else {
+      // Keep the new style in the same place as the original one
+      this.insert(newTag);
+    }
+    this.insertNewline(newTag as InDOMNode);
   }
 
-  insertNewline() {
-    this.end.parentElement.insertBefore(this.end.ownerDocument.createTextNode('\n'), this.end);
+  insertNewline(node: InDOMNode = this.end): void {
+    node.parentElement.insertBefore(node.ownerDocument.createTextNode('\n'), node);
   }
 }
 


### PR DESCRIPTION
This addresses the issue raised in #1033 ("2. Import app.scss from app.js") that link tags added through imports of CSS in JS get added next to the script entrypoint (at the body's end) rather than to the document's head, causing a FOUC in FastBoot rendered pages.

This was tested locally with my test app (https://github.com/simonihmig/embroider-sass-app/tree/import-app), so I am quite confident it does the right thing. Idk if we need automated tests for this, I haven't found any related test coverage, but maybe I missed something with the (new) test setup? We *could* add unit tests for the `Placeholder` class, but that seems to yield relatively little value given the rather trivial implementation. Better maybe would be some webpack-related e2e-like tests. To ensure the output in the generated index.html, especially the order of styles and scripts, one would probably need (jest) tests that parse the build output, rather than regular ember app tests?