### PR TITLE
fix a rebuild crash in dummy apps on windows

### DIFF
--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -1,5 +1,5 @@
 import { Node } from 'broccoli-node-api';
-import { join, relative, dirname, isAbsolute } from 'path';
+import { join, relative, dirname, isAbsolute, sep } from 'path';
 import { emptyDirSync, ensureSymlinkSync, ensureDirSync, realpathSync, copySync, writeJSONSync } from 'fs-extra';
 import { Stage, Package, PackageCache, WaitForTrees, mangledEngineRoot } from '@embroider/core';
 import V1InstanceCache from './v1-instance-cache';
@@ -123,7 +123,7 @@ export default class CompatAddons implements Stage {
           // the addon, because that would overwrite the real app build.
           ignore.push(rel);
 
-          if (rel === 'tests/dummy') {
+          if (rel === `tests${sep}dummy`) {
             // special case: classic dummy apps are weird because they put the
             // tests (which are truly part of the app, not the addon) inside the
             // addon instead of inside the app.


### PR DESCRIPTION
Rebuilds could crash on windows when working with a v1 addon's dummy app.

We already defend against the weird circularity of dummy apps, but the check didn't work on windows.

This has test coverage that will land as part of #1246, because that includes a refactor of the test suite that reveals this problem.