### PR TITLE
Update `master` to `main` in links

### DIFF
--- a/ADDON-AUTHOR-GUIDE.md
+++ b/ADDON-AUTHOR-GUIDE.md
@@ -4,7 +4,7 @@ This document lays out the recommended best practices for addon authors who want
 
 ## Give me the tl;dr: what should I do?
 
-The best thing for all addons authors to do right now is to achieve the "Embroider Safe" support level. Follow the instructions in the [@embroider/test-setup README](https://github.com/embroider-build/embroider/tree/master/packages/test-setup) to add the `embroider-safe` scenario to your ember-try config.
+The best thing for all addons authors to do right now is to achieve the "Embroider Safe" support level. Follow the instructions in the [@embroider/test-setup README](https://github.com/embroider-build/embroider/tree/main/packages/test-setup) to add the `embroider-safe` scenario to your ember-try config.
 
 There are other levels of support beyond "Embroider Safe", but as long as you get that far you unblock the ability of your users to use Embroider. And the good news is that many addons are already Embroider Safe without doing any work, and all they really need to do is verify by adding a new scenario to their test suite.
 
@@ -30,7 +30,7 @@ We call addons that can be understood by `@embroider/compat` "Embroider Safe". "
 
 Your addon may already be Embroider Safe! Many addons are. We've done a lot of work in the `@embroider/compat` package to be able to compile v1 addons on-the-fly into v2 addons.
 
-The best way to see if your addon is Embroider safe is to add the `@embroider/test-setup` package and runs its `embroider-safe` ember-try scenario. See its [README](https://github.com/embroider-build/embroider/tree/master/packages/test-setup) for full details.
+The best way to see if your addon is Embroider safe is to add the `@embroider/test-setup` package and runs its `embroider-safe` ember-try scenario. See its [README](https://github.com/embroider-build/embroider/tree/main/packages/test-setup) for full details.
 
 If your tests _don't_ work under Embroider when you try this, please file an issue on the Embroider repo. We can help you triage whether there's a missing feature in `@embroider/compat` that would allow your addon to work unchanged, or whether there is a better way to refactor your addon to avoid incompatible behavior.
 
@@ -69,8 +69,8 @@ Several of these examples use a monorepo as a way to keep a clean separation bet
 
 We support some tools to make V2 addon development more convenient:
 
-- [@embroider/addon-shim](https://github.com/embroider-build/embroider/blob/master/packages/addon-shim/README.md) makes your V2 addon understandable to ember-cli. All V2 addons should use this.
-- [@embroider/addon-dev](https://github.com/embroider-build/embroider/blob/master/packages/addon-dev/README.md) is an optional `devDependency` for your addon that provides build tooling. This gives you more flexibility over how you author your addon (like taking advantage of automatic template-colocation or using TypeScript) while still producing a spec-compliant package for publication to NPM.
+- [@embroider/addon-shim](https://github.com/embroider-build/embroider/blob/main/packages/addon-shim/README.md) makes your V2 addon understandable to ember-cli. All V2 addons should use this.
+- [@embroider/addon-dev](https://github.com/embroider-build/embroider/blob/main/packages/addon-dev/README.md) is an optional `devDependency` for your addon that provides build tooling. This gives you more flexibility over how you author your addon (like taking advantage of automatic template-colocation or using TypeScript) while still producing a spec-compliant package for publication to NPM.
 
 ## Replacing the {{component}} helper
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ return require('@embroider/compat').compatBuild(app, Webpack, {
 });
 ```
 
-The options are documented in detail in [Core Options](https://github.com/embroider-build/embroider/blob/master/packages/core/src/options.ts), [Compat Options](https://github.com/embroider-build/embroider/blob/master/packages/compat/src/options.ts), and [Webpack Options](https://github.com/embroider-build/embroider/blob/master/packages/webpack/src/options.ts).
+The options are documented in detail in [Core Options](https://github.com/embroider-build/embroider/blob/main/packages/core/src/options.ts), [Compat Options](https://github.com/embroider-build/embroider/blob/main/packages/compat/src/options.ts), and [Webpack Options](https://github.com/embroider-build/embroider/blob/main/packages/webpack/src/options.ts).
 
 The recommended steps when introducing Embroider into an existing app are:
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -32,7 +32,7 @@ export default interface Options {
   // Enables per-route code splitting. Any route names that match these patterns
   // will be split out of the initial app payload. If you use this, you must
   // also add @embroider/router to your app. See [@embroider/router's
-  // README](https://github.com/embroider-build/embroider/blob/master/packages/router/README.md)
+  // README](https://github.com/embroider-build/embroider/blob/main/packages/router/README.md)
   splitAtRoutes?: (RegExp | string)[];
 
   // Every file within your application's `app` directory is categorized as a

--- a/packages/test-setup/README.md
+++ b/packages/test-setup/README.md
@@ -68,7 +68,7 @@ This function always accepts your `app` (the value returned from `new EmberApp` 
 
 When Embroider is not present in the app's dependencies, it does exactly the same thing as `app.toTree()`. But when Embroider is present, it uses Embroider and if it sees one of our pre-defined scenario names in the environment variable `EMBROIDER_TEST_SETUP_OPTIONS`, it will merge those pre-defined options into any options that you provided.
 
-For detailed documentation on what can go in `embroiderOptions`, see the comments in [Core Options](`https://github.com/embroider-build/embroider/blob/master/packages/core/src/options.ts`) and [Compat Options](https://github.com/embroider-build/embroider/blob/master/packages/compat/src/options.ts).
+For detailed documentation on what can go in `embroiderOptions`, see the comments in [Core Options](`https://github.com/embroider-build/embroider/blob/main/packages/core/src/options.ts`) and [Compat Options](https://github.com/embroider-build/embroider/blob/main/packages/compat/src/options.ts).
 
 If you normally pass extra broccoli trees to the `app.toTree()` method, you can still do so and should use the `extraPublicTrees` option:
 

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -18,7 +18,7 @@ ember install @embroider/util
 
 ### `ensureSafeComponent`
 
-This function aids you in eliminating un-analyzable usage of the `{{component}}` helper. For the full explanation of why and how you would do this, see [the Addon Author Guide](https://github.com/embroider-build/embroider/blob/master/ADDON-AUTHOR-GUIDE.md).
+This function aids you in eliminating un-analyzable usage of the `{{component}}` helper. For the full explanation of why and how you would do this, see [the Addon Author Guide](https://github.com/embroider-build/embroider/blob/main/ADDON-AUTHOR-GUIDE.md).
 
 Example usage in Javascript:
 

--- a/packages/util/addon/index.js
+++ b/packages/util/addon/index.js
@@ -31,7 +31,7 @@ function handleString(name, thingWithOwner) {
     false,
     {
       id: 'ensure-safe-component.string',
-      url: 'https://github.com/embroider-build/embroider/blob/master/ADDON-AUTHOR-GUIDE.md#when-youre-passing-a-component-to-someone-else',
+      url: 'https://github.com/embroider-build/embroider/blob/main/REPLACING-COMPONENT-HELPER.md#when-youre-passing-a-component-to-someone-else',
       until: 'embroider',
       for: '@embroider/util',
       since: '0.27.0',


### PR DESCRIPTION
Avoids the `Branch master was renamed to main.` info alert when clicking on any of these links.