### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,28 @@ jobs:
       - name: suite
         run: ${{ matrix.command }}
         working-directory: ${{ matrix.dir }}
+
+  # https://github.com/changesets/action
+  release:
+    name: Release
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: yarn release
+          title: 'Release Preview'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "scripts": {
+    "release": "changeset publish",
     "clean": "git clean -x -f",
     "compile": "tsc",
     "lint": "concurrently 'yarn:lint:*'",


### PR DESCRIPTION
I imagine the workflow would be as follows:
 - merge a bunch of PRs willy nilly, contributors don't need to do anything different from what they're doing today
 - when it comes time to _prepare_ for a release, we will
    - run [`npx changeset-recover@beta`](https://github.com/nullvoxpopuli/changeset-recover) to help fill out the Changelog (in bite-sized, PR-oriented pieces that the tooling calls "changesets" (for those unfamiliar: https://github.com/changesets/changesets/ ))
    - edit the generated files to tidy up the generate Changelog entry
      - select whether the change is a bugfix (patch), minor change, or major / breaking change
      - edit the changelog entry, which defaults to a combination of both the PR title and PR description - and if an associated PR can't be found, the commit message will be used (useful for direct commits to `main`)
    - commit and push up these new `.changeset/*.md` files
    - C.I. (the action added here in this workflow file) will then create a PR to `main` that allows you to preview how the versions will change on each of the packages
      - Since we want a single changelog, there is one more manual step: combine all the changelogs -- this can be done by pushing to the branch that is created. 
        <br/>
        I'm still thinking about a tool for this, because this amount of manual work isn't fun -- for this particular repo, since the packages themselves don't have changelogs at all, this tool might be reasonbly easy to write -- I'd kinda need to see the format that these single-version changelog entries use since the changelog files would be "created for the first time" by the changeset tool. My hunch Is that I can write a local tool to this repo that just pulls in the entirety of the changelog files into the main changelog and then deletes the per-package ones 
    - _only_ when the "version preview PR" is merged, the release will occur automatically
      - _what is done?_
        - a tag for each package in the format: `packageName@version` - examples: [xstate](https://github.com/statelyai/xstate/tags) [ember-resources](https://github.com/NullVoxPopuli/ember-resources/tags)
        - a release page entry per package titled `packageName@version` - examples: [xstate](https://github.com/statelyai/xstate/releases), [ember-resources](https://github.com/NullVoxPopuli/ember-resources/releases)
        - each package is pushed to npm
        
----

Assumptions:
 - the `prepare` script runs automatically   
 - these permissions set in `/settings/actions`: 
   
  ![image](https://user-images.githubusercontent.com/199018/215538672-86d1c445-5ba5-455b-a0d2-fb3b779532f8.png)
