### PR TITLE
Fix unsafe reuse of broccoli trees in OneShot

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -11,7 +11,7 @@ import EmptyPackageTree from './empty-package-tree';
 export default function cachedBuildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): Node {
   let tree = buildCompatAddon(originalPackage, v1Cache);
   if (!originalPackage.mayRebuild) {
-    tree = new OneShot(tree, originalPackage.name);
+    tree = OneShot.create(tree, originalPackage.name);
   }
   return tree;
 }

--- a/packages/compat/src/one-shot.ts
+++ b/packages/compat/src/one-shot.ts
@@ -17,12 +17,23 @@ class NerfHeimdallBuilder extends Builder {
   buildHeimdallTree() {}
 }
 
+let seen = new WeakMap<Node, Node>();
+
 // Wraps a broccoli tree such that it (and everything it depends on) will only
 // build a single time.
 export default class OneShot extends Plugin {
   private builder: NerfHeimdallBuilder | null;
 
-  constructor(originalTree: Node, private addonName: string) {
+  static create(originalTree: Node, privateAddonName: string) {
+    let output = seen.get(originalTree);
+    if (!output) {
+      output = new this(originalTree, privateAddonName);
+      seen.set(originalTree, output);
+    }
+    return output;
+  }
+
+  private constructor(originalTree: Node, private addonName: string) {
     // from broccoli's perspective, we don't depend on any input trees!
     super([], {
       annotation: `@embroider/compat: ${addonName}`,


### PR DESCRIPTION
The OneShot transform consumes a broccoli tree a single time, detaching us permanently from future updates to that tree, which avoids needing to revalidate all the third-party v1-to-v2 addon conversion during rebuilds. 

Since OneShot fully consumes a broccoli tree in a separate broccoli pipeline, it's not safe to consume that same tree again in a different pipeline. But an addon can manipulate cacheKeyForTree such that two distinct copies of an addon emit the same broccoli tree instance as their v2Tree, which we send into OneShot. This fails in a very byzantine way.

It's the source of the problems people have been having with test-waiters (https://github.com/embroider-build/embroider/issues/1056) because that addon aggressively tries to deduplicate itself.

The fix is to not rerun OneShot if we encounter an identical tree a second time.

(It would be nice to do away with OneShot but I think the best way to do that would be to rely on BROCCOLI_ENABLED_MEMOIZE, and I don't know when or if that feature is going to get enabled by default in broccoli.)