### PR TITLE
Add typecsript sample rollup config + exploration of different plugins' side-effects

### DIFF
--- a/packages/addon-dev/sample-typescript-babel.config.cjs
+++ b/packages/addon-dev/sample-typescript-babel.config.cjs
@@ -21,6 +21,7 @@ module.exports = {
         legacy: true,
       },
     ],
+    [resolve('@babel/plugin-proposal-class-properties')],
     resolve('@embroider/addon-dev/template-colocation-plugin'),
   ],
 };

--- a/packages/addon-dev/sample-typescript-babel.config.cjs
+++ b/packages/addon-dev/sample-typescript-babel.config.cjs
@@ -1,0 +1,26 @@
+'use strict';
+
+const { resolve } = require;
+
+module.exports = {
+  presets: [resolve('@babel/preset-typescript')],
+  plugins: [
+    [
+      resolve('@babel/plugin-transform-typescript'),
+      {
+        allowDeclareFields: true,
+        onlyRemoveTypeImports: true,
+        // Default enums are IIFEs
+        optimizeConstEnums: true,
+      },
+    ],
+    [
+      resolve('@babel/plugin-proposal-decorators'),
+      {
+        // The stage 1 implementation
+        legacy: true,
+      },
+    ],
+    resolve('@embroider/addon-dev/template-colocation-plugin'),
+  ],
+};

--- a/packages/addon-dev/sample-typescript-rollup.config.js
+++ b/packages/addon-dev/sample-typescript-rollup.config.js
@@ -1,0 +1,113 @@
+/**
+  *  This file should live at ./config/rollup.config.js
+  *  and the babel config at ./config/babel.config.js (if the babel config is ESM)
+  *    _if the babel config is CJS, it can be at the addon root_
+  *
+  *  The command to build:
+  *
+  *    `rollup -c ./config/rollup.config.js`
+  */
+import path from 'path';
+
+import alias from '@rollup/plugin-alias';
+import multiInput from 'rollup-plugin-multi-input';
+import ts from 'rollup-plugin-ts';
+import { defineConfig } from 'rollup';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { Addon } from '@embroider/addon-dev/rollup';
+
+import babelConfig from './babel.config';
+import packageJson from '../package.json';
+
+const addon = new Addon({
+  srcDir: 'src',
+  destDir: 'dist',
+});
+
+const transpilation = [
+  // Instruct rollup how to resolve ts and hbs imports
+  // (importing a template-only component, for example)
+  nodeResolve({ resolveOnly: ['./'], extensions: ['.js', '.ts', '.hbs'] }),
+
+  // Allow top-level imports (what folks are used to from v1 addons)
+  // During the build, anything referencing a top-level import will be
+  // replaced with a relative import.
+  // DANGER: it's somewhat easy to cause circular references with this tool
+  alias({
+    entries: [
+      {
+        find: '#types',
+        replacement: path.resolve('src', '-private', 'types.ts'),
+      },
+      {
+        find: packageJson.name,
+        replacement: path.resolve('src'),
+      },
+      {
+        find: `${packageJson.name}/(.*)`,
+        replacement: path.resolve('src/$1'),
+      },
+    ],
+  }),
+
+  // This babel config should *not* apply presets or compile away ES modules.
+  // It exists only to provide development niceties for you, like automatic
+  // template colocation.
+  // See `babel.config.json` for the actual Babel configuration!
+  ts({
+    // can be changed to swc or other transpilers later
+    // but we need the ember plugins converted first
+    // (template compilation and co-location)
+    transpiler: 'babel',
+    browserslist: false,
+    babelConfig,
+    // setting this true greatly improves performance, but
+    // at the cost of safety (and no declarations output in your dist directory).
+    transpileOnly: false,
+    tsconfig: {
+      fileName: 'tsconfig.json',
+      hook: (config) => ({ ...config, declaration: true }),
+    },
+  }),
+
+  // Follow the V2 Addon rules about dependencies. Your code can import from
+  // `dependencies` and `peerDependencies` as well as standard Ember-provided
+  // package names.
+  addon.dependencies(),
+
+  // Ensure that standalone .hbs files are properly integrated as Javascript.
+  addon.hbs(),
+
+  // addons are allowed to contain imports of .css files, which we want rollup
+  // to leave alone and keep in the published output.
+  // addon.keepAssets(['**/*.css']),
+];
+
+// these should be JS, even though the authored format is TS
+const globallyAvailable = ['components/**/*.js', 'services/*.js'];
+
+export default defineConfig({
+  input: ['src/**/*{js,hbs,ts}'],
+  output: addon.output(),
+  plugins: [
+    // allows specifying glob inputs so we can transpile each module separately
+    multiInput(),
+
+    ...transpilation,
+
+    // These are the modules that users should be able to import from your
+    // addon. Anything not listed here may get optimized away.
+    addon.publicEntrypoints([...globallyAvailable]),
+
+    // These are the modules that should get reexported into the traditional
+    // "app" tree. Things in here should also be in publicEntrypoints above, but
+    // not everything in publicEntrypoints necessarily needs to go here.
+    //
+    // This generates an `_app_/` directory in your output directory
+    // and updates an 'ember-addon.app-js' entry in your package.json
+    addon.appReexports([...globallyAvailable]),
+
+    // Remove leftover build artifacts when starting a new build.
+    addon.clean(),
+  ],
+});

--- a/packages/addon-dev/sample-typescript-rollup.config.js
+++ b/packages/addon-dev/sample-typescript-rollup.config.js
@@ -1,11 +1,8 @@
 import path from 'path';
 
-import alias from '@rollup/plugin-alias';
 import ts from 'rollup-plugin-ts';
 import { defineConfig } from 'rollup';
 import { Addon } from '@embroider/addon-dev/rollup';
-
-import packageJson from './package.json';
 
 const addon = new Addon({
   srcDir: 'src',
@@ -31,27 +28,6 @@ export default defineConfig({
     // This generates an `_app_/` directory in your output directory
     // and updates an 'ember-addon.app-js' entry in your package.json
     addon.appReexports([...globallyAvailable]),
-
-    // Allow top-level imports (what folks are used to from v1 addons)
-    // During the build, anything referencing a top-level import will be
-    // replaced with a relative import.
-    // DANGER: it's somewhat easy to cause circular references with this tool
-    alias({
-      entries: [
-        {
-          find: '#types',
-          replacement: path.resolve('src', '-private', 'types.ts'),
-        },
-        {
-          find: packageJson.name,
-          replacement: path.resolve('src'),
-        },
-        {
-          find: `${packageJson.name}/(.*)`,
-          replacement: path.resolve('src/$1'),
-        },
-      ],
-    }),
 
     // This babel config should *not* apply presets or compile away ES modules.
     // It exists only to provide development niceties for you, like automatic

--- a/packages/addon-dev/sample-typescript-rollup.config.js
+++ b/packages/addon-dev/sample-typescript-rollup.config.js
@@ -10,94 +10,28 @@
 import path from 'path';
 
 import alias from '@rollup/plugin-alias';
-import multiInput from 'rollup-plugin-multi-input';
 import ts from 'rollup-plugin-ts';
 import { defineConfig } from 'rollup';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { Addon } from '@embroider/addon-dev/rollup';
 
-import babelConfig from './babel.config';
-import packageJson from '../package.json';
+import packageJson from './package.json';
 
 const addon = new Addon({
   srcDir: 'src',
   destDir: 'dist',
 });
 
-const transpilation = [
-  // Instruct rollup how to resolve ts and hbs imports
-  // (importing a template-only component, for example)
-  nodeResolve({ resolveOnly: ['./'], extensions: ['.js', '.ts', '.hbs'] }),
-
-  // Allow top-level imports (what folks are used to from v1 addons)
-  // During the build, anything referencing a top-level import will be
-  // replaced with a relative import.
-  // DANGER: it's somewhat easy to cause circular references with this tool
-  alias({
-    entries: [
-      {
-        find: '#types',
-        replacement: path.resolve('src', '-private', 'types.ts'),
-      },
-      {
-        find: packageJson.name,
-        replacement: path.resolve('src'),
-      },
-      {
-        find: `${packageJson.name}/(.*)`,
-        replacement: path.resolve('src/$1'),
-      },
-    ],
-  }),
-
-  // This babel config should *not* apply presets or compile away ES modules.
-  // It exists only to provide development niceties for you, like automatic
-  // template colocation.
-  // See `babel.config.json` for the actual Babel configuration!
-  ts({
-    // can be changed to swc or other transpilers later
-    // but we need the ember plugins converted first
-    // (template compilation and co-location)
-    transpiler: 'babel',
-    browserslist: false,
-    babelConfig,
-    // setting this true greatly improves performance, but
-    // at the cost of safety (and no declarations output in your dist directory).
-    transpileOnly: false,
-    tsconfig: {
-      fileName: 'tsconfig.json',
-      hook: (config) => ({ ...config, declaration: true }),
-    },
-  }),
-
-  // Follow the V2 Addon rules about dependencies. Your code can import from
-  // `dependencies` and `peerDependencies` as well as standard Ember-provided
-  // package names.
-  addon.dependencies(),
-
-  // Ensure that standalone .hbs files are properly integrated as Javascript.
-  addon.hbs(),
-
-  // addons are allowed to contain imports of .css files, which we want rollup
-  // to leave alone and keep in the published output.
-  // addon.keepAssets(['**/*.css']),
+const globallyAvailable = [
+  'components/**/*.{js,ts}', 'services/**/*.{js,ts}', 'helpers/**/*.{js,ts}',
+  'instance-initializers/**/*.{js,ts}'
 ];
 
-// these should be JS, even though the authored format is TS
-const globallyAvailable = ['components/**/*.js', 'services/*.js'];
-
 export default defineConfig({
-  input: ['src/**/*{js,hbs,ts}'],
   output: addon.output(),
   plugins: [
-    // allows specifying glob inputs so we can transpile each module separately
-    multiInput(),
-
-    ...transpilation,
-
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints([...globallyAvailable]),
+    addon.publicEntrypoints(['*.{js,ts}', ...globallyAvailable]),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
@@ -106,6 +40,62 @@ export default defineConfig({
     // This generates an `_app_/` directory in your output directory
     // and updates an 'ember-addon.app-js' entry in your package.json
     addon.appReexports([...globallyAvailable]),
+
+    // Allow top-level imports (what folks are used to from v1 addons)
+    // During the build, anything referencing a top-level import will be
+    // replaced with a relative import.
+    // DANGER: it's somewhat easy to cause circular references with this tool
+    alias({
+      entries: [
+        {
+          find: '#types',
+          replacement: path.resolve('src', '-private', 'types.ts'),
+        },
+        {
+          find: packageJson.name,
+          replacement: path.resolve('src'),
+        },
+        {
+          find: `${packageJson.name}/(.*)`,
+          replacement: path.resolve('src/$1'),
+        },
+      ],
+    }),
+
+    // This babel config should *not* apply presets or compile away ES modules.
+    // It exists only to provide development niceties for you, like automatic
+    // template colocation.
+    // See `babel.config.json` for the actual Babel configuration!
+    ts({
+      // can be changed to swc or other transpilers later
+      // but we need the ember plugins converted first
+      // (template compilation and co-location)
+      transpiler: 'babel',
+      browserslist: false,
+      // NOTE: babel config must be CJS if in the same directory as CWD
+      //       https://github.com/wessberg/rollup-plugin-ts/issues/167
+      //       otherwise ESM babel.config.js can be imported and set here
+      // babelConfig,
+      // setting this true greatly improves performance, but
+      // at the cost of safety (and no declarations output in your dist directory).
+      transpileOnly: false,
+      tsconfig: {
+        fileName: 'tsconfig.json',
+        hook: (config) => ({ ...config, declaration: true }),
+      },
+    }),
+
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
+
+    // Ensure that standalone .hbs files are properly integrated as Javascript.
+    addon.hbs(),
+
+    // addons are allowed to contain imports of .css files, which we want rollup
+    // to leave alone and keep in the published output.
+    addon.keepAssets(['**/*.css']),
 
     // Remove leftover build artifacts when starting a new build.
     addon.clean(),

--- a/packages/addon-dev/sample-typescript-rollup.config.js
+++ b/packages/addon-dev/sample-typescript-rollup.config.js
@@ -1,12 +1,3 @@
-/**
-  *  This file should live at ./config/rollup.config.js
-  *  and the babel config at ./config/babel.config.js (if the babel config is ESM)
-  *    _if the babel config is CJS, it can be at the addon root_
-  *
-  *  The command to build:
-  *
-  *    `rollup -c ./config/rollup.config.js`
-  */
 import path from 'path';
 
 import alias from '@rollup/plugin-alias';

--- a/packages/addon-dev/sample-typescript-rollup.config.mjs
+++ b/packages/addon-dev/sample-typescript-rollup.config.mjs
@@ -27,12 +27,12 @@ export default defineConfig({
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
     addon.publicEntrypoints([
-      'index.js',
-      'components/**/*.js',
-      'helpers/**/*.js',
-      'modifiers/**/*.js',
-      'services/**/*.js',
-      'test-support/**/*.js',
+      'index.ts',
+      'components/**/*.ts',
+      'helpers/**/*.ts',
+      'modifiers/**/*.ts',
+      'services/**/*.ts',
+      'test-support/**/*.ts',
     ]),
 
     // These are the modules that should get reexported into the traditional

--- a/packages/addon-dev/sample-typescript-rollup.config.mjs
+++ b/packages/addon-dev/sample-typescript-rollup.config.mjs
@@ -27,24 +27,24 @@ export default defineConfig({
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
     addon.publicEntrypoints([
-      'index.ts',
-      'components/**/*.ts',
-      'helpers/**/*.ts',
-      'modifiers/**/*.ts',
-      'services/**/*.ts',
-      'test-support/**/*.ts',
+      'index.js',
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+      'test-support/**/*.js',
     ]),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
     addon.appReexports([
-      'index.{js,ts}',
-      'components/**/*.{js,ts}',
-      'helpers/**/*.{js,ts}',
-      'modifiers/**/*.{js,ts}',
-      'services/**/*.{js,ts}',
-      'test-support/**/*.{js,ts}',
+      'index.js',
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+      'test-support/**/*.js',
     ]),
     // This babel config should *not* apply presets or compile away ES modules.
     // It exists only to provide development niceties for you, like automatic

--- a/packages/addon-dev/sample-typescript-rollup.config.mjs
+++ b/packages/addon-dev/sample-typescript-rollup.config.mjs
@@ -55,8 +55,12 @@ export default defineConfig({
       // but we need the ember plugins converted first
       // (template compilation and co-location)
       transpiler: 'babel',
+      // without the browserlist, recently landed JS features are polyfilled.
+      // It should be primarily up to the consuming app whether or not they need to
+      // polyfill whatever JS features.
       browserslist: ['last 2 firefox versions', 'last 2 chrome versions'],
       tsconfig: {
+        // when `hooks` is specified, fileName is required
         fileName: 'tsconfig.json',
         hook: (config) => ({
           ...config,


### PR DESCRIPTION
With `rollup-plugin-ts`
 - https://github.com/NullVoxPopuli/ember-addon-v2-typescript-demo
   - component, helper, instance initializer 
   - (all app-re-exports)
   - Issues
     - [x] `@glimmer/component` is undefined
       - this was caused by `"type": "module"` in the addon's package.json. We can't use `"type": "module"` quite yet
     - [x] https://github.com/embroider-build/embroider/issues/1121
   
 - https://github.com/NullVoxPopuli/ember-statechart-component/pull/244
   - gave up (for now) on this demo due to peerDep issues
     - https://github.com/embroider-build/embroider/issues/1062
     
 - https://github.com/NullVoxPopuli/ember-resources/pull/366
   - only utils, no app re-exports, compiled to single file
   - pending release of https://github.com/embroider-build/embroider/pull/1106
   - pending fix for: https://github.com/embroider-build/embroider/issues/1020
   - this approach convinced me to avoid the multi-input plugin
    
      <details><summary>because it does this:</summary>
    
      it has a bunch of weird imports.
      I understand it importing my own stuff so that it doesn't get optimized away (but these are side-effecting imports?) very weird
      
      ```js
      export { LifecycleResource } from './-private/resources/lifecycle.js';
      export { Resource } from './-private/resources/simple.js';
      export { useTask } from './-private/ember-concurrency.js';
      export { trackedFunction } from './-private/tracked-function.js';
      export { use } from './-private/use.js';
      export { useFunction } from './-private/use-function.js';
      export { useHelper } from './-private/use-helper.js';
      export { useResource } from './-private/use-resource.js';
      import '@glimmer/tracking/primitives/cache';
      import '@ember/application';
      import '@ember/destroyable';
      import '@ember/helper';
      import '@ember/debug';
      import './-private/resources/ember-concurrency-task.js';
      import '@ember/object';
      import './-private/utils.js';
      import './-private/resources/function-runner.js';
      import '@ember/runloop';
      import '@ember/test-waiters';
      //# sourceMappingURL=index.js.map
      ```
    
    
      </details>
    



## Resolves
 
 - https://github.com/embroider-build/embroider/issues/1095
 - https://github.com/embroider-build/embroider/issues/1094
 
 
## TODO

- [x] Figure out how to avoid specifying `input` at all
  - pending PR from @josemarluedke https://github.com/embroider-build/embroider/pull/1106
- [x] Figure out why `setComponentTemplate` appears to be invoked twice per template
  
   <details><summary>sample output from: 

    https://github.com/NullVoxPopuli/ember-addon-v2-typescript-demo

    </summary>

    ```js
    ❯ cat dist/components/demo/index.js
    import { setComponentTemplate } from '@ember/component';
    import { hbs } from 'ember-cli-htmlbars';
    import { __decorate } from 'tslib';
    import Component from '@glimmer/component';
    import { tracked } from '@glimmer/tracking';

    var TEMPLATE = setComponentTemplate(TEMPLATE, hbs`Hello there!

    <out>{{this.active}}</out>

    <button {{on 'click' this.flip}}>
      flip
    </button>
    `);

    class Demo extends Component {
      constructor(...args) {
        super(...args);
        this.active = false;

        this.flip = () => this.active = !this.active;
      }

    }

    __decorate([tracked], Demo.prototype, "active", void 0);

    setComponentTemplate(TEMPLATE, Demo);

    export { Demo as default };
    //# sourceMappingURL=index.js.map
    ```

    </details>
    
    Potential solve:
    https://github.com/embroider-build/embroider/pull/1134

- [x] Ensure that app-js in package.json is updated
- [x] Ensure that template-only components can be imported
  - [x] Pending: https://github.com/embroider-build/embroider/pull/1126
- [x] Ensure that *at least* test-support is its own file
- [x] Answer the questions
  - [x] do we shipped compiled templates are no?
    - in most of the v2 addons out there that have components, they are still requiring the app to do the `hbs` to opcode conversion
      - discussion: https://github.com/embroider-build/embroider/pull/1107#discussion_r799062129
        tldr: the compiled format is tightly coupled to exact ember version, so it's unsafe to ship compiled templates.
         it _may_ make sense if you can _guarantee_ that addons and apps will always have the same exact ember version
         (maybe if you're doing a monorepo at work or something where everything is private)
  - [x] how should folks specify that they want sourcemaps?
    - Proposal: https://github.com/embroider-build/embroider/pull/1104