### PR TITLE
Disable publicAssetURL for FastBoot script render

### DIFF
--- a/packages/core/src/html-entrypoint.ts
+++ b/packages/core/src/html-entrypoint.ts
@@ -99,19 +99,28 @@ export class HTMLEntrypoint {
             if (!base) {
               // this bundle only exists in the fastboot variant
               let element = placeholder.start.ownerDocument.createElement('fastboot-script');
-              element.setAttribute('src', this.publicAssetURL + fastboot);
+              // HACK: actual URL in `publicAssetURL` breaks fastboot loading; only absolute path works
+              let src = this.publicAssetURL.match(/^http/) ? '/' : this.publicAssetURL;
+              element.setAttribute('src', src + fastboot);
               placeholder.insert(element);
               placeholder.insertNewline();
             } else if (!fastboot || base === fastboot) {
               // no specialized fastboot variant
               let src = this.publicAssetURL + base;
-              placeholder.insertURL(src);
+              // HACK: actually, URL in `publicAssetURL` breaks fastboot loading; only absolute path works
+              // so even if there is not specialized fastboot variant, we need to add one without the URL
+              let element = placeholder.insertURL(src);
+              if (element && this.publicAssetURL.match(/^http/)) {
+                element.setAttribute('data-fastboot-src', '/' + base);
+              }
             } else {
               // we have both and they differ
               let src = this.publicAssetURL + base;
               let element = placeholder.insertURL(src);
               if (element) {
-                element.setAttribute('data-fastboot-src', this.publicAssetURL + fastboot);
+                // HACK: actual URL in `publicAssetURL` breaks fastboot loading; only absolute path works
+                let src = this.publicAssetURL.match(/^http/) ? '/' : this.publicAssetURL;
+                element.setAttribute('data-fastboot-src', src + fastboot);
               }
             }
           }
@@ -155,7 +164,9 @@ function maybeInsertLazyBundles(
   if (!insertedLazy && placeholder.isScript()) {
     for (let bundle of lazyBundles) {
       let element = placeholder.start.ownerDocument.createElement('fastboot-script');
-      element.setAttribute('src', publicAssetURL + bundle);
+      // HACK: actual URL in `publicAssetURL` breaks fastboot loading; only absolute path works
+      let src = publicAssetURL.match(/^http/) ? '/' : publicAssetURL;
+      element.setAttribute('src', src + bundle);
       placeholder.insert(element);
       placeholder.insertNewline();
     }


### PR DESCRIPTION
When `publicAssetURL` is supplied and starts with `http`, generate
script tags for FastBoot without it.