### PR TITLE
Improve types of `ensure-safe-component` helper

### DIFF
--- a/.changeset/plenty-chairs-relate.md
+++ b/.changeset/plenty-chairs-relate.md
@@ -1,0 +1,10 @@
+---
+'@embroider/util': patch
+---
+
+Improve types of `ensure-safe-component` helper
+
+This will improve the Glint type of `ensure-safe-component` in two ways:
+
+- when a component class is passed, the return type will _not_ get narrowed down to an (mostly unusable) `ComponentLike<unknown>`, but to the type of the passed component itself
+- when a string is passed that has an entry in the `@glint/environment-ember-loose` template registry, then the registered type will be returned instead of again `ComponentLike<unknown>`

--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -1,10 +1,15 @@
 import { ComponentLike } from '@glint/template';
+import TemplateRegistry from '@glint/environment-ember-loose/registry';
 import Helper from '@ember/component/helper';
 
 export function ensureSafeComponent<C extends string | ComponentLike<any>>(
   component: C,
   thingWithOwner: unknown
-): C extends string ? ComponentLike<unknown> : C;
+): C extends keyof TemplateRegistry
+  ? TemplateRegistry[C]
+  : C extends string
+  ? ComponentLike<unknown>
+  : C;
 
 export class EnsureSafeComponentHelper<
   C extends string | ComponentLike<any>
@@ -12,5 +17,9 @@ export class EnsureSafeComponentHelper<
   Args: {
     Positional: [component: C];
   };
-  Return: C extends string ? ComponentLike<unknown> : C;
+  Return: C extends keyof TemplateRegistry
+    ? TemplateRegistry[C]
+    : C extends string
+    ? ComponentLike<unknown>
+    : C;
 }> {}

--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -1,14 +1,13 @@
 import { ComponentLike } from '@glint/template';
 import Helper from '@ember/component/helper';
 
-export function ensureSafeComponent<C extends string | ComponentLike<S>, S>(
+export function ensureSafeComponent<C extends string | ComponentLike<any>>(
   component: C,
   thingWithOwner: unknown
 ): C extends string ? ComponentLike<unknown> : C;
 
 export class EnsureSafeComponentHelper<
-  C extends string | ComponentLike<S>,
-  S
+  C extends string | ComponentLike<any>
 > extends Helper<{
   Args: {
     Positional: [component: C];

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -33,10 +33,14 @@
   },
   "peerDependencies": {
     "ember-source": "*",
-    "@glint/template": "^1.0.0-beta.1"
+    "@glint/template": "^1.0.0-beta.3",
+    "@glint/environment-ember-loose": "^1.0.0-beta.3"
   },
   "peerDependenciesMeta": {
     "@glint/template": {
+      "optional": true
+    },
+    "@glint/environment-ember-loose": {
       "optional": true
     }
   },
@@ -52,7 +56,8 @@
     "@embroider/webpack": "2.1.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@glint/template": "^1.0.0-beta.1",
+    "@glint/template": "^1.0.0-beta.3",
+    "@glint/environment-ember-loose": "^1.0.0-beta.3",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,10 +1882,15 @@
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
-"@glint/template@^1.0.0-beta.1":
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@glint/template/-/template-1.0.0-beta.2.tgz#ed13ca4f0e6c616579d9eb9c6b11eac49899c742"
-  integrity sha512-gaWiWAjvmgOTmHUqXt+fACINMSnOxKcPYEwb6A6DNYpCaKWxhxqIjIrQLdrumULLK9+MbxMrIa3Od05FcIDQFQ==
+"@glint/environment-ember-loose@^1.0.0-beta.3":
+  version "1.0.0-beta.3"
+  resolved "https://registry.npmjs.org/@glint/environment-ember-loose/-/environment-ember-loose-1.0.0-beta.3.tgz#aade64eca87a3802b1068f1d7dd6be429117fb6e"
+  integrity sha512-Aby8penf3PB2VJrp9Ni33ZAcmFz8OpZ3wA2rz9DirOQhGrdDoTxcvNli6wu0R/NBqjjgKhM2WGzbxJ8NRdfdxA==
+
+"@glint/template@^1.0.0-beta.3":
+  version "1.0.0-beta.3"
+  resolved "https://registry.npmjs.org/@glint/template/-/template-1.0.0-beta.3.tgz#5866c0ffc1d8273f2e9b2fd186b65f5d4e6dbc15"
+  integrity sha512-jxn4yGzNZ1A4NGzvjYht0NlVziHyzjj/rm4rGsP1mVUO2Dd/LHhhxR6NUlSw9MFDZ0fCinULVwQtAKQLEpIpPw==
 
 "@handlebars/parser@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
This will improve the Glint type of `ensure-safe-component` in two ways:

- when a component class is passed, the return type will _not_ get narrowed down to an (mostly unusable) `ComponentLike<unknown>`, but to the type of the passed component itself

  For more context see @dfreeman's [comment here](https://github.com/typed-ember/glint/issues/518#issuecomment-1400306133) 

- when a string is passed that has an entry in the `@glint/environment-ember-loose` template registry, then the registered type will be returned instead of again `ComponentLike<unknown>`

Fixes https://github.com/typed-ember/glint/issues/518

This has no test coverage here, as we don't have any type testing infrastructure set up. But I tested this locally in a Glint-enabled project using `yalc`, and both changes seem to work fine! 

Would still love a review from either @dfreeman or @chriskrycho to be sure! 🙏