### PR TITLE
Add message to clarify error for non-serializable configs

### DIFF
--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -466,6 +466,7 @@ function isSerializable(obj: object): boolean {
     return true;
   }
 
+  console.error('non serializable item found in config:', obj);
   return false;
 }
 


### PR DESCRIPTION
This is such a tiny change, but this error has been coming up in some apps and it gave me very little clue of what to do about it. Only after digging through the source and putting in debug messages did I realize that my environment file had some regex values, and those are not allowed?

I'm not sure of the details as to _why_ regex values aren't allowed in the config currently, but I will say any apps that are using Fastboot and have set it up according to their docs will probably run into this cryptic error without a clear path to solve it. 

https://ember-fastboot.com/docs/user-guide#the-host-whitelist
> For security, you must specify a hostWhitelist of expected hosts in your application's config/environment.js:
> hostWhitelist entries can be a String or RegExp to match multiple hosts.
