### PR TITLE
Ignore resolve requests that start with !

### DIFF
--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -110,7 +110,8 @@ class WebpackModuleRequest implements ModuleRequest {
       typeof state.context === 'string' &&
       typeof state.contextInfo?.issuer === 'string' &&
       state.contextInfo.issuer !== '' &&
-      !state.request.startsWith(virtualLoaderName) // prevents recursion on requests we have already sent to our virtual loader
+      !state.request.startsWith(virtualLoaderName) && // prevents recursion on requests we have already sent to our virtual loader
+      !state.request.startsWith('!') // ignores internal webpack resolvers
     ) {
       return new WebpackModuleRequest(state);
     }

--- a/tests/scenarios/v2-addon-test.ts
+++ b/tests/scenarios/v2-addon-test.ts
@@ -22,12 +22,14 @@ appScenarios
           import Component from '@glimmer/component';
           import { hbs } from 'ember-cli-htmlbars';
           import { setComponentTemplate } from '@ember/component';
+          import './example-component.css';
           const TEMPLATE = hbs('<div data-test-example>{{this.message}}</div>')
           export default class ExampleComponent extends Component {
             message = "it worked"
           }
           setComponentTemplate(TEMPLATE, ExampleComponent);
         `,
+        'example-component.css': '/* not empty */ h1 { color: red }',
       },
       'import-from-npm.js': `
         export default async function() { 


### PR DESCRIPTION
This PR fixes an issue where the `@embroider/webpack` plugin is trying to resolve things that it probably shouldn't. This problem and the proposed solution was discussed at the webpack weekly meetings and I only have a vague understanding of the cause but I'll do my best to explain in the background section below.

**Note:** I know that this implementation is likely a bit naive and we can probably fix it a better way. 

~I will also spend a little bit of time to see if I can create a failing test that this will actually fix but I have a feeling I might need a bit of help considering I don't fully understand the issue 🙈~

Edit: this PR now has a failing test that is fixed with the implementation 🎉 

## Background

To replicate this issue you can run this reproduction repo https://github.com/mainmatter/embroider-peerdependency-bug against the current `main` of embroider. When you follow the steps in that reproduction you will get the following error: 

```
Module not found: Error: ember-welcome-page is trying to import from !.. but that is not one of its explicit dependencies
```

dropping a debugger where the error is being thrown you can check the call stack and the issue is related to the fact that the [`preHandleExternal()`](https://github.com/embroider-build/embroider/blob/4f583c9b87a6da95b59ecde0939d4177dfd15d3b/packages/core/src/module-resolver.ts#L273) is called with a `request.specifier` of the following: 

```
!../../../../../../../../../opensource/ember/embroider/node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js
```

This issue seems to have been created due to recent refactoring and the consensus seems to be that we just don't want this webpack plugin to deal with anything that starts with a `!` and it should fall back to the other resolvers in the stack. 

**Note:** we first said that we should add this to the ignore list in https://github.com/embroider-build/embroider/blob/22d54ebaebdcfe68212fff2bae0161b27b29a43c/packages/webpack/src/webpack-resolver-plugin.ts#L108 but that function seems to have been removed in recent refactorings 🙃 

When I first came across this bug I was able to identify that it was first introduced in this commit:  https://github.com/embroider-build/embroider/commit/6f56f0dddd8478f4a81ae2cc34dce9405c566db3 which is titled `improved self-name resolution`. I'm not sure exactly what this is trying to do 🤷 but it's the info I was able to glean.
