### PR TITLE
Simplified template resolution

### DIFF
--- a/packages/compat/tests/audit.test.ts
+++ b/packages/compat/tests/audit.test.ts
@@ -28,7 +28,6 @@ describe('audit', function () {
     const resolvableExtensions = ['.js', '.hbs'];
 
     let resolverConfig: CompatResolverOptions = {
-      emberVersion: emberTemplateCompiler().version,
       appRoot: app.baseDir,
       modulePrefix: 'audit-this-app',
       options: {
@@ -42,6 +41,13 @@ describe('audit', function () {
       renameModules: {},
       extraImports: [],
       activeAddons: {},
+      engines: [
+        {
+          packageName: 'audit-this-app',
+          activeAddons: [],
+          root: app.baseDir,
+        },
+      ],
       relocatedFiles: {},
       resolvableExtensions,
     };
@@ -53,7 +59,6 @@ describe('audit', function () {
 
     let transformOpts: ResolverTransformOptions = {
       appRoot: resolverConfig.appRoot,
-      emberVersion: resolverConfig.emberVersion,
     };
     let transform: Transform = [require.resolve('../src/resolver-transform'), transformOpts];
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   ResolverFunction,
   SyncResolverFunction,
 } from './module-resolver';
+export { virtualContent } from './virtual-content';
 export type { Engine } from './app-files';
 
 // this is reexported because we already make users manage a peerDep from some

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -1,0 +1,85 @@
+import { compile } from './js-handlebars';
+
+const externalPrefix = '/@embroider/external/';
+const amdComponentShimMarker = '?embroider-amd-component';
+
+// NEXT Action: can we get our general virtual file support to look like it's in
+// a place in the filesystem? Possibly our resolver can notice when requests are
+// coming from one of our virtual modules and rehome them.
+const amdComponentShimPattern = /(?<payload>[^\/]+)\?embroider-amd-component$/;
+
+// Given a filename that was passed to your ModuleRequest's `virtualize()`,
+// this produces the corresponding contents. It's a static, stateless function
+// because we recognize that that process that did resolution might not be the
+// same one that loads the content.
+export function virtualContent(filename: string): string {
+  if (filename.startsWith(externalPrefix)) {
+    return externalShim({ moduleName: filename.slice(externalPrefix.length) });
+  }
+  let match = amdComponentShimPattern.exec(filename);
+  if (match) {
+    let [hbsSpecifier, hbsRuntime, jsSpecifier, jsRuntime] = JSON.parse(decodeURIComponent(match.groups!.payload)) as [
+      string,
+      string,
+      string | undefined,
+      string | undefined
+    ];
+    return amdComponentShim({ hbsSpecifier, hbsRuntime, jsSpecifier, jsRuntime });
+  }
+  throw new Error(`not an @embroider/core virtual file: ${filename}`);
+}
+
+const externalShim = compile(`
+{{#if (eq moduleName "require")}}
+const m = window.requirejs;
+{{else}}
+const m = window.require("{{{js-string-escape moduleName}}}");
+{{/if}}
+{{!-
+  There are plenty of hand-written AMD defines floating around
+  that lack this, and they will break when other build systems
+  encounter them.
+
+  As far as I can tell, Ember's loader was already treating this
+  case as a module, so in theory we aren't breaking anything by
+  marking it as such when other packagers come looking.
+
+  todo: get review on this part.
+-}}
+if (m.default && !m.__esModule) {
+  m.__esModule = true;
+}
+module.exports = m;
+`) as (params: { moduleName: string }) => string;
+
+const amdComponentShim = compile(`
+import template from "{{{js-string-escape hbsSpecifier}}}";
+window.define("{{{js-string-escape hbsRuntime}}}", () => template);
+{{#if jsSpecifier}}
+import component from "{{{js-string-escape jsSpecifier}}}";
+window.define("{{{js-string-escape jsRuntime}}}", () => template);
+{{/if}}
+export default todoLoadCurriedComponent();
+`) as (params: {
+  hbsSpecifier: string;
+  hbsRuntime: string;
+  jsSpecifier: string | undefined;
+  jsRuntime: string | undefined;
+}) => string;
+
+export function virtualExternalModule(specifier: string): string {
+  return externalPrefix + specifier;
+}
+
+export function virtualAMDComponent(
+  fromFile: string,
+  hbsModule: { specifier: string; runtime: string },
+  jsModule: { specifier: string; runtime: string } | null
+): string {
+  let payload = [hbsModule.specifier, hbsModule.runtime];
+  if (jsModule) {
+    payload.push(jsModule.specifier);
+    payload.push(jsModule.runtime);
+  }
+  return `${fromFile}/${encodeURIComponent(JSON.stringify(payload))}${amdComponentShimMarker}`;
+}

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -30,6 +30,7 @@
     "css-loader": "^5.2.6",
     "csso": "^4.2.0",
     "debug": "^4.3.2",
+    "escape-string-regexp": "^4.0.0",
     "fs-extra": "^9.1.0",
     "jsdom": "^16.6.0",
     "lodash": "^4.17.21",

--- a/packages/webpack/src/virtual-loader.ts
+++ b/packages/webpack/src/virtual-loader.ts
@@ -1,10 +1,9 @@
-import { Resolver } from '@embroider/core';
+import { virtualContent } from '@embroider/core';
 import { LoaderContext } from 'webpack';
 
 export default function virtualLoader(this: LoaderContext<unknown>) {
-  let filename = this.loaders[this.loaderIndex].options;
-  if (typeof filename === 'string') {
-    return Resolver.virtualContent(filename);
+  if (typeof this.query === 'string' && this.query[0] === '?') {
+    return virtualContent(this.query.slice(1));
   }
-  throw new Error(`@embroider/webpack/src/virtual-loader received unexpected request: ${filename}`);
+  throw new Error(`@embroider/webpack/src/virtual-loader received unexpected request: ${this.query}`);
 }

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -163,6 +163,8 @@ class WebpackModuleRequest implements ModuleRequest {
     return new WebpackModuleRequest(this.state) as this;
   }
   virtualize(filename: string) {
-    return this.alias(`${virtualLoaderName}?${filename}!`);
+    let next = this.alias(`${virtualLoaderName}?${filename}!`);
+    next.isVirtual = true;
+    return next;
   }
 }

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -8,10 +8,13 @@ import {
 } from '@embroider/core';
 import type { Compiler, Module } from 'webpack';
 import assertNever from 'assert-never';
+import escapeRegExp from 'escape-string-regexp';
 
 export { EmbroiderResolverOptions as Options };
 
 const virtualLoaderName = '@embroider/webpack/src/virtual-loader';
+const virtualLoaderPath = resolve(__dirname, './virtual-loader.js');
+const virtualRequestPattern = new RegExp(`^${escapeRegExp(virtualLoaderPath)}\\?(?<filename>.+)!`);
 
 export class EmbroiderPlugin {
   #resolver: EmbroiderResolver;
@@ -34,7 +37,7 @@ export class EmbroiderPlugin {
   }
 
   apply(compiler: Compiler) {
-    this.#addLoaderAlias(compiler, virtualLoaderName, resolve(__dirname, './virtual-loader'));
+    this.#addLoaderAlias(compiler, virtualLoaderName, virtualLoaderPath);
 
     compiler.hooks.normalModuleFactory.tap('@embroider/webpack', nmf => {
       let defaultResolve = getDefaultResolveHook(nmf.hooks.resolve.taps);
@@ -105,6 +108,20 @@ class WebpackModuleRequest implements ModuleRequest {
   fromFile: string;
 
   static from(state: any): WebpackModuleRequest | undefined {
+    // when the files emitted from our virtual-loader try to import things,
+    // those requests show in webpack as having no issuer. But we can see here
+    // which requests they are and adjust the issuer so they resolve things from
+    // the correct logical place.
+    if (!state.contextInfo?.issuer && Array.isArray(state.dependencies)) {
+      for (let dep of state.dependencies) {
+        let match = virtualRequestPattern.exec(dep._parentModule?.userRequest);
+        if (match) {
+          state.contextInfo.issuer = match.groups!.filename;
+          state.context = dirname(state.contextInfo.issuer);
+        }
+      }
+    }
+
     if (
       typeof state.request === 'string' &&
       typeof state.context === 'string' &&
@@ -146,7 +163,6 @@ class WebpackModuleRequest implements ModuleRequest {
     return new WebpackModuleRequest(this.state) as this;
   }
   virtualize(filename: string) {
-    this.state.request = `${virtualLoaderName}?${filename}!`;
-    return new WebpackModuleRequest(this.state, true) as this;
+    return this.alias(`${virtualLoaderName}?${filename}!`);
   }
 }


### PR DESCRIPTION
This is another extraction from the work in #1357.

It should be able to complete the "stretch goal" described in https://github.com/embroider-build/embroider/pull/1339 by eliminating all real module resolution in our template transform.

I noticed that https://github.com/emberjs/ember.js/pull/19878 got back ported to Ember 3.28, so I don't think we need to keep our workaround for it anymore, and dropping the workaround made this work easier.