### PR TITLE
add inter-package version safety check

### DIFF
--- a/tests/scenarios/inter-version-test.ts
+++ b/tests/scenarios/inter-version-test.ts
@@ -1,0 +1,32 @@
+import QUnit from 'qunit';
+import glob from 'globby';
+import { resolve } from 'path';
+import { readJSONSync } from 'fs-extra';
+import { satisfies } from 'semver';
+
+const { module: Qmodule, test } = QUnit;
+
+Qmodule('package inter-version consistency', () => {
+  let rootDir = resolve(__dirname, '..', '..');
+  let packages = new Map();
+  for (let pattern of readJSONSync(resolve(__dirname, '../../package.json')).workspaces.packages) {
+    for (let dir of glob.sync(pattern, { cwd: rootDir, expandDirectories: false, onlyDirectories: true })) {
+      let pkg = readJSONSync(resolve(rootDir, dir, 'package.json'));
+      packages.set(pkg.name, pkg);
+      test(pkg.name, assert => {
+        assert.ok('some packages have no interior deps and that is ok');
+        for (let section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+          for (let [name, range] of Object.entries(pkg[section] ?? {})) {
+            let other = packages.get(name);
+            if (other) {
+              assert.ok(
+                satisfies(other.version, range as string),
+                `${name} in ${section} ${other.version} does not satisfy ${range}`
+              );
+            }
+          }
+        }
+      });
+    }
+  }
+});

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -13,6 +13,7 @@
     "qunit": "^2.16.0",
     "resolve": "^1.20.0",
     "scenario-tester": "^2.0.1",
+    "semver": "^7.3.8",
     "ts-node": "^9.1.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18284,6 +18284,13 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
Now that our release process isn't all lockstep, it's easy to get this wrong, so I'm just preempting adding a test for it.