### PR TITLE
exclude inner node modules

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -59,6 +59,6 @@ function buildCompatAddon(originalPackage: Package, v1Cache: V1InstanceCache): N
 function withoutNodeModules(originalPackage: Package): Node {
   let Klass = originalPackage.mayRebuild ? WatchedDir : UnwatchedDir;
   return buildFunnel(new Klass(originalPackage.root), {
-    exclude: ['node_modules'],
+    exclude: ['node_modules', '*/node_modules'],
   });
 }


### PR DESCRIPTION
When we encounter a v2 addon that has v1 addon as dependencies, we need to move it even tough it doesn't need to be rewritten. Our code for doing that excludes node_modules, but we should also exclude inner nested node_modules.

This comes up when testing a v2 addon that nests its test-app inside itself using symlinked node_modules. Without this you encounter a symlink cycle that's hard to diagnose and only strikes on some OS / disk combinations.