### PR TITLE
Add support for keeping public assets and ember-addon.public-assets meta in sync

### DIFF
--- a/packages/addon-dev/src/rollup-public-assets.ts
+++ b/packages/addon-dev/src/rollup-public-assets.ts
@@ -2,18 +2,25 @@ import { readJsonSync, writeJsonSync } from 'fs-extra';
 import walkSync from 'walk-sync';
 import type { Plugin } from 'rollup';
 
-export default function publicAssets(opts: { exclude: string[] }): Plugin {
+export default function publicAssets(
+  path: string,
+  opts: { include: string[]; exclude: string[] }
+): Plugin {
+  const includeGlobPatterns = opts?.include;
+  const excludedGlobPatterns = opts?.exclude || [];
+
   return {
     name: 'public-assets-bundler',
     generateBundle() {
       let pkg = readJsonSync('package.json');
-      const filenames = walkSync('public', {
+      const filenames = walkSync(path, {
         directories: false,
-        ignore: opts?.exclude || [],
+        globs: includeGlobPatterns,
+        ignore: excludedGlobPatterns,
       });
       const publicAssets: Record<string, string> = filenames.reduce(
         (acc: Record<string, string>, v): Record<string, string> => {
-          acc['./public/' + v] = ['/', pkg.name, '/', v].join('');
+          acc[`./${path}/${v}`] = ['/', pkg.name, '/', path, '/', v].join('');
           return acc;
         },
         {}

--- a/packages/addon-dev/src/rollup-public-reexports.ts
+++ b/packages/addon-dev/src/rollup-public-reexports.ts
@@ -7,13 +7,10 @@ export default function publicAssets(opts: { exclude: string[] }): Plugin {
     name: 'public-assets-bundler',
     generateBundle() {
       let pkg = readJsonSync('package.json');
-      let filenames;
-
-      filenames = walkSync('public', {
+      const filenames = walkSync('public', {
         directories: false,
-        ignore: opts.exclude || [],
+        ignore: opts?.exclude || [],
       });
-
       const publicAssets: Record<string, string> = filenames.reduce(
         (acc: Record<string, string>, v): Record<string, string> => {
           acc['./public/' + v] = ['/', pkg.name, '/', v].join('');

--- a/packages/addon-dev/src/rollup-public-reexports.ts
+++ b/packages/addon-dev/src/rollup-public-reexports.ts
@@ -1,0 +1,32 @@
+import { readJsonSync, writeJsonSync } from 'fs-extra';
+import walkSync from 'walk-sync';
+import type { Plugin } from 'rollup';
+
+export default function publicAssets(opts: { exclude: string[] }): Plugin {
+  return {
+    name: 'public-assets-bundler',
+    generateBundle() {
+      let pkg = readJsonSync('package.json');
+      let filenames;
+
+      filenames = walkSync('public', {
+        directories: false,
+        ignore: opts.exclude || [],
+      });
+
+      const publicAssets: Record<string, string> = filenames.reduce(
+        (acc: Record<string, string>, v): Record<string, string> => {
+          acc['./public/' + v] = ['/', pkg.name, '/', v].join('');
+          return acc;
+        },
+        {}
+      );
+
+      pkg['ember-addon'] = Object.assign({}, pkg['ember-addon'], {
+        'public-assets': publicAssets,
+      });
+
+      writeJsonSync('package.json', pkg, { spaces: 2 });
+    },
+  };
+}

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -85,7 +85,7 @@ export class Addon {
     return dependencies();
   }
 
-  publicAssets(path: string, opts: { include: string[], exclude: string[] }) {
+  publicAssets(path: string, opts: { include: string[]; exclude: string[] }) {
     return publicAssets(path, opts);
   }
 }

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -4,7 +4,7 @@ import { default as appReexports } from './rollup-app-reexports';
 import { default as clean } from 'rollup-plugin-delete';
 import { default as keepAssets } from './rollup-keep-assets';
 import { default as dependencies } from './rollup-addon-dependencies';
-import { default as publicReexports } from './rollup-public-reexports';
+import { default as publicAssets } from './rollup-public-assets';
 import type { Plugin } from 'rollup';
 
 export class Addon {
@@ -85,7 +85,7 @@ export class Addon {
     return dependencies();
   }
 
-  publicAssets(opts: { exclude: string[] }) {
-    return publicReexports(opts);
+  publicAssets(path: string, opts: { include: string[], exclude: string[] }) {
+    return publicAssets(path, opts);
   }
 }

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -4,6 +4,7 @@ import { default as appReexports } from './rollup-app-reexports';
 import { default as clean } from 'rollup-plugin-delete';
 import { default as keepAssets } from './rollup-keep-assets';
 import { default as dependencies } from './rollup-addon-dependencies';
+import { default as publicReexports } from './rollup-public-reexports';
 import type { Plugin } from 'rollup';
 
 export class Addon {
@@ -82,5 +83,9 @@ export class Addon {
 
   dependencies() {
     return dependencies();
+  }
+
+  publicAssets(opts: { exclude: string[] }) {
+    return publicReexports(opts);
   }
 }


### PR DESCRIPTION
While migrating an addon to the v2 format, I noticed that we need to declare the files from the `public` directory in the `ember-addon.public-assets` meta in the package.json, which is easy if there isn't much of them, but can get out of hand quickly (I have a couple addons providing a lot of assets to the parent app)

This adds support for keeping an addon's package.json `ember-addon.public-assets` meta in sync with the `public` directory by default.

By passing `opts.exclude` (glob pattern array), you can still ignore some of the files if needed.

```javascript
export default {
  output: addon.output(),

  plugins: [
    addon.publicEntrypoints([]),

   // Other plugins declared in the samples

    addon.publicAssets('assets'), // Or addon.publicAssets('assets', { include: ['**/*.svg'], exclude: ['**/*.png'] }) to skip all PNG files and include SVG ones
  ]
};

```