### PR TITLE
Revert "Fix cacheKeyForTree & OneShot incompatibility"

### DIFF
--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -119,6 +119,11 @@ export default class V1App {
   }
 
   @Memoize()
+  get addonTreeCache(): Map<string, Node> {
+    return new Map();
+  }
+
+  @Memoize()
   get preprocessRegistry() {
     return this.requireFromEmberCLI('ember-cli-preprocess-registry/preprocessors');
   }


### PR DESCRIPTION
This reverts commit ebe4aed33220e070b3b69cf34b87917da91f01a3.

This change isn't needed because I eliminated OneShot instead in https://github.com/embroider-build/embroider/pull/1115, so we can keep the per-tree caching, which is closer to what the classic build does.