### PR TITLE
CI needs to check types in our typescript-app scenario

### DIFF
--- a/tests/scenarios/typescript-app-test.ts
+++ b/tests/scenarios/typescript-app-test.ts
@@ -75,5 +75,10 @@ tsAppScenarios
         let result = await app.execute(`ember test`);
         assert.equal(result.exitCode, 0, result.output);
       });
+
+      test(`check types`, async function (assert) {
+        let result = await app.execute(`yarn tsc`);
+        assert.equal(result.exitCode, 0, result.output);
+      });
     });
   });

--- a/tests/ts-app-template/package.json
+++ b/tests/ts-app-template/package.json
@@ -33,6 +33,8 @@
     "@embroider/webpack": "1.9.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@tsconfig/ember": "^1.0.0",
+    "@types/ember": "^4.0.2",
     "@types/ember-qunit": "^5.0.0",
     "@types/ember-resolver": "^5.0.11",
     "@types/ember__application": "^4.0.0",

--- a/tests/ts-app-template/tsconfig.json
+++ b/tests/ts-app-template/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
-    "noEmitOnError": false
-  },
-  "paths": {
-    "ts-app-template/tests/*": ["tests/*"],
-    "ts-app-template/*": ["app/*"],
-    "*": ["types/*"]
+    // The combination of `baseUrl` with `paths` allows Ember's classic package
+    // layout, which is not resolvable with the Node resolution algorithm, to
+    // work with TypeScript.
+    "baseUrl": ".",
+    "paths": {
+      "ts-app-tepmlate/tests/*": ["tests/*"],
+      "ts-app-template/*": ["app/*"],
+      "*": ["types/*"]
+    }
   },
   "include": ["app/**/*", "tests/**/*", "types/**/*"]
 }
-


### PR DESCRIPTION
The typescript-app scenario was not getting type-checked (and in fact didn't pass, although that was due to the test and not actual embroider functionality).