### PR TITLE
don't confuse webpack requests with packageNames

### DIFF
--- a/packages/shared-internals/src/package-name.ts
+++ b/packages/shared-internals/src/package-name.ts
@@ -1,8 +1,16 @@
 import { isAbsolute } from 'path';
 
 export default function absolutePackageName(specifier: string): string | undefined {
-  if (specifier[0] === '.' || isAbsolute(specifier)) {
-    // Not an absolute specifier
+  if (
+    // relative paths:
+    specifier[0] === '.' ||
+    // webpack-specific microsyntax for internal requests:
+    specifier[0] === '!' ||
+    specifier[0] === '-' ||
+    // absolute paths:
+    isAbsolute(specifier)
+  ) {
+    // Does not refer to a package
     return;
   }
   let parts = specifier.split('/');


### PR DESCRIPTION
This came up in ember-auto-import, which uses this utility, but it's probably relevant to embroider too.

We use `packageName` to tests whether a given module specifier is trying to address an NPM package. It shouldn't treat `!../../whatever!../stuff` as containing a package named `!..`.

I tried to use [validate-npm-package-name](https://github.com/npm/validate-npm-package-name/) for this, but it turns out a lot of very weird names are actually totally legal from its perspective, so I'm going with the more narrow case of identifying known prefix characters that webpack injects.