### PR TITLE
Make the helper keyword handling less strict

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -329,15 +329,12 @@ function handleComponentHelper(
   resolver.resolveComponentHelper(locator, moduleName, param.loc, impliedBecause);
 }
 
-function handleDynamicHelper(param: ASTv1.Node, resolver: Resolver, moduleName: string): void {
-  switch (param.type) {
-    case 'StringLiteral':
-      resolver.resolveDynamicHelper({ type: 'literal', path: param.value }, moduleName, param.loc);
-      break;
-    case 'TextNode':
-      resolver.resolveDynamicHelper({ type: 'literal', path: param.chars }, moduleName, param.loc);
-      break;
-    default:
-      resolver.resolveDynamicHelper({ type: 'other' }, moduleName, param.loc);
+function handleDynamicHelper(param: ASTv1.Expression, resolver: Resolver, moduleName: string): void {
+  // We only need to handle StringLiterals since Ember already throws an error if unsupported values
+  // are passed to the helper keyword.
+  // If a helper reference is passed in we don't need to do anything since it's either the result of a previous
+  // helper keyword invocation, or a helper reference that was imported somewhere.
+  if (param.type === 'StringLiteral') {
+    resolver.resolveDynamicHelper({ type: 'literal', path: param.value }, moduleName, param.loc);
   }
 }

--- a/tests/fixtures/engines-host-app/tests/acceptance/basics-test.js
+++ b/tests/fixtures/engines-host-app/tests/acceptance/basics-test.js
@@ -14,7 +14,7 @@ function arrayOfCSSRules(styleSheets, cssSelector, cssProperty) {
     }
   }
 
-  return values;
+  return values.sort();
 }
 
 // We don't yet support lazy CSS in apps that are using fastboot. This test
@@ -39,11 +39,14 @@ module('Acceptance | basics', function (hooks) {
     let rules = arrayOfCSSRules(document.styleSheets, '.shared-style-target', 'content');
 
     if (ensureCSSisLazy) {
-      assert.deepEqual(rules, [
-        'engines-host-app/vendor/styles.css',
-        'eager-engine/addon/styles/addon.css',
-        'engines-host-app/app/styles/app.css',
-      ]);
+      assert.deepEqual(
+        rules,
+        [
+          'engines-host-app/vendor/styles.css',
+          'eager-engine/addon/styles/addon.css',
+          'engines-host-app/app/styles/app.css',
+        ].sort()
+      );
     }
 
     await visit('/style-check');
@@ -91,7 +94,9 @@ module('Acceptance | basics', function (hooks) {
         'macro-sample-addon/addon/styles/addon.css',
         'lazy-engine/addon/styles/addon.css',
         ensureCSSisLazy ? undefined : 'lazy-in-repo-engine/addon/styles/addon.css',
-      ].filter(Boolean)
+      ]
+        .filter(Boolean)
+        .sort()
     );
 
     await visit('/style-check');


### PR DESCRIPTION
The current implementation throws an error if you try to curry helpers using the helper keyword. This reduces the strictness of the resolver since Ember itself catches the cases were users provide unsupported dynamic values to the helper keyword.

This PR is a continuation of the discussion in the previous PR: https://github.com/embroider-build/embroider/pull/1120#discussion_r816763874