### PR TITLE
Fix `Maximum call stack size exceeded` error

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -279,6 +279,7 @@ export default class V1Addon {
     // is just misleading to stage3 packagers that might look (rollup does).
     delete pkg.main;
     delete pkg.module;
+    delete pkg.exports;
 
     return pkg;
   }


### PR DESCRIPTION
Today I was running into the same issue that @void-mAlex has reported in yesterday's office hours, and as we discussed it removing the `exports` from the rewritten package.json indeed fixes the problem. At least for me, maybe @void-mAlex you can double check that on your side too?