### PR TITLE
Add semverRange <=4.11.0 for ember-data

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-data.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-data.ts
@@ -3,6 +3,7 @@ import { PackageRules } from '..';
 let rules: PackageRules[] = [
   {
     package: '@ember-data/store',
+    semverRange: '<=4.11.0',
     addonModules: {
       '-private.js': {
         dependsOnModules: ['@ember-data/record-data/-private'],

--- a/packages/compat/src/compat-adapters/ember-data.ts
+++ b/packages/compat/src/compat-adapters/ember-data.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { Memoize } from 'typescript-memoize';
 import { Node } from 'broccoli-node-api';
 import { sync as resolveSync } from 'resolve';
+import semver from 'semver';
 
 export class EmberDataBase extends V1Addon {
   // May of the ember-data packages use rollup to try to hide their internal
@@ -13,6 +14,10 @@ export class EmberDataBase extends V1Addon {
   // behavior is correct.
   customizes(...names: string[]) {
     return super.customizes(...names.filter(n => n !== 'treeForAddon'));
+  }
+
+  static shouldApplyAdapter(addonInstance: any) {
+    return semver.lt(addonInstance.pkg.version, '4.11.1');
   }
 }
 


### PR DESCRIPTION
fix #1322

Starting with ember-data `v4.11.1` there is not anymore necessary to add package rules (https://github.com/emberjs/data/pull/8427)