### PR TITLE
Allow running publish-unstable on workflow_dispatch

### DIFF
--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -4,6 +4,7 @@
 name: Publish Unstable
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Sometimes the GitHub API fails with `Error: 429 Too many Requests`. This can happen during the publish-unstable workflow, which isn't great, but we can wait for quota to recover a bit, and re-run the workflow manually.

This is done with the `workflow_dispatch` trigger, as implemented in this PR.

I've also done this on [on my own repo](https://github.com/NullVoxPopuli/limber/blob/main/.github/workflows/preview-embroider-upgrade.yml#L3), for syncing a branch that tests the latest `unstable` release of all the embroider packages.

I first learned about this strategy from: https://dev.to/this-is-learning/manually-trigger-a-github-action-with-workflowdispatch-3mga

Here are the docs on [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
And [How to manually run a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
![image](https://user-images.githubusercontent.com/199018/229860938-093d3990-42ff-43f7-9816-be4d38118fbd.png)
