### PR TITLE
Resolver transform fixes

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -10,7 +10,7 @@ import type { ASTv1, ASTPluginBuilder, ASTPluginEnvironment, WalkerPath } from '
 import type { WithJSUtils } from 'babel-plugin-ember-template-compilation';
 import assertNever from 'assert-never';
 
-type Env = WithJSUtils<ASTPluginEnvironment> & { filename: string; contents: string };
+type Env = WithJSUtils<ASTPluginEnvironment> & { filename: string; contents: string; strict?: boolean };
 
 export interface Options {
   resolver: Resolver;
@@ -24,6 +24,7 @@ export default function makeResolverTransform({ resolver, patchHelpersBug }: Opt
     contents,
     meta: { jsutils },
     syntax: { builders },
+    strict,
   }) => {
     let scopeStack = new ScopeStack();
     let emittedAMDDeps: Set<string> = new Set();
@@ -97,6 +98,13 @@ export default function makeResolverTransform({ resolver, patchHelpersBug }: Opt
         default:
           assertNever(resolution);
       }
+    }
+
+    if (strict) {
+      return {
+        name: 'embroider-build-time-resolver-strict-noop',
+        visitor: {},
+      };
     }
 
     return {

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -362,6 +362,132 @@ describe('compat-resolver', function () {
       `);
   });
 
+  test('acceptsComponentArguments works on all copies of a lexically-inserted component, element syntax', function () {
+    let packageRules = [
+      {
+        package: 'the-test-package',
+        components: {
+          '<HelloWorld />': {
+            acceptsComponentArguments: ['iAmAComponent'],
+          },
+        },
+      },
+    ];
+    let transform = configure({ staticComponents: true, packageRules }, { startingFrom: 'js' });
+    givenFile('components/hello-world.js');
+    givenFile('components/first-target.js');
+    givenFile('components/second-target.js');
+
+    expect(
+      transform(
+        'templates/application.hbs',
+        `
+          import { precompileTemplate } from '@ember/template-compilation';
+          precompileTemplate("<HelloWorld @iAmAComponent='first-target' /><HelloWorld @iAmAComponent='second-target' />");
+        `
+      )
+    ).toEqualCode(`
+      import secondTarget from "../components/second-target.js";
+      import firstTarget from "../components/first-target.js";
+      import HelloWorld from "../components/hello-world.js";
+      import { precompileTemplate } from "@ember/template-compilation";
+      precompileTemplate(
+        "<HelloWorld @iAmAComponent={{firstTarget}} /><HelloWorld @iAmAComponent={{secondTarget}} />",
+        {
+          scope: () => ({
+            HelloWorld,
+            firstTarget,
+            secondTarget,
+          }),
+        }
+      );
+    `);
+  });
+
+  test('acceptsComponentArguments works on all copies of a lexically-inserted component, mustache syntax', function () {
+    let packageRules = [
+      {
+        package: 'the-test-package',
+        components: {
+          '<Hello />': {
+            acceptsComponentArguments: ['iAmAComponent'],
+          },
+        },
+      },
+    ];
+    let transform = configure({ staticComponents: true, packageRules }, { startingFrom: 'js' });
+    givenFile('components/hello.js');
+    givenFile('components/first-target.js');
+    givenFile('components/second-target.js');
+
+    expect(
+      transform(
+        'templates/application.hbs',
+        `
+          import { precompileTemplate } from '@ember/template-compilation';
+          precompileTemplate("{{hello iAmAComponent='first-target' }}{{hello iAmAComponent='second-target' }}");
+        `
+      )
+    ).toEqualCode(`
+      import secondTarget from "../components/second-target.js";
+      import firstTarget from "../components/first-target.js";
+      import hello from "../components/hello.js";
+      import { precompileTemplate } from "@ember/template-compilation";
+      precompileTemplate(
+        "{{hello iAmAComponent=firstTarget}}{{hello iAmAComponent=secondTarget}}",
+        {
+          scope: () => ({
+            hello,
+            firstTarget,
+            secondTarget,
+          }),
+        }
+      );
+    `);
+  });
+
+  test('acceptsComponentArguments works on all copies of a lexically-inserted component, mustache-block syntax', function () {
+    let packageRules = [
+      {
+        package: 'the-test-package',
+        components: {
+          '<Hello />': {
+            acceptsComponentArguments: ['iAmAComponent'],
+          },
+        },
+      },
+    ];
+    let transform = configure({ staticComponents: true, packageRules }, { startingFrom: 'js' });
+    givenFile('components/hello.js');
+    givenFile('components/first-target.js');
+    givenFile('components/second-target.js');
+
+    expect(
+      transform(
+        'templates/application.hbs',
+        `
+          import { precompileTemplate } from '@ember/template-compilation';
+          precompileTemplate("{{#hello iAmAComponent='first-target' }}{{/hello}}{{#hello iAmAComponent='second-target' }}{{/hello}}");
+        `
+      )
+    ).toEqualCode(`
+      import secondTarget from "../components/second-target.js";
+      import firstTarget from "../components/first-target.js";
+      import hello from "../components/hello.js";
+      import { precompileTemplate } from "@ember/template-compilation";
+      precompileTemplate(
+        '{{#hello iAmAComponent=firstTarget}}{{/hello}}{{#hello iAmAComponent=secondTarget}}{{/hello}}',
+        {
+          scope: () => ({
+            hello,
+            firstTarget,
+            secondTarget,
+          }),
+        }
+      );
+    `);
+  });
+
   test.skip('angle contextual component, lower', function () {
     let findDependencies = configure({ staticComponents: true });
     givenFile('components/hello-world.js');

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -998,7 +998,7 @@ describe('compat-resolver', function () {
     // our transform tried to resolve Thing).
     expect(
       transform(
-        'components/example.js.hbs',
+        'components/example.js',
         `
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("<Thing />", {
@@ -1010,6 +1010,50 @@ describe('compat-resolver', function () {
       import { precompileTemplate } from '@ember/template-compilation';
       export default precompileTemplate("<Thing />", {
         strict: true,
+      });
+    `);
+  });
+
+  test('respects lexically scoped component', function () {
+    let transform = configure({ staticComponents: true }, { startingFrom: 'js' });
+    expect(
+      transform(
+        'components/example.js',
+        `
+          import { precompileTemplate } from '@ember/template-compilation';
+          import Thing from 'whatever';
+          precompileTemplate("<Thing />", {
+            scope: () => ({ Thing }),
+          });
+        `
+      )
+    ).toEqualCode(`
+      import { precompileTemplate } from '@ember/template-compilation';
+      import Thing from 'whatever';
+      precompileTemplate("<Thing />", {
+        scope: () => ({ Thing }),
+      });
+    `);
+  });
+
+  test('respects lexically scoped helper', function () {
+    let transform = configure({ staticComponents: true, staticHelpers: true }, { startingFrom: 'js' });
+    expect(
+      transform(
+        'components/example.js',
+        `
+          import { precompileTemplate } from '@ember/template-compilation';
+          import thing from 'whatever';
+          precompileTemplate("<div class={{thing flavor=1}}></div>", {
+            scope: () => ({ thing }),
+          });
+        `
+      )
+    ).toEqualCode(`
+      import { precompileTemplate } from '@ember/template-compilation';
+      import thing from 'whatever';
+      precompileTemplate("<div class={{thing flavor=1}}></div>", {
+        scope: () => ({ thing }),
       });
     `);
   });

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -1595,7 +1595,7 @@ describe('compat-resolver', function () {
     }).toThrow(/Missing component: fancy-title in templates\/application\.hbs/);
   });
 
-  test.skip('acceptsComponentArguments on element with valid literal', function () {
+  test('acceptsComponentArguments on element with valid literal', function () {
     let packageRules = [
       {
         package: 'the-test-package',
@@ -1606,19 +1606,21 @@ describe('compat-resolver', function () {
         },
       },
     ];
-    let findDependencies = configure({ staticComponents: true, packageRules });
-    givenFile('templates/components/form-builder.hbs');
-    givenFile('templates/components/fancy-title.hbs');
-    expect(findDependencies('templates/application.hbs', `<FormBuilder @title={{"fancy-title"}} />`)).toEqual([
-      {
-        runtimeName: 'the-app/templates/components/fancy-title',
-        path: './components/fancy-title.hbs',
-      },
-      {
-        runtimeName: 'the-app/templates/components/form-builder',
-        path: './components/form-builder.hbs',
-      },
-    ]);
+    let transform = configure({ staticComponents: true, packageRules });
+    givenFile('components/form-builder.js');
+    givenFile('components/fancy-title.js');
+    expect(transform('templates/application.hbs', `<FormBuilder @title={{"fancy-title"}} />`)).toEqualCode(`
+      import fancyTitle from "../components/fancy-title.js";
+      import FormBuilder from "../components/form-builder.js";
+      import { precompileTemplate } from "@ember/template-compilation";
+      export default precompileTemplate("<FormBuilder @title={{fancyTitle}} />", {
+        moduleName: "my-app/templates/application.hbs",
+        scope: () => ({
+          FormBuilder,
+          fancyTitle,
+        }),
+      });
+    `);
   });
 
   test('acceptsComponentArguments on element with valid attribute', function () {


### PR DESCRIPTION
~Two~ Several bug fixes:

 - don't bother trying to do global resolution in strict templates. They don't need it. They are natively doing what embroider works to make traditional templates do.
 - respect existing lexically scoped values passed to templates. Even non-strict templates can have things in lexical scope and those are not subject to global resolving.
 - fix the `acceptsComponentArguments` packageRule in a case where there are multiple invocations of the same component in the same template where no renaming was required to avoid collisions with the javascript scope.