### PR TITLE
Align webpack's outputPath with the whole app

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -184,10 +184,10 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
         ],
       },
       output: {
-        path: join(this.outputPath, 'assets'),
-        filename: `chunk.[chunkhash].js`,
-        chunkFilename: `chunk.[chunkhash].js`,
-        publicPath: publicAssetURL + 'assets/',
+        path: join(this.outputPath),
+        filename: `assets/chunk.[chunkhash].js`,
+        chunkFilename: `assets/chunk.[chunkhash].js`,
+        publicPath: publicAssetURL,
       },
       optimization: {
         splitChunks: {
@@ -417,7 +417,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
 
         getOrCreate(output.entrypoints, id, () => new Map()).set(
           variantIndex,
-          entrypointAssets.map(asset => 'assets/' + asset.name)
+          entrypointAssets.map(asset => asset.name)
         );
         if (variant.runtime !== 'browser') {
           // in the browser we don't need to worry about lazy assets (they will be
@@ -428,9 +428,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
             flatMap(
               chunks.filter(chunk => chunk.runtime?.includes(id)),
               chunk => chunk.files
-            )
-              .filter(file => !entrypointAssets?.find(a => a.name === file))
-              .map(file => `assets/${file}`)
+            ).filter(file => !entrypointAssets?.find(a => a.name === file)) as string[]
           );
         }
       }

--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -11,6 +11,9 @@ export interface BabelLoaderOptions {
 }
 
 export interface Options {
+  // This allows you to extend the webpack config in arbitrary ways. Your
+  // changes will get applied on top of the defaults provided by
+  // @embroider/webpack.
   webpackConfig: Configuration;
 
   // the base public URL for your assets in production. Use this when you want
@@ -18,6 +21,31 @@ export interface Options {
   // actual index.html will be served on.
   //
   // This should be a URL ending in "/".
+  //
+  // For example:
+  //
+  // 1. If your build produces the file "./dist/assets/chunk.123.js"
+  // 2. And you set publicAssetURL to "https://cdn/"
+  // 3. Browsers will try to locate the file at
+  //    "https://cdn/assets/chunk.123.js".
+  //
+  // Notice that `publicAssetURL` gets applied relative to your whole built
+  // application -- not a particular subdirectory like "/assets". If you don't
+  // want a part of the path to show up in the public URLs, you should adjust the
+  // actual locations of the output files to remove that directory. For example:
+  //
+  // webpackConfig: {
+  //   output: {
+  //     // This overrides our default of "assets/chunk.[chunkhash].js"
+  //     // to move the chunks to the root of the app, eliminating the assets subdirectory.
+  //     filename: `mychunk.[chunkhash].js`,
+  //     chunkFilename: `mychunk.[chunkhash].js`,
+  //   },
+  //   publicOutputPath: "https://cdn/",
+  // },
+  //
+  // The above example will result in CDN URLs like "https://cdn/mychunk.123.js".
+  //
   publicAssetURL?: string;
 
   // [thread-loader](https://github.com/webpack-contrib/thread-loader) options.


### PR DESCRIPTION
We hard-code webpack's output path to be the "assets" subdirectory of the built app (which appears as "./dist/assets" after you run a build).

This is needlessly confusing and limiting, because webpack's view of the world doesn't match what the app author actually writes. Mostly this doesn't matter when people are using all the defaults, but if they wanted to customize (for example) the location of the generated chunks they can't escape the assets subdir.

This PR fixes this problem by setting webpack's `output.path` to the root of the (output) ember app (meaning the "./dist" subdir in a typical build), and making corresponding adjustments to `output.filename` and `output.chunkFileName` so that we're still producing the same files by default, but they're now addressed relative to the whole app.

This is fix for https://github.com/embroider-build/embroider/issues/1157.