### PR TITLE
restrict semverRange for ember-power-select packageRules

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-power-select.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-power-select.ts
@@ -2,6 +2,7 @@ import { PackageRules } from '..';
 
 let rules: PackageRules = {
   package: 'ember-power-select',
+  semverRange: '< 5.0.1',
   addonModules: {
     './components/power-select.js': {
       dependsOnComponents: [


### PR DESCRIPTION
Based on our [conversation](https://github.com/cibernox/ember-power-select/pull/1508#issuecomment-1039457327) and  and taking this [commit's](https://github.com/cibernox/ember-power-select/commit/895e19a3693440e61cd5578a5d146227e3afdafa) version as the introduction of "ensure-safe-component", this PR adds semverRange below v5.0.1