### PR TITLE
native v2 addons can always import from NPM

### DIFF
--- a/packages/macros/src/babel/dependency-satisfies.ts
+++ b/packages/macros/src/babel/dependency-satisfies.ts
@@ -25,7 +25,7 @@ export default function dependencySatisfies(path: NodePath<t.CallExpression>, st
   let sourceFileName = sourceFile(path, state);
   try {
     let us = state.packageCache.ownerOfFile(sourceFileName);
-    if (!us || us.dependencies.every(dep => dep.name !== packageName.value)) {
+    if (!us?.hasDependency(packageName.value)) {
       return false;
     }
 

--- a/packages/macros/src/glimmer/dependency-satisfies.ts
+++ b/packages/macros/src/glimmer/dependency-satisfies.ts
@@ -23,7 +23,7 @@ export default function dependencySatisfies(
   let range = node.params[1].value;
 
   let us = packageCache.ownerOfFile(baseDir || moduleName);
-  if (!us || us.dependencies.every(dep => dep.name !== packageName)) {
+  if (!us?.hasDependency(packageName)) {
     return false;
   }
 

--- a/tests/scenarios/v2-addon-test.ts
+++ b/tests/scenarios/v2-addon-test.ts
@@ -46,9 +46,24 @@ appScenarios
               setComponentTemplate(TEMPLATE, ExampleComponent);
             `,
         },
+        'import-from-npm.js': `
+          export default async function() { 
+            let { message } = await import('third-party');
+            return message() 
+          }
+        `,
       },
     });
     addon.linkDependency('@embroider/addon-shim', { baseDir: __dirname });
+    addon.addDependency('third-party', {
+      files: {
+        'index.js': `
+          export function message() {
+            return 'content from third-party';
+          }
+        `,
+      },
+    });
 
     project.addDevDependency(addon);
 
@@ -76,6 +91,17 @@ appScenarios
                 assert.ok(document.querySelector('[data-test-example]'), 'it worked');
               });
             });
+          `,
+        },
+        unit: {
+          'import-test.js': `
+           import { module, test } from 'qunit';
+           import example from 'v2-addon/import-from-npm';
+           module('Unit | import', function(hooks) {
+             test('v2 addons can import() from NPM', async function(assert) {
+              assert.equal(await example(), 'content from third-party');
+             });
+           });
           `,
         },
       },


### PR DESCRIPTION
This check was intended to prevent v1 addons from accidentally gaining new semantics under embroider, but it needs to be relaxed for v2 addons which *are* supposed to be able to import from NPM without any special dependency on ember-auto-import.

This bug doesn't actually fail for static imports, because those are allowed to fall through to webpack and it finds them anyway. But for dynamic imports, it causes us to insert our runtime error.