### PR TITLE
improving ember-data test coverage

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-data.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-data.ts
@@ -10,6 +10,9 @@ let rules: PackageRules[] = [
       '-private/system/core-store.js': {
         dependsOnModules: ['@ember-data/record-data/-private'],
       },
+      '-private/system/model/internal-model.js': {
+        dependsOnModules: ['@ember-data/model/-private'],
+      },
     },
   },
 ];

--- a/tests/scenarios/static-app-test.ts
+++ b/tests/scenarios/static-app-test.ts
@@ -13,6 +13,16 @@ appScenarios
 
     merge(project.files, {
       app: {
+        adapters: {
+          'post.js': `
+            import JSONAPIAdapter from '@ember-data/adapter/json-api';
+            export default class PostAdapter extends JSONAPIAdapter {
+              findRecord(store, type, id, snapshot) {
+                return { data: { type: 'posts', id: '0 ', attributes: { title: 'Hello world' } } };
+              }
+            }
+          `,
+        },
         components: {
           'fancy-box.js': `
             import Component from '@glimmer/component';
@@ -138,19 +148,6 @@ appScenarios
             this.route('ember-data-example');
           });
         `,
-      },
-      public: {
-        posts: {
-          '0': JSON.stringify({
-            data: {
-              type: 'posts',
-              id: '0 ',
-              attributes: {
-                title: 'Hello world',
-              },
-            },
-          }),
-        },
       },
       tests: {
         acceptance: {

--- a/tests/scenarios/static-app-test.ts
+++ b/tests/scenarios/static-app-test.ts
@@ -58,6 +58,27 @@ appScenarios
             export default helper(loadedHelpers);
           `,
         },
+        models: {
+          'post.js': `
+            import Model, { attr } from '@ember-data/model';
+            export default class PostModel extends Model {
+              @attr() title;
+            }
+          `,
+        },
+        routes: {
+          'ember-data-example.js': `
+            import Route from '@ember/routing/route';
+            import { inject as service } from '@ember/service';
+
+            export default class EmberDataExampleRoute extends Route {
+              @service() store;
+              model() {
+                return this.store.findRecord('post', 0);
+              }
+            }
+          `,
+        },
         templates: {
           components: {
             'default-title.hbs': `
@@ -98,6 +119,7 @@ appScenarios
             <FancyBox @title="With Default" />
             <FancyBox @title="With Custom" @titleComponent="my-title" />
           `,
+          'ember-data-example.hbs': `<h1>{{@model.title}}</h1>`,
         },
         'router.js': `
           import EmberRouter from '@ember/routing/router';
@@ -113,8 +135,22 @@ appScenarios
             this.route('components-example');
             this.route('static-component-rules-example');
             this.route('macros-example');
+            this.route('ember-data-example');
           });
         `,
+      },
+      public: {
+        posts: {
+          '0': JSON.stringify({
+            data: {
+              type: 'posts',
+              id: '0 ',
+              attributes: {
+                title: 'Hello world',
+              },
+            },
+          }),
+        },
       },
       tests: {
         acceptance: {
@@ -209,6 +245,21 @@ appScenarios
                 assert.equal(currentURL(), '/static-component-rules-example');
                 assert.ok(document.querySelector('[data-example="default"].the-default-title-component'), 'default exists');
                 assert.ok(document.querySelector('[data-example="customized"].my-title-component'), 'customized exists');
+              });
+            });
+          `,
+          'ember-data-example-test.js': `
+            import { module, test } from 'qunit';
+            import { visit, currentURL } from '@ember/test-helpers';
+            import { setupApplicationTest } from 'ember-qunit';
+
+            module('Acceptance | ember data example', function (hooks) {
+              setupApplicationTest(hooks);
+
+              test('visiting /ember-data-example', async function (assert) {
+                await visit('/ember-data-example');
+                assert.equal(currentURL(), '/ember-data-example');
+                assert.dom('h1').containsText('Hello world');
               });
             });
           `,


### PR DESCRIPTION
This exercises ember-data within the fully-static app scenario. And adds a default packageRule that covers something needed by ember-data 3.24.