### PR TITLE
Use a custom changelog line generator function to avoid adding meaningless changelog entries 

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * Modified version of
+ * https://github.com/changesets/changesets/blob/main/packages/changelog-git/src/index.ts
+ *
+ * This is because we do not add changelog entries per-PR (upon merge), and we instead add them
+ * later, (per changeset-recover, https://github.com/nullvoxpopuli/changeset-recover)
+ *
+ * All of the built-in changelog line generators provided by changesets assume a
+ * "add changeset before merge" workflow, and add git/github references accordingly.
+ *
+ * Here, we ignore the commit, and just use the changeset summary.
+ *
+ * See docs here: https://github.com/changesets/changesets/blob/main/docs/modifying-changelog-format.md
+ */
+async function getReleaseLine(changeset, _type) {
+  const [firstLine, ...futureLines] = changeset.summary.split('\n').map(l => l.trimRight());
+
+  let returnVal = firstLine;
+
+  if (futureLines.length > 0) {
+    returnVal += `\n${futureLines.map(l => `  ${l}`).join('\n')}`;
+  }
+
+  return returnVal;
+}
+
+async function getDependencyReleaseLine(changesets, dependenciesUpdated) {
+  if (dependenciesUpdated.length === 0) return '';
+
+  console.log(changesets);
+
+  const changesetLinks = [`- Updated dependencies`];
+
+  const updatedDependenciesList = dependenciesUpdated.map(
+    dependency => `  - ${dependency.name}@${dependency.newVersion}`
+  );
+
+  return [...changesetLinks, ...updatedDependenciesList].join('\n');
+}
+
+module.exports = {
+  getReleaseLine,
+  getDependencyReleaseLine,
+};

--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -15,7 +15,7 @@
  * See docs here: https://github.com/changesets/changesets/blob/main/docs/modifying-changelog-format.md
  */
 async function getReleaseLine(changeset, _type) {
-  const [firstLine, ...futureLines] = changeset.summary.split('\n').map(l => l.trimRight());
+  let [firstLine, ...futureLines] = changeset.summary.split('\n').map(l => l.trimRight());
 
   let returnVal = firstLine;
 
@@ -29,11 +29,8 @@ async function getReleaseLine(changeset, _type) {
 async function getDependencyReleaseLine(changesets, dependenciesUpdated) {
   if (dependenciesUpdated.length === 0) return '';
 
-  console.log(changesets);
-
-  const changesetLinks = [`- Updated dependencies`];
-
-  const updatedDependenciesList = dependenciesUpdated.map(
+  let changesetLinks = [`- Updated dependencies`];
+  let updatedDependenciesList = dependenciesUpdated.map(
     dependency => `  - ${dependency.name}@${dependency.newVersion}`
   );
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.2.0/schema.json",
-  "changelog": "@changesets/changelog-git",
+  "changelog": "./changelog.cjs",
   "commit": false,
   "fixed": [["@embroider/compat", "@embroider/core", "@embroider/test-setup", "@embroider/webpack"]],
   "access": "public",

--- a/package.json
+++ b/package.json
@@ -59,20 +59,21 @@
     "**/graceful-fs": "^4.0.0"
   },
   "devDependencies": {
+    "@changesets/changelog-git": "^0.1.14",
     "@changesets/changelog-github": "^0.4.7",
     "@changesets/cli": "^2.25.0",
     "@types/jest": "^29.2.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
+    "changeset-recover": "0.1.0-beta.10",
     "concurrently": "^7.2.1",
     "cross-env": "^7.0.3",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-prettier": "^3.1.4",
-    "changeset-recover": "0.1.0-beta.10",
-    "patch-package": "^6.5.1",
     "jest": "^29.2.1",
+    "patch-package": "^6.5.1",
     "prettier": "^2.3.1",
     "typescript": "4.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "**/graceful-fs": "^4.0.0"
   },
   "devDependencies": {
-    "@changesets/changelog-git": "^0.1.14",
-    "@changesets/changelog-github": "^0.4.7",
     "@changesets/cli": "^2.25.0",
     "@types/jest": "^29.2.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,15 +1113,6 @@
   dependencies:
     "@changesets/types" "^5.2.1"
 
-"@changesets/changelog-github@^0.4.7":
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/@changesets/changelog-github/-/changelog-github-0.4.8.tgz#b7f8ae85d0c0ff08028d924c5e59a1cbd3742634"
-  integrity sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==
-  dependencies:
-    "@changesets/get-github-info" "^0.5.2"
-    "@changesets/types" "^5.2.1"
-    dotenv "^8.1.0"
-
 "@changesets/cli@^2.25.0":
   version "2.26.1"
   resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.26.1.tgz#2d10858d7d32314a524e383111c96d831eb0402f"
@@ -1191,14 +1182,6 @@
     chalk "^2.1.0"
     fs-extra "^7.0.1"
     semver "^5.4.1"
-
-"@changesets/get-github-info@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@changesets/get-github-info/-/get-github-info-0.5.2.tgz#0cde2cadba57db85c714dc303c077da919a574e5"
-  integrity sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==
-  dependencies:
-    dataloader "^1.4.0"
-    node-fetch "^2.5.0"
 
 "@changesets/get-release-plan@^3.0.16":
   version "3.0.16"
@@ -6772,11 +6755,6 @@ data-urls@^3.0.1:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-dataloader@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
-  integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
-
 date-fns@^2.28.0, date-fns@^2.29.1, date-fns@^2.29.2:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
@@ -7133,11 +7111,6 @@ dot-prop@^5.2.0:
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
-
-dotenv@^8.1.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
-  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 duplexer3@^0.1.4:
   version "0.1.5"
@@ -13890,7 +13863,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==


### PR DESCRIPTION
In the Release Preview PR: https://github.com/embroider-build/embroider/pull/1408

We have a bunch of commits that are duplicated: 
![image](https://user-images.githubusercontent.com/199018/235777093-455d7ebb-d68d-4c60-bc8e-0911e6961c88.png)


This is because `changesets` is using the commit that the `changeset` file was added, rather than the commit of the actual change.

There are two problems:
 - repeated "dependency updated" entries
 - every change has the same commit.

This PR addresses both of those things.

Preview: 
![image](https://user-images.githubusercontent.com/199018/235779279-4cef40b7-0864-41d9-a31c-0e9557547e15.png)


This uses a tweaked version of the changelog-git plugin: https://github.com/changesets/changesets/blob/main/packages/changelog-git/src/index.ts