### PR TITLE
Layer template resolver on top of module resolver

### DIFF
--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -562,7 +562,7 @@ export class Audit {
     let current: Request | undefined = request;
 
     while (true) {
-      current = this.nextRequest(current, resolver.beforeResolve(current.specifier, current.fromFile));
+      current = this.nextRequest(current, await resolver.beforeResolve(current.specifier, current.fromFile));
       if (!current) {
         return;
       }
@@ -581,7 +581,7 @@ export class Audit {
         if (err.code !== 'MODULE_NOT_FOUND') {
           throw err;
         }
-        let retry = this.nextRequest(current, resolver.fallbackResolve(current.specifier, current.fromFile));
+        let retry = this.nextRequest(current, await resolver.fallbackResolve(current.specifier, current.fromFile));
         if (!retry) {
           // the request got virtualized
           return;

--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -248,13 +248,8 @@ export class Audit {
     return config;
   }
 
-  @Memoize()
   private get resolverParams(): ResolverOptions {
-    let config = {
-      ...readJSONSync(join(this.appDir, '_adjust_imports.json')),
-      ...readJSONSync(join(this.appDir, '_relocated_files.json')),
-    };
-    return config;
+    return readJSONSync(join(this.appDir, '.embroider', 'resolver.json'));
   }
 
   private resolver = new Resolver(this.resolverParams);

--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readJSONSync } from 'fs-extra';
 import { dirname, join, resolve as resolvePath } from 'path';
 import resolveModule from 'resolve';
-import { AppMeta, explicitRelative, hbsToJS, Resolution, Resolver, ResolverOptions } from '@embroider/core';
+import { AppMeta, explicitRelative, hbsToJS, Decision, Resolver, ResolverOptions } from '@embroider/core';
 import { Memoize } from 'typescript-memoize';
 import chalk from 'chalk';
 import jsdom from 'jsdom';
@@ -538,23 +538,23 @@ export class Audit {
 
   private nextRequest(
     prevRequest: { specifier: string; fromFile: string },
-    resolution: Resolution
+    decision: Decision
   ): { specifier: string; fromFile: string } | undefined {
-    switch (resolution.result) {
+    switch (decision.result) {
       case 'virtual':
         // nothing to audit
         return undefined;
       case 'alias':
         // follow the redirect
-        let specifier = resolution.specifier;
-        let fromFile = resolution.fromFile ?? prevRequest.fromFile;
+        let specifier = decision.specifier;
+        let fromFile = decision.fromFile ?? prevRequest.fromFile;
         return { specifier, fromFile };
       case 'rehome':
-        return { specifier: prevRequest.specifier, fromFile: resolution.fromFile };
+        return { specifier: prevRequest.specifier, fromFile: decision.fromFile };
       case 'continue':
         return prevRequest;
       default:
-        throw assertNever(resolution);
+        throw assertNever(decision);
     }
   }
 

--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -531,17 +531,12 @@ export class Audit {
   }
 
   private async resolve(specifier: string, fromFile: string) {
-    try {
-      let resolution = await this.resolver.nodeResolve(specifier, fromFile);
-      if (resolution.type === 'virtual') {
-        // nothing to audit
-        return undefined;
-      }
-      return resolution.filename;
-    } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
-        throw err;
-      }
+    let resolution = await this.resolver.nodeResolve(specifier, fromFile);
+    if (resolution.type === 'virtual') {
+      // nothing to audit
+      return undefined;
+    }
+    if (resolution.type === 'not_found') {
       if (['@embroider/macros', '@ember/template-factory'].includes(specifier)) {
         // the audit process deliberately removes the @embroider/macros babel
         // plugins, so the imports are still present and should be left alone.
@@ -549,6 +544,7 @@ export class Audit {
       }
       return { isResolutionFailure: true as true };
     }
+    return resolution.filename;
   }
 
   private pushFinding(finding: Finding) {

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -30,7 +30,7 @@ import { sync as resolveSync } from 'resolve';
 import { MacrosConfig } from '@embroider/macros/src/node';
 import bind from 'bind-decorator';
 import { pathExistsSync } from 'fs-extra';
-import { tmpdir, ResolverOptions } from '@embroider/core';
+import { ResolverOptions } from '@embroider/core';
 import type { Transform } from 'babel-plugin-ember-template-compilation';
 
 interface TreeNames {
@@ -365,11 +365,6 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
       extraImports: outer ? this.extraImports() : [],
       relocatedFiles: {}, // this is the only part we can't completely fill out here. It needs to wait for the AppBuilder to finish smooshing together all appTrees
       resolvableExtensions: this.resolvableExtensions(),
-
-      // it's important that this is a persistent location, because we fill it
-      // up as a side-effect of babel transpilation, and babel is subject to
-      // persistent caching.
-      externalsDir: join(tmpdir, 'embroider', 'externals'),
       appRoot: this.root,
     };
   }

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -769,16 +769,6 @@ export default class CompatResolver {
       };
     }
   }
-  private resolvedDep(absPath: string, targetPackage: Package | AppPackagePlaceholder | undefined): ResolvedDep {
-    let self = this;
-    const a = absPath;
-    return {
-      absPath,
-      get runtimeName() {
-        return self.absPathToRuntimeName(a, targetPackage);
-      },
-    };
-  }
 }
 
 // we don't have a real Package for the app itself because the resolver has work

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -229,7 +229,7 @@ export default class CompatResolver {
 
   @Memoize()
   private get rules() {
-    // keyed by their first resolved dependency's runtimeName.
+    // keyed by their first resolved dependency's absPath.
     let components: Map<string, PreprocessedComponentRule> = new Map();
 
     // keyed by our own dasherized interpretation of the component's name.

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -140,10 +140,6 @@ export interface CompatResolverOptions extends CoreResolverOptions {
   options: UserConfig;
 }
 
-export function rehydrate(params: CompatResolverOptions) {
-  return new CompatResolver(params);
-}
-
 export interface AuditMessage {
   message: string;
   detail: string;
@@ -155,21 +151,10 @@ export interface AuditMessage {
 export default class CompatResolver {
   private auditHandler: undefined | ((msg: AuditMessage) => void);
 
-  _parallelBabel: {
-    requireFile: string;
-    buildUsing: string;
-    params: CompatResolverOptions;
-  };
-
   private resolver: Resolver;
 
   constructor(private params: CompatResolverOptions) {
     this.params.options = extractOptions(this.params.options);
-    this._parallelBabel = {
-      requireFile: __filename,
-      buildUsing: 'rehydrate',
-      params,
-    };
     this.resolver = new Resolver(this.params);
     if ((globalThis as any).embroider_audit) {
       this.auditHandler = (globalThis as any).embroider_audit;
@@ -441,28 +426,28 @@ export default class CompatResolver {
   }
 
   private *componentTemplateCandidates(target: { packageName: string; memberName: string }) {
-    yield join(target.packageName, 'templates', 'components', target.memberName);
-    yield join(target.packageName, 'components', target.memberName, 'template');
+    yield `${target.packageName}/templates/components/${target.memberName}`;
+    yield `${target.packageName}/components/${target.memberName}/template`;
 
     if (
       typeof this.params.podModulePrefix !== 'undefined' &&
       this.params.podModulePrefix !== '' &&
       target.packageName === this.appPackage.name
     ) {
-      yield join(this.params.podModulePrefix, 'components', target.memberName, 'template');
+      yield `${this.params.podModulePrefix}/components/${target.memberName}/template`;
     }
   }
 
   private *componentJSCandidates(target: { packageName: string; memberName: string }) {
-    yield join(target.packageName, 'components', target.memberName);
-    yield join(target.packageName, 'components', target.memberName, 'component');
+    yield `${target.packageName}/components/${target.memberName}`;
+    yield `${target.packageName}/components/${target.memberName}/component`;
 
     if (
       typeof this.params.podModulePrefix !== 'undefined' &&
       this.params.podModulePrefix !== '' &&
       target.packageName === this.appPackage.name
     ) {
-      yield join(this.params.podModulePrefix, 'components', target.memberName, 'component');
+      yield `${this.params.podModulePrefix}/components/${target.memberName}/component`;
     }
   }
 

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -401,7 +401,7 @@ export default class CompatResolver {
     }
   }
 
-  absPathToRuntimeName(absPath: string, owningPackage?: { root: string; name: string }) {
+  private absPathToRuntimeName(absPath: string, owningPackage?: { root: string; name: string }) {
     return this.absPathToRuntimePath(absPath, owningPackage)
       .replace(this.resolvableExtensionsPattern, '')
       .replace(/\/index$/, '');

--- a/packages/compat/tests/audit.test.ts
+++ b/packages/compat/tests/audit.test.ts
@@ -40,7 +40,6 @@ describe('audit', function () {
         renamePackages: {},
         renameModules: {},
         extraImports: [],
-        externalsDir: '/tmp/embroider-externals',
         activeAddons: {},
         relocatedFiles: {},
         resolvableExtensions,

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -1,7 +1,7 @@
 import { removeSync, mkdtempSync, writeFileSync, ensureDirSync, writeJSONSync, realpathSync } from 'fs-extra';
 import { join, dirname } from 'path';
 import Options, { optionsWithDefaults } from '../src/options';
-import { hbsToJS, tmpdir, throwOnWarnings, ResolverOptions } from '@embroider/core';
+import { hbsToJS, tmpdir, throwOnWarnings, ResolverOptions, AddonMeta } from '@embroider/core';
 import { emberTemplateCompiler } from '@embroider/test-support';
 import Resolver from '../src/resolver';
 import { PackageRules } from '../src';
@@ -13,6 +13,15 @@ import { TransformOptions, transformSync } from '@babel/core';
 describe('compat-resolver', function () {
   let appDir: string;
 
+  function addonPackageJSON(name: string) {
+    let meta: AddonMeta = { type: 'addon', version: 2, 'auto-upgraded': true };
+    return JSON.stringify({
+      name,
+      keywords: ['ember-addon'],
+      'ember-addon': meta,
+    });
+  }
+
   function configure(
     compatOptions: Options,
     otherOptions: {
@@ -23,7 +32,11 @@ describe('compat-resolver', function () {
     } = {}
   ) {
     appDir = realpathSync(mkdtempSync(join(tmpdir, 'embroider-compat-tests-')));
-    writeJSONSync(join(appDir, 'package.json'), { name: 'the-app' });
+    writeJSONSync(join(appDir, 'package.json'), {
+      name: 'the-app',
+      keywords: ['ember-addon'],
+      'ember-addon': { type: 'app', version: 2, 'auto-upgraded': true },
+    });
     let resolver = new Resolver({
       emberVersion: emberTemplateCompiler().version,
       root: appDir,
@@ -875,7 +888,7 @@ describe('compat-resolver', function () {
     let transform = configure({
       staticComponents: true,
     });
-    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon"}`);
+    givenFile('node_modules/my-addon/package.json', addonPackageJSON('my-addon'));
     givenFile('node_modules/my-addon/components/thing.js');
     expect(transform('templates/application.hbs', `{{component "my-addon@thing"}}`)).toEqualCode(`
       import thing from "../node_modules/my-addon/components/thing.js";
@@ -901,7 +914,7 @@ describe('compat-resolver', function () {
         },
       }
     );
-    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon"}`);
+    givenFile('node_modules/my-addon/package.json', addonPackageJSON('my-addon'));
     givenFile('node_modules/my-addon/components/thing.js');
     expect(transform('templates/application.hbs', `{{component "has-been-renamed@thing"}}`)).toEqualCode(`
       import thing from "../node_modules/my-addon/components/thing.js";
@@ -921,7 +934,7 @@ describe('compat-resolver', function () {
       },
       { plugins: [emberHolyFuturisticNamespacingBatmanTransform] }
     );
-    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon"}`);
+    givenFile('node_modules/my-addon/package.json', addonPackageJSON('my-addon'));
     givenFile('node_modules/my-addon/components/thing.js');
     expect(transform('templates/application.hbs', `<MyAddon$Thing />`)).toEqualCode(`
       import MyAddonThing from "../node_modules/my-addon/components/thing.js";
@@ -941,7 +954,7 @@ describe('compat-resolver', function () {
       },
       { plugins: [emberHolyFuturisticNamespacingBatmanTransform] }
     );
-    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon"}`);
+    givenFile('node_modules/my-addon/package.json', addonPackageJSON('my-addon'));
     givenFile('node_modules/my-addon/components/thing.js');
     expect(transform('node_modules/my-addon/components/foo.hbs', `<MyAddon$Thing />`)).toEqualCode(`
       import MyAddonThing from "./thing.js";
@@ -961,7 +974,7 @@ describe('compat-resolver', function () {
       },
       { plugins: [emberHolyFuturisticNamespacingBatmanTransform] }
     );
-    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon" }`);
+    givenFile('node_modules/my-addon/package.json', addonPackageJSON('my-addon'));
     givenFile('node_modules/my-addon/helpers/thing.js');
     expect(transform('templates/application.hbs', `{{my-addon$thing}}`)).toEqualCode(`
       import thing from "../node_modules/my-addon/helpers/thing.js";
@@ -988,7 +1001,7 @@ describe('compat-resolver', function () {
         plugins: [emberHolyFuturisticNamespacingBatmanTransform],
       }
     );
-    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon"}`);
+    givenFile('node_modules/my-addon/package.json', addonPackageJSON('my-addon'));
     givenFile('node_modules/my-addon/helpers/thing.js');
     expect(transform('templates/application.hbs', `{{has-been-renamed$thing}}`)).toEqualCode(`
       import thing from "../node_modules/my-addon/helpers/thing.js";
@@ -2382,7 +2395,7 @@ describe('compat-resolver', function () {
       },
     ];
     let transform = configure({ staticComponents: true, packageRules });
-    givenFile('node_modules/my-addon/package.json', `{ "name": "my-addon"}`);
+    givenFile('node_modules/my-addon/package.json', addonPackageJSON('my-addon'));
     givenFile('node_modules/my-addon/templates/index.hbs');
     givenFile('templates/components/alpha.hbs');
     givenFile('components/alpha.js');

--- a/packages/core/src/app-files.ts
+++ b/packages/core/src/app-files.ts
@@ -1,6 +1,6 @@
 import { sep } from 'path';
 import { Package, AddonPackage } from '@embroider/shared-internals';
-import AppDiffer from './app-differ';
+import type AppDiffer from './app-differ';
 
 export interface RouteFiles {
   route?: string;

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -703,9 +703,10 @@ export class AppBuilder<TreeNames> {
       .reverse()
       .forEach(a => a.differ.update());
     return this.appDiffers.map(a => {
-      return Object.assign({}, a.engine, {
+      return {
+        ...a.engine,
         appFiles: new AppFiles(a.differ, this.resolvableExtensionsPattern, this.adapter.podModulePrefix()),
-      });
+      };
     });
   }
 

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -8,12 +8,7 @@ import { Options as ModuleResolveroptions } from './module-resolver';
 export type Options = Pick<ModuleResolveroptions, 'extraImports'>;
 
 interface State {
-  opts: Options | DeflatedOptions;
-}
-
-export interface DeflatedOptions {
-  adjustImportsOptionsPath: string;
-  relocatedFilesPath: string;
+  opts: Options;
 }
 
 type BabelTypes = typeof t;
@@ -24,9 +19,8 @@ export default function main(babel: typeof Babel) {
     visitor: {
       Program: {
         enter(path: NodePath<t.Program>, state: State) {
-          let opts = ensureOpts(state);
           let adder = new ImportUtil(t, path);
-          addExtraImports(adder, t, path, opts.extraImports);
+          addExtraImports(adder, t, path, state.opts.extraImports);
         },
       },
     },
@@ -62,13 +56,4 @@ function amdDefine(t: BabelTypes, adder: ImportUtil, path: NodePath<t.Program>, 
       t.functionExpression(null, [], t.blockStatement([t.returnStatement(value)])),
     ])
   );
-}
-
-function ensureOpts(state: State): Options {
-  let { opts } = state;
-  if ('adjustImportsOptionsPath' in opts) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return (state.opts = { ...require(opts.adjustImportsOptionsPath), ...require(opts.relocatedFilesPath) });
-  }
-  return opts;
 }

--- a/packages/core/src/babel-plugin-adjust-imports.ts
+++ b/packages/core/src/babel-plugin-adjust-imports.ts
@@ -18,53 +18,6 @@ export interface DeflatedOptions {
 
 type BabelTypes = typeof t;
 
-type DefineExpressionPath = NodePath<t.CallExpression> & {
-  node: t.CallExpression & {
-    arguments: [t.StringLiteral, t.ArrayExpression, Function];
-  };
-};
-
-export function isImportSyncExpression(t: BabelTypes, path: NodePath<any>) {
-  if (
-    !path ||
-    !path.isCallExpression() ||
-    path.node.callee.type !== 'Identifier' ||
-    !path.get('callee').referencesImport('@embroider/macros', 'importSync')
-  ) {
-    return false;
-  }
-
-  const args = path.node.arguments;
-  return Array.isArray(args) && args.length === 1 && t.isStringLiteral(args[0]);
-}
-
-export function isDynamicImportExpression(t: BabelTypes, path: NodePath<any>) {
-  if (!path || !path.isCallExpression() || path.node.callee.type !== 'Import') {
-    return false;
-  }
-
-  const args = path.node.arguments;
-  return Array.isArray(args) && args.length === 1 && t.isStringLiteral(args[0]);
-}
-
-export function isDefineExpression(t: BabelTypes, path: NodePath<any>): path is DefineExpressionPath {
-  // should we allow nested defines, or stop at the top level?
-  if (!path.isCallExpression() || path.node.callee.type !== 'Identifier' || path.node.callee.name !== 'define') {
-    return false;
-  }
-
-  const args = path.node.arguments;
-
-  // only match define with 3 arguments define(name: string, deps: string[], cb: Function);
-  return (
-    Array.isArray(args) &&
-    args.length === 3 &&
-    t.isStringLiteral(args[0]) &&
-    t.isArrayExpression(args[1]) &&
-    t.isFunction(args[2])
-  );
-}
-
 export default function main(babel: typeof Babel) {
   let t = babel.types;
   return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   ResolverFunction,
   SyncResolverFunction,
 } from './module-resolver';
+export type { Engine } from './app-files';
 
 // this is reexported because we already make users manage a peerDep from some
 // other packages (like embroider/webpack and @embroider/compat

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@ export { compile as jsHandlebarsCompile } from './js-handlebars';
 export { AppAdapter, AppBuilder, EmberENV } from './app';
 export { todo, unsupported, warn, debug, expectWarning, throwOnWarnings } from './messages';
 export { mangledEngineRoot } from './engine-mangler';
-export { Resolver, Options as ResolverOptions, Decision } from './module-resolver';
+export { Resolver, Options as ResolverOptions, ModuleRequest, Resolution, ResolverFunction } from './module-resolver';
 
 // this is reexported because we already make users manage a peerDep from some
 // other packages (like embroider/webpack and @embroider/compat

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,14 @@ export { compile as jsHandlebarsCompile } from './js-handlebars';
 export { AppAdapter, AppBuilder, EmberENV } from './app';
 export { todo, unsupported, warn, debug, expectWarning, throwOnWarnings } from './messages';
 export { mangledEngineRoot } from './engine-mangler';
-export { Resolver, Options as ResolverOptions, ModuleRequest, Resolution, ResolverFunction } from './module-resolver';
+export {
+  Resolver,
+  Options as ResolverOptions,
+  ModuleRequest,
+  Resolution,
+  ResolverFunction,
+  SyncResolverFunction,
+} from './module-resolver';
 
 // this is reexported because we already make users manage a peerDep from some
 // other packages (like embroider/webpack and @embroider/compat

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@ export { compile as jsHandlebarsCompile } from './js-handlebars';
 export { AppAdapter, AppBuilder, EmberENV } from './app';
 export { todo, unsupported, warn, debug, expectWarning, throwOnWarnings } from './messages';
 export { mangledEngineRoot } from './engine-mangler';
-export { Resolver, Options as ResolverOptions, Resolution } from './module-resolver';
+export { Resolver, Options as ResolverOptions, Decision } from './module-resolver';
 
 // this is reexported because we already make users manage a peerDep from some
 // other packages (like embroider/webpack and @embroider/compat

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -48,7 +48,7 @@ export class Resolver {
 
   constructor(private options: Options) {}
 
-  beforeResolve(specifier: string, fromFile: string): Resolution {
+  async beforeResolve(specifier: string, fromFile: string): Promise<Resolution> {
     let resolution = this.internalBeforeResolve(specifier, fromFile);
     debug('[%s] %s %s => %r', 'before', specifier, fromFile, resolution);
     return resolution;
@@ -71,7 +71,7 @@ export class Resolver {
     return resolution;
   }
 
-  fallbackResolve(specifier: string, fromFile: string): Resolution {
+  async fallbackResolve(specifier: string, fromFile: string): Promise<Resolution> {
     let resolution = this.postHandleExternal(specifier, fromFile);
     debug('[%s] %s %s => %r', 'fallback', specifier, fromFile, resolution);
     return resolution;

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -20,7 +20,6 @@ export interface Options {
     target: string;
     runtimeName?: string;
   }[];
-  externalsDir: string;
   activeAddons: {
     [packageName: string]: string;
   };

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -170,7 +170,7 @@ export class Resolver {
       if (request.isVirtual) {
         return {
           type: 'found',
-          result: { type: 'virtual' as 'virtual', content: Resolver.virtualContent(request.fromFile) },
+          result: { type: 'virtual' as 'virtual', content: Resolver.virtualContent(request.specifier) },
         };
       }
       try {

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -4,6 +4,7 @@ import { PackageCache, Package, V2Package, explicitRelative } from '@embroider/s
 import { compile } from './js-handlebars';
 import makeDebug from 'debug';
 import assertNever from 'assert-never';
+const debug = makeDebug('embroider:resolver');
 
 export interface Options {
   renamePackages: {
@@ -28,17 +29,28 @@ export interface Options {
 
 const externalPrefix = '/@embroider/external/';
 
-export type Decision =
-  | { result: 'continue' }
-  | { result: 'alias'; specifier: string; fromFile?: string }
-  | { result: 'rehome'; fromFile: string }
-  | { result: 'virtual'; filename: string };
+export interface ModuleRequest {
+  specifier: string;
+  fromFile: string;
+  isVirtual: boolean;
+  alias(newSpecifier: string, newFromFile?: string): this;
+  rehome(newFromFile: string): this;
+  virtualize(virtualFilename: string): this;
+}
+
+// This is generic because different build systems have different ways of
+// representing a found module, and we just pass those values through.
+export type Resolution<T = unknown, E = unknown> = { type: 'found'; result: T } | { type: 'not_found'; err: E };
+
+export type ResolverFunction<R extends ModuleRequest = ModuleRequest, T = unknown, E = unknown> = (
+  request: R
+) => Promise<Resolution<T, E>>;
 
 export class Resolver {
-  // Given a filename that was returned with result === 'virtual', this produces
-  // the corresponding contents. It's a static, stateless function because we
-  // recognize that that process that did resolution might not be the same one
-  // that loads the content.
+  // Given a filename that was passed to your ModuleRequest's `virtualize()`,
+  // this produces the corresponding contents. It's a static, stateless function
+  // because we recognize that that process that did resolution might not be the
+  // same one that loads the content.
   static virtualContent(filename: string): string | undefined {
     if (filename.startsWith(externalPrefix)) {
       return externalShim({ moduleName: filename.slice(externalPrefix.length) });
@@ -48,33 +60,56 @@ export class Resolver {
 
   constructor(private options: Options) {}
 
-  async beforeResolve(specifier: string, fromFile: string): Promise<Decision> {
-    let resolution = this.internalBeforeResolve(specifier, fromFile);
-    debug('[%s] %s %s => %r', 'before', specifier, fromFile, resolution);
-    return resolution;
-  }
-
-  private internalBeforeResolve(specifier: string, fromFile: string): Decision {
-    if (specifier === '@embroider/macros') {
+  async beforeResolve<R extends ModuleRequest>(request: R): Promise<R> {
+    if (request.specifier === '@embroider/macros') {
       // the macros package is always handled directly within babel (not
       // necessarily as a real resolvable package), so we should not mess with it.
       // It might not get compiled away until *after* our plugin has run, which is
       // why we need to know about it.
-      return { result: 'continue' };
+      return request;
     }
 
-    let maybeRenamed = this.handleRenaming(specifier, fromFile);
-    let resolution = this.preHandleExternal(maybeRenamed, fromFile);
-    if (resolution.result === 'continue' && maybeRenamed !== specifier) {
-      return { result: 'alias', specifier: maybeRenamed };
-    }
-    return resolution;
+    return this.preHandleExternal(this.handleRenaming(request));
   }
 
-  async fallbackResolve(specifier: string, fromFile: string): Promise<Decision> {
-    let resolution = this.postHandleExternal(specifier, fromFile);
-    debug('[%s] %s %s => %r', 'fallback', specifier, fromFile, resolution);
-    return resolution;
+  async fallbackResolve<R extends ModuleRequest>(request: R): Promise<R> {
+    return this.postHandleExternal(request);
+  }
+
+  // This encapsulates the whole resolving process. Given a `defaultResolve`
+  // that calls your build system's normal module resolver, this does both pre-
+  // and post-resolution adjustments as needed to implement our compatibility
+  // rules.
+  //
+  // Depending on the plugin architecture you're working in, it may be easier to
+  // call beforeResolve and fallbackResolve directly, in which case matching the
+  // details of the recursion to what this method does are your responsibility.
+  async resolve<R extends ModuleRequest, T, E>(
+    request: R,
+    defaultResolve: ResolverFunction<R, T, E>
+  ): Promise<Resolution<T, E>> {
+    request = await this.beforeResolve(request);
+    let resolution = await defaultResolve(request);
+    switch (resolution.type) {
+      case 'found':
+        return resolution;
+      case 'not_found':
+        break;
+      default:
+        throw assertNever(resolution);
+    }
+    let nextRequest = await this.fallbackResolve(request);
+    if (nextRequest === request) {
+      // no additional fallback is available.
+      return resolution;
+    }
+    if (nextRequest.isVirtual) {
+      // virtual requests are terminal, there is no more beforeResolve or
+      // fallbackResolve around them. The defaultResolve is expected to know how
+      // to implement them.
+      return await defaultResolve(nextRequest);
+    }
+    return await this.resolve(nextRequest, defaultResolve);
   }
 
   private owningPackage(fromFile: string): Package | undefined {
@@ -92,33 +127,34 @@ export class Resolver {
     }
   }
 
-  private handleRenaming(specifier: string, fromFile: string) {
-    let packageName = getPackageName(specifier);
+  private handleRenaming<R extends ModuleRequest>(request: R): R {
+    let packageName = getPackageName(request.specifier);
     if (!packageName) {
-      return specifier;
+      return request;
     }
 
     for (let [candidate, replacement] of Object.entries(this.options.renameModules)) {
-      if (candidate === specifier) {
-        return replacement;
+      if (candidate === request.specifier) {
+        debug(`[beforeResolve] aliased ${request.specifier} in ${request.fromFile} to ${replacement}`);
+        return request.alias(replacement);
       }
       for (let extension of this.options.resolvableExtensions) {
-        if (candidate === specifier + '/index' + extension) {
-          return replacement;
+        if (candidate === request.specifier + '/index' + extension) {
+          return request.alias(replacement);
         }
-        if (candidate === specifier + extension) {
-          return replacement;
+        if (candidate === request.specifier + extension) {
+          return request.alias(replacement);
         }
       }
     }
 
     if (this.options.renamePackages[packageName]) {
-      return specifier.replace(packageName, this.options.renamePackages[packageName]);
+      return request.alias(request.specifier.replace(packageName, this.options.renamePackages[packageName]));
     }
 
-    let pkg = this.owningPackage(fromFile);
+    let pkg = this.owningPackage(request.fromFile);
     if (!pkg || !pkg.isV2Ember()) {
-      return specifier;
+      return request;
     }
 
     if (pkg.meta['auto-upgraded'] && pkg.name === packageName) {
@@ -126,17 +162,17 @@ export class Resolver {
       // packages get this help, v2 packages are natively supposed to make their
       // own modules resolvable, and we want to push them all to do that
       // correctly.
-      return this.resolveWithinPackage(specifier, pkg);
+      return request.alias(this.resolveWithinPackage(request.specifier, pkg));
     }
 
-    let originalPkg = this.originalPackage(fromFile);
+    let originalPkg = this.originalPackage(request.fromFile);
     if (originalPkg && pkg.meta['auto-upgraded'] && originalPkg.name === packageName) {
       // A file that was relocated out of a package is importing that package's
       // name, it should find its own original copy.
-      return this.resolveWithinPackage(specifier, originalPkg);
+      return request.alias(this.resolveWithinPackage(request.specifier, originalPkg));
     }
 
-    return specifier;
+    return request;
   }
 
   private resolveWithinPackage(specifier: string, pkg: Package): string {
@@ -148,10 +184,11 @@ export class Resolver {
     return specifier.replace(pkg.name, pkg.root);
   }
 
-  private preHandleExternal(specifier: string, fromFile: string): Decision {
+  private preHandleExternal<R extends ModuleRequest>(request: R): R {
+    let { specifier, fromFile } = request;
     let pkg = this.owningPackage(fromFile);
     if (!pkg || !pkg.isV2Ember()) {
-      return { result: 'continue' };
+      return request;
     }
 
     let packageName = getPackageName(specifier);
@@ -165,16 +202,16 @@ export class Resolver {
       let packageRelativeSpecifier = explicitRelative(pkg.root, absoluteSpecifier);
       if (isExplicitlyExternal(packageRelativeSpecifier, pkg)) {
         let publicSpecifier = absoluteSpecifier.replace(pkg.root, pkg.name);
-        return external(publicSpecifier);
+        return external('beforeResolve', request, publicSpecifier);
       } else {
-        return { result: 'continue' };
+        return request;
       }
     }
 
     // absolute package imports can also be explicitly external based on their
     // full specifier name
     if (isExplicitlyExternal(specifier, pkg)) {
-      return external(specifier);
+      return external('beforeResolve', request, specifier);
     }
 
     if (!pkg.meta['auto-upgraded'] && emberVirtualPeerDeps.has(packageName)) {
@@ -193,10 +230,9 @@ export class Resolver {
       if (!this.options.activeAddons[packageName]) {
         throw new Error(`${pkg.name} is trying to import the app's ${packageName} package, but it seems to be missing`);
       }
-      return {
-        result: 'rehome',
-        fromFile: resolve(this.options.appRoot, 'package.json'),
-      };
+      let newHome = resolve(this.options.appRoot, 'package.json');
+      debug(`[beforeResolve] rehomed ${request.specifier} from ${request.fromFile} to ${newHome}`);
+      return request.rehome(newHome);
     }
 
     if (pkg.meta['auto-upgraded'] && !pkg.hasDependency('ember-auto-import')) {
@@ -205,7 +241,7 @@ export class Resolver {
         if (!dep.isEmberPackage()) {
           // classic ember addons can only import non-ember dependencies if they
           // have ember-auto-import.
-          return external(specifier);
+          return external('beforeResolve', request, specifier);
         }
       } catch (err) {
         if (err.code !== 'MODULE_NOT_FOUND') {
@@ -235,29 +271,27 @@ export class Resolver {
         }
       }
     }
-    return { result: 'continue' };
+    return request;
   }
 
-  private postHandleExternal(specifier: string, fromFile: string): Decision {
+  private postHandleExternal<R extends ModuleRequest>(request: R): R {
+    let { specifier, fromFile } = request;
     let pkg = this.owningPackage(fromFile);
     if (!pkg || !pkg.isV2Ember()) {
-      return { result: 'continue' };
+      return request;
     }
 
     let packageName = getPackageName(specifier);
     if (!packageName) {
       // this is a relative import, we have nothing more to for it.
-      return { result: 'continue' };
+      return request;
     }
 
     let originalPkg = this.originalPackage(fromFile);
     if (originalPkg) {
       // we didn't find it from the original package, so try from the relocated
       // package
-      return {
-        result: 'rehome',
-        fromFile: resolve(originalPkg.root, 'package.json'),
-      };
+      return request.rehome(resolve(originalPkg.root, 'package.json'));
     }
 
     // auto-upgraded packages can fall back to the set of known active addons
@@ -265,13 +299,12 @@ export class Resolver {
     // v2 packages can fall back to the set of known active addons only to find
     // themselves (which is needed due to app tree merging)
     if ((pkg.meta['auto-upgraded'] || packageName === pkg.name) && this.options.activeAddons[packageName]) {
-      return {
-        result: 'alias',
-        specifier: this.resolveWithinPackage(
+      return request.alias(
+        this.resolveWithinPackage(
           specifier,
           PackageCache.shared('embroider-stage3', this.options.appRoot).get(this.options.activeAddons[packageName])
-        ),
-      };
+        )
+      );
     }
 
     if (pkg.meta['auto-upgraded']) {
@@ -279,19 +312,19 @@ export class Resolver {
       // runtime. Native v2 packages can only get this behavior in the
       // isExplicitlyExternal case above because they need to explicitly ask for
       // externals.
-      return external(specifier);
+      return external('fallbackResolve', request, specifier);
     } else {
       // native v2 packages don't automatically externalize *everything* the way
       // auto-upgraded packages do, but they still externalize known and approved
       // ember virtual packages (like @ember/component)
       if (emberVirtualPackages.has(packageName)) {
-        return external(specifier);
+        return external('fallbackResolve', request, specifier);
       }
     }
 
     // this is falling through with the original specifier which was
     // non-resolvable, which will presumably cause a static build error in stage3.
-    return { result: 'continue' };
+    return request;
   }
 }
 
@@ -320,11 +353,10 @@ function reliablyResolvable(pkg: V2Package, packageName: string) {
   return false;
 }
 
-function external(specifier: string): Decision {
-  return {
-    result: 'virtual',
-    filename: externalPrefix + specifier,
-  };
+function external<R extends ModuleRequest>(label: string, request: R, specifier: string): R {
+  let filename = externalPrefix + specifier;
+  debug(`[${label}] virtualized ${request.specifier} as ${filename}`);
+  return request.virtualize(filename);
 }
 
 const externalShim = compile(`
@@ -349,23 +381,3 @@ if (m.default && !m.__esModule) {
 }
 module.exports = m;
 `) as (params: { moduleName: string }) => string;
-
-const debug = makeDebug('embroider:resolver');
-makeDebug.formatters.r = (r: Decision) => {
-  switch (r.result) {
-    case 'alias':
-      if (r.fromFile) {
-        return `alias:${r.specifier} from ${r.fromFile}`;
-      } else {
-        return `alias:${r.specifier}`;
-      }
-    case 'rehome':
-      return `rehome:${r.fromFile}`;
-    case 'continue':
-      return 'continue';
-    case 'virtual':
-      return 'virtual';
-    default:
-      throw assertNever(r);
-  }
-};

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -165,7 +165,7 @@ export class Resolver {
   nodeResolve(
     specifier: string,
     fromFile: string
-  ): { type: 'virtual'; content: string } | { type: 'real'; filename: string } {
+  ): { type: 'virtual'; content: string } | { type: 'real'; filename: string } | { type: 'not_found'; err: Error } {
     let resolution = this.resolveSync(new NodeModuleRequest(specifier, fromFile), request => {
       if (request.isVirtual) {
         return {
@@ -188,7 +188,7 @@ export class Resolver {
     });
     switch (resolution.type) {
       case 'not_found':
-        throw resolution.err;
+        return resolution;
       case 'found':
         return resolution.result;
       default:

--- a/packages/shared-internals/src/metadata.ts
+++ b/packages/shared-internals/src/metadata.ts
@@ -15,7 +15,6 @@ export interface AppMeta {
     majorVersion: 7;
     fileFilter: string;
   };
-  'resolvable-extensions': string[];
   'root-url': string;
   version: 2;
 }

--- a/packages/webpack/src/virtual-loader.ts
+++ b/packages/webpack/src/virtual-loader.ts
@@ -4,10 +4,7 @@ import { LoaderContext } from 'webpack';
 export default function virtualLoader(this: LoaderContext<unknown>) {
   let filename = this.loaders[this.loaderIndex].options;
   if (typeof filename === 'string') {
-    let content = Resolver.virtualContent(filename);
-    if (content) {
-      return content;
-    }
+    return Resolver.virtualContent(filename);
   }
   throw new Error(`@embroider/webpack/src/virtual-loader received unexpected request: ${filename}`);
 }

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -129,7 +129,7 @@ class ResolverPlugin {
       { name: 'my-resolver-plugin', stage: 10 },
       async (request, context, callback) => {
         try {
-          if (!isRelevantRequest(request) || request.request.startsWith('@embroider/externals/')) {
+          if (!isRelevantRequest(request) || request.request.startsWith('/@embroider/externals/')) {
             callback();
             return;
           }

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -84,7 +84,7 @@ function getDefaultResolveHook(taps: { name: string; fn: Function }[]): DefaultR
 // for use by @embroider/core's resolver.
 function getAdaptedResolve(
   defaultResolve: DefaultResolve
-): ResolverFunction<WebpackModuleRequest, Module, null | Error> {
+): ResolverFunction<WebpackModuleRequest, Resolution<Module, null | Error>> {
   return function (request: WebpackModuleRequest): Promise<Resolution<Module, null | Error>> {
     return new Promise(resolve => {
       defaultResolve(request.state, (err, value) => {

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -1,5 +1,11 @@
 import { dirname, resolve } from 'path';
-import { Resolver as EmbroiderResolver, ResolverOptions as EmbroiderResolverOptions, Decision } from '@embroider/core';
+import {
+  Resolver as EmbroiderResolver,
+  ResolverOptions as EmbroiderResolverOptions,
+  ModuleRequest,
+  ResolverFunction,
+  Resolution,
+} from '@embroider/core';
 import type { Compiler, Module } from 'webpack';
 import assertNever from 'assert-never';
 
@@ -27,71 +33,35 @@ export class EmbroiderPlugin {
     }
   }
 
-  #handle(decision: Decision, state: Request) {
-    switch (decision.result) {
-      case 'alias':
-        state.request = decision.specifier;
-        if (decision.fromFile) {
-          state.contextInfo.issuer = decision.fromFile;
-          state.context = dirname(decision.fromFile);
-        }
-        break;
-      case 'rehome':
-        state.contextInfo.issuer = decision.fromFile;
-        state.context = dirname(decision.fromFile);
-        break;
-      case 'virtual':
-        state.request = `${virtualLoaderName}?${decision.filename}!`;
-        break;
-      case 'continue':
-        break;
-      default:
-        throw assertNever(decision);
-    }
-  }
-
-  async #resolve(defaultResolve: (state: unknown) => Promise<Module>, state: unknown): Promise<Module> {
-    if (isRelevantRequest(state)) {
-      let decision = await this.#resolver.beforeResolve(state.request, state.contextInfo.issuer);
-      if (decision.result !== 'continue') {
-        this.#handle(decision, state);
-      }
-    }
-    try {
-      return await defaultResolve(state);
-    } catch (err) {
-      if (!isRelevantRequest(state)) {
-        throw err;
-      }
-      let decision = await this.#resolver.fallbackResolve(state.request, state.contextInfo.issuer);
-      if (decision.result === 'continue') {
-        throw err;
-      } else {
-        this.#handle(decision, state);
-        return await this.#resolve(defaultResolve, state);
-      }
-    }
-  }
-
   apply(compiler: Compiler) {
     this.#addLoaderAlias(compiler, virtualLoaderName, resolve(__dirname, './virtual-loader'));
 
-    compiler.hooks.normalModuleFactory.tap('my-experiment', nmf => {
-      // Despite being absolutely riddled with way-too-powerful tap points,
-      // webpack still doesn't succeed in making it possible to provide a
-      // fallback to the default resolve hook in the NormalModuleFactory. So
-      // instead we will find the default behavior and call it from our own tap,
-      // giving us a chance to handle its failures.
-      let { fn } = nmf.hooks.resolve.taps.find(t => t.name === 'NormalModuleFactory')!;
-      let defaultResolve = fn as unknown as (state: unknown, callback: CB) => void;
-      let pDefaultResolve = promisifyDefaultResolve(defaultResolve);
+    compiler.hooks.normalModuleFactory.tap('@embroider/webpack', nmf => {
+      let defaultResolve = getDefaultResolveHook(nmf.hooks.resolve.taps);
+      let adaptedResolve = getAdaptedResolve(defaultResolve);
 
-      nmf.hooks.resolve.tapAsync({ name: 'my-experiment', stage: 50 }, (state: unknown, callback: CB) =>
-        this.#resolve(pDefaultResolve, state).then(
-          result => callback(null, result),
+      nmf.hooks.resolve.tapAsync({ name: '@embroider/webpack', stage: 50 }, (state: unknown, callback: CB) => {
+        if (!isRelevantRequest(state)) {
+          defaultResolve(state, callback);
+          return;
+        }
+
+        this.#resolver.resolve(new WebpackModuleRequest(state), adaptedResolve).then(
+          resolution => {
+            switch (resolution.type) {
+              case 'not_found':
+                callback(resolution.err);
+                break;
+              case 'found':
+                callback(null, resolution.result);
+                break;
+              default:
+                throw assertNever(resolution);
+            }
+          },
           err => callback(err)
-        )
-      );
+        );
+      });
     });
   }
 }
@@ -104,20 +74,70 @@ interface Request {
   };
 }
 
-type CB = (err: Error | null, result?: Module) => void;
+type CB = (err: null | Error, result?: Module | undefined) => void;
+type DefaultResolve = (state: unknown, callback: CB) => void;
 
-function promisifyDefaultResolve(defaultResolve: (state: unknown, callback: CB) => void) {
-  return async function (state: unknown): Promise<Module> {
-    return new Promise((resolve, reject) => {
-      defaultResolve(state, (err, value) => {
+// Despite being absolutely riddled with way-too-powerful tap points,
+// webpack still doesn't succeed in making it possible to provide a
+// fallback to the default resolve hook in the NormalModuleFactory. So
+// instead we will find the default behavior and call it from our own tap,
+// giving us a chance to handle its failures.
+function getDefaultResolveHook(taps: { name: string; fn: Function }[]): DefaultResolve {
+  let { fn } = taps.find(t => t.name === 'NormalModuleFactory')!;
+  return fn as DefaultResolve;
+}
+
+// This converts the raw function we got out of webpack into the right interface
+// for use by @embroider/core's resolver.
+function getAdaptedResolve(
+  defaultResolve: DefaultResolve
+): ResolverFunction<WebpackModuleRequest, Module, null | Error> {
+  return function (request: WebpackModuleRequest): Promise<Resolution<Module, null | Error>> {
+    return new Promise(resolve => {
+      defaultResolve(request.state, (err, value) => {
         if (err) {
-          reject(err);
+          // unfortunately webpack doesn't let us distinguish between Not Found
+          // and other unexpected exceptions here.
+          resolve({ type: 'not_found', err });
         } else {
-          resolve(value!);
+          resolve({ type: 'found', result: value! });
         }
       });
     });
   };
+}
+
+class WebpackModuleRequest implements ModuleRequest {
+  specifier: string;
+  fromFile: string;
+
+  constructor(public state: Request, public isVirtual = false) {
+    // these get copied here because we mutate the underlying state as we
+    // convert one request into the next, and it seems better for debuggability
+    // if the fields on the previous request don't change when you make a new
+    // one (although it is true that only the newest one has a a valid `state`
+    // that can actually be handed back to webpack)
+    this.specifier = state.request;
+    this.fromFile = state.contextInfo.issuer;
+  }
+
+  alias(newSpecifier: string, newFromFile?: string) {
+    this.state.request = newSpecifier;
+    if (newFromFile) {
+      this.state.contextInfo.issuer = newFromFile;
+      this.state.context = dirname(newFromFile);
+    }
+    return new WebpackModuleRequest(this.state) as this;
+  }
+  rehome(newFromFile: string) {
+    this.state.contextInfo.issuer = newFromFile;
+    this.state.context = dirname(newFromFile);
+    return new WebpackModuleRequest(this.state) as this;
+  }
+  virtualize(filename: string) {
+    this.state.request = `${virtualLoaderName}?${filename}!`;
+    return new WebpackModuleRequest(this.state, true) as this;
+  }
 }
 
 function isRelevantRequest(request: any): request is Request {


### PR DESCRIPTION
Now that we have a new standardized module-resolver API (`import { Resolver } from '@embroider/core'`), we need to use it not just from javascript but also from inside non-strict templates when we're doing build-time resolution of traditionally global components / helpers / modifiers. That is the goal of this refactor PR.

 At a minimum, we want the `@embroider/compat/src/resolver` to call out to `@embroider/core/src/module-resolver` so everything gets uniform treatment. 

As a stretch goal, it would be nice if the actual transformation used by the compat resolver did no resolution at all, instead emitting import statements for the logical pieces it would have resolved, so that the normal module resolver pass can handle them instead. This would be better because it would eliminate the last place where we're resolving from inside babel (and thus inside babel's cache). It will take some experimentation to figure out if this can handle all the compatibility cases we support.