### PR TITLE
Make `ensureSafeComponent` usable with Glint

### DIFF
--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -1,6 +1,17 @@
 import { ComponentLike } from '@glint/template';
+import Helper from '@ember/component/helper';
 
 export function ensureSafeComponent<C extends string | ComponentLike<S>, S>(
   component: C,
   thingWithOwner: unknown
 ): C extends string ? ComponentLike<unknown> : C;
+
+export class EnsureSafeComponentHelper<
+  C extends string | ComponentLike<S>,
+  S
+> extends Helper<{
+  Args: {
+    Positional: [component: C];
+  };
+  Return: C extends string ? ComponentLike<unknown> : C;
+}> {}

--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -1,4 +1,6 @@
-export function ensureSafeComponent(
-  component: unknown,
+import { ComponentLike } from '@glint/template';
+
+export function ensureSafeComponent<C extends string | ComponentLike<S>, S>(
+  component: C,
   thingWithOwner: unknown
-): unknown;
+): C extends string ? ComponentLike<unknown> : C;

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -32,7 +32,13 @@
     "ember-cli-babel": "^7.26.11"
   },
   "peerDependencies": {
-    "ember-source": "*"
+    "ember-source": "*",
+    "@glint/template": "^1.0.0-beta.1"
+  },
+  "peerDependenciesMeta": {
+    "@glint/template": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.19.6",
@@ -46,6 +52,7 @@
     "@embroider/webpack": "2.0.2",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@glint/template": "^1.0.0-beta.1",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,6 +1975,11 @@
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
+"@glint/template@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@glint/template/-/template-1.0.0-beta.1.tgz#2474d5cde637c8742f3da39c53ccffae03bcb997"
+  integrity sha512-JQboeRc9BCuYu2Avle592L+gWxKvJggwxkNKxpHlOeg9Xng5f/sMvG6yWssC8J4fURJmH5tvF7e/BgdUAMegeg==
+
 "@handlebars/parser@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"


### PR DESCRIPTION
Introduce a peer (and dev) dependency on `@glint/template` for the type of `ensureSafeComponent` to always return a `ComponentLike`, which is what its implementation does from the point of view of a consumer using Glint. This is an optional peer dependency, but should be installed by anyone using TS who wants to use Glint types.

Note: This would be a breaking change if our TS support story were stable; in this case it is *part of* making our support story stable.