### PR TITLE
Implement `usesCorrectAssetUrl` option for @embroider/webpack

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -90,9 +90,12 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
       throw new Error(`@embroider/webpack requires webpack@^5.0.0, but found version ${webpack.version}`);
     }
 
+    this.publicAssetURL = options?.publicAssetURL;
+    if (this.publicAssetURL && !options?.usesCorrectAssetURL) {
+      this.publicAssetURL += 'assets/';
+    }
     this.pathToVanillaApp = realpathSync(pathToVanillaApp);
     this.extraConfig = options?.webpackConfig;
-    this.publicAssetURL = options?.publicAssetURL;
     this.extraThreadLoaderOptions = options?.threadLoaderOptions;
     this.extraBabelLoaderOptions = options?.babelLoaderOptions;
     this.extraCssLoaderOptions = options?.cssLoaderOptions;
@@ -190,7 +193,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
         path: join(this.outputPath, 'assets'),
         filename: `chunk.[chunkhash].js`,
         chunkFilename: `chunk.[chunkhash].js`,
-        publicPath: publicAssetURL + 'assets/',
+        publicPath: publicAssetURL,
       },
       optimization: {
         splitChunks: {
@@ -420,7 +423,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
 
         getOrCreate(output.entrypoints, id, () => new Map()).set(
           variantIndex,
-          entrypointAssets.map(asset => 'assets/' + asset.name)
+          entrypointAssets.map(asset => asset.name)
         );
         if (variant.runtime !== 'browser') {
           // in the browser we don't need to worry about lazy assets (they will be

--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -20,6 +20,15 @@ export interface Options {
   // This should be a URL ending in "/".
   publicAssetURL?: string;
 
+  // in early versions of @embroider/webpack the `publicAssetURL` option was
+  // defined incorrectly and made the assumption that it should prepend
+  // `assets/` to all asset URL paths. Setting this option disables this
+  // automatic path modification which means that the `publicAssetURL` option
+  // correctly defines the location where the the `assets` directory is being
+  // served as opposed to where the whole app dist is served (which previously
+  // needed to contain an `assets/` subdirectory)
+  usesCorrectAssetURL?: boolean;
+
   // [thread-loader](https://github.com/webpack-contrib/thread-loader) options.
   // If set to false, `thread-loader` will not be used. If set to an object, it
   // will be used to configure `thread-loader`. If not specified,


### PR DESCRIPTION
Related to https://github.com/embroider-build/embroider/issues/1157

This PR implements the proposed `usesCorrectAssetURL` option for `@embroider/webpack`'s config.

This option, designed to be used as follows:

```js
  let appTree = compatBuild(app, EmbroiderWebpack, {
    packagerOptions: {
      publicAssetURL: 'https://my.cdn.com/my-path/',
      usesCorrectAssetURL: true,
      webpackConfig: {
```

changes the semantics of `@embroider/webpack`'s `publicAssetURL` option to align with `ember-auto-import`'s implementation of its `publicAssetURL` option.

Crucially, when `usesCorrectAssetURL` is set to true, the `publicAssetURL` option allows you to specify the location that your assets directory will be served from - as opposed to the previous behaviour where you needed to describe where your top-level app was being served from and enforcing that it contained an `assets/` subdirectory.

### Example (using the above config)

When `usesCorrectAssetURL` is omitted or otherwise falsy: **(backwards compatibility)**
* embroider behaves as it did before, generating `<script>` and `<link>` tags in the output HTML that have URLs of the form `${publicAssetURL}assets/${filename}` (eg. `https://my.cdn.com/my-path/assets/vendor.js`)

When `usesCorrectAssetURL` is true:
* embroider no longer automatically includes `assets/` in the URLs for `<script>` and `<link>` tags in the output HTML, resulting in URLs of the form `${publicAssetURL}${filename}` (eg. `https://my.cdn.com/my-path/vendor.js`)

<details>
 <summary><h3>Testing</h3></summary>

I'm unsure if there's a happy path for testing changes like these. I've just been linking my local `embroider` fork into an ember app with the above `packagerOptions` config and it produces the following:

### With `usesCorrectAssetURL: true`

```html
<!DOCTYPE html><html><head>

[...]

<link href="https://my.cdn.com/my-path/vendor.css" rel="stylesheet">


<link href="https://my.cdn.com/my-path/embercom.css" rel="stylesheet">

  </head>
  <body>

<script src="https://my.cdn.com/my-path/vendor.js"></script>


<script src="https://my.cdn.com/my-path/chunk.876c3d90f7caea296607.js"></script>
<script src="https://my.cdn.com/my-path/chunk.702cc3c409226e12664f.js"></script>

</body></html>
```

### With `usesCorrectAssetURL: true`

```html
<!DOCTYPE html><html><head>

[...]

<link href="https://my.cdn.com/my-path/assets/vendor.css" rel="stylesheet">


<link href="https://my.cdn.com/my-path/assets/embercom.css" rel="stylesheet">

  </head>
  <body>

<script src="https://my.cdn.com/my-path/assets/vendor.js"></script>


<script src="https://my.cdn.com/my-path/assets/chunk.4e823312543c21b16509.js"></script>
<script src="https://my.cdn.com/my-path/assets/chunk.95038e80377cfcb4dcb0.js"></script>


</body></html> 
```

</details>