### PR TITLE
Ensure OneShot tmp dir cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     tags:
       - 'v*'
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   preflight:


### PR DESCRIPTION
Move builder creation into build() call because when the builder is created it creates temp dirs and if you load the build file but don't build it never cleans up.