### PR TITLE
for embroider server running on windows, index.js can be ejected from …

### DIFF
--- a/packages/compat/src/compat-adapters/@glimmer/tracking.ts
+++ b/packages/compat/src/compat-adapters/@glimmer/tracking.ts
@@ -12,25 +12,20 @@ import { outputFileSync, copyFileSync } from 'fs-extra';
   reexport the things from ember that are needed.
 */
 class RedirectToEmber extends Plugin {
-  private didBuild = false;
-
   build() {
-    if (!this.didBuild) {
-      copyFileSync(join(this.inputPaths[0], 'package.json'), join(this.outputPath, 'package.json'));
-      outputFileSync(
-        join(this.outputPath, 'index.js'),
-        // Prior to ember-source 4.1, cached didn't exist
-        // using this way of importing from metal, cached will be undefined if pre 4.1
-        `import * as metal from "@ember/-internals/metal";
-const { cached, tracked } = metal;
-export { cached, tracked };`
-      );
-      outputFileSync(
-        join(this.outputPath, 'primitives', 'cache.js'),
-        `export { createCache, getValue, isConst } from "@ember/-internals/metal";`
-      );
-      this.didBuild = true;
-    }
+    copyFileSync(join(this.inputPaths[0], 'package.json'), join(this.outputPath, 'package.json'));
+    outputFileSync(
+      join(this.outputPath, 'index.js'),
+      // Prior to ember-source 4.1, cached didn't exist
+      // using this way of importing from metal, cached will be undefined if pre 4.1
+      `import * as metal from "@ember/-internals/metal";
+    const { cached, tracked } = metal;
+    export { cached, tracked };`
+    );
+    outputFileSync(
+      join(this.outputPath, 'primitives', 'cache.js'),
+      `export { createCache, getValue, isConst } from "@ember/-internals/metal";`
+    );
   }
 }
 


### PR DESCRIPTION
…the $TMPDIR cache

resulting in a broken build that can never recover by itself without restarting the dev server

this manifests itself as an error saying @glimmer/tracking/index.js cannot be found

removing the didBuild check results in a few extra invocations of the files output but over the course of a day it's low compared to the disruption caused by the build breakage even if it's not directly caused by the build itself
this change would allow for a better developer experience on windows