### PR TITLE
Detect babel-plugin-ember-template-complation when other plugins are …

### DIFF
--- a/packages/compat/src/detect-babel-plugins.ts
+++ b/packages/compat/src/detect-babel-plugins.ts
@@ -76,4 +76,5 @@ const htmlbarPathMatches = [
   ['ember-cli-htmlbars', 'lib', 'require-from-worker.js'].join(sep),
   ['ember-cli-htmlbars', 'index'].join(sep),
   ['ember-cli-htmlbars', 'lib', 'require-from-worker'].join(sep),
+  ['babel-plugin-ember-template-compilation', 'src', 'node-main.js'].join(sep),
 ];


### PR DESCRIPTION
…preventing parallelization

We need to detect and replace the template compilation plugin that is likely to be present in a v1 addon. We were missing one new-ish case:
  - ember-cli-htmlbars 6.0
  - with an ember version that doesn't need the old modulesApiPolyfill
  - when some other babel plugin is preventing ember-cli-babel from parallelizing.

The symptom when this fails is that templates get compiled to wire format too early, so we miss doing staticComponent (and helper and modifier) analysis, so you end up with missing components / helpers / modifiers in a v1 addon at runtime.

Fixes #1296 