### PR TITLE
compat is supposed to access shared-internals through core

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -30,7 +30,6 @@
     "@babel/preset-env": "^7.14.5",
     "@babel/traverse": "^7.14.5",
     "@embroider/macros": "1.9.0",
-    "@embroider/shared-internals": "1.8.3",
     "@types/babel__code-frame": "^7.0.2",
     "@types/yargs": "^17.0.3",
     "assert-never": "^1.1.0",

--- a/packages/compat/src/compat-adapters/ember-cli-fastboot.ts
+++ b/packages/compat/src/compat-adapters/ember-cli-fastboot.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import writeFile from 'broccoli-file-creator';
 import { Memoize } from 'typescript-memoize';
 import bind from 'bind-decorator';
-import { AddonMeta } from '@embroider/shared-internals';
+import { AddonMeta } from '@embroider/core';
 
 export default class EmberCliFastboot extends V1Addon {
   customizes(...trees: string[]): boolean {

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -30,7 +30,7 @@ import { sync as resolveSync } from 'resolve';
 import { MacrosConfig } from '@embroider/macros/src/node';
 import bind from 'bind-decorator';
 import { pathExistsSync } from 'fs-extra';
-import { tmpdir } from '@embroider/shared-internals';
+import { tmpdir } from '@embroider/core';
 import { Options as AdjustImportsOptions } from '@embroider/core/src/babel-plugin-adjust-imports';
 import type { Transform } from 'babel-plugin-ember-template-compilation';
 

--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -1,6 +1,6 @@
 import { App, Addons as CompatAddons, Options, PrebuiltAddons } from '.';
 import { toBroccoliPlugin, PackagerConstructor, Variant, EmberAppInstance } from '@embroider/core';
-import { tmpdir } from '@embroider/shared-internals';
+import { tmpdir } from '@embroider/core';
 import { Node } from 'broccoli-node-api';
 import writeFile from 'broccoli-file-creator';
 import mergeTrees from 'broccoli-merge-trees';

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -1,8 +1,7 @@
 import { removeSync, mkdtempSync, writeFileSync, ensureDirSync, writeJSONSync, realpathSync } from 'fs-extra';
 import { join, dirname } from 'path';
 import Options, { optionsWithDefaults } from '../src/options';
-import { hbsToJS, tmpdir } from '@embroider/shared-internals';
-import { throwOnWarnings } from '@embroider/core';
+import { hbsToJS, tmpdir, throwOnWarnings } from '@embroider/core';
 import { emberTemplateCompiler } from '@embroider/test-support';
 import { Options as AdjustImportsOptions } from '@embroider/core/src/babel-plugin-adjust-imports';
 import Resolver from '../src/resolver';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,5 +19,5 @@ export { todo, unsupported, warn, debug, expectWarning, throwOnWarnings } from '
 export { mangledEngineRoot } from './engine-mangler';
 
 // this is reexported because we already make users manage a peerDep from some
-// other packages (like embroider/webpack and @embroider/
+// other packages (like embroider/webpack and @embroider/compat
 export * from '@embroider/shared-internals';


### PR DESCRIPTION
...because we already make apps manage a peerDep on core, and we want everybody on the same copy.