### PR TITLE
Fix imported CSS with FastBoot

### DIFF
--- a/packages/core/src/html-entrypoint.ts
+++ b/packages/core/src/html-entrypoint.ts
@@ -154,10 +154,12 @@ function maybeInsertLazyBundles(
 ): boolean {
   if (!insertedLazy && placeholder.isScript()) {
     for (let bundle of lazyBundles) {
-      let element = placeholder.start.ownerDocument.createElement('fastboot-script');
-      element.setAttribute('src', publicAssetURL + bundle);
-      placeholder.insert(element);
-      placeholder.insertNewline();
+      if (bundle.endsWith('.js')) {
+        let element = placeholder.start.ownerDocument.createElement('fastboot-script');
+        element.setAttribute('src', publicAssetURL + bundle);
+        placeholder.insert(element);
+        placeholder.insertNewline();
+      }
     }
     return true;
   }


### PR DESCRIPTION
When importing CSS from a JS module in a FastBoot enabled app, Embroider would emit something like this into index.html:

```
<fastboot-script src="/assets/chunk.957ca35b25015b34de4d.js"></fastboot-script>
<fastboot-script src="/assets/chunk.96eb691090beaf949370.css"></fastboot-script>
```

This makes FastBoot try to parse and evaluate CSS as JavaScript, which obviously fails.

I tried to add a test case to `fastboot-app`, but this fails due to even more FastBoot/CSS issues (#1049)...