### PR TITLE
defend against infinite loop on broken babel config

### DIFF
--- a/packages/core/src/portable-babel-config.ts
+++ b/packages/core/src/portable-babel-config.ts
@@ -72,7 +72,7 @@ class PortableBabelConfig {
           // trim back down our array, because trailing undefined will get
           // converted into null via json.stringify, and babel will complain
           // about that.
-          while (dehydrated.value[dehydrated.value.length - 1] == null) {
+          while (dehydrated.value.length > 0 && dehydrated.value[dehydrated.value.length - 1] == null) {
             dehydrated.value.pop();
           }
           if (dehydrated.value.length === 1) {


### PR DESCRIPTION
It's not legal to have an empty array as a plugin in a babel config -- that definitely makes babel blow up. But in that case, our serialization code runs first and can get trapped in an infinite loop on the bad plugin.

This prevents the loop so you can get to the real babel crash instead.