### PR TITLE
Run the `clean` plugin of `addon-dev` as late as possible

### DIFF
--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -47,7 +47,7 @@ export class Addon {
   // By default rollup does not clear the output directory between builds. This
   // does that.
   clean() {
-    return clean({ targets: `${this.#destDir}/*` });
+    return clean({ targets: `${this.#destDir}/*`, hook: 'generateBundle' });
   }
 
   // V2 Addons are allowed to contain imports of .css files. This tells rollup


### PR DESCRIPTION
This attempts to fix the problem described in https://github.com/embroider-build/addon-blueprint/issues/32.

While it is not the perfect solution like a truly atomic build update, it seems "good enough". Previously the cleanup would happen at the earliest point in time, at [`buildStart`](https://github.com/vladshcherbin/rollup-plugin-delete/blob/master/src/index.js#L5), making the time window large enough for Ember CLI to see the transient build output in an inconsistent state. Now it happens at the *latest* possible time, at [`generateBundle`](https://rollupjs.org/guide/en/#generatebundle) right before files are written, making the time window small enough to not cause any problems in practice. (successfully tested locally)