### PR TITLE
test-setup: use caret version modifier for Embroider dependencies

### DIFF
--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -5,7 +5,7 @@ import type { Webpack } from '@embroider/webpack';
 type EmberWebpackOptions = typeof Webpack extends PackagerConstructor<infer Options> ? Options : never;
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const currentEmbroiderVersion = require('../package.json').version;
+const currentEmbroiderVersion = `^${require('../package.json').version}`;
 
 /*
   Use this instead of `app.toTree()` in your ember-cli-build.js:


### PR DESCRIPTION
When all monorepo packages were released in-sync, this ensured `test-setup` is referring always to the latest. But with the release process decoupled now, `test-setup` would effectively pull in an older pinned version of Embroider. This adds the caret modifier to allow pulling the latest version (on the same major).

Fixes #1268.