### PR TITLE
clarify which package rules apply inside vs outside a component

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16130,11 +16130,6 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack-virtual-modules@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz#362f14738a56dae107937ab98ea7062e8bdd3b6c"
-  integrity sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==
-
 webpack@^5, webpack@^5.38.1, webpack@^5.72.1, webpack@^5.74.0:
   version "5.75.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.75.0.tgz#1e440468647b2505860e94c9ff3e44d5b582c152"


### PR DESCRIPTION
Previously we were keying all component rules off the actual on-disk file for that component, even when those rules were being consume at *invocation sites* of the component rather than inside the component itself. This meant that we could not apply those rules if we move component resolution out of the AST transform stage.

But it's actually OK to key the exterior rules off the component's globally-addressable (or at least engine-scoped) name, since the point of the rules is to control classic global resolution.

This is an extraction from findings in #1357. I want to land some smaller steps from that work separately to keep green tests at each point.