### PR TITLE
fix exception in macros babel plugin

### DIFF
--- a/packages/macros/src/babel/evaluate-json.ts
+++ b/packages/macros/src/babel/evaluate-json.ts
@@ -222,6 +222,9 @@ export class Evaluator {
 
     if (path.isObjectExpression()) {
       let props = assertArray(path.get('properties')).map(p => {
+        if (p.isSpreadElement()) {
+          return [{ confident: false }, { confident: false }];
+        }
         let key = assertNotArray(p.get('key'));
         let keyEvalValue = this.evaluateKey(key);
         let value = assertNotArray(p.get('value'));

--- a/packages/macros/tests/babel/eval.test.ts
+++ b/packages/macros/tests/babel/eval.test.ts
@@ -23,6 +23,11 @@ describe('evaluation', function () {
           expect(code).toMatch(`result = 42`);
         });
 
+        test('object literal non-nullish member access parses OK', () => {
+          let code = transform(`const result = { ...content\n}?.[0].content;`);
+          expect(code).toMatch(`const result = { ...content\n}?.[0].content;`);
+        });
+
         test('optional chaining nullish member access', () => {
           let code = transform(`const result = knownUndefinedValue?.x;`);
           expect(code).toMatch(`result = undefined`);


### PR DESCRIPTION
This fixes a crash in the macros babel plugin that could be triggered by a particular combination of SpreadElement and OptionalMemberExpression.