### PR TITLE
Prevent redundant toTree wrapping for macros

### DIFF
--- a/packages/macros/src/ember-addon-main.ts
+++ b/packages/macros/src/ember-addon-main.ts
@@ -3,6 +3,8 @@ import { join } from 'path';
 import { BuildPluginParams } from './glimmer/ast-transform';
 import { MacrosConfig, isEmbroiderMacrosPlugin } from './node';
 
+const wrappedTrees = new Set<Object>();
+
 export = {
   name: '@embroider/macros',
   included(this: any, parent: any) {
@@ -53,7 +55,7 @@ export = {
     // as macrosConfig is 1:1 with the appInstance, if
     // the toTree method is already wrapped, we don't need
     // to wrap it again
-    if (!originalToTree.__hasMacrosConfigWrapper) {
+    if (!wrappedTrees.has(originalToTree)) {
       // When we're used inside the traditional ember-cli build pipeline without
       // Embroider, we unfortunately need to hook into here uncleanly because we
       // need to delineate the point in time after which writing macro config is
@@ -63,7 +65,7 @@ export = {
         macrosConfig.finalize();
         return originalToTree.apply(appInstance, args);
       };
-      appInstance.toTree.__hasMacrosConfigWrapper = true;
+      wrappedTrees.add(appInstance.toTree);
     }
   },
 

--- a/packages/macros/src/ember-addon-main.ts
+++ b/packages/macros/src/ember-addon-main.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { BuildPluginParams } from './glimmer/ast-transform';
 import { MacrosConfig, isEmbroiderMacrosPlugin } from './node';
 
-const wrappedTrees = new Set<Object>();
+let hasWrappedToTree = false;
 
 export = {
   name: '@embroider/macros',
@@ -52,10 +52,7 @@ export = {
 
     const originalToTree = appInstance.toTree;
 
-    // as macrosConfig is 1:1 with the appInstance, if
-    // the toTree method is already wrapped, we don't need
-    // to wrap it again
-    if (!wrappedTrees.has(originalToTree)) {
+    if (!hasWrappedToTree) {
       // When we're used inside the traditional ember-cli build pipeline without
       // Embroider, we unfortunately need to hook into here uncleanly because we
       // need to delineate the point in time after which writing macro config is
@@ -65,7 +62,7 @@ export = {
         macrosConfig.finalize();
         return originalToTree.apply(appInstance, args);
       };
-      wrappedTrees.add(appInstance.toTree);
+      hasWrappedToTree = true;
     }
   },
 


### PR DESCRIPTION
In an app with _many_ addons, we are seeing this wrapping get applied a significant number of times, eventually leading to  "Maximum call stack size exceeded" errors when toTree is finally executed.

When I copy the stack trace out of visual code just before the "Maximum call stack size exceeded" error, there are 7364 lines in the stack that match `node_modules/@embroider/macros/src/ember-addon-main.js:56`

I think this wrapper only needs to be applied once per app instance. Is there something else I should be doing to prevent `@embroider/macros` `included` method from getting hit so much?

<img width="422" alt="Screen Shot 2022-06-03 at 12 15 34 PM" src="https://user-images.githubusercontent.com/20404/171905007-daa2d44b-a79b-4115-b0cb-6cfa61d77c07.png">

<img width="736" alt="Screen Shot 2022-06-03 at 12 19 33 PM" src="https://user-images.githubusercontent.com/20404/171905576-331ab8e5-fe7a-4651-9ea7-cea651f678fb.png">