### PR TITLE
Fix an order bug in linkNonCopiedDeps

### DIFF
--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -148,7 +148,18 @@ export default class CompatAddons implements Stage {
           // shell for its real module namespace.
           copySync(join(destination, 'package.json'), join(newPkg.root, 'package.json'));
         }
+      }
+    });
 
+    // this has to be a separate pass over the packages because
+    // linkNonCopiedDeps resolves dependencies, so we want all the packages
+    // already in their new places before they start trying to resolve each
+    // other.
+    [...this.packageCache.moved.values()].forEach((newPkg, index) => {
+      if (
+        !this.didBuild || // always copy on the first build
+        (newPkg.mayRebuild && changedMap.get(movedAddons[index]))
+      ) {
         // for engines, this isn't the mangled destination (we don't need
         // resolvable node_modules there), this is the empty shell of their real
         // location


### PR DESCRIPTION
`linkNonCopiedDeps` causes packages to resolve their deps. But because we were running it within the pass that creates the moved packages, it was possible for a package to fail to resolve a peer dep that hadn't moved yet.

This fixes it by moving linkNonCopied deps into a separate pass.