### PR TITLE
Ensure self-references within a dummy apps work for `@` resolution.

### DIFF
--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -467,7 +467,9 @@ export default class CompatResolver implements Resolver {
       if (renamed) {
         packageName = renamed;
       }
-      return this._tryHelper(parts[1], from, cache.resolve(packageName, cache.ownerOfFile(from)!));
+      let owner = cache.ownerOfFile(from)!;
+      let targetPackage = owner.name === packageName ? owner : cache.resolve(packageName, owner);
+      return this._tryHelper(parts[1], from, targetPackage);
     } else {
       return this._tryHelper(path, from, this.appPackage);
     }
@@ -501,7 +503,9 @@ export default class CompatResolver implements Resolver {
       if (renamed) {
         packageName = renamed;
       }
-      return this._tryModifier(parts[1], from, cache.resolve(packageName, cache.ownerOfFile(from)!));
+      let owner = cache.ownerOfFile(from)!;
+      let targetPackage = owner.name === packageName ? owner : cache.resolve(packageName, owner);
+      return this._tryModifier(parts[1], from, targetPackage);
     } else {
       return this._tryModifier(path, from, this.appPackage);
     }
@@ -540,7 +544,10 @@ export default class CompatResolver implements Resolver {
       if (renamed) {
         packageName = renamed;
       }
-      return this._tryComponent(parts[1], from, withRuleLookup, cache.resolve(packageName, cache.ownerOfFile(from)!));
+      let owner = cache.ownerOfFile(from)!;
+      let targetPackage = owner.name === packageName ? owner : cache.resolve(packageName, owner);
+
+      return this._tryComponent(parts[1], from, withRuleLookup, targetPackage);
     } else {
       return this._tryComponent(path, from, withRuleLookup, this.appPackage);
     }

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -648,6 +648,38 @@ describe('compat-resolver', function () {
       },
     ]);
   });
+  test('angle bracket invocation of component with @ syntax', function () {
+    let findDependencies = configure(
+      {
+        staticComponents: true,
+      },
+      { plugins: { ast: [emberHolyFuturisticNamespacingBatmanTransform] } }
+    );
+    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon"}`);
+    givenFile('node_modules/my-addon/components/thing.js');
+    expect(findDependencies('templates/application.hbs', `<MyAddon$Thing />`)).toEqual([
+      {
+        path: '../node_modules/my-addon/components/thing.js',
+        runtimeName: 'my-addon/components/thing',
+      },
+    ]);
+  });
+  test('angle bracket invocation of component with @ syntax - self reference inside node_modules', function () {
+    let findDependencies = configure(
+      {
+        staticComponents: true,
+      },
+      { plugins: { ast: [emberHolyFuturisticNamespacingBatmanTransform] } }
+    );
+    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon"}`);
+    givenFile('node_modules/my-addon/components/thing.js');
+    expect(findDependencies('node_modules/my-addon/components/foo.hbs', `<MyAddon$Thing />`)).toEqual([
+      {
+        path: './thing.js',
+        runtimeName: 'my-addon/components/thing',
+      },
+    ]);
+  });
   test('helper with @ syntax', function () {
     let findDependencies = configure(
       {


### PR DESCRIPTION
Fixes https://github.com/embroider-build/embroider/issues/1072