### PR TITLE
Add `modifier` to the list of built-ins

### DIFF
--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -94,7 +94,7 @@ const builtInHelpers = [
   'link-to',
   'loc',
   'log',
-  // 'modifier',
+  'modifier',
   'mount',
   'mut',
   'on',


### PR DESCRIPTION
Small follow-up of #1151. I forgot to uncomment that in the list :smile:. 

It could theoretically cause a `Missing helper: modifier` error if `staticHelpers` is enabled and no arguments are passed: `{{(modifier)}}` but that seems like a very weird thing to do, and the template compiler already catches this:
> Assertion Failed: The modifier keyword requires at least one positional arguments