### PR TITLE
improve test suite compat

### DIFF
--- a/packages/core/src/app-files.ts
+++ b/packages/core/src/app-files.ts
@@ -39,9 +39,7 @@ export class AppFiles {
       }
 
       if (relativePath.startsWith('tests/')) {
-        if (/-test\.\w+$/.test(relativePath)) {
-          tests.push(relativePath);
-        }
+        tests.push(relativePath);
         continue;
       }
 


### PR DESCRIPTION
There's no reason not to provide every module under /tests to the runtime loader. This is closer to how classic builds work and doesn't have a downside.

In an earlier version, we used to need to identify which files were actually tests because we would eagerly evaluate them all (and skip the traditional ember test loader), but that was already scrapped in favor of easier compatibility for test suites, so I don't think this has a downside.

The motivating use case for this was ember-data-factory-guy, which does runtime lookup of modules in `tests/factories` that don't match the `-test.js` naming convention.