### PR TITLE
restore original ts extension priority

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -231,7 +231,7 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     // For TS, we defer to ember-cli-babel, and the setting for
     // "enableTypescriptTransform" can be set with and without
     // ember-cli-typescript
-    return ['.ts', '.wasm', '.mjs', '.js', '.json', '.hbs', '.hbs.js'];
+    return ['.wasm', '.mjs', '.js', '.json', '.ts', '.hbs', '.hbs.js'];
   }
 
   private *emberEntrypoints(htmlTreePath: string): IterableIterator<Asset> {

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -231,7 +231,7 @@ class CompatAppAdapter implements AppAdapter<TreeNames> {
     // For TS, we defer to ember-cli-babel, and the setting for
     // "enableTypescriptTransform" can be set with and without
     // ember-cli-typescript
-    return ['.wasm', '.mjs', '.js', '.json', '.hbs', '.hbs.js', '.ts'];
+    return ['.ts', '.wasm', '.mjs', '.js', '.json', '.hbs', '.hbs.js'];
   }
 
   private *emberEntrypoints(htmlTreePath: string): IterableIterator<Asset> {


### PR DESCRIPTION
I don't really know what https://github.com/embroider-build/embroider/commit/7882a2da97ce31f720dc7eabb8bef7d149a5b18b was trying to achieve and it definitely looks weird and it's the cause of #1336 and probably #1341.

Maybe CI will tell me why this was done in the first place...