### PR TITLE
Fix check in `dependencySatisfies` in monorepo

### DIFF
--- a/packages/shared-internals/src/package-cache.ts
+++ b/packages/shared-internals/src/package-cache.ts
@@ -11,7 +11,7 @@ export default class PackageCache {
     let cache = getOrCreate(this.resolutionCache, fromPackage, () => new Map() as Map<string, Package | null>);
     let result = getOrCreate(cache, packageName, () => {
       // the type cast is needed because resolvePackagePath itself is erroneously typed as `any`.
-      let packagePath = resolvePackagePath(packageName, this.basedir(fromPackage)) as string | null;
+      let packagePath = resolvePackagePath(packageName, this.appRoot) as string | null;
       if (!packagePath) {
         // this gets our null into the cache so we don't keep trying to resolve
         // a thing that is not found
@@ -43,10 +43,9 @@ export default class PackageCache {
 
   get(packageRoot: string) {
     let root = realpathSync(packageRoot);
-    let p = getOrCreate(this.rootCache, root, () => {
+    return getOrCreate(this.rootCache, root, () => {
       return new Package(root, this, root === this.appRoot);
     });
-    return p;
   }
 
   ownerOfFile(filename: string): Package | undefined {


### PR DESCRIPTION
Came across exact same issue described in #1051 while working on [porting `ember-animated` to V2 addon](https://github.com/ember-animation/ember-animated/pull/388) and all scenarios for versions 3.20 and below failed.

Note that I've ensured all `@embroider/*` packages are latest (via deps updates or resolutions).

Situation is exactly what was described in #1051:
`ember-animated` is a monorepo with `docs` app running on 3.28 and when running ember-try scenario for 3.20, [this check](https://github.com/embroider-build/embroider/blob/v1.2.0/packages/util/addon/ember-private-api.js#L10-L12) in `@embroider/util` returns true, as both `@embroider/util` and `ember-source@4.1` are in the hoisted main `node_modules`, while the `test-app` in question has its own `ember-source@3.20` in its *local* `node_modules`.

I'm not sure this is right way to fix the issue nor how to properly test it with current test harness setup:

using `appRoot` totally makes sense for `dependencySatisfies` macro (as we need to rely on the host app deps) but may not be the right choice when we invoke `packageCache.resolve` on [this line](https://github.com/embroider-build/embroider/blob/v1.2.0/packages/shared-internals/src/package.ts#L173).

@ef4 would love your input on this.

cc @simonihmig as original reporter of #1051, not sure if issue still persists for you.