### PR TITLE
Detect addons with customized treeForMethod names

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -70,6 +70,19 @@ const dynamicTreeHooks = Object.freeze([
   'treeForVendor',
 ]);
 
+const defaultMethods = {
+  app: 'treeForApp',
+  addon: 'treeForAddon',
+  'addon-styles': 'treeForAddonStyles',
+  'addon-templates': 'treeForAddonTemplates',
+  'addon-test-support': 'treeForAddonTestSupport',
+  public: 'treeForPublic',
+  styles: 'treeForStyles',
+  templates: 'treeForTemplates',
+  'test-support': 'treeForTestSupport',
+  vendor: 'treeForVendor',
+};
+
 const appPublicationDir = '_app_';
 const fastbootPublicationDir = '_fastboot_';
 
@@ -400,10 +413,20 @@ export default class V1Addon {
           // customized hook exists in actual code exported from their index.js
           this.mainModule[treeName] ||
           // addon instance doesn't match its own prototype
-          (realAddon.__proto__ && realAddon[treeName] !== realAddon.__proto__[treeName])
+          (realAddon.__proto__ && realAddon[treeName] !== realAddon.__proto__[treeName]) ||
+          this.customizesHookName(treeName)
         );
       })
     );
+  }
+
+  private customizesHookName(treeName: string): boolean {
+    for (let [name, methodName] of Object.entries(defaultMethods)) {
+      if (methodName === treeName) {
+        return this.addonInstance.treeForMethods?.[name] !== methodName;
+      }
+    }
+    return false;
   }
 
   @Memoize()

--- a/packages/shared-internals/src/ember-cli-models.ts
+++ b/packages/shared-internals/src/ember-cli-models.ts
@@ -109,6 +109,7 @@ interface BaseAddonInstance {
     public: string;
     vendor: string;
   };
+  treeForMethods: Record<string, string>;
 }
 
 export type AddonTreePath = keyof BaseAddonInstance['treePaths'];


### PR DESCRIPTION
The normal way for addons to implement custom treeFor hooks is to... just implement them.

But some addons mutate the `treeForMethods` table instead. In fact, some addons [mutate *other addons* `treeForMethods` table](https://github.com/webark/ember-component-css/blob/fee293efff035e5f999bf65a99d8b980a627ac24/index.js#L89). 😭 