### PR TITLE
Add test for app depending on an addon depending on an optional peerDependency

### DIFF
--- a/tests/scenarios/v2-addon-peer-deps-test.ts
+++ b/tests/scenarios/v2-addon-peer-deps-test.ts
@@ -1,0 +1,67 @@
+import { appScenarios, baseV2Addon, baseAddon } from './scenarios';
+import { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+import merge from 'lodash/merge';
+
+const { module: Qmodule, test } = QUnit;
+
+appScenarios
+  .map('v2-addon-with-optional-peer-dep-on-v1-addon', project => {
+    let v1Addon = baseAddon();
+
+    v1Addon.pkg.name = 'v1-addon';
+    merge(v1Addon.files, {
+      addon: {
+        'index.js': `export class TrackedAsyncData {}`,
+      },
+    });
+
+    let v2Addon = baseV2Addon();
+
+    merge(v2Addon.files, {
+      'index.js': `export { TrackedAsyncData } from 'v1-addon';`,
+    });
+
+    v2Addon.pkg.name = 'v2-addon';
+    v2Addon.pkg.peerDependencies = {
+      'v1-addon': v1Addon.version,
+    };
+    v2Addon.pkg.peerDependenciesMeta = {
+      'v1-addon': {
+        optional: true,
+      },
+    };
+
+    project.addDependency(v2Addon);
+    project.addDependency(v1Addon);
+
+    merge(project.files, {
+      tests: {
+        unit: {
+          'import-test.js': `
+           import { module, test } from 'qunit';
+           import { TrackedAsyncData } from 'v2-addon';
+
+           module('Unit | import', function(hooks) {
+             test('v2 addons can import() from optional peer dep', async function(assert) {
+              assert.ok(TrackedAsyncData, 'import success');
+             });
+           });
+          `,
+        },
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test(`yarn test`, async function (assert) {
+        let result = await app.execute('yarn test');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
+  });

--- a/tests/scenarios/v2-addon-test.ts
+++ b/tests/scenarios/v2-addon-test.ts
@@ -30,9 +30,9 @@ appScenarios
         `,
       },
       'import-from-npm.js': `
-        export default async function() { 
+        export default async function() {
           let { message } = await import('third-party');
-          return message() 
+          return message()
         }
         `,
     });


### PR DESCRIPTION
This test was meant to reproduce the issue I'm running in to here:
 - https://github.com/NullVoxPopuli/ember-resources/runs/5961868348?check_suite_focus=true#step:7:459

but everything is fine and dandy.

Could this be pnpm (the ember-resources repo) vs yarn (embroider) issue? idk

Locally, on the ember-resources PR, I did the require.resolve trick to make sure that the package is resolvable to node:
```
❯ node -e "console.log(require.resolve('ember-async-data'))"
<repo>/node_modules/.pnpm/ember-async-data@0.6.0/node_modules/ember-async-data/index.js
```