### PR TITLE
Fix preprocessors tree by wrapping with moduleName

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@embroider/sample-transforms": "0.0.0",
     "@embroider/test-support": "0.36.0",
+    "@glimmer/syntax": "0.80.0",
     "@types/babel__core": "^7.1.14",
     "@types/babel__generator": "^7.6.2",
     "@types/babel__template": "^7.4.0",
@@ -77,9 +78,9 @@
     "@types/resolve": "^1.20.0",
     "@types/semver": "^7.3.6",
     "@types/strip-bom": "^4.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
+    "broccoli-stew": "^3.0.0",
     "ember-cli-htmlbars-3": "npm:ember-cli-htmlbars@3",
-    "@glimmer/syntax": "0.80.0",
+    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-engines": "^0.8.19",
     "typescript": "*"
   },

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -488,14 +488,22 @@ export default class V1Addon {
 
   // applies preprocessors to JS and HBS
   private transpile(tree: Node) {
+    tree = buildFunnel(tree, { destDir: this.moduleName });
+
     tree = this.addonInstance.preprocessJs(tree, '/', this.moduleName, {
       registry: this.addonInstance.registry,
     });
+
     if (this.addonInstance.shouldCompileTemplates() && this.addonInstance.registry.load('template')?.length > 0) {
       tree = this.app.preprocessRegistry.preprocessTemplates(tree, {
         registry: this.addonInstance.registry,
       });
     }
+
+    tree = buildFunnel(tree, {
+      srcDir: this.moduleName,
+    });
+
     return tree;
   }
 

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -488,10 +488,18 @@ export default class V1Addon {
 
   // applies preprocessors to JS and HBS
   private transpile(tree: Node) {
+    // Namespace the tree being passed to preprocessJs with the moduleName
+    // to mimic classic build
     tree = buildFunnel(tree, { destDir: this.moduleName });
 
     tree = this.addonInstance.preprocessJs(tree, '/', this.moduleName, {
       registry: this.addonInstance.registry,
+    });
+
+    // Remove namespacing so that it gets written out to the node_modules
+    // directory correctly.
+    tree = buildFunnel(tree, {
+      srcDir: this.moduleName,
     });
 
     if (this.addonInstance.shouldCompileTemplates() && this.addonInstance.registry.load('template')?.length > 0) {
@@ -499,10 +507,6 @@ export default class V1Addon {
         registry: this.addonInstance.registry,
       });
     }
-
-    tree = buildFunnel(tree, {
-      srcDir: this.moduleName,
-    });
 
     return tree;
   }

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -551,10 +551,16 @@ export default class V1App {
     // auto-import is supported natively so we don't need it here
     this.app.registry.remove('js', 'ember-auto-import-analyzer');
 
-    return this.preprocessors.preprocessJs(tree, `/`, '/', {
+    tree = buildFunnel(tree, { destDir: this.name });
+
+    tree = this.preprocessors.preprocessJs(tree, `/`, '/', {
       annotation: 'v1-app-preprocess-js',
       registry: this.app.registry,
     });
+
+    tree = buildFunnel(tree, { srcDir: this.name });
+
+    return tree;
   }
 
   get htmlbarsPlugins(): TemplateCompilerPlugins {

--- a/packages/compat/tests/preprocessors.test.ts
+++ b/packages/compat/tests/preprocessors.test.ts
@@ -53,7 +53,6 @@ module.exports = {
           tree,
           '**/*.{js,css}',
           function (content, relativePath) {
-            console.log('$$$$' + relativePath);
             return \`/*path@\${relativePath}*/\n\${content}\`;
           }
         );
@@ -95,6 +94,7 @@ module.exports = {
         tests: false,
       },
     });
+    console.log(build.outputPath);
     expectFile = expectFilesAt(build.outputPath);
   });
 
@@ -110,16 +110,16 @@ module.exports = {
     expectFile('node_modules/my-preprocessor/package.json').exists();
   });
 
-  test.skip('app has correct path embedded in comment', () => {
+  test('app has correct path embedded in comment', () => {
     const assertFile = expectFile('components/from-the-app.js');
     assertFile.exists();
     // This is the expected output during an classic build.
-    assertFile.matches(/path:my-app\/components\/from-the-app\.js/, 'has a path comment in app components');
+    assertFile.matches(/path@my-app\/components\/from-the-app\.js/, 'has a path comment in app components');
   });
 
   test('addon has correct path embedded in comment', () => {
     expectFile('node_modules/my-preprocessor/package.json').exists();
     const assertFile = expectFile('node_modules/my-addon/components/greeting.js');
-    assertFile.matches(/\/\/path:my-addon\/components\/from-the-app\.js/, 'has a path comment in app components');
+    assertFile.matches(/path@my-addon\/components\/greeting\.js/, 'has a path comment in app components');
   });
 });

--- a/packages/compat/tests/preprocessors.test.ts
+++ b/packages/compat/tests/preprocessors.test.ts
@@ -84,7 +84,9 @@ module.exports = {
       },
     });
 
-    addon.addDependency(PACKAGE_MY_PREPROCESSOR);
+    // We must explicitly pass the addonPreprocessor using the
+    // name is not sufficient.
+    addon.addDependency(addonPreprocessor);
 
     build = await BuildResult.build(app, {
       stage: 2,

--- a/packages/compat/tests/preprocessors.test.ts
+++ b/packages/compat/tests/preprocessors.test.ts
@@ -13,8 +13,6 @@ describe('preprocessors tests', function () {
   beforeAll(async function () {
     app = Project.emberNew('my-app');
 
-    const PACKAGE_MY_PREPROCESSOR = 'my-preprocessor';
-
     merge(app.files, {
       config: {
         'targets.js': `module.exports = { browsers: ['last 1 Chrome versions'] }`,
@@ -30,6 +28,7 @@ describe('preprocessors tests', function () {
       },
     });
 
+    const PACKAGE_MY_PREPROCESSOR = 'my-preprocessor';
     let addonPreprocessor = app.addAddon(PACKAGE_MY_PREPROCESSOR);
 
     const INDEX_JS_WITH_PREPROCESSOR = `const { map } = require('broccoli-stew');

--- a/packages/compat/tests/preprocessors.test.ts
+++ b/packages/compat/tests/preprocessors.test.ts
@@ -1,0 +1,125 @@
+import { Project, BuildResult, expectFilesAt, ExpectFile } from '@embroider/test-support';
+import { throwOnWarnings } from '@embroider/core';
+import merge from 'lodash/merge';
+
+describe('preprocessors tests', function () {
+  jest.setTimeout(120000);
+  let build: BuildResult;
+  let app: Project;
+  let expectFile: ExpectFile;
+
+  throwOnWarnings();
+
+  beforeAll(async function () {
+    app = Project.emberNew('my-app');
+
+    const PACKAGE_MY_PREPROCESSOR = 'my-preprocessor';
+
+    merge(app.files, {
+      config: {
+        'targets.js': `module.exports = { browsers: ['last 1 Chrome versions'] }`,
+      },
+      app: {
+        components: {
+          'from-the-app.js': `
+            import Component from '@glimmer/component';
+            export default class extends Component {}
+            `,
+          'from-the-app.hbs': `<div>{{this.title}}</div><Greeting/>`,
+        },
+      },
+    });
+
+    let addonPreprocessor = app.addAddon(PACKAGE_MY_PREPROCESSOR);
+
+    const INDEX_JS_WITH_PREPROCESSOR = `const { map } = require('broccoli-stew');
+
+module.exports = {
+  name: require('./package').name,
+
+  setupPreprocessorRegistry(type, registry) {
+    if (type !== 'parent') {
+      return;
+    }
+
+    registry.add('js', {
+      name: 'special-path-processor',
+      toTree(tree, inputPath) {
+        if (inputPath !== '/') {
+          return tree;
+        }
+
+        let augmented = map(
+          tree,
+          '**/*.{js,css}',
+          function (content, relativePath) {
+            console.log('$$$$' + relativePath);
+            return \`/*path@\${relativePath}*/\n\${content}\`;
+          }
+        );
+        return augmented;
+      },
+    });
+  }
+};
+`;
+
+    addonPreprocessor.linkDevPackage('broccoli-stew');
+    addonPreprocessor.files['index.js'] = INDEX_JS_WITH_PREPROCESSOR;
+
+    let addon = app.addAddon('my-addon');
+
+    merge(addon.files, {
+      app: {
+        components: {
+          'greeting.js': `export { default } from 'my-addon/components/greeting';`,
+        },
+      },
+      addon: {
+        components: {
+          'greeting.js': `
+            import Component from '@glimmer/component';
+            export default class extends Component {}
+          `,
+          'greeting.hbs': `Hello World`,
+        },
+      },
+    });
+
+    addon.addDependency(PACKAGE_MY_PREPROCESSOR);
+
+    build = await BuildResult.build(app, {
+      stage: 2,
+      type: 'app',
+      emberAppOptions: {
+        tests: false,
+      },
+    });
+    expectFile = expectFilesAt(build.outputPath);
+  });
+
+  afterAll(async () => {
+    await build.cleanup();
+  });
+
+  test('dependencies are setup for this test suite correctly', () => {
+    expectFile('package.json').exists();
+    expectFile('package.json').matches(/my-preprocessor/, 'has the preprocessor dependency');
+    expectFile('node_modules/my-addon/package.json').exists();
+    expectFile('node_modules/my-addon/package.json').matches(/my-preprocessor/, 'has the preprocessor dependency');
+    expectFile('node_modules/my-preprocessor/package.json').exists();
+  });
+
+  test.skip('app has correct path embedded in comment', () => {
+    const assertFile = expectFile('components/from-the-app.js');
+    assertFile.exists();
+    // This is the expected output during an classic build.
+    assertFile.matches(/path:my-app\/components\/from-the-app\.js/, 'has a path comment in app components');
+  });
+
+  test('addon has correct path embedded in comment', () => {
+    expectFile('node_modules/my-preprocessor/package.json').exists();
+    const assertFile = expectFile('node_modules/my-addon/components/greeting.js');
+    assertFile.matches(/\/\/path:my-addon\/components\/from-the-app\.js/, 'has a path comment in app components');
+  });
+});

--- a/packages/compat/tests/preprocessors.test.ts
+++ b/packages/compat/tests/preprocessors.test.ts
@@ -93,7 +93,7 @@ module.exports = {
         tests: false,
       },
     });
-    console.log(build.outputPath);
+
     expectFile = expectFilesAt(build.outputPath);
   });
 


### PR DESCRIPTION
This PR addresses the following issues:
- https://github.com/embroider-build/embroider/issues/1206
- https://github.com/salsify/ember-css-modules/issues/278

Replicated the issue here:
https://github.com/wondersloth/demo-embroider-preprocessors-bug

In a classic build the tree passed to the [preprocessor is scoped with the moduleName.](https://github.com/ember-cli/ember-cli/blob/177f52340dcaa59cf27402ed77fda5e55860fd35/lib/models/addon.js#L1195)

In embroider, th app or addon tree is not scoped with the name/moduleName

<img width="406" alt="screenshot" src="https://user-images.githubusercontent.com/129781/169361198-810daa8b-195b-4326-8e6e-11d33f624971.png">

This creates backcompat issues with addons like `ember-css-modules` that uses the file path to generate hash for some values. [Initial attempt fixing from an addon](https://github.com/salsify/ember-css-modules/pull/279).


- [X] Validated fix via `yarn link @embroider/compat` in `demo-embroider-preprocessors-bug`
- [x] Fix `v1-app.ts` to scope/wrap with moduleName when passing to preprocessors.
- [x] Fix tests so that preprocessors apply transform  to `my-addon`. 

