### PR TITLE
ember-addon keyword required?

### DIFF
--- a/packages/shared-internals/src/package.ts
+++ b/packages/shared-internals/src/package.ts
@@ -53,7 +53,9 @@ export default class Package {
 
   isEmberPackage(): boolean {
     let keywords = this.packageJSON.keywords;
-    return Boolean(keywords && (keywords as string[]).includes('ember-addon'));
+    let hasKeyword = Boolean(keywords && (keywords as string[]).includes('ember-addon'));
+
+    return hasKeyword || this.isV2Addon();
   }
 
   isEngine(): boolean {
@@ -66,7 +68,7 @@ export default class Package {
   }
 
   isV2Ember(): this is V2Package {
-    return this.isEmberPackage() && get(this.packageJSON, 'ember-addon.version') === 2;
+    return get(this.packageJSON, 'ember-addon.version') === 2;
   }
 
   isV2App(): this is V2AppPackage {


### PR DESCRIPTION
I don't know if this is required or not -- but it's bitten me a few times.

We also have the `ember-addon` object (soon to be just `ember`), which also specifies addonness -- which I can include in this PR -- but wanted to verify about the keyword first