### PR TITLE
fix: account for separate node_moduels trees for moduleExists 

### DIFF
--- a/packages/macros/src/babel/module-exists.ts
+++ b/packages/macros/src/babel/module-exists.ts
@@ -3,7 +3,6 @@ import type { types as t } from '@babel/core';
 import State from './state';
 import error from './error';
 import { assertArray } from './evaluate-json';
-import resolve from 'resolve';
 import { dirname } from 'path';
 
 export default function moduleExists(path: NodePath<t.CallExpression>, state: State): boolean {
@@ -15,7 +14,7 @@ export default function moduleExists(path: NodePath<t.CallExpression>, state: St
     throw error(assertArray(path.get('arguments'))[0], `the first argument to moduleExists must be a string literal`);
   }
   try {
-    resolve.sync(moduleSpecifier.value, { basedir: dirname(state.sourceFile) });
+    require.resolve(moduleSpecifier.value, { paths: [process.cwd(), state.sourceFile, dirname(state.sourceFile)] });
     return true;
   } catch (err) {
     if (err.code !== 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
When using hardlinks with pnpm, with `hoist=false` set to prevent accidental resolutions, a package with optional peer-dependencies consumed by another in-repo package that provides that peer-dependency *may* fail to resolve that package.

Note: this appears to be reproducible but not consistent, I have not yet opened a bug in pnpm though I'm convinced it likely is one.