### PR TITLE
Add @ember/object to emberVirtualPackages

### DIFF
--- a/packages/shared-internals/src/ember-standard-modules.ts
+++ b/packages/shared-internals/src/ember-standard-modules.ts
@@ -28,10 +28,14 @@ emberVirtualPeerDeps.add('@ember/string');
 
 // these can also appear in ember code and should get compiled away by babel,
 // but we may need to tell a build tool that is inspecting pre-transpiled code
-// (like snowpack) not to worrya bout these packages.
+// (like snowpack) not to worry about these packages.
 emberVirtualPackages.add('@glimmer/env');
 emberVirtualPackages.add('ember');
 emberVirtualPackages.add('@embroider/macros');
+
+// rfc176-data only covers things up to the point where Ember stopped needing
+// the modules-api-polyfill. Newer APIs need to be added here.
+emberVirtualPackages.add('@ember/owner');
 
 // These are the known names that people use to import template precomiplation
 // macros from.


### PR DESCRIPTION
For compatibility, we need to know the full set of virtual package names used by Ember. Historically we got that from the ember-rfc176-data package, but that is no longer updated for new APIs because the modules-api-polyfill that it was created to power is no longer needed.

Without this, v2 addons under embroider will fail to resolve these package names.


Rebase of: https://github.com/embroider-build/embroider/pull/1394 to see if that's all that is needed to fix