### PR TITLE
restore component invokes rules support

### DIFF
--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -67,11 +67,10 @@ interface InternalModule {
     isCJS: boolean;
     isAMD: boolean;
     dependencies: string[];
+    transpiledContent: string | Buffer;
   };
 
   resolved?: Map<string, string | ResolutionFailure>;
-
-  content?: string | Buffer;
 
   linked?: {
     exports: Set<string>;
@@ -140,7 +139,7 @@ export class AuditResults {
             }))
           : [],
         exports: module.linked?.exports ? [...module.linked.exports] : [],
-        content: module.content ? module.content.toString() : '',
+        content: module.parsed?.transpiledContent ? module.parsed?.transpiledContent.toString() : '',
       };
       results.modules[explicitRelative(baseDir, filename)] = publicModule;
     }
@@ -332,7 +331,6 @@ export class Audit {
       } else {
         module.parsed = visitResult;
         module.resolved = await this.resolveDeps(visitResult.dependencies, filename);
-        module.content = content;
       }
     }
   }
@@ -479,6 +477,7 @@ export class Audit {
       isCJS: false,
       isAMD: false,
       dependencies,
+      transpiledContent: content,
     };
   }
 
@@ -504,6 +503,7 @@ export class Audit {
         isCJS: result.isCJS,
         isAMD: result.isAMD,
         dependencies: result.imports.map(i => i.source),
+        transpiledContent: result.transpiledContent,
       };
     } catch (err) {
       if (['BABEL_PARSE_ERROR', 'BABEL_TRANSFORM_ERROR'].includes(err.code)) {

--- a/packages/compat/src/audit/babel-visitor.ts
+++ b/packages/compat/src/audit/babel-visitor.ts
@@ -41,10 +41,10 @@ export function auditJS(rawSource: string, filename: string, babelConfig: Transf
   let sawDefine: boolean = false;
   /* eslint-enable @typescript-eslint/no-inferrable-types */
 
-  let ast = transformSync(rawSource, Object.assign({ filename: filename }, babelConfig))!.ast!;
+  let { ast, code } = transformSync(rawSource, Object.assign({ filename: filename }, babelConfig))!;
   let saveCodeFrame = frames.forSource(rawSource);
 
-  traverse(ast, {
+  traverse(ast!, {
     Identifier(path: NodePath<t.Identifier>) {
       if (path.node.name === 'module' && isFreeVariable(path)) {
         sawModule = true;
@@ -154,7 +154,7 @@ export function auditJS(rawSource: string, filename: string, babelConfig: Transf
 
   let isCJS = imports.length === 0 && exports.size === 0 && (sawModule || sawExports);
   let isAMD = imports.length === 0 && exports.size === 0 && sawDefine;
-  return { imports, exports, isCJS, isAMD, problems };
+  return { imports, exports, isCJS, isAMD, problems, transpiledContent: code! };
 }
 
 export class CodeFrameStorage {

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -308,6 +308,16 @@ class TemplateResolver implements ASTPlugin {
           let processedRules = preprocessComponentRule(rules);
           let dasherizedName = this.standardDasherize(snippet, rule);
           components.set(dasherizedName, processedRules);
+          if (rules.layout) {
+            for (let root of rule.roots) {
+              if (rules.layout.addonPath) {
+                files.set(join(root, rules.layout.addonPath), processedRules);
+              }
+              if (rules.layout.appPath) {
+                files.set(join(root, rules.layout.appPath), processedRules);
+              }
+            }
+          }
         }
       }
       if (rule.appTemplates) {

--- a/packages/compat/tests/audit.test.ts
+++ b/packages/compat/tests/audit.test.ts
@@ -316,23 +316,21 @@ describe('audit', function () {
     expect(Object.keys(result.modules).length).toBe(3);
   });
 
-  test.skip('finds missing component in standalone hbs', async function () {
+  test('finds missing component in standalone hbs', async function () {
     merge(app.files, {
       'hello.hbs': `<NoSuchThing />`,
     });
     let result = await audit();
     expect(withoutCodeFrames(result.findings)).toEqual([
       {
-        message: 'Missing component',
-        detail: 'NoSuchThing',
+        message: 'unable to resolve dependency',
+        detail: '#embroider_compat/components/no-such-thing',
         filename: './hello.hbs',
       },
     ]);
-    expect(result.findings[0].codeFrame).toBeDefined();
-    expect(Object.keys(result.modules).length).toBe(3);
   });
 
-  test.skip('finds missing component in inline hbs', async function () {
+  test('finds missing component in inline hbs', async function () {
     merge(app.files, {
       'app.js': `
         import { hbs } from 'ember-cli-htmlbars';
@@ -342,16 +340,14 @@ describe('audit', function () {
     let result = await audit();
     expect(withoutCodeFrames(result.findings)).toEqual([
       {
-        message: 'Missing component',
-        detail: 'NoSuchThing',
+        message: 'unable to resolve dependency',
+        detail: '#embroider_compat/components/no-such-thing',
         filename: './app.js',
       },
     ]);
-    expect(result.findings[0].codeFrame).toBeDefined();
-    expect(Object.keys(result.modules).length).toBe(2);
   });
 
-  test.skip('traverse through template even when it has some errors', async function () {
+  test('traverse through template even when it has some errors', async function () {
     merge(app.files, {
       'hello.hbs': `<NoSuchThing /><Second />`,
       components: {
@@ -363,12 +359,12 @@ describe('audit', function () {
     let result = await audit();
     expect(withoutCodeFrames(result.findings)).toEqual([
       {
-        message: 'Missing component',
-        detail: 'NoSuchThing',
+        message: 'unable to resolve dependency',
+        detail: '#embroider_compat/components/no-such-thing',
         filename: './hello.hbs',
       },
     ]);
-    expect(Object.keys(result.modules).length).toBe(4);
+    expect(Object.keys(result.modules)).toContain('./components/second.js');
   });
 
   test('failure to parse JS is reported and does not cause cascading errors', async function () {

--- a/packages/shared-internals/src/index.ts
+++ b/packages/shared-internals/src/index.ts
@@ -1,5 +1,5 @@
 export { AppMeta, AddonMeta, PackageInfo } from './metadata';
-export { explicitRelative, extensionsPattern } from './paths';
+export { explicitRelative, extensionsPattern, unrelativize } from './paths';
 export { getOrCreate } from './get-or-create';
 export { default as Package, V2AddonPackage as AddonPackage, V2AppPackage as AppPackage, V2Package } from './package';
 export { default as PackageCache } from './package-cache';

--- a/packages/shared-internals/src/paths.ts
+++ b/packages/shared-internals/src/paths.ts
@@ -1,4 +1,5 @@
-import { relative, isAbsolute, dirname, join, basename } from 'path';
+import { relative, isAbsolute, dirname, join, basename, resolve } from 'path';
+import type Package from './package';
 
 // by "explicit", I mean that we want "./local/thing" instead of "local/thing"
 // because
@@ -28,4 +29,11 @@ export function explicitRelative(fromDir: string, toFile: string) {
 // in those extensions.
 export function extensionsPattern(extensions: string[]): RegExp {
   return new RegExp(`(${extensions.map(e => `${e.replace('.', '\\.')}`).join('|')})$`, 'i');
+}
+
+export function unrelativize(pkg: Package, specifier: string, fromFile: string) {
+  if (pkg.packageJSON.exports) {
+    throw new Error(`unsupported: classic ember packages cannot use package.json exports`);
+  }
+  return resolve(dirname(fromFile), specifier).replace(pkg.root, pkg.name);
 }

--- a/packages/shared-internals/src/paths.ts
+++ b/packages/shared-internals/src/paths.ts
@@ -1,4 +1,4 @@
-import { relative, isAbsolute, dirname, join, basename, resolve } from 'path';
+import { relative, isAbsolute, dirname, join, basename, resolve, sep } from 'path';
 import type Package from './package';
 
 // by "explicit", I mean that we want "./local/thing" instead of "local/thing"
@@ -33,7 +33,11 @@ export function extensionsPattern(extensions: string[]): RegExp {
 
 export function unrelativize(pkg: Package, specifier: string, fromFile: string) {
   if (pkg.packageJSON.exports) {
-    throw new Error(`unsupported: classic ember packages cannot use package.json exports`);
+    throw new Error(`unsupported: engines cannot use package.json exports`);
   }
-  return resolve(dirname(fromFile), specifier).replace(pkg.root, pkg.name);
+  let result = resolve(dirname(fromFile), specifier).replace(pkg.root, pkg.name);
+  if (sep !== '/') {
+    result = result.split(sep).join('/');
+  }
+  return result;
 }

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -10,7 +10,7 @@ import { Project, Scenarios } from 'scenario-tester';
 import { CompatResolverOptions } from '@embroider/compat/src/resolver-transform';
 import { PackageRules } from '@embroider/compat';
 
-const { module: Qmodule, test, skip } = QUnit;
+const { module: Qmodule, test } = QUnit;
 
 Scenarios.fromProject(() => new Project())
   .map('compat-resolver-test', app => {
@@ -1887,7 +1887,7 @@ Scenarios.fromProject(() => new Project())
         );
       });
 
-      skip('respects invokes rule on a component', async function () {
+      test('respects invokes rule on a component', async function () {
         givenFiles({
           'components/my-thing.hbs': `{{component this.which}}`,
         });
@@ -1906,9 +1906,9 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('components/my-thing.hbs').equalsCode(`
           window.define("my-app/components/alpha", function () {
-            return _ref0;
+            return importSync("#embroider_compat/components/alpha");
           });
-          import _ref0 from "#embroider_compat/components/alpha";
+          import { importSync } from "@embroider/macros";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{component this.which}}", {
             moduleName: "my-app/components/my-thing.hbs"

--- a/tests/scenarios/compat-stage2-test.ts
+++ b/tests/scenarios/compat-stage2-test.ts
@@ -12,7 +12,7 @@ import merge from 'lodash/merge';
 import QUnit from 'qunit';
 import { setupAuditTest } from '@embroider/test-support/audit-assertions';
 
-const { module: Qmodule, test, skip } = QUnit;
+const { module: Qmodule, test } = QUnit;
 
 let stage2Scenarios = appScenarios.map('compat-stage2-build', app => {
   renameApp(app, 'my-app');
@@ -467,7 +467,7 @@ stage2Scenarios
 
       let expectAudit = setupAuditTest(hooks, () => app.dir);
 
-      skip('no audit issues', function () {
+      test('no audit issues', function () {
         // among other things, this is asserting that dynamicComponent in
         // hello-world.hbs is not an error because the rules covered it
         expectAudit.hasNoFindings();
@@ -511,7 +511,7 @@ stage2Scenarios
           .isTemplateOnlyComponent('./templates/components/first-choice.hbs');
       });
 
-      skip('addon/hello-world.js', function () {
+      test('addon/hello-world.js', function () {
         let assertFile = expectFile('node_modules/my-addon/components/hello-world.js').transform(build.transpile);
         assertFile.matches(
           /window\.define\(["']\my-addon\/synthetic-import-1["'],\s*function\s\(\)\s*\{\s*return\s+esc\(require\(["']\.\.\/synthetic-import-1/
@@ -521,7 +521,7 @@ stage2Scenarios
         );
       });
 
-      skip('app/hello-world.js', function () {
+      test('app/hello-world.js', function () {
         let assertFile = expectFile('./components/hello-world.js').transform(build.transpile);
         assertFile.matches(
           /window\.define\(["']\my-addon\/synthetic-import-1["'],\s*function\s\(\)\s*\{\s*return\s+esc\(require\(["']\.\.\/node_modules\/my-addon\/synthetic-import-1/


### PR DESCRIPTION
This unskips some tests that were disabled in #1363 by finishing the new implementation of the component.invokes packageRule.