### PR TITLE
workaround upstream node breakage

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -70,7 +70,7 @@
     "prettier": "^2.5.1",
     "rollup": "^2.67.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.0.2",
+    "rollup-plugin-ts": "~3.0.2",
     "typescript": "^4.7.4"
   },
   "peerDependencies": {

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -66,7 +66,7 @@
     "ember-source-latest": "npm:ember-source@latest",
     "ember-truth-helpers": "^3.0.0",
     "rollup": "^2.69.1",
-    "rollup-plugin-ts": "^3.0.0",
+    "rollup-plugin-ts": "~3.0.0",
     "typescript": "~4.4.2"
   },
   "volta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14250,7 +14250,7 @@ rollup-plugin-delete@^2.0.0:
   dependencies:
     del "^5.1.0"
 
-rollup-plugin-ts@^3.0.0, rollup-plugin-ts@^3.0.2:
+rollup-plugin-ts@~3.0.0, rollup-plugin-ts@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-ts/-/rollup-plugin-ts-3.0.2.tgz#ee1a3f9ffe202ceff0b4d2f725fa268fa0c921bf"
   integrity sha512-67qi2QTHewhLyKDG6fX3jpohWpmUPPIT/xJ7rsYK46X6MqmoWy64Ti0y8ygPfLv8mXDCdRZUofM3mTxDfCswRA==


### PR DESCRIPTION
Newer rollup-plugin-ts pulls in a dep that breaks on our oldest supported node version.