### PR TITLE
Fixes require babel filter config

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -1468,7 +1468,7 @@ function stringOrBufferEqual(a: string | Buffer, b: string | Buffer): boolean {
 }
 
 const babelFilterTemplate = compile(`
-const { babelFilter } = require('@embroider/core');
+const { babelFilter } = require(${JSON.stringify(require.resolve('./index.js'))});
 module.exports = babelFilter({{{json-stringify skipBabel}}}, "{{{js-string-escape appRoot}}}");
 `) as (params: { skipBabel: Options['skipBabel']; appRoot: string }) => string;
 


### PR DESCRIPTION
Require the resolution of @embroider/core in the emitted config file.