### PR TITLE
ensure addon app-js trees are merged in the correct order

### DIFF
--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -78,7 +78,6 @@ export default class V1InstanceCache {
     let v1Addon = new Klass(addonInstance, this.options, this.app, this.app.packageCache, this.orderIdx);
     let pkgs = getOrCreate(this.addons, v1Addon.root, () => []);
     pkgs.push(v1Addon);
-    addonInstance.addons.forEach(a => this.addAddon(a));
   }
 
   getAddons(root: string): V1Addon[] {

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -69,6 +69,10 @@ export default class V1InstanceCache {
   }
 
   private addAddon(addonInstance: AddonInstance) {
+    // Traverse and add any nested addons. This must happen _before_ we add
+    // the addon itself to correctly preserve the addon ordering.
+    addonInstance.addons.forEach(a => this.addAddon(a));
+
     this.orderIdx += 1;
     let Klass = this.adapterClass(addonInstance);
     let v1Addon = new Klass(addonInstance, this.options, this.app, this.app.packageCache, this.orderIdx);

--- a/packages/core/src/app-differ.ts
+++ b/packages/core/src/app-differ.ts
@@ -37,11 +37,6 @@ export default class AppDiffer {
     ownFastbootJSDir?: string | undefined,
     private babelParserConfig?: TransformOptions | undefined
   ) {
-    // ensure addons are applied in the correct order, if set (via @embroider/compat/v1-addon)
-    activeAddonDescendants = activeAddonDescendants.sort((a, b) => {
-      return (a.meta['order-index'] || 0) - (b.meta['order-index'] || 0);
-    });
-
     this.sources = activeAddonDescendants.map(addon => maybeSource(addon, 'app-js')).filter(Boolean) as Source[];
 
     this.sources.push({

--- a/packages/core/src/app-differ.ts
+++ b/packages/core/src/app-differ.ts
@@ -37,6 +37,11 @@ export default class AppDiffer {
     ownFastbootJSDir?: string | undefined,
     private babelParserConfig?: TransformOptions | undefined
   ) {
+    // ensure addons are applied in the correct order, if set (via @embroider/compat/v1-addon)
+    activeAddonDescendants = activeAddonDescendants.sort((a, b) => {
+      return (a.meta['order-index'] || 0) - (b.meta['order-index'] || 0);
+    });
+
     this.sources = activeAddonDescendants.map(addon => maybeSource(addon, 'app-js')).filter(Boolean) as Source[];
 
     this.sources.push({

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -597,12 +597,20 @@ export class AppBuilder<TreeNames> {
   // Inner engines themselves will be returned, but not those engines' children.
   // The output set's insertion order is the proper ember-cli compatible
   // ordering of the addons.
-  private findActiveAddons(pkg: Package, engine: EngineSummary): void {
+  private findActiveAddons(pkg: Package, engine: EngineSummary, isChild = false): void {
     for (let child of this.adapter.activeAddonChildren(pkg)) {
       if (!child.isEngine()) {
-        this.findActiveAddons(child, engine);
+        this.findActiveAddons(child, engine, true);
       }
       engine.addons.add(child);
+    }
+    // ensure addons are applied in the correct order, if set (via @embroider/compat/v1-addon)
+    if (!isChild) {
+      engine.addons = new Set(
+        [...engine.addons].sort((a, b) => {
+          return (a.meta['order-index'] || 0) - (b.meta['order-index'] || 0);
+        })
+      );
     }
   }
 


### PR DESCRIPTION
This resolves a compatibility issue in which the order that `addon.app-js` trees are merged is not consistent with classic builds. The fix here is to sort the addons by the `order-index` (if present).

I have yet to be able to reproduce a test case of the issue, but can confirm this resolves the issue discovered in our app.