### PR TITLE
Change namespace for cancel-in-progress

### DIFF
--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: publish-unstable-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This decouples `publish-unstable.yml` `cancel-in-progress` from that in `ci.yml`.