### PR TITLE
Throw error when setting non-serializable macro config

### DIFF
--- a/packages/macros/tests/babel/set-config.test.ts
+++ b/packages/macros/tests/babel/set-config.test.ts
@@ -1,0 +1,42 @@
+import { MacrosConfig } from '../../src/node';
+import { allBabelVersions } from './helpers';
+
+describe(`setConfig`, function () {
+  allBabelVersions(function () {
+    test('works with empty config', () => {
+      let config = {};
+
+      let macroConfig = MacrosConfig.for({}, __dirname);
+      macroConfig.setConfig(__filename, 'qunit', config);
+    });
+
+    test('works with POJO config', () => {
+      let config = {
+        str: 'yes',
+        num: 10,
+        bool: true,
+        undef: undefined,
+        nil: null,
+        arr: ['yes', 10, true, undefined, null, { inArr: true }],
+        obj: { nested: true },
+      };
+
+      let macroConfig = MacrosConfig.for({}, __dirname);
+      macroConfig.setConfig(__filename, 'qunit', config);
+    });
+
+    test('throws for non-serializable config', () => {
+      let config = {
+        obj: {
+          regex: /regex/,
+        },
+      };
+
+      let macroConfig = MacrosConfig.for({}, __dirname);
+
+      expect(() => macroConfig.setConfig(__filename, 'qunit', config)).toThrow(
+        `[Embroider:MacrosConfig] the given config from '${__filename}' for packageName 'qunit' is not JSON serializable.`
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR ensures an error is thrown when trying to set a non-serializable macro config.

Not sure about the tests, if that is the correct way to put them or if there is a better way to add them - happy to change that if somebody points me to a better/correct way!

Closes https://github.com/embroider-build/embroider/issues/1082