### PR TITLE
Addon Dev - Allow ts,gts,gjs files as publicEntrypoints

### DIFF
--- a/packages/addon-dev/src/rollup-app-reexports.ts
+++ b/packages/addon-dev/src/rollup-app-reexports.ts
@@ -13,7 +13,10 @@ export default function appReexports(opts: {
       let pkg = readJsonSync('package.json');
       let appJS: Record<string, string> = {};
       for (let filename of Object.keys(bundle)) {
-        if (opts.include.some((glob) => minimatch(filename, glob))) {
+        if (
+          opts.include.some((glob) => minimatch(filename, glob)) &&
+          !minimatch(filename, '**/*.d.ts')
+        ) {
           appJS[`./${filename}`] = `./dist/_app_/${filename}`;
           this.emitFile({
             type: 'asset',

--- a/packages/addon-dev/src/rollup-public-entrypoints.ts
+++ b/packages/addon-dev/src/rollup-public-entrypoints.ts
@@ -2,6 +2,10 @@ import walkSync from 'walk-sync';
 import type { Plugin } from 'rollup';
 import { join } from 'path';
 
+function normalizeFileExt(fileName: string) {
+  return fileName.replace(/\.ts|\.gts|\.gjs$/, '.js');
+}
+
 export default function publicEntrypoints(args: {
   srcDir: string;
   include: string[];
@@ -15,7 +19,7 @@ export default function publicEntrypoints(args: {
         this.emitFile({
           type: 'chunk',
           id: join(args.srcDir, name),
-          fileName: name,
+          fileName: normalizeFileExt(name),
         });
       }
     },


### PR DESCRIPTION
Closes #1094

For `appReexports` to work, they need to match the input file name, see `.{ts,js}`

```js
const globallyAvailable = [
  'components/**/*.{ts,js}',
  'instance-initializers/*.{ts,js}',
  'helpers/**/*.{ts,js}',
];

export default defineConfig({
  output: addon.output(),
  plugins: [
    // .. etc
    addon.publicEntrypoints(['index.ts', ...globallyAvailable]),
    addon.appReexports([...globallyAvailable]),
    // .. etc
  ],
});
```