### PR TITLE
remove forced optional-chaining and nullish-coalescing-operator babel plugins

### DIFF
--- a/packages/babel-loader-8/index.js
+++ b/packages/babel-loader-8/index.js
@@ -20,15 +20,6 @@ module.exports = require('babel-loader').custom(babel => {
         loader.plugins = [];
       }
 
-      // webpack uses acorn and acorn doesn't parse these features yet, so we
-      // always tranpile them away regardless of what preset-env is doing
-      if (!loader.plugins.some(pluginMatches(/@babel\/plugin-proposal-optional-chaining/))) {
-        loader.plugins.push(require.resolve('@babel/plugin-proposal-optional-chaining'));
-      }
-      if (!loader.plugins.some(pluginMatches(/@babel\/plugin-proposal-nullish-coalescing-operator/))) {
-        loader.plugins.push(require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'));
-      }
-
       return {
         custom,
         loader,

--- a/packages/babel-loader-8/package.json
+++ b/packages/babel-loader-8/package.json
@@ -10,8 +10,6 @@
   "main": "index.js",
   "dependencies": {
     "@babel/core": "^7.14.5",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
-    "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "babel-loader": "8"
   },
   "peerDependencies": {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -21,8 +21,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.14.5",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
-    "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@embroider/babel-loader-8": "1.9.0",
     "@embroider/hbs-loader": "1.9.0",
     "@embroider/shared-internals": "1.8.3",


### PR DESCRIPTION
[Optional chaining](https://github.com/acornjs/acorn/blob/master/acorn/CHANGELOG.md#730-2020-06-11) and [nullish coalescing operators](https://github.com/acornjs/acorn/blob/master/acorn/CHANGELOG.md#730-2020-06-11) are now supported in Acorn. I tested this in a fairly large ember application and didn't run into any issues.