### PR TITLE
reinstate logic around parsing of invokes packageRules

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -39,6 +39,12 @@ export default function makeResolverTransform({ resolver, patchHelpersBug }: Opt
     let scopeStack = new ScopeStack();
     let emittedAMDDeps: Set<string> = new Set();
 
+    const invokeDependencies = resolver.enter(filename);
+    for (let packageRuleInvokeDependency of invokeDependencies) {
+      emitAMD(packageRuleInvokeDependency.hbsModule);
+      emitAMD(packageRuleInvokeDependency.jsModule);
+    }
+
     // The first time we insert a component as a lexical binding
     //   - if there's no JS-scope collision with the name, we're going to bind the existing name
     //     - in this case, any subsequent invocations of the same component just got automatically fixed too

--- a/packages/compat/src/resolver.ts
+++ b/packages/compat/src/resolver.ts
@@ -188,7 +188,16 @@ export default class CompatResolver {
       this.auditHandler = (globalThis as any).embroider_audit;
     }
   }
-
+  enter(moduleName: string) {
+    let rules = this.findComponentRules(moduleName);
+    let deps: ComponentResolution[];
+    if (rules?.dependsOnComponents) {
+      deps = rules.dependsOnComponents.map(snippet => this.resolveComponentSnippet(snippet, rules!, moduleName));
+    } else {
+      deps = [];
+    }
+    return deps;
+  }
   private findComponentRules(absPath: string): PreprocessedComponentRule | undefined {
     let rules = this.rules.components.get(absPath);
     if (rules) {

--- a/packages/compat/tests/resolver.test.ts
+++ b/packages/compat/tests/resolver.test.ts
@@ -2318,7 +2318,7 @@ describe('compat-resolver', function () {
     );
   });
 
-  test.skip('respects invokes rule on a component', function () {
+  test('respects invokes rule on a component', function () {
     let packageRules: PackageRules[] = [
       {
         package: 'the-test-package',
@@ -2335,16 +2335,18 @@ describe('compat-resolver', function () {
     givenFile('components/alpha.js');
 
     expect(transform('templates/components/form-builder.hbs', `{{component this.which}}`)).toEqualCode(`
-      import "../../components/alpha.js";
-      import "./components/alpha.hbs";
+      import alpha0 from "../../components/alpha.js";
+      import alpha from "./alpha.hbs";
       import { precompileTemplate } from "@ember/template-compilation";
+      window.define("the-app/templates/components/alpha", () => alpha);
+      window.define("the-app/components/alpha", () => alpha0);
       export default precompileTemplate("{{component this.which}}", {
         moduleName: "my-app/templates/components/form-builder.hbs"
       });
     `);
   });
 
-  test.skip('respects invokes rule on a non-component app template', function () {
+  test('respects invokes rule on a non-component app template', function () {
     let packageRules: PackageRules[] = [
       {
         package: 'the-test-package',
@@ -2361,16 +2363,18 @@ describe('compat-resolver', function () {
     givenFile('components/alpha.js');
 
     expect(transform('templates/index.hbs', `{{component this.which}}`)).toEqualCode(`
-      import "../../components/alpha.js";
-      import "./components/alpha.hbs";
+      import alpha0 from "../components/alpha.js";
+      import alpha from "./components/alpha.hbs";
       import { precompileTemplate } from "@ember/template-compilation";
+      window.define("the-app/templates/components/alpha", () => alpha);
+      window.define("the-app/components/alpha", () => alpha0);
       export default precompileTemplate("{{component this.which}}", {
         moduleName: "my-app/templates/index.hbs"
       });
     `);
   });
 
-  test.skip('respects invokes rule on a non-component addon template', function () {
+  test('respects invokes rule on a non-component addon template', function () {
     let packageRules: PackageRules[] = [
       {
         package: 'my-addon',
@@ -2388,9 +2392,11 @@ describe('compat-resolver', function () {
     givenFile('components/alpha.js');
 
     expect(transform('node_modules/my-addon/templates/index.hbs', `{{component this.which}}`)).toEqualCode(`
-      import "../../components/alpha.js";
-      import "./components/alpha.hbs";
+      import alpha0 from "../../../components/alpha.js";
+      import alpha from "../../../templates/components/alpha.hbs";
       import { precompileTemplate } from "@ember/template-compilation";
+      window.define("the-app/templates/components/alpha", () => alpha);
+      window.define("the-app/components/alpha", () => alpha0);
       export default precompileTemplate("{{component this.which}}", {
         moduleName: "my-app/node_modules/my-addon/templates/index.hbs"
       });


### PR DESCRIPTION
restores enter hook on resolver to be called resolverTransform is run 
restores skipped tests and updated to match expected AMD defines

@ef4 I've kept things as similarly structured as possible to the code from 1.8.3 tag where these tests were running previously
let me know if something is out of place