### PR TITLE
Accept optional `mapFilename` config for `rollup-app-reexports`

### DIFF
--- a/packages/addon-dev/src/rollup-app-reexports.ts
+++ b/packages/addon-dev/src/rollup-app-reexports.ts
@@ -6,22 +6,25 @@ export default function appReexports(opts: {
   from: string;
   to: string;
   include: string[];
+  mapFilename?: (filename: string) => string;
 }): Plugin {
   return {
     name: 'app-reexports',
     generateBundle(_, bundle) {
       let pkg = readJsonSync('package.json');
       let appJS: Record<string, string> = {};
-      for (let filename of Object.keys(bundle)) {
+      for (let addonFilename of Object.keys(bundle)) {
+        let appFilename = opts.mapFilename?.(addonFilename) ?? addonFilename;
+
         if (
-          opts.include.some((glob) => minimatch(filename, glob)) &&
-          !minimatch(filename, '**/*.d.ts')
+          opts.include.some((glob) => minimatch(addonFilename, glob)) &&
+          !minimatch(addonFilename, '**/*.d.ts')
         ) {
-          appJS[`./${filename}`] = `./dist/_app_/${filename}`;
+          appJS[`./${appFilename}`] = `./dist/_app_/${appFilename}`;
           this.emitFile({
             type: 'asset',
-            fileName: `_app_/${filename}`,
-            source: `export { default } from "${pkg.name}/${filename}";\n`,
+            fileName: `_app_/${appFilename}`,
+            source: `export { default } from "${pkg.name}/${addonFilename}";\n`,
           });
         }
       }

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -18,11 +18,15 @@ export class Addon {
   // Given a list of globs describing modules in your srcDir, this generates
   // corresponding appTree modules that contain reexports, and updates your
   // package.json metadata to list them all.
-  appReexports(patterns: string[]): Plugin {
+  appReexports(
+    patterns: string[],
+    opts: { mapFilename?: (fileName: string) => string } = {}
+  ): Plugin {
     return appReexports({
       from: this.#srcDir,
       to: this.#destDir,
       include: patterns,
+      mapFilename: opts.mapFilename,
     });
   }
 

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -51,6 +51,10 @@ appScenarios
           destDir: 'dist',
         });
 
+        const reexportMappings = {
+          'components/demo/namespace-me.js': 'components/demo/namespace/namespace-me.js',
+        };
+
         export default {
           output: addon.output(),
 
@@ -62,7 +66,10 @@ appScenarios
             addon.appReexports([
               'components/demo/index.js',
               'components/demo/out.js',
-            ]),
+              'components/demo/namespace-me.js',
+            ], {
+              mapFilename: (name) => reexportMappings[name] || name,
+            }),
 
             addon.hbs(),
             addon.dependencies(),
@@ -83,6 +90,9 @@ appScenarios
             `,
             'out.hbs': `
               <out>{{yield}}</out>
+            `,
+            'namespace-me.hbs': `
+              namespaced component
             `,
             'index.js': `
                 import Component from '@glimmer/component';
@@ -149,6 +159,12 @@ appScenarios
 
               assert.dom('out').containsText('hi');
             });
+
+            test('<Demo::Namespace::NamespaceMe />', async function (assert) {
+              await render(hbs\`<Demo::Namespace::NamespaceMe />\`);
+
+              assert.dom().containsText('namespaced component');
+            });
           });
         `,
       },
@@ -180,6 +196,7 @@ appScenarios
           assert.deepEqual(reExports, {
             './components/demo/index.js': './dist/_app_/components/demo/index.js',
             './components/demo/out.js': './dist/_app_/components/demo/out.js',
+            './components/demo/namespace/namespace-me.js': './dist/_app_/components/demo/namespace/namespace-me.js',
           });
         });
 


### PR DESCRIPTION
I brought this up in Discord the other day and didn't get any immediate vehement "no way" responses, so I'm going ahead and proposing it here.

Tl;dr: in `@embroider/addon-dev`'s tooling for generating app reexports, I'd like to be able to define a mapping between the source and reexport paths for an entity instead of assuming they're exactly the same.

## Background

For addons that expose many resolvable entities (components, helpers, services, etc), it can be helpful to somehow namespace those entities to make it clear to consumers where they're coming from when they see a component invocation or service injection.

Short of no-longer-the-future [Batman namespacing](https://github.com/rwjblue/ember-holy-futuristic-template-namespacing-batman), a lighter-weight way to do that is by grouping those entities together under a directory so that everything your addon exposes is clearly prefixed with an indicator of where it's from. Concretely, rather than directly having `components/foo` in my `cool-addon` package, I might have `components/cool-addon/foo`, and consumers would write `<CoolAddon::Foo />` in their templates.

It's a bit cumbersome to have that extra directory in the canonical path for the implementation, though: it's an additional layer of nesting to navigate through in editors and code browsers, and you end up writing somewhat redundant import paths like `cool-addon/components/cool-addon/foo`. The latter point also becomes a bit more painful as [first-class component templates](https://github.com/emberjs/rfcs/pull/779) pick up steam and consumers begin needing to care about the import paths of the components, helpers and modifiers they use.

To mitigate this in a v1 addon, I can put my reexport in `app/components/cool-addon/foo.js` while leaving my implementation in `addon/components/foo.hbs`, but since reexports are managed as part of build tooling for v2 addons, I don't have that flexibility.

## This Change

This change adds an optional `appReexports` function that devs can pass to `appReexports` to remap the names of files emitted as part of their `app-js` content.

```js
  plugins: [
    // ...
    addon.appReexports([
      'components/**/*.js',
      'services/**/*.js',
    ], {
      mapFilename: (name) => name.replace(/^(services|components)\//, '$1/cool-addon/'),
    }),
    // ...
  ],
```

By configuring my v2 `cool-addon` like the snippet above, I can provide a reasonably ergonomic form factor for consuming my `Foo` component unambiguously in a loose-mode template (`<CoolAddon::Foo />`) or a strict-mode one (`import Foo from 'cool-addon/components/foo'`).