### PR TITLE
Move dummy app support down into packageCache

### DIFF
--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -16,10 +16,10 @@ import {
   OutputFileToInputFileMap,
   PackageInfo,
   AddonInstance,
+  getAppRoot,
 } from '@embroider/core';
 import { writeJSONSync, ensureDirSync, copySync, readdirSync, pathExistsSync, existsSync } from 'fs-extra';
 import AddToTree from './add-to-tree';
-import DummyPackage, { OwningAddon } from './dummy-package';
 import { TransformOptions } from '@babel/core';
 import { isEmbroiderMacrosPlugin, MacrosConfig } from '@embroider/macros/src/node';
 import resolvePackagePath from 'resolve-package-path';
@@ -747,9 +747,7 @@ function throwIfMissing<T>(
 class V1DummyApp extends V1App {
   constructor(app: EmberAppInstance) {
     super(app);
-    this.owningAddon = new OwningAddon(this.app.project.root, this.packageCache);
-    this.packageCache.seed(this.owningAddon);
-    this.packageCache.seed(new DummyPackage(this.root, this.owningAddon, this.packageCache));
+    this.owningAddon = this.packageCache.get(this.app.project.root);
   }
 
   get name(): string {
@@ -758,8 +756,7 @@ class V1DummyApp extends V1App {
   }
 
   get root(): string {
-    // this is the Known Hack for finding the true root of the dummy app.
-    return join(this.app.project.configPath(), '..', '..');
+    return getAppRoot(this.app);
   }
 }
 

--- a/packages/macros/src/ember-addon-main.ts
+++ b/packages/macros/src/ember-addon-main.ts
@@ -1,4 +1,4 @@
-import { AppInstance } from '@embroider/shared-internals';
+import { AppInstance, getAppRoot } from '@embroider/shared-internals';
 import { join } from 'path';
 import { BuildPluginParams } from './glimmer/ast-transform';
 import { MacrosConfig, isEmbroiderMacrosPlugin } from './node';
@@ -114,12 +114,6 @@ export = {
   options: {},
 };
 
-// this can differ from appInstance.project.root because Dummy apps are terrible
-function getAppRoot(appInstance: AppInstance): string {
-  return join(appInstance.project.configPath(), '..', '..');
-}
-
 function getMacrosConfig(appInstance: AppInstance): MacrosConfig {
-  let appRoot = join(appInstance.project.configPath(), '..', '..');
-  return MacrosConfig.for(appInstance, appRoot);
+  return MacrosConfig.for(appInstance, getAppRoot(appInstance));
 }

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import crypto from 'crypto';
 import findUp from 'find-up';
 import type { PluginItem } from '@babel/core';
-import { PackageCache, getOrCreate } from '@embroider/shared-internals';
+import { PackageCache, getOrCreate, getAppRoot, AppInstance, AddonInstance } from '@embroider/shared-internals';
 import { FirstTransformParams, makeFirstTransform, makeSecondTransform } from './glimmer/ast-transform';
 import State from './babel/state';
 import partition from 'lodash/partition';
@@ -306,9 +306,17 @@ export default class MacrosConfig {
   // normal node_modules resolution can find their dependencies. In other words,
   // owningPackageRoot is needed when you use this inside classic ember-cli, and
   // it's not appropriate inside embroider.
-  babelPluginConfig(appOrAddonInstance?: any): PluginItem[] {
+  babelPluginConfig(appOrAddonInstance?: AppInstance | AddonInstance): PluginItem[] {
     let self = this;
-    let owningPackageRoot = appOrAddonInstance ? appOrAddonInstance.root || appOrAddonInstance.project.root : null;
+    let owningPackageRoot: string | undefined;
+
+    if (appOrAddonInstance) {
+      if ('root' in appOrAddonInstance) {
+        owningPackageRoot = appOrAddonInstance.root;
+      } else {
+        owningPackageRoot = getAppRoot(appOrAddonInstance);
+      }
+    }
     let opts: State['opts'] = {
       // this is deliberately lazy because we want to allow everyone to finish
       // setting config before we generate the userConfigs

--- a/packages/shared-internals/src/dummy-package.ts
+++ b/packages/shared-internals/src/dummy-package.ts
@@ -1,4 +1,5 @@
-import { Package, PackageCache } from '@embroider/core';
+import Package from './package';
+import PackageCache from './package-cache';
 import { Memoize } from 'typescript-memoize';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -24,17 +25,5 @@ export default class DummyPackage extends Package {
     }
     deps.set(this.owningAddon.name, this.owningAddon);
     return deps;
-  }
-}
-
-// A specialized Package that represents an Addon that owns the current Dummy
-// App. It's special because it always supports rebuilds.
-export class OwningAddon extends Package {
-  constructor(root: string, packageCache: PackageCache) {
-    super(root, packageCache, false);
-  }
-
-  get mayRebuild(): boolean {
-    return true;
   }
 }

--- a/packages/shared-internals/src/ember-cli-models.ts
+++ b/packages/shared-internals/src/ember-cli-models.ts
@@ -1,5 +1,6 @@
 import type { Funnel } from 'broccoli-funnel';
 import type { Node } from 'broccoli-node-api';
+import { join } from 'path';
 import { PackageInfo } from './metadata';
 export interface Project {
   targets: unknown;
@@ -55,6 +56,8 @@ export interface EmberAppInstance {
   getLintTests(): Node;
   otherAssetPaths: any[];
   addonPostprocessTree: (which: string, tree: Node) => Node;
+  import(path: string, opts?: { type?: string }): void;
+  toTree(additionalTrees?: Node[]): Node;
 }
 
 interface BaseAddonInstance {
@@ -136,4 +139,10 @@ export function findTopmostAddon(addon: AddonInstance): ShallowAddonInstance {
   } else {
     return addon;
   }
+}
+
+// this can differ from appInstance.project.root because Dummy apps are terrible
+export function getAppRoot(appInstance: AppInstance): string {
+  // this is the Known Hack for finding the true root of the dummy app.
+  return join(appInstance.project.configPath(), '..', '..');
 }


### PR DESCRIPTION
We have pretty good support for classic Dummy apps in Embroider builds, but our PackageCache infrastructure is also used in classic builds (by @embroider/macros and by ember-auto-import) and there it ends up failing to understand dummy apps consistently.

Critically, a dummy app needs to be represented by a different Package from the actual NPM package it lives inside, because the dummy app has access to devDependencies and the addon does not.

This PR is refactoring the dummy app support down a layer directly into the PackageCache.