### PR TITLE
Add static asset loader for fonts and images.

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -214,6 +214,17 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
       module: {
         rules: [
           {
+            test: /\.(jpg|jpeg|png|woff|woff2|eot|ttf|svg)$/,
+            use: [
+              {
+                loader: 'url-loader',
+                options: {
+                  limit: 8192,
+                },
+              },
+            ],
+          },          
+          {
             test: /\.hbs$/,
             use: nonNullArray([
               maybeThreadLoader(babel.isParallelSafe, this.extraThreadLoaderOptions),


### PR DESCRIPTION
People don't like configuring webpack (this is known, across all ecosystems, not just ember).

Today, we support importing CSS in JS, like :

```js
import 'some-path/to-a.css'
```
for example, which mostly does the right thing, and adds the CSS file to your module graph (doesn't make the CSS available in JS for use class-use in JS, etc)

However, this file also has fonts in it.

ember-auto-import and embroider don't currently have a font loader.

In this PR, I've added a config while working with @spuxx1701, which I believe is "just from around the internet".

It brings up some questions:
 - are there different ways we want to handle image formats?
    - low-quality-image-placeholders?
    - size optimizations?
 - are there different ways we want to handle SVG?
    - `<use>`   
    - as components?
 - for fonts, do similar questions about technique exist that we maybe can't solve for everyone?
   - if not, should this PR _only_ focus on fonts, since images and SVGs can be handled at least 5 ways each?