### PR TITLE
add-dev: HBS files were not watched for rebuilds

### DIFF
--- a/packages/addon-dev/src/rollup-hbs-plugin.ts
+++ b/packages/addon-dev/src/rollup-hbs-plugin.ts
@@ -34,6 +34,7 @@ export default function rollupHbsPlugin(): Plugin {
 
       switch (meta.type) {
         case 'template':
+          this.addWatchFile(meta.originalId);
           let input = readFileSync(meta.originalId, 'utf8');
           let code = hbsToJS(input);
           return {


### PR DESCRIPTION
When developing a v2 addon, you don't get automatic rebuilds when you touch an HBS file. This fixes that.