### PR TITLE
fix default css chunk naming

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -568,8 +568,8 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
         loaders: [MiniCssExtractPlugin.loader, cssLoader],
         plugins: [
           new MiniCssExtractPlugin({
-            filename: `chunk.[chunkhash].css`,
-            chunkFilename: `chunk.[chunkhash].css`,
+            filename: `assets/chunk.[chunkhash].css`,
+            chunkFilename: `assets/chunk.[chunkhash].css`,
             // in the browser, MiniCssExtractPlugin can manage it's own runtime
             // lazy loading of stylesheets.
             //


### PR DESCRIPTION
In https://github.com/embroider-build/embroider/pull/1194 we adjusted the webpack outputPath and made a compensating adjustment to the default JS chunk names so they would still end up in the same place. But we neglected to make a compensating change to the default chunk naming for production CSS chunks.

This caused the chunks to unintentionally move up one level in the directory hierarchy. This doesn't break anything, but it's inconsistent. This PR puts them back inside "assets" like before.