### PR TITLE
Strip extension from reexport of `rollup-app-reexports`

### DIFF
--- a/packages/addon-dev/src/rollup-app-reexports.ts
+++ b/packages/addon-dev/src/rollup-app-reexports.ts
@@ -1,4 +1,5 @@
 import { readJsonSync, writeJsonSync } from 'fs-extra';
+import { extname } from 'path';
 import minimatch from 'minimatch';
 import type { Plugin } from 'rollup';
 
@@ -24,7 +25,10 @@ export default function appReexports(opts: {
           this.emitFile({
             type: 'asset',
             fileName: `_app_/${appFilename}`,
-            source: `export { default } from "${pkg.name}/${addonFilename}";\n`,
+            source: `export { default } from "${pkg.name}/${addonFilename.slice(
+              0,
+              -extname(addonFilename).length
+            )}";\n`,
           });
         }
       }


### PR DESCRIPTION
This makes `rollup-app-reexports` strip file extensions (`.js`) from reexports, aligning with (the blueprint of) v1 addons, and allowing better interoperability with `package.json#exports` with path mappings including extensions, as discussed in https://github.com/typed-ember/glint/issues/338.