### PR TITLE
continue deploying unstable packages even with an error

### DIFF
--- a/test-packages/unstable-release/.eslintrc.cjs
+++ b/test-packages/unstable-release/.eslintrc.cjs
@@ -12,7 +12,8 @@ module.exports = {
   },
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   env: {
-    browser: true,
+    browser: false,
+    node: true,
   },
   overrides: [
     // node files

--- a/test-packages/unstable-release/publish.js
+++ b/test-packages/unstable-release/publish.js
@@ -5,9 +5,25 @@ import { dirname } from 'path';
 async function publish() {
   let publicWorkspaces = await listPublicWorkspaces();
 
+  const errors = [];
+
   for (let workspace of publicWorkspaces) {
     console.info(`Publishing ${workspace}`);
-    await execaCommand('npm publish --tag=unstable --verbose', { cwd: dirname(workspace) });
+    try {
+      await execaCommand('npm publish --tag=unstable --verbose', { cwd: dirname(workspace) });
+    } catch (err) {
+      console.info(`Publishing ${workspace} has failed. A full list of errors will be printed at the end of this run`);
+      errors.push(err);
+      continue;
+    }
+
+    console.info(`Publishing ${workspace} completed successfully!`);
+  }
+
+  if (errors.length) {
+    console.error('Errors were encountered while publishing these packages');
+    errors.forEach(error => console.log(error.stderr));
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
One of the previous runs of NPM Publish for the unstable packages actually errored: https://github.com/embroider-build/embroider/actions/runs/4610016561/jobs/8147947998

In this case, the logical thing to do would be to rerun the process, but that wouldn't work if the release finished somewhere in the middle of the process because it would fail to deploy the first package again (because that version already exists).

This PR changes the semantics of the deploy step for unstable and it no longer stops on the first error it encounters. This means that we will be able to re-run the process without any issue if we have strange API problems again 👍 