### PR TITLE
add .hbs.js to the list of resolvable extensions by webpack

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -232,7 +232,7 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     // For TS, we defer to ember-cli-babel, and the setting for
     // "enableTypescriptTransform" can be set with and without
     // ember-cli-typescript
-    return ['.wasm', '.mjs', '.js', '.json', '.hbs', '.ts'];
+    return ['.wasm', '.mjs', '.js', '.json', '.hbs', '.hbs.js', '.ts'];
   }
 
   private *emberEntrypoints(htmlTreePath: string): IterableIterator<Asset> {


### PR DESCRIPTION
caters for importing `./template` when the template was rewritten to have a js scope
fixes #1300 