### PR TITLE
Use consistent separator on windows

### DIFF
--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -1,6 +1,6 @@
 import { Memoize } from 'typescript-memoize';
 import { sync as pkgUpSync } from 'pkg-up';
-import { join, dirname, isAbsolute } from 'path';
+import { join, dirname, isAbsolute, sep } from 'path';
 import buildFunnel from 'broccoli-funnel';
 import mergeTrees from 'broccoli-merge-trees';
 import { WatchedDir } from 'broccoli-source';
@@ -321,7 +321,7 @@ export default class V1App {
       // `app.import('node_modules/something/...')`, so we go find its answer.
       for (let { name, path } of this.app._nodeModules.values()) {
         if (match[1] === name) {
-          return filename.replace(match[0], path + '/');
+          return filename.replace(match[0], path + sep);
         }
       }
       throw new Error(`bug: expected ember-cli to already have a resolved path for asset ${filename}`);


### PR DESCRIPTION
When an addon does app.import of a file out of node_modules, the path we use to refer to that file had a mix of different path separators. That doesn't actually break, but the inconsistency made it hard to test and our test suite revealed the problem (in #1246).

Test coverage for this gets enabled when #1246 merges.