### PR TITLE
FIX: rollup-hbs-plugin add resolveId hook

### DIFF
--- a/packages/addon-dev/src/rollup-hbs-plugin.ts
+++ b/packages/addon-dev/src/rollup-hbs-plugin.ts
@@ -4,8 +4,7 @@ import { readFileSync } from 'fs';
 const backtick = '`';
 
 export default function rollupHbsPlugin(): Plugin {
-  const templateFilter = createFilter('**/*.hbs');
-  const moduleFilter = createFilter('**/*.hbs.js');
+  const filter = createFilter('**/*.hbs');
 
   return {
     name: 'rollup-hbs-plugin',
@@ -17,7 +16,7 @@ export default function rollupHbsPlugin(): Plugin {
 
       const id = resolution?.id;
 
-      if (!templateFilter(id)) return null;
+      if (!filter(id)) return null;
 
       // This creates an `*.hbs.js` that we will populate in `load()` hook.
       return {
@@ -31,8 +30,6 @@ export default function rollupHbsPlugin(): Plugin {
       };
     },
     load(id: string) {
-      if (!moduleFilter(id)) return null;
-
       const meta = this.getModuleInfo(id)?.meta;
       const originalId = meta?.['rollup-hbs-plugin']?.originalId;
 

--- a/packages/addon-dev/src/rollup-hbs-plugin.ts
+++ b/packages/addon-dev/src/rollup-hbs-plugin.ts
@@ -4,19 +4,48 @@ import { readFileSync } from 'fs';
 const backtick = '`';
 
 export default function rollupHbsPlugin(): Plugin {
-  const filter = createFilter('**/*.hbs');
+  const templateFilter = createFilter('**/*.hbs');
+  const moduleFilter = createFilter('**/*.hbs.js');
 
   return {
     name: 'rollup-hbs-plugin',
+    async resolveId(source: string, importer: string | undefined, options) {
+      const resolution = await this.resolve(source, importer, {
+        skipSelf: true,
+        ...options,
+      });
+
+      const id = resolution?.id;
+
+      if (!templateFilter(id)) return null;
+
+      // This creates an `*.hbs.js` that we will populate in `load()` hook.
+      return {
+        ...resolution,
+        id: id + '.js',
+        meta: {
+          'rollup-hbs-plugin': {
+            originalId: id,
+          },
+        },
+      };
+    },
     load(id: string) {
-      if (!filter(id)) return;
-      let input = readFileSync(id, 'utf8');
+      if (!moduleFilter(id)) return null;
+
+      const meta = this.getModuleInfo(id)?.meta;
+      const originalId = meta?.['rollup-hbs-plugin']?.originalId;
+
+      if (!originalId) {
+        return;
+      }
+
+      let input = readFileSync(originalId, 'utf8');
       let code =
         `import { hbs } from 'ember-cli-htmlbars';\n` +
         `export default hbs${backtick}${input}${backtick};`;
       return {
         code,
-        id: id + '.js',
       };
     },
   };


### PR DESCRIPTION
- In the `load()` hook, `id` isn't a valid property in the returned object.
- This assumed that a resolution was created for the intermediate
  file `*.hbs.js` file.
- This created an issue where a babel plugin could not transform
  `*.hbs.js` files.
- Added `resolveId()` hook to create a resolution for `*.hbs` to `*.hbs.js` file.