### PR TITLE
Add sourcemap: true to rollup output defaults

### DIFF
--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -76,6 +76,7 @@ export class Addon {
       format: 'es',
       entryFileNames: '[name]',
       hoistTransitiveImports: false,
+      sourcemap: true,
     };
   }
 


### PR DESCRIPTION
the default is
 - separate files
 - very hi-fi sourcemaps (in TS projects, you see TS in the devtools)