### PR TITLE
Enter unstable prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,30 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@embroider/addon-dev": "3.0.0",
+    "@embroider/addon-shim": "1.8.4",
+    "@embroider/babel-loader-8": "2.0.0",
+    "@embroider/compat": "2.1.1",
+    "@embroider/core": "2.1.1",
+    "@embroider/hbs-loader": "2.0.0",
+    "@embroider/macros": "1.10.0",
+    "@embroider/router": "2.0.0",
+    "@embroider/shared-internals": "2.0.0",
+    "@embroider/test-setup": "2.1.1",
+    "@embroider/util": "1.10.0",
+    "@embroider/webpack": "2.1.1",
+    "@embroider/sample-transforms": "0.0.0",
+    "@embroider/test-support": "0.36.0",
+    "addon-template": "0.0.0",
+    "app-template": "0.0.0",
+    "@embroider/test-scenarios": "0.0.5",
+    "ts-app-template": "0.0.0",
+    "v2-addon-template": "0.0.1",
+    "@types/babel__traverse": "7.0.6",
+    "@types/broccoli-concat": "0.0.0",
+    "@types/broccoli-funnel": "0.0.0",
+    "@types/ember-cli-htmlbars": "0.0.0"
+  },
+  "changesets": []
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,6 +1,6 @@
 {
   "mode": "pre",
-  "tag": "beta",
+  "tag": "unstable",
   "initialVersions": {
     "@embroider/addon-dev": "3.0.0",
     "@embroider/addon-shim": "1.8.4",


### PR DESCRIPTION
This PR tells `changesets` to enter _pre-release mode_.
(via `yarn changeset pre enter unstable`)
Because _unstable_ is used as the tag, this will use the `unstable` tag on npm 

The main potential downside to _unstable mode_ is that GitHub releases are still made..

Once this PR is merged, and https://github.com/embroider-build/embroider/pull/1360 is merged,
the GitHub Actions automated PR will create a "Release Preview PR" for "unstable" versions of all the affected packages.

When we're ready to exit unstable, we can run `yarn changeset pre exit`, and GitHub actions will open a "Release Preview PR" that will show what the versions will be for all the affected packages and also delete the .changeset/*.md files