### PR TITLE
Cancel workflows when they become outdated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   preflight:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed that multiple workflows were added to the queue when I pushed new commits and the previous ones weren't canceled.
This change ensures that workflows are canceled when new changes come in which means resources aren't wasted on outdated workflows.

ember-cli added the same config a while a go: https://github.com/ember-cli/ember-cli/pull/9726

More information: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency