### PR TITLE
Fix duplicate HTML content on rebuilds

### DIFF
--- a/packages/core/src/html-entrypoint.ts
+++ b/packages/core/src/html-entrypoint.ts
@@ -90,6 +90,7 @@ export class HTMLEntrypoint {
         let matchingFastbootBundles = fastbootVariant >= 0 ? match.get(fastbootVariant) || [] : [];
 
         for (let placeholder of placeholders) {
+          placeholder.clear();
           if (supportsFastboot && placeholder.isScript()) {
             // if there is any fastboot involved, we will emit the lazy bundles
             // right before our first script.


### PR DESCRIPTION
Fixes #1211. This should have been added when HTMLEntrypoint was written, but was missed at that point and didn't actually matter until other changes circa #1117 provided more stable inputs and revealed this state leak.