### PR TITLE
Followup to "Detect addons with customized treeForMethod names"

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -421,9 +421,14 @@ export default class V1Addon {
   }
 
   private customizesHookName(treeName: string): boolean {
+    if (!this.addonInstance.treeForMethods) {
+      // weird old addons don't even extend ember-cli's Addon base class and
+      // might not have this.
+      return false;
+    }
     for (let [name, methodName] of Object.entries(defaultMethods)) {
       if (methodName === treeName) {
-        return this.addonInstance.treeForMethods?.[name] !== methodName;
+        return this.addonInstance.treeForMethods[name] !== methodName;
       }
     }
     return false;


### PR DESCRIPTION
The bugfix in #1230 caused us to start detecting some very weird old addons as having customized trees, and we can't really do anything with those. It was better to give them the stock tree behaviors.