### PR TITLE
Ember power select staticComponents

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-power-select.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-power-select.ts
@@ -24,7 +24,7 @@ let rules: PackageRules = {
       },
       acceptsComponentArguments: [
         'afterOptionsComponent',
-        'beforeOptionsComponent',
+        // 'beforeOptionsComponent',
         'optionsComponent',
         'placeholderComponent',
         'searchMessageComponent',
@@ -38,7 +38,7 @@ let rules: PackageRules = {
       },
       acceptsComponentArguments: [
         'afterOptionsComponent',
-        'beforeOptionsComponent',
+        // 'beforeOptionsComponent',
         'groupComponent',
         'optionsComponent',
         'placeholderComponent',

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -292,6 +292,12 @@ function handleComponentHelper(
       } else if (param.path.type === 'PathExpression' && param.path.original === 'component') {
         // safe because we will handle this inner `{{component ...}}` mustache on its own
         return;
+      } else if(param.path.type === 'PathExpression' && param.path.original === 'if') {
+        //<Profile @analyticsComponent={{if @analyticsComponent (component...) (component...)}} />
+        //{{#let (if @analyticsComponent (component...) (component...)) as |AnalyticsComp|}}{{/let}}
+        //safe because it will be handled?
+        return;
+    
       } else {
         locator = { type: 'other' };
       }


### PR DESCRIPTION
Hello, I was trying to make [ember-eui](https://github.com/prysmex/ember-eui) compatible with embroider with staticComponents, the only thing left to do is to make ember-power-select safe for staticComponents... after a lot of debugging, I have one question... this PR is just to prove my point, not an actual fix...

Addon dependency rules for ember-power-select currently enforces a safe component for beforeOptionsComponent and internally it's actually [optional](
https://github.com/cibernox/ember-power-select/blob/c2f917e1b03aef0b85a0a09b12f9e05e9b04749d/addon/components/power-select.hbs#L90) so basically this  can't work as-is with staticComponents...  as the resolver won't accept anything other than a safe component. But the current API accepts `null` 
