### PR TITLE
Reuse the `loc` of the macroMaybeAttrs hashes for the created attributes

### DIFF
--- a/packages/macros/src/glimmer/macro-maybe-attrs.ts
+++ b/packages/macros/src/glimmer/macro-maybe-attrs.ts
@@ -20,11 +20,11 @@ export function maybeAttrs(elementNode: any, node: any, builders: any) {
 
   if (result.value) {
     for (let bareAttr of bareAttrs) {
-      elementNode.attributes.push(builders.attr(bareAttr.original, builders.text('')));
+      elementNode.attributes.push(builders.attr(bareAttr.original, builders.text(''), bareAttr.loc));
     }
 
     for (let attr of node.hash.pairs) {
-      elementNode.attributes.push(builders.attr(attr.key, builders.mustache(attr.value)));
+      elementNode.attributes.push(builders.attr(attr.key, builders.mustache(attr.value), attr.loc));
     }
   }
 }


### PR DESCRIPTION
The newer template compiler sorts attributes based on their `loc` location when printing. Since previously no `loc` info was added to the newly created attributes, they were being moved to the front of the element. By reusing their original `loc` data we can ensure that the order from the source file is maintained.

This commit was included in #1103 since it's a requirement for the tests to pass under the newer compiler version. 