### PR TITLE
Always unroll `each()` macro

### DIFF
--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -106,6 +106,26 @@ if (macroCondition(foo)) {
 }
 ```
 
+### each
+
+The `each` macro can be used to unroll `for ... of` loops, replacing entire loop with each iteration of the body. This can be useful when importing an array of files with `importSync` below. Doing so will ensure only the files needed are included in the build output, rather than lazy loading all possible file inclusions. This macro requires one argument, a statically analyzable array.
+
+```js
+import { each, getOwnConfig, importSync } from "@embroider/macros";
+
+for (let asset of each(getOwnConfig().importAssets)) {
+  importSync(asset);
+}
+
+// Compiles to the following, given getOwnConfig() returns;
+// { importAssets: ["pkg-name/assets/foo", "pkg-name/assets/bar"]}
+
+importSync("pkg-name/assets/foo");
+importSync("pkg-name/assets/bar");
+```
+
+Note that variable names in the loop body are simply replaced with the element value as-is. Ex: `importSync(``pkg-name/assets/${asset}``);` becomes `importSync(``pkg-name/assets/${"foo"}``);` and `importSync("pkg-name/assets/" + asset);` becomes `importSync("pkg-name/assets/" + "foo");`
+
 ### importSync
 
 The primary reason for Embroider's existence is to create statically analyzable builds. An under pinning of this

--- a/packages/macros/src/babel/each.ts
+++ b/packages/macros/src/babel/each.ts
@@ -45,21 +45,16 @@ export function insertEach(path: EachPath, state: State, context: typeof Babel) 
     throw error(args[0], `the argument to the each() macro must be statically known`);
   }
 
-  if (state.opts.mode === 'compile-time' && !Array.isArray(array.value)) {
+  if (!Array.isArray(array.value)) {
     throw error(args[0], `the argument to the each() macro must be an array`);
   }
 
-  if (state.opts.mode === 'run-time') {
-    let callee = path.get('right').get('callee');
-    state.neededRuntimeImports.set(callee.node.name, 'each');
-  } else {
-    for (let element of array.value) {
-      let literalElement = buildLiterals(element, context);
-      for (let target of nameRefs) {
-        target.replaceWith(literalElement);
-      }
-      path.insertBefore(cloneDeep(path.get('body').node, state));
+  for (let element of array.value) {
+    let literalElement = buildLiterals(element, context);
+    for (let target of nameRefs) {
+      target.replaceWith(literalElement);
     }
-    path.remove();
+    path.insertBefore(cloneDeep(path.get('body').node, state));
   }
+  path.remove();
 }

--- a/packages/macros/tests/babel/each.test.ts
+++ b/packages/macros/tests/babel/each.test.ts
@@ -13,12 +13,16 @@ describe('each', function () {
     createTests: allModes(function (transform, { applyMode }) {
       beforeEach(function () {
         macrosConfig = MacrosConfig.for({});
-        macrosConfig.setOwnConfig(__filename, { plugins: ['alpha', 'beta'], flavor: 'chocolate' });
+        macrosConfig.setOwnConfig(__filename, {
+          importAssets: ['pkg-name/assets/foo', 'pkg-name/assets/bar'],
+          plugins: ['alpha', 'beta'],
+          flavor: 'chocolate',
+        });
         applyMode(macrosConfig);
         macrosConfig.finalize();
       });
 
-      test('plugins example unrolls correctly', () => {
+      test('rfc example unrolls correctly', () => {
         let code = transform(`
       import { each, getOwnConfig, importSync } from '@embroider/macros';
       let plugins = [];
@@ -28,6 +32,18 @@ describe('each', function () {
       `);
         expect(code).toMatch(/plugins\.push\(require\(["']beta['"]\)\)/);
         expect(code).toMatch(/plugins\.push\(require\(["']alpha['"]\)\)/);
+        expect(code).not.toMatch(/for/);
+      });
+
+      test('documentation example unrolls correctly', () => {
+        let code = transform(`
+      import { each, getOwnConfig, importSync } from "@embroider/macros";
+      for (let asset of each(getOwnConfig().importAssets)) {
+        importSync(asset);
+      }
+      `);
+        expect(code).toMatch(/require\(["']pkg-name\/assets\/foo['"]\)/);
+        expect(code).toMatch(/require\(["']pkg-name\/assets\/bar['"]\)/);
         expect(code).not.toMatch(/for/);
       });
 


### PR DESCRIPTION
Currently the `each()` [example in the Embroider RFC](https://github.com/emberjs/rfcs/blob/master/text/0507-embroider-v2-package-format.md#javascript-macro-each) (shown below) doesn't always work because the loop doesn't get unrolled in dev builds, resulting in invalid calls to `importSync()` due to [(template) string literals](https://github.com/emberjs/rfcs/blob/master/text/0507-embroider-v2-package-format.md#supported-subset-of-dynamic-import-syntax) being [required](https://github.com/ef4/ember-auto-import/blob/d7031b95168c7f280d8be74d08a56e375b965104/packages/ember-auto-import/ts/analyzer-plugin.ts#L55-L57). In my digging, I don't see why the loop _can't_ always be unrolled so this PR removes the run-time vs build-time differences for this macro, allowing the RFC example to work for all builds.

```js
// This example:
import { getOwnConfig, each, importSync } from "@ember/macros";
let plugins = [];
for (let plugin of each(getOwnConfig().registeredPlugins)) {
  plugins.push(importSync(plugin).default);
}

// could compile to this, given OwnConfig
// containing { registeredPlugins: ['@bigco/bar-chart', '@bigco/line-chart']}

let plugins = [];
plugins.push(importSync("@bigco/bar-chart").default);
plugins.push(importSync("@bigco/line-chart").default);
```

Fixes #1063 