### PR TITLE
Fix thread-load JOBS handling/documentation

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -557,12 +557,21 @@ const threadLoaderOptions = {
   poolTimeout: Infinity,
 };
 
+function canUseThreadLoader(extraOptions: object | false | undefined) {
+  // If the environment sets JOBS to 0, or if our extraOptions are set to false,
+  // we have been explicitly configured not to use thread-loader
+  if (process.env.JOBS === '0' || extraOptions === false) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
 function warmUp(extraOptions: object | false | undefined) {
-  // We don't know if we'll be parallel-safe or not, but if the environment sets
-  // JOBS to 0, or our extraOptions are set to false, we know we won't use
-  // thread-loader, so no need to consume extra resources warming the worker
-  // pool
-  if (process.env.JOBS === '1' || extraOptions === false) {
+  // We don't know if we'll be parallel-safe or not, but if we've been
+  // configured to not use thread-loader, then there is no need to consume extra
+  // resources warming the worker pool
+  if (!canUseThreadLoader(extraOptions)) {
     return null;
   }
 
@@ -573,7 +582,7 @@ function warmUp(extraOptions: object | false | undefined) {
 }
 
 function maybeThreadLoader(isParallelSafe: boolean, extraOptions: object | false | undefined) {
-  if (process.env.JOBS === '0' || extraOptions === false || !isParallelSafe) {
+  if (!canUseThreadLoader(extraOptions) || !isParallelSafe) {
     return null;
   }
 

--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -25,7 +25,7 @@ export interface Options {
   // will be used to configure `thread-loader`. If not specified,
   // `thread-loader` will be used with a default configuration.
   //
-  // Note that setting `JOBS=1` in the environment will also disable
+  // Note that setting `JOBS=0` in the environment will also disable
   // `thread-loader`.
   threadLoaderOptions?: object | false;
 


### PR DESCRIPTION
04d39ba3183ed56010114edf1d5d21f1474de497 missed one JOBS check, and left it checking for `1` instead of `0`, and also didn't update the documentation/comment. Fortunately, it was relatively harmless (related to warming the thread-loader pool, which is just a performance thing)  So I consolidated the code into a helper function to ensure consistency, and updated the comment.