### PR TITLE
register node tests with scenario-tester

### DIFF
--- a/tests/scenarios/jest-suites-test.ts
+++ b/tests/scenarios/jest-suites-test.ts
@@ -1,15 +1,19 @@
 import QUnit from 'qunit';
 import { resolve } from 'path';
-import { PreparedApp } from 'scenario-tester';
+import { PreparedApp, Project, Scenarios } from 'scenario-tester';
 
 const { module: Qmodule, test } = QUnit;
 
 // this is the bridge between our older Jest-based node tests and our newer
 // scenario-tester powered tests
-Qmodule('node', function () {
-  test('run node tests', async function (assert) {
-    let app = new PreparedApp(resolve(__dirname, '..', '..'));
-    let result = await app.execute('yarn jest --forceExit');
-    assert.equal(result.exitCode, 0, result.output);
+Scenarios.fromProject(() => new Project('node-tests'))
+  .map('node', () => {})
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function () {
+      test('run node tests', async function (assert) {
+        let app = new PreparedApp(resolve(__dirname, '..', '..'));
+        let result = await app.execute('yarn jest --forceExit');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
   });
-});


### PR DESCRIPTION
The older jest-based tests are not running in CI  because we only make CI jobs for known Scenarios and they weren't wrapped in a Scenario.