### PR TITLE
Drop unused optional peer

### DIFF
--- a/packages/addon-dev/package.json
+++ b/packages/addon-dev/package.json
@@ -47,14 +47,6 @@
     "tmp": "^0.1.0",
     "typescript": "*"
   },
-  "peerDependencies": {
-    "ember-source": "*"
-  },
-  "peerDependenciesMeta": {
-    "ember-source": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": "12.* || 14.* || >= 16"
   },


### PR DESCRIPTION
Now that template-transform-plugin is removed, we don't use this optional peer dep anymore.