### PR TITLE
Support a project having prerelease versions

### DIFF
--- a/packages/macros/tests/babel/dependency-satisfies.test.ts
+++ b/packages/macros/tests/babel/dependency-satisfies.test.ts
@@ -147,19 +147,6 @@ describe(`dependencySatisfies`, function () {
         expect(runDefault(code)).toBe(true);
       });
 
-      test(`it considers a project's star-releases as allowed`, () => {
-        project.addDependency('foo', '*');
-        let code = transform(
-          `
-          import { dependencySatisfies } from '@embroider/macros';
-          export default function() {
-            return dependencySatisfies('foo', '>= 3.27.0-alpha.1 || >= 3.27.0-beta.1');
-          }
-        `
-        );
-        expect(runDefault(code)).toBe(true);
-      });
-
       test('monorepo resolutions resolve correctly', () => {
         project.addDependency('@embroider/util', '1.2.3');
         let code = transform(`

--- a/packages/macros/tests/babel/dependency-satisfies.test.ts
+++ b/packages/macros/tests/babel/dependency-satisfies.test.ts
@@ -147,6 +147,19 @@ describe(`dependencySatisfies`, function () {
         expect(runDefault(code)).toBe(true);
       });
 
+      test(`in monorepos, the * dep is commonly used to mean "latest"`, () => {
+        project.addDependency('foo', '*');
+        let code = transform(
+          `
+          import { dependencySatisfies } from '@embroider/macros';
+          export default function() {
+            return dependencySatisfies('foo', '>= 3.27.0-alpha.1 || >= 3.27.0-beta.1');
+          }
+        `
+        );
+        expect(runDefault(code)).toBe(true);
+      });
+
       test('monorepo resolutions resolve correctly', () => {
         project.addDependency('@embroider/util', '1.2.3');
         let code = transform(`

--- a/packages/macros/tests/babel/dependency-satisfies.test.ts
+++ b/packages/macros/tests/babel/dependency-satisfies.test.ts
@@ -134,13 +134,39 @@ describe(`dependencySatisfies`, function () {
         expect(runDefault(code)).toBe(true);
       });
 
+      test(`it considers a project's used pre-releases as allowed`, () => {
+        project.addDependency('foo', '4.2.0-beta.1');
+        let code = transform(
+          `
+          import { dependencySatisfies } from '@embroider/macros';
+          export default function() {
+            return dependencySatisfies('foo', '>= 3.27.0-alpha.1 || >= 3.27.0-beta.1');
+          }
+        `
+        );
+        expect(runDefault(code)).toBe(true);
+      });
+
+      test(`it considers a project's star-releases as allowed`, () => {
+        project.addDependency('foo', '*');
+        let code = transform(
+          `
+          import { dependencySatisfies } from '@embroider/macros';
+          export default function() {
+            return dependencySatisfies('foo', '>= 3.27.0-alpha.1 || >= 3.27.0-beta.1');
+          }
+        `
+        );
+        expect(runDefault(code)).toBe(true);
+      });
+
       test('monorepo resolutions resolve correctly', () => {
         project.addDependency('@embroider/util', '1.2.3');
         let code = transform(`
         import { dependencySatisfies } from '@embroider/macros';
 
         export default function() {
-          return { 
+          return {
             // specified in dependencies
             util: dependencySatisfies('@embroider/util', '*'),
 

--- a/packages/macros/tests/babel/dependency-satisfies.test.ts
+++ b/packages/macros/tests/babel/dependency-satisfies.test.ts
@@ -148,7 +148,13 @@ describe(`dependencySatisfies`, function () {
       });
 
       test(`in monorepos, the * dep is commonly used to mean "latest"`, () => {
-        project.addDependency('foo', '*');
+        project.addDependency('foo', '4.2.0-beta.1', project => {
+          project.pkg.dependencies = {
+            ...project.pkg.dependencies,
+            foo: '*',
+          };
+        });
+
         let code = transform(
           `
           import { dependencySatisfies } from '@embroider/macros';

--- a/tests/scenarios/macro-test.ts
+++ b/tests/scenarios/macro-test.ts
@@ -188,7 +188,6 @@ appReleaseScenario
       ...project.pkg.devDependencies,
       'ember-source': '4.2.0-beta.1',
     };
-    project.writeSync();
 
     merge(project.files, {
       tests: {


### PR DESCRIPTION
This is what was going on with https://github.com/embroider-build/embroider/issues/1066

Demonstration of `semver` behavior here: https://runkit.com/nullvoxpopuli/semver
Reproduction of behavior: https://github.com/NullVoxPopuli/limber/pull/375
(This PR is the last thing between me and _finally_ merging that https://github.com/NullVoxPopuli/limber/pull/375 🙃 )

tldr: `satisfies` does not return true if the version is a pre-release. the pre-release option to `satisfies` is only for the `range` parameter
 
 I've also been wondering if there is a better way to share code between the glimmer and babel versions of `dependencySatisfies` -- though, I don't know why the glimmer version exists, because I thought it was all build-time transforms anyway?