### PR TITLE
Enable changelog generation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.2.0/schema.json",
-  "changelog": false,
+  "changelog": "@changesets/changelog-git",
   "commit": false,
   "fixed": [["@embroider/compat", "@embroider/core", "@embroider/test-setup", "@embroider/webpack"]],
   "access": "public",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,13 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": [
+    "@embroider/test-scenarios",
+    "v2-addon-template",
+    "ts-app-template",
+    "app-template",
+    "addon-template"
+  ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
This will fix the failing "Release" job on CI.yml.

We'll only know _for sure_ once this PR is merged though.

They "Release" job is skipped on branches/PRs