### PR TITLE
Update the ember-template-compiler to v4.1.0

### DIFF
--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -874,7 +874,7 @@ describe('compat-resolver', function () {
       findDependencies(
         'templates/application.hbs',
         `
-        {{outlet "foo"}}
+        {{outlet}}
         {{yield bar}}
         {{#with (hash submit=(action doit)) as |thing| }}
         {{/with}}

--- a/test-packages/support/vendor/README.md
+++ b/test-packages/support/vendor/README.md
@@ -1,3 +1,3 @@
-This is vendored from ember 3.25.0.
+This is vendored from ember 4.1.0.
 
 I did it this way because if I try to depend directly on ember-source, I end up with a version of fs-tree-diff that has bad types in it that messes up my build.


### PR DESCRIPTION
I started looking into https://github.com/embroider-build/embroider/issues/1018 again and I noticed the tests failed because the template compiler doesn't support the new helpers yet.

I just plucked this out of the ember-source package of a 4.1.0 Ember app. Let me know if there is a better way to update it :smile:.