### PR TITLE
Update changset for test-setup

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,14 @@
   "changelog": false,
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [
+    [
+      "@embroider/compat",
+      "@embroider/core",
+      "@embroider/test-setup",
+      "@embroider/webpack"
+    ]
+  ],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/tame-carrots-relax.md
+++ b/.changeset/tame-carrots-relax.md
@@ -1,0 +1,14 @@
+---
+'@embroider/test-setup': minor
+---
+
+`@embroider/test-setup` only installs the dependencies that match the version that `@embroider/test-setup` is set to.
+The Changesets release tool has a feature to link packages togother such that they all share the same version.
+Documentation on that is here: https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#linked-array-of-arrays-of-package-names
+
+The packages that, with the currenty implementation of `@embroider/test-setup`, must always be linked are:
+
+- `@embroider/compat`
+- `@embroider/core`
+- `@embroider/webpack`
+- `@embroider/test-setup`


### PR DESCRIPTION
Output of `yarn changeset status`:
```
yarn run v1.22.19
$ <repo>/node_modules/.bin/changeset status
🦋  info NO packages to be bumped at patch
🦋  ---
🦋  info Packages to be bumped at minor:
🦋  info 
🦋  - @embroider/test-setup
🦋  ---
🦋  info NO packages to be bumped at major
Done in 0.45s.}

```

This should allow 1.9.0 of `@embroider/test-setup` to use the already released packages