### PR TITLE
Bugfix: inconsistent handling of webpack virtual modules

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -39,8 +39,7 @@
     "style-loader": "^2.0.0",
     "supports-color": "^8.1.0",
     "terser": "^5.7.0",
-    "thread-loader": "^3.0.4",
-    "webpack-virtual-modules": "^0.5.0"
+    "thread-loader": "^3.0.4"
   },
   "devDependencies": {
     "@types/csso": "^3.5.1",

--- a/packages/webpack/src/virtual-loader.ts
+++ b/packages/webpack/src/virtual-loader.ts
@@ -1,0 +1,13 @@
+import { Resolver } from '@embroider/core';
+import { LoaderContext } from 'webpack';
+
+export default function virtualLoader(this: LoaderContext<unknown>) {
+  let filename = this.loaders[this.loaderIndex].options;
+  if (typeof filename === 'string') {
+    let content = Resolver.virtualContent(filename);
+    if (content) {
+      return content;
+    }
+  }
+  throw new Error(`@embroider/webpack/src/virtual-loader received unexpected request: ${filename}`);
+}

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -129,7 +129,7 @@ class ResolverPlugin {
       { name: 'my-resolver-plugin', stage: 10 },
       async (request, context, callback) => {
         try {
-          if (!isRelevantRequest(request) || request.request.startsWith('@embroider/externals/')) {
+          if (!isRelevantRequest(request) || request.request.startsWith('/@embroider/externals/')) {
             callback();
             return;
           }

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -104,7 +104,7 @@ class ResolverPlugin {
     // precedence over other resolving decisions.
     resolver.getHook('raw-resolve').tapAsync('my-resolver-plugin', async (request, context, callback) => {
       try {
-        if (!isRelevantRequest(request) || request.request.startsWith('@embroider/externals/')) {
+        if (!isRelevantRequest(request) || request.request.startsWith('/@embroider/externals/')) {
           callback();
           return;
         }

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -16,7 +16,7 @@ appScenarios
     addon.pkg.name = 'v2-addon';
     addon.pkg.files = ['dist'];
     addon.pkg.exports = {
-      './*': './dist/*',
+      './*': './dist/*.js',
       './addon-main.js': './addon-main.js',
       './package.json': './package.json',
     };

--- a/tests/scenarios/v2-addon-dev-typescript-test.ts
+++ b/tests/scenarios/v2-addon-dev-typescript-test.ts
@@ -13,7 +13,7 @@ appScenarios
     addon.pkg.name = 'v2-addon';
     addon.pkg.files = ['dist'];
     addon.pkg.exports = {
-      './*': './dist/*',
+      './*': './dist/*.js',
       './addon-main.js': './addon-main.js',
       './package.json': './package.json',
     };


### PR DESCRIPTION
This should match the pattern we use when emitting virtual modules.

It works *sometimes* as it was, but not reliably. This change seems to make the tests pass every time.