### PR TITLE
only rehome a request if it would resolve in a different package

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -710,7 +710,12 @@ export class Resolver {
       // this is the easy case -- a package that uses exports can safely resolve
       // its own name, so it's enough to let it resolve the (self-targeting)
       // specifier from its own package root.
-      return request.rehome(resolve(pkg.root, 'package.json'));
+      const resolvedPkgJson = resolve(pkg.root, 'package.json');
+      if (request.fromFile === resolvedPkgJson) {
+        return request;
+      } else {
+        return request.rehome(resolvedPkgJson);
+      }
     } else {
       // otherwise we need to just assume that internal naming is simple
       return request.alias(request.specifier.replace(pkg.name, '.')).rehome(resolve(pkg.root, 'package.json'));

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -119,7 +119,11 @@ class NodeModuleRequest implements ModuleRequest {
     return new NodeModuleRequest(specifier, this.fromFile) as this;
   }
   rehome(fromFile: string): this {
-    return new NodeModuleRequest(this.specifier, fromFile) as this;
+    if (this.fromFile === fromFile) {
+      return this;
+    } else {
+      return new NodeModuleRequest(this.specifier, fromFile) as this;
+    }
   }
   virtualize(filename: string) {
     return new NodeModuleRequest(filename, this.fromFile, true) as this;
@@ -710,12 +714,7 @@ export class Resolver {
       // this is the easy case -- a package that uses exports can safely resolve
       // its own name, so it's enough to let it resolve the (self-targeting)
       // specifier from its own package root.
-      const resolvedPkgJson = resolve(pkg.root, 'package.json');
-      if (request.fromFile === resolvedPkgJson) {
-        return request;
-      } else {
-        return request.rehome(resolvedPkgJson);
-      }
+      return request.rehome(resolve(pkg.root, 'package.json'));
     } else {
       // otherwise we need to just assume that internal naming is simple
       return request.alias(request.specifier.replace(pkg.name, '.')).rehome(resolve(pkg.root, 'package.json'));

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -161,9 +161,13 @@ class WebpackModuleRequest implements ModuleRequest {
     return new WebpackModuleRequest(this.babelLoaderPrefix, this.state) as this;
   }
   rehome(newFromFile: string) {
-    this.state.contextInfo.issuer = newFromFile;
-    this.state.context = dirname(newFromFile);
-    return new WebpackModuleRequest(this.babelLoaderPrefix, this.state) as this;
+    if (this.fromFile === newFromFile) {
+      return this;
+    } else {
+      this.state.contextInfo.issuer = newFromFile;
+      this.state.context = dirname(newFromFile);
+      return new WebpackModuleRequest(this.babelLoaderPrefix, this.state) as this;
+    }
   }
   virtualize(filename: string) {
     let next = this.alias(`${this.babelLoaderPrefix}${virtualLoaderName}?${filename}!`);


### PR DESCRIPTION
this stops infinite loops from v2 addons that misdeclare exports fields reports correct misconfigured export from within stage3 bundler

checked that this would give a nice error for the case that https://github.com/embroider-build/embroider/pull/1386 fixed
this should still help for proper v2 addons that have bad exports declarations