### PR TITLE
WriteV1Config: fix /tests support

### DIFF
--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -150,8 +150,10 @@ export default class V1App {
   }
 
   @Memoize()
-  get testConfig(): V1Config {
-    return new V1Config(this.configTree, 'test');
+  get testConfig(): V1Config | undefined {
+    if (this.shouldBuildTests) {
+      return new V1Config(this.configTree, 'test');
+    }
   }
 
   get autoRun(): boolean {

--- a/packages/compat/src/v1-app.ts
+++ b/packages/compat/src/v1-app.ts
@@ -149,6 +149,11 @@ export default class V1App {
     return new V1Config(this.configTree, this.app.env);
   }
 
+  @Memoize()
+  get testConfig(): V1Config {
+    return new V1Config(this.configTree, 'test');
+  }
+
   get autoRun(): boolean {
     return this.app.options.autoRun;
   }
@@ -659,7 +664,7 @@ export default class V1App {
     let appTree = this.appTree;
     let testsTree = this.testsTree;
     let lintTree = this.lintTree;
-    let config = new WriteV1Config(this.config, this.storeConfigInMeta);
+    let config = new WriteV1Config(this.config, this.storeConfigInMeta, this.testConfig);
     let patterns = this.configReplacePatterns;
     let configReplaced = new this.configReplace(config, this.configTree, {
       configPath: join('environments', `${this.app.env}.json`),

--- a/packages/compat/src/v1-config.ts
+++ b/packages/compat/src/v1-config.ts
@@ -31,7 +31,7 @@ export class V1Config extends Plugin {
 export class WriteV1Config extends Plugin {
   private lastContents: string | undefined;
   constructor(private inputTree: V1Config, private storeConfigInMeta: boolean, private testInputTree?: V1Config) {
-    super([inputTree, testInputTree as V1Config], {
+    super([inputTree, testInputTree as V1Config].filter(Boolean), {
       persistentOutput: true,
       needsCache: false,
     });

--- a/packages/compat/src/v1-config.ts
+++ b/packages/compat/src/v1-config.ts
@@ -42,16 +42,20 @@ export class WriteV1Config extends Plugin {
     if (this.storeConfigInMeta) {
       contents = metaLoader();
     } else {
-      contents = `
-      import { isTesting } from '@embroider/macros';
-      let env;
-      if (isTesting()) {
-        env = ${JSON.stringify(this.testInputTree?.readConfig())};
+      if (this.testInputTree) {
+        contents = `
+        import { isTesting } from '@embroider/macros';
+        let env;
+        if (isTesting()) {
+          env = ${JSON.stringify(this.testInputTree.readConfig())};
+        } else {
+          env = ${JSON.stringify(this.inputTree.readConfig())};
+        }
+        export default env;
+        `;
       } else {
-        env = ${JSON.stringify(this.inputTree.readConfig())};
+        contents = `export default ${JSON.stringify(this.inputTree.readConfig())};`;
       }
-      export default env;
-      `;
     }
     if (!this.lastContents || this.lastContents !== contents) {
       outputFileSync(filename, contents);

--- a/tests/scenarios/app-config-environment-test.ts
+++ b/tests/scenarios/app-config-environment-test.ts
@@ -1,0 +1,81 @@
+import merge from 'lodash/merge';
+import { appScenarios } from './scenarios';
+import { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+
+const { module: Qmodule, test } = QUnit;
+
+appScenarios
+  .only('release')
+  .map('app-config-environment', project => {
+    merge(project.files, {
+      'ember-cli-build.js': `
+        'use strict';
+
+        const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+        const { maybeEmbroider } = require('@embroider/test-setup');
+
+        module.exports = function (defaults) {
+          let app = new EmberApp(defaults, {
+            tests: true,
+            storeConfigInMeta: false,
+          });
+          return maybeEmbroider(app, {});
+        };
+      `,
+      config: {
+        'environment.js': `module.exports = function(environment) {
+          // DEFAULT config/environment.js
+          let ENV = {
+            modulePrefix: 'my-app',
+            environment,
+            rootURL: '/',
+            locationType: 'history',
+            EmberENV: {
+              EXTEND_PROTOTYPES: false,
+              FEATURES: {},
+            },
+            APP: {},
+          };
+
+          if (environment === 'test') {
+            ENV.locationType = 'none';
+            ENV.APP.LOG_ACTIVE_GENERATION = false;
+            ENV.APP.LOG_VIEW_LOOKUPS = false;
+            ENV.APP.rootElement = '#ember-testing';
+            ENV.APP.autoboot = false;
+          };
+
+          // CUSTOM
+          ENV.someCustomField = true;
+          return ENV;
+        };`,
+      },
+      tests: {
+        unit: {
+          'store-config-in-meta-test.js': `
+            import { module, test } from 'qunit';
+            import ENV from 'app-template/config/environment';
+
+            module('Unit | storeConfigInMeta', function (hooks) {
+              test('it has loaded the correct config values', async function (assert) {
+                assert.equal(ENV.someCustomField, true);
+              });
+            });`,
+        },
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test(`yarn test ran with custom unit test`, async function (assert) {
+        let result = await app.execute(`yarn test`);
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
+  });

--- a/tests/scenarios/app-config-environment-test.ts
+++ b/tests/scenarios/app-config-environment-test.ts
@@ -44,10 +44,11 @@ appScenarios
             ENV.APP.LOG_VIEW_LOOKUPS = false;
             ENV.APP.rootElement = '#ember-testing';
             ENV.APP.autoboot = false;
+
+            // CUSTOM
+            ENV.someCustomField = true;
           };
 
-          // CUSTOM
-          ENV.someCustomField = true;
           return ENV;
         };`,
       },
@@ -57,7 +58,7 @@ appScenarios
             import { module, test } from 'qunit';
             import ENV from 'app-template/config/environment';
 
-            module('Unit | storeConfigInMeta', function (hooks) {
+            module('Unit | storeConfigInMeta set to false', function (hooks) {
               test('it has loaded the correct config values', async function (assert) {
                 assert.equal(ENV.someCustomField, true);
               });
@@ -73,9 +74,16 @@ appScenarios
         app = await scenario.prepare();
       });
 
-      test(`yarn test ran with custom unit test`, async function (assert) {
-        let result = await app.execute(`yarn test`);
-        assert.equal(result.exitCode, 0, result.output);
+      test(`ember test ran against dev build with custom unit test`, async function (assert) {
+        // here we build the app with environment set to dev so that we can use
+        // the build output directory as the input path to an `ember test` run
+        // later. This difference in environment is important because it's the
+        // only way for us to test ember-cli-build.js' `tests: true` behavior,
+        // and is equivalent to visiting the app's /tests page
+        let devBuildResult = await app.execute(`pnpm build --environment=development`);
+        assert.equal(devBuildResult.exitCode, 0, devBuildResult.output);
+        let testRunResult = await app.execute(`pnpm test:ember --path dist`);
+        assert.equal(testRunResult.exitCode, 0, testRunResult.output);
       });
     });
   });


### PR DESCRIPTION
Addresses https://github.com/embroider-build/embroider/issues/1387 (development config incorrectly loaded instead of test config when visiting `/tests` with `tests: true`, `storeConfigInMeta: false`)

This PR applies the conditional logic suggested in https://github.com/embroider-build/embroider/issues/1387#issuecomment-1488835984

<img width="1728" alt="Screenshot 2023-05-08 at 10 38 45" src="https://user-images.githubusercontent.com/7144173/236791078-de9108fb-da31-447e-bc0a-dcb9e8e05285.png">

<details>
    <summary>Example module output with `tests: true`</summary>
 
 ```
 __webpack_require__.r(__webpack_exports__);
/* harmony export */ __webpack_require__.d(__webpack_exports__, {
/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
/* harmony export */ });
/* harmony import */ var _Users_petermeehan_src_embroider_packages_macros_src_addon_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../../../../../../../../Users/petermeehan/src/embroider/packages/macros/src/addon/runtime */ "../../../../../../../../Users/petermeehan/src/embroider/packages/macros/src/addon/runtime.js");

let env;
if ((0,_Users_petermeehan_src_embroider_packages_macros_src_addon_runtime__WEBPACK_IMPORTED_MODULE_0__.isTesting)()) {
  env = {
    "modulePrefix": "with",
    "environment": "test",
    "rootURL": "/",
    "locationType": "none",
    "EmberENV": {
      "FEATURES": {},
      "_APPLICATION_TEMPLATE_WRAPPER": false,
      "_DEFAULT_ASYNC_OBSERVERS": true,
      "_JQUERY_INTEGRATION": false,
      "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true
    },
    "APP": {
      "rootElement": "#ember-testing",
      "LOG_ACTIVE_GENERATION": false,
      "LOG_VIEW_LOOKUPS": false,
      "autoboot": false,
      "name": "with",
      "version": "0.0.0+ab033a51"
    }
  };
} else {
  env = {
    "modulePrefix": "with",
    "environment": "development",
    "rootURL": "/",
    "locationType": "history",
    "EmberENV": {
      "FEATURES": {},
      "_APPLICATION_TEMPLATE_WRAPPER": false,
      "_DEFAULT_ASYNC_OBSERVERS": true,
      "_JQUERY_INTEGRATION": false,
      "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true
    },
    "APP": {
      "rootElement": ".non-testing-div",
      "name": "with",
      "version": "0.0.0+ab033a51"
    }
  };
}
/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (env);

//# sourceURL=webpack://with/./config/environment.js?
 ```
 
</details>

<details>
    <summary>Example module output with `tests: false`</summary>

```
__webpack_require__.r(__webpack_exports__);
/* harmony export */ __webpack_require__.d(__webpack_exports__, {
/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
/* harmony export */ });
/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({
  "modulePrefix": "with",
  "environment": "development",
  "rootURL": "/",
  "locationType": "history",
  "EmberENV": {
    "FEATURES": {},
    "_APPLICATION_TEMPLATE_WRAPPER": false,
    "_DEFAULT_ASYNC_OBSERVERS": true,
    "_JQUERY_INTEGRATION": false,
    "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true
  },
  "APP": {
    "rootElement": ".non-testing-div",
    "name": "with",
    "version": "0.0.0+ab033a51"
  }
});

//# sourceURL=webpack://with/./config/environment.js?
```

</details>

<details>
    <summary>Answered questions about the implementation for this.</summary>

- Is changing the type signature of WriteV1Config acceptable? Is there a better way to create an instance of `V1Config` with env hardcoded to `test` and pass it in?
  - Discussed in office hours. It's fine.
- Could this change negatively impact the behaviour of non test builds?
  - Test suite didn't surface anything and my local testing of `tests: true` and `false` shows the expected config being loaded
- Is creating a broccoli plugin with `super([inputTree, undefined])` equivalent to `super([inputTree])`?
  - Answer: [Nope](https://github.com/embroider-build/embroider/actions/runs/4913893317/jobs/8778607080)
- Is there a good way to add a test for this?
  - Discussed in office hours: Yes, add a `scenario`. I'm tracking this work here (https://github.com/22a/embroider/pull/1) instead of cluttering this PR with messy attempts to learn the scenario system

</details>

