### PR TITLE
bump unstable versions by at least a patch

### DIFF
--- a/test-packages/unstable-release/version.js
+++ b/test-packages/unstable-release/version.js
@@ -33,7 +33,12 @@ const NEW_VERSIONS = {};
 
 async function setVersion(sha, filePath) {
   let json = await fse.readJSON(filePath);
-  json.version = `${json.version}-unstable.${sha}`;
+
+  // we need to at the very least bump the patch version of the unstable packages so
+  // that ^ dependenies won't pick up the stable versions
+  const [major, minor, patch] = json.version.split('.');
+
+  json.version = `${major}.${minor}.${parseInt(patch) + 1}-unstable.${sha}`;
 
   NEW_VERSIONS[json.name] = json.version;
 


### PR DESCRIPTION
I was having some issues where pnpm was picking up some wrong versions during an ember-try run and I was pulling my hair out 🙃 

I noticed that `@embroider/compat` version `2.1.1` was being used instead of the version `2.1.1-unstable.00ec2e7` that was specified in the package.json. No matter what I did I couldn't get pnpm to pick up correct version. Then I noticed that we're using carat dependencies in the package json on ember-try ever since https://github.com/embroider-build/embroider/pull/1328 and that seems to have caused my issue. 

Apparently the version `^2.1.1-unstable.00ec2e7` is satisfied by `2.1.1` 😭 

![Screenshot 2023-03-30 at 17 09 43](https://user-images.githubusercontent.com/594890/228898458-be090954-e5f2-432f-9e43-101746293a82.png)

This PR will make sure that all new packages that are deployed with the unstable packages will be at least one step higher and won't match any more 

