### PR TITLE
Rename strict flag to strictMode

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -22,7 +22,7 @@ import { camelCase, mergeWith } from 'lodash';
 type Env = WithJSUtils<ASTPluginEnvironment> & {
   filename: string;
   contents: string;
-  strict?: boolean;
+  strictMode?: boolean;
   locals?: string[];
 };
 
@@ -473,17 +473,17 @@ class TemplateResolver implements ASTPlugin {
 
       2. Have a mustache statement like: `{{something}}`, where `something` is:
 
-        a. Not a variable in scope (for example, there's no preceeding line 
+        a. Not a variable in scope (for example, there's no preceeding line
            like `<Parent as |something|>`)
         b. Does not start with `@` because that must be an argument from outside this template.
-        c. Does not contain a dot, like `some.thing` (because that case is classically 
+        c. Does not contain a dot, like `some.thing` (because that case is classically
            never a global component resolution that we would need to handle)
-        d. Does not start with `this` (this rule is mostly redundant with the previous rule, 
+        d. Does not start with `this` (this rule is mostly redundant with the previous rule,
            but even a standalone `this` is never a component invocation).
-        e. Does not have any arguments. If there are argument like `{{something a=b}}`, 
-           there is still ambiguity between helper vs component, but there is no longer 
+        e. Does not have any arguments. If there are argument like `{{something a=b}}`,
+           there is still ambiguity between helper vs component, but there is no longer
            the possibility that this was just rendering some data.
-        f. Does not take a block, like `{{#something}}{{/something}}` (because that is 
+        f. Does not take a block, like `{{#something}}{{/something}}` (because that is
            always a component, no ambiguity.)
 
     We can't tell if this problematic case is really:
@@ -497,7 +497,7 @@ class TemplateResolver implements ASTPlugin {
 
       2. A component invocation, which you could have written `<Something />`
          instead. Angle-bracket invocation has been available and easy-to-adopt
-         for a very long time. 
+         for a very long time.
 
       3. Property-this-fallback for `{{this.something}}`. Property-this-fallback
          is eliminated at Ember 4.0, so people have been heavily pushed to get
@@ -863,7 +863,7 @@ class TemplateResolver implements ASTPlugin {
 export default function makeResolverTransform({ appRoot }: Options) {
   let config: CompatResolverOptions = readJSONSync(join(appRoot, '.embroider', 'resolver.json'));
   const resolverTransform: ASTPluginBuilder<Env> = env => {
-    if (env.strict) {
+    if (env.strictMode) {
       return {
         name: 'embroider-build-time-resolver-strict-noop',
         visitor: {},

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -473,17 +473,17 @@ class TemplateResolver implements ASTPlugin {
 
       2. Have a mustache statement like: `{{something}}`, where `something` is:
 
-        a. Not a variable in scope (for example, there's no preceeding line
+        a. Not a variable in scope (for example, there's no preceeding line 
            like `<Parent as |something|>`)
         b. Does not start with `@` because that must be an argument from outside this template.
-        c. Does not contain a dot, like `some.thing` (because that case is classically
+        c. Does not contain a dot, like `some.thing` (because that case is classically 
            never a global component resolution that we would need to handle)
-        d. Does not start with `this` (this rule is mostly redundant with the previous rule,
+        d. Does not start with `this` (this rule is mostly redundant with the previous rule, 
            but even a standalone `this` is never a component invocation).
-        e. Does not have any arguments. If there are argument like `{{something a=b}}`,
-           there is still ambiguity between helper vs component, but there is no longer
+        e. Does not have any arguments. If there are argument like `{{something a=b}}`, 
+           there is still ambiguity between helper vs component, but there is no longer 
            the possibility that this was just rendering some data.
-        f. Does not take a block, like `{{#something}}{{/something}}` (because that is
+        f. Does not take a block, like `{{#something}}{{/something}}` (because that is 
            always a component, no ambiguity.)
 
     We can't tell if this problematic case is really:
@@ -497,7 +497,7 @@ class TemplateResolver implements ASTPlugin {
 
       2. A component invocation, which you could have written `<Something />`
          instead. Angle-bracket invocation has been available and easy-to-adopt
-         for a very long time.
+         for a very long time. 
 
       3. Property-this-fallback for `{{this.something}}`. Property-this-fallback
          is eliminated at Ember 4.0, so people have been heavily pushed to get

--- a/packages/util/tests/integration/helpers/ensure-safe-component-test.js
+++ b/packages/util/tests/integration/helpers/ensure-safe-component-test.js
@@ -188,7 +188,7 @@ module('Integration | Helper | ensure-safe-component', function (hooks) {
                 <Thing />
              {{/let}}`,
             {
-              strict: true,
+              strictMode: true,
               scope: () => ({
                 ensureSafeComponent,
               }),

--- a/packages/util/tests/integration/helpers/ensure-safe-component-test.js
+++ b/packages/util/tests/integration/helpers/ensure-safe-component-test.js
@@ -10,7 +10,6 @@ import { ensureSafeComponent } from '@embroider/util';
 import * as SomeComponentModule from 'dummy/components/some-component';
 import ColocatedExample from 'dummy/components/colocated-example';
 import { setOwner } from '@ember/application';
-import { precompileTemplate } from '@ember/template-compilation';
 
 const SomeComponent = SomeComponentModule.default;
 
@@ -175,35 +174,5 @@ module('Integration | Helper | ensure-safe-component', function (hooks) {
     await settled();
     assert.strictEqual(this.element.textContent.trim(), 'second:goodbye');
     assert.deepEqual(log, ['target instantiated', 'new target instantiated']);
-  });
-
-  module('with strict: true', function () {
-    test('reference to class property-as-component is allowed', async function (assert) {
-      const Thing = setComponentTemplate(hbs`thing`, templateOnlyComponent());
-
-      this.inner = ensureSafeComponent(
-        setComponentTemplate(
-          precompileTemplate(
-            `{{#let (component (ensureSafeComponent this.thing)) as |Thing|}}
-                <Thing />
-             {{/let}}`,
-            {
-              strictMode: true,
-              scope: () => ({
-                ensureSafeComponent,
-              }),
-            }
-          ),
-          class extends Component {
-            thing = Thing;
-          }
-        ),
-        this
-      );
-      await render(hbs`
-        <this.inner @name={{component "some-component"}} />
-      `);
-      assert.strictEqual(this.element.textContent.trim(), 'thing');
-    });
   });
 });

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -525,7 +525,7 @@ Scenarios.fromProject(() => new Project())
           }
         );
 
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import secondTarget_ from "#embroider_compat/components/second-target";
           import firstTarget_ from "#embroider_compat/components/first-target";
           import helloWorld_ from "#embroider_compat/components/hello-world";
@@ -558,7 +558,7 @@ Scenarios.fromProject(() => new Project())
           }
         );
 
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import secondTarget_ from "#embroider_compat/components/second-target";
           import firstTarget_ from "#embroider_compat/components/first-target";
           import helloWorld_ from "#embroider_compat/components/hello-world";
@@ -591,7 +591,7 @@ Scenarios.fromProject(() => new Project())
           }
         );
 
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import secondTarget_ from "#embroider_compat/components/second-target";
           import firstTarget_ from "#embroider_compat/components/first-target";
           import helloWorld_ from "#embroider_compat/ambiguous/hello-world";
@@ -612,7 +612,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{(this.myHelper)}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{(this.myHelper)}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -625,7 +625,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{(this.myHelper 42)}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{(this.myHelper 42)}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -638,7 +638,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{#if (this.myHelper)}}{{/if}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#if (this.myHelper)}}{{/if}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -651,7 +651,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<Stuff @value={{myHelper 1}}/>`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import myHelper_ from "#embroider_compat/helpers/myHelper";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<Stuff @value={{myHelper_ 1}} />", {
@@ -668,7 +668,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div class={{myHelper 1}}/>`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import myHelper_ from "#embroider_compat/helpers/myHelper";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div class={{myHelper_ 1}} />", {
@@ -698,7 +698,7 @@ Scenarios.fromProject(() => new Project())
             },
           }
         );
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import myHelper_ from "#embroider_compat/helpers/myHelper";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{myHelper_}}", {
@@ -715,7 +715,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{#this.myComponent}}hello{{/this.myComponent}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#this.myComponent}}hello{{/this.myComponent}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -728,7 +728,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{#this.myComponent 42}}hello{{/this.myComponent}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`          
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#this.myComponent 42}}hello{{/this.myComponent}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -741,8 +741,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{component 'hello-world'}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import helloWorld_ from "#embroider_compat/components/hello-world";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import helloWorld_ from "#embroider_compat/components/hello-world";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{component helloWorld_}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -758,8 +758,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{helper 'hello-world'}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import helloWorld_ from "#embroider_compat/helpers/hello-world";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import helloWorld_ from "#embroider_compat/helpers/hello-world";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{helper helloWorld_}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -775,8 +775,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{#component "hello-world"}}{{/component}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import helloWorld_ from "#embroider_compat/components/hello-world";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import helloWorld_ from "#embroider_compat/components/hello-world";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#component helloWorld_}}{{/component}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -792,8 +792,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{(component "hello-world")}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import helloWorld_ from "#embroider_compat/components/hello-world";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import helloWorld_ from "#embroider_compat/components/hello-world";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{(component helloWorld_)}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -809,8 +809,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{(helper "hello-world")}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import helloWorld_ from "#embroider_compat/helpers/hello-world";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import helloWorld_ from "#embroider_compat/helpers/hello-world";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{(helper helloWorld_)}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -832,7 +832,7 @@ Scenarios.fromProject(() => new Project())
           `,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`  
           import helloWorld_ from "#embroider_compat/helpers/hello-world";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("\\n            {{#let (helper helloWorld_ name=\\"World\\") as |hello|}}\\n              {{#let (helper hello name=\\"Tomster\\") as |helloTomster|}}\\n                {{helloTomster name=\\"Zoey\\"}}\\n              {{/let}}\\n            {{/let}}\\n          ", {
@@ -849,8 +849,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div {{(modifier 'hello-world')}} />`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import helloWorld_ from "#embroider_compat/modifiers/hello-world";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import helloWorld_ from "#embroider_compat/modifiers/hello-world";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div {{(modifier helloWorld_)}} />", {
             moduleName: "my-app/templates/application.hbs",
@@ -866,7 +866,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div {{scroll-top}}/>`,
         });
         await configure({ staticModifiers: false });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`  
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div {{scroll-top}} />", {
             moduleName: "my-app/templates/application.hbs"
@@ -879,8 +879,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div {{scroll-top}}/>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div {{scrollTop_}} />", {
             moduleName: "my-app/templates/application.hbs",
@@ -896,8 +896,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div {{scroll-top @scrollTopPos}}/>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div {{scrollTop_ @scrollTopPos}} />", {
             moduleName: "my-app/templates/application.hbs",
@@ -913,8 +913,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<Thing {{scroll-top @scrollTopPos}}/>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<Thing {{scrollTop_ @scrollTopPos}} />", {
             moduleName: "my-app/templates/application.hbs",
@@ -930,8 +930,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<Thing as |f|><f.Input {{scroll-top @scrollTopPos}}/></Thing>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
-          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";
+        expectTranspiled('templates/application.hbs').equalsCode(`  
+          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";        
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<Thing as |f|><f.Input {{scrollTop_ @scrollTopPos}} /></Thing>", {
             moduleName: "my-app/templates/application.hbs",
@@ -947,7 +947,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<input {{@auto-focus}} />`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`  
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<input {{@auto-focus}} />", {
             moduleName: "my-app/templates/application.hbs"
@@ -960,7 +960,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<Form as |f|> <input {{f.auto-focus}} /></Form>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`  
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<Form as |f|> <input {{f.auto-focus}} /></Form>", {
             moduleName: "my-app/templates/application.hbs"
@@ -977,7 +977,7 @@ Scenarios.fromProject(() => new Project())
         {{/let}}`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`
+        expectTranspiled('templates/application.hbs').equalsCode(`  
           import addListener_ from "#embroider_compat/modifiers/add-listener";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#let (modifier addListener_) as |addListener|}}\\n          {{#let (modifier addListener \\"click\\") as |addClickListener|}}\\n            <button {{addClickListener this.handleClick}}>Test</button>\\n          {{/let}}\\n        {{/let}}", {
@@ -1142,7 +1142,7 @@ Scenarios.fromProject(() => new Project())
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{component (ensure-safe-component this.which)}}", {
             moduleName: "my-app/templates/application.hbs"
-          });
+          }); 
         `);
       });
 

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -525,7 +525,7 @@ Scenarios.fromProject(() => new Project())
           }
         );
 
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import secondTarget_ from "#embroider_compat/components/second-target";
           import firstTarget_ from "#embroider_compat/components/first-target";
           import helloWorld_ from "#embroider_compat/components/hello-world";
@@ -558,7 +558,7 @@ Scenarios.fromProject(() => new Project())
           }
         );
 
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import secondTarget_ from "#embroider_compat/components/second-target";
           import firstTarget_ from "#embroider_compat/components/first-target";
           import helloWorld_ from "#embroider_compat/components/hello-world";
@@ -591,7 +591,7 @@ Scenarios.fromProject(() => new Project())
           }
         );
 
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import secondTarget_ from "#embroider_compat/components/second-target";
           import firstTarget_ from "#embroider_compat/components/first-target";
           import helloWorld_ from "#embroider_compat/ambiguous/hello-world";
@@ -612,7 +612,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{(this.myHelper)}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{(this.myHelper)}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -625,7 +625,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{(this.myHelper 42)}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{(this.myHelper 42)}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -638,7 +638,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{#if (this.myHelper)}}{{/if}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#if (this.myHelper)}}{{/if}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -651,7 +651,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<Stuff @value={{myHelper 1}}/>`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import myHelper_ from "#embroider_compat/helpers/myHelper";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<Stuff @value={{myHelper_ 1}} />", {
@@ -668,7 +668,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div class={{myHelper 1}}/>`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import myHelper_ from "#embroider_compat/helpers/myHelper";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div class={{myHelper_ 1}} />", {
@@ -698,7 +698,7 @@ Scenarios.fromProject(() => new Project())
             },
           }
         );
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import myHelper_ from "#embroider_compat/helpers/myHelper";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{myHelper_}}", {
@@ -715,7 +715,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{#this.myComponent}}hello{{/this.myComponent}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#this.myComponent}}hello{{/this.myComponent}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -728,7 +728,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{#this.myComponent 42}}hello{{/this.myComponent}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`          
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#this.myComponent 42}}hello{{/this.myComponent}}", {
             moduleName: "my-app/templates/application.hbs"
@@ -741,8 +741,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{component 'hello-world'}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import helloWorld_ from "#embroider_compat/components/hello-world";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import helloWorld_ from "#embroider_compat/components/hello-world";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{component helloWorld_}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -758,8 +758,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{helper 'hello-world'}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import helloWorld_ from "#embroider_compat/helpers/hello-world";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import helloWorld_ from "#embroider_compat/helpers/hello-world";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{helper helloWorld_}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -775,8 +775,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{#component "hello-world"}}{{/component}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import helloWorld_ from "#embroider_compat/components/hello-world";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import helloWorld_ from "#embroider_compat/components/hello-world";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#component helloWorld_}}{{/component}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -792,8 +792,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{(component "hello-world")}}`,
         });
         await configure({ staticComponents: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import helloWorld_ from "#embroider_compat/components/hello-world";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import helloWorld_ from "#embroider_compat/components/hello-world";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{(component helloWorld_)}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -809,8 +809,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `{{(helper "hello-world")}}`,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import helloWorld_ from "#embroider_compat/helpers/hello-world";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import helloWorld_ from "#embroider_compat/helpers/hello-world";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{(helper helloWorld_)}}", {
             moduleName: "my-app/templates/application.hbs",
@@ -832,7 +832,7 @@ Scenarios.fromProject(() => new Project())
           `,
         });
         await configure({ staticHelpers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import helloWorld_ from "#embroider_compat/helpers/hello-world";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("\\n            {{#let (helper helloWorld_ name=\\"World\\") as |hello|}}\\n              {{#let (helper hello name=\\"Tomster\\") as |helloTomster|}}\\n                {{helloTomster name=\\"Zoey\\"}}\\n              {{/let}}\\n            {{/let}}\\n          ", {
@@ -849,8 +849,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div {{(modifier 'hello-world')}} />`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import helloWorld_ from "#embroider_compat/modifiers/hello-world";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import helloWorld_ from "#embroider_compat/modifiers/hello-world";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div {{(modifier helloWorld_)}} />", {
             moduleName: "my-app/templates/application.hbs",
@@ -866,7 +866,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div {{scroll-top}}/>`,
         });
         await configure({ staticModifiers: false });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div {{scroll-top}} />", {
             moduleName: "my-app/templates/application.hbs"
@@ -879,8 +879,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div {{scroll-top}}/>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div {{scrollTop_}} />", {
             moduleName: "my-app/templates/application.hbs",
@@ -896,8 +896,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<div {{scroll-top @scrollTopPos}}/>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<div {{scrollTop_ @scrollTopPos}} />", {
             moduleName: "my-app/templates/application.hbs",
@@ -913,8 +913,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<Thing {{scroll-top @scrollTopPos}}/>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<Thing {{scrollTop_ @scrollTopPos}} />", {
             moduleName: "my-app/templates/application.hbs",
@@ -930,8 +930,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<Thing as |f|><f.Input {{scroll-top @scrollTopPos}}/></Thing>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
-          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";        
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import scrollTop_ from "#embroider_compat/modifiers/scroll-top";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<Thing as |f|><f.Input {{scrollTop_ @scrollTopPos}} /></Thing>", {
             moduleName: "my-app/templates/application.hbs",
@@ -947,7 +947,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<input {{@auto-focus}} />`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<input {{@auto-focus}} />", {
             moduleName: "my-app/templates/application.hbs"
@@ -960,7 +960,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `<Form as |f|> <input {{f.auto-focus}} /></Form>`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("<Form as |f|> <input {{f.auto-focus}} /></Form>", {
             moduleName: "my-app/templates/application.hbs"
@@ -977,7 +977,7 @@ Scenarios.fromProject(() => new Project())
         {{/let}}`,
         });
         await configure({ staticModifiers: true });
-        expectTranspiled('templates/application.hbs').equalsCode(`  
+        expectTranspiled('templates/application.hbs').equalsCode(`
           import addListener_ from "#embroider_compat/modifiers/add-listener";
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{#let (modifier addListener_) as |addListener|}}\\n          {{#let (modifier addListener \\"click\\") as |addClickListener|}}\\n            <button {{addClickListener this.handleClick}}>Test</button>\\n          {{/let}}\\n        {{/let}}", {
@@ -1142,7 +1142,7 @@ Scenarios.fromProject(() => new Project())
           import { precompileTemplate } from "@ember/template-compilation";
           export default precompileTemplate("{{component (ensure-safe-component this.which)}}", {
             moduleName: "my-app/templates/application.hbs"
-          }); 
+          });
         `);
       });
 
@@ -1179,7 +1179,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs.js': `
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("<Thing />", {
-            strict: true,
+            strictMode: true,
           });
         `,
         });
@@ -1189,7 +1189,7 @@ Scenarios.fromProject(() => new Project())
         expectTranspiled('templates/application.hbs.js').equalsCode(`
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("<Thing />", {
-            strict: true,
+            strictMode: true,
           });
       `);
       });


### PR DESCRIPTION
Turns out we've had a discrepancy between strict and strictMode :upside_down_face: 

 - RFC update (and context / background): https://github.com/emberjs/rfcs/pull/920


There is another option to rename all the `strictMode` things to `strict`, but I think this would be more disruptive.
 