### PR TITLE
fix: reset HTMLEntrypoint state after build (fix #1211)

### DIFF
--- a/packages/core/src/html-entrypoint.ts
+++ b/packages/core/src/html-entrypoint.ts
@@ -8,7 +8,7 @@ import Placeholder from './html-placeholder';
 import { Variant } from './packager';
 
 export class HTMLEntrypoint {
-  private dom: JSDOM;
+  private dom!: JSDOM;
   private placeholders: Map<string, Placeholder[]> = new Map();
   modules: string[] = [];
   scripts: string[] = [];
@@ -20,6 +20,10 @@ export class HTMLEntrypoint {
     private publicAssetURL: string,
     public filename: string
   ) {
+    this.initialize();
+  }
+
+  initialize() {
     this.dom = new JSDOM(readFileSync(join(this.pathToVanillaApp, this.filename), 'utf8'));
 
     for (let tag of this.handledStyles()) {

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -205,6 +205,10 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
           compiler.hooks.done.tapPromise('EmbroiderPlugin', async stats => {
             this.summarizeStats(stats, variant, variantIndex);
             await this.writeFiles(this.bundleSummary, appInfo, variantIndex);
+            // If this webpack instance / appInfo will be reused for a
+            // subsequent build then we need to be careful not to reuse the
+            // internal JSDOM state encapsulated within it.
+            appInfo.entrypoints.forEach(ep => ep.initialize());
           });
         },
       ],


### PR DESCRIPTION
I'm not sure if this is "the right solution", but it did seem the most obvious one to me as an outsider, and it does appear to work (fixes #1211). I don't love that it exposes a method (`HTMLEntrypoint::initialize`) that should probably be private somehow (e.g. calling it after construction but before being "done" may lead to weird/inconsistent states), but I needed a way for the Webpack plugin to reset the HTMLEntrypoint to its pristine/initial state so that it could be reused for subsequent calls to `build` that used the cached `webpack` instance (and perhaps a stern warning in a doc comment would be sufficient here...). Open to feedback / alternatives, of course, just wanted to help get this unblocked.

@krisselden I think you made the original PR that refactored the file output to a Webpack plugin. Do you have thoughts on this?