### PR TITLE
Fix @cached decorator export from fake @glimmer/tracking module

### DIFF
--- a/packages/compat/src/compat-adapters/@glimmer/tracking.ts
+++ b/packages/compat/src/compat-adapters/@glimmer/tracking.ts
@@ -17,15 +17,17 @@ class RedirectToEmber extends Plugin {
   build() {
     if (!this.didBuild) {
       copyFileSync(join(this.inputPaths[0], 'package.json'), join(this.outputPath, 'package.json'));
-      outputFileSync(join(this.outputPath, 'index.js'), `export { tracked } from '@ember/-internals/metal';`);
       outputFileSync(
-        join(this.outputPath, 'primitives', 'cache.js'),
+        join(this.outputPath, 'index.js'),
         // Prior to ember-source 4.1, cached didn't exist
         // using this way of importing from metal, cached will be undefined if pre 4.1
         `import * as metal from "@ember/-internals/metal";
-const { cached, createCache, getValue, isConst } = metal;
-export { cached, createCache, getValue, isConst };
-`
+const { cached, tracked } = metal;
+export { cached, tracked };`
+      );
+      outputFileSync(
+        join(this.outputPath, 'primitives', 'cache.js'),
+        `export { createCache, getValue, isConst } from "@ember/-internals/metal";`
       );
       this.didBuild = true;
     }

--- a/tests/scenarios/glimmer-tracking-test.ts
+++ b/tests/scenarios/glimmer-tracking-test.ts
@@ -1,10 +1,11 @@
-import { appReleaseScenario } from './scenarios';
+import { appScenarios } from './scenarios';
 import { PreparedApp } from 'scenario-tester';
 import QUnit from 'qunit';
 import merge from 'lodash/merge';
 const { module: Qmodule, test } = QUnit;
 
-appReleaseScenario
+appScenarios
+  .only('release')
   .map('transform @glimmer/tracking', project => {
     merge(project.files, {
       app: {

--- a/tests/scenarios/glimmer-tracking-test.ts
+++ b/tests/scenarios/glimmer-tracking-test.ts
@@ -1,0 +1,61 @@
+import { appReleaseScenario } from './scenarios';
+import { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+import merge from 'lodash/merge';
+const { module: Qmodule, test } = QUnit;
+
+appReleaseScenario
+  .map('transform @glimmer/tracking', project => {
+    merge(project.files, {
+      app: {
+        components: {
+          'demo.js': `
+            import Component from '@glimmer/component';
+            import { cached } from '@glimmer/tracking';
+
+            export default class Demo extends Component {
+              @cached
+              get foo() {
+                return 'boop';
+              }
+            }
+          `,
+          'demo.hbs': `{{this.foo}}`,
+        },
+      },
+      tests: {
+        rendering: {
+          'demo-test.js': `
+
+            import { module, test } from 'qunit';
+            import { render } from '@ember/test-helpers';
+            import { setupRenderingTest } from 'ember-qunit';
+            import { hbs } from 'ember-cli-htmlbars';
+
+            module('<Demo>', function(hooks) {
+              setupRenderingTest(hooks);
+
+              test(\`doesn't error\`, async function(assert) {
+                await render(hbs\`<Demo />\`);
+
+                assert.dom().hasText('boop');
+              });
+            });
+          `,
+        },
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test(`yarn test`, async function (assert) {
+        let result = await app.execute('yarn test');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
+  });


### PR DESCRIPTION
Discovered during: https://github.com/embroider-build/embroider/issues/1132#issuecomment-1045280240

(I put `@cached` in the wrong spot :( )