### PR TITLE
Fix @embroider/addon-dev keepAssets resolve priority

### DIFF
--- a/.changeset/thick-knives-vanish.md
+++ b/.changeset/thick-knives-vanish.md
@@ -1,0 +1,7 @@
+---
+"@embroider/addon-dev": patch
+---
+
+Fix an issue with `@embroider/addon-dev`'s `keepAssets` rollup plugin where the filesystem was hit for every possible file (including non-existing ones) when trying to determine if an import matched the provided globs.
+
+This potentially speeds rollup builds by 3x, depending on other plugins present in the rollup config.

--- a/packages/addon-dev/src/rollup-keep-assets.ts
+++ b/packages/addon-dev/src/rollup-keep-assets.ts
@@ -17,16 +17,25 @@ export default function keepAssets({
     // imports of assets should be left alone in the source code. This can cover
     // the case of .css as defined in the embroider v2 addon spec.
     async resolveId(source, importer, options) {
+      // We need to check if the `source` (what the importer is trying to import)
+      // matches our patterns, because we don't want to hit the file system if
+      // the pattern doesn't match.
+      //
+      // Without doing so can multiply the build time by 3x.
+      let isMatch = include.some((pattern) => minimatch(source, pattern));
+
+      // Let some other plugin handle this source
+      if (!isMatch) return null;
+
       const resolution = await this.resolve(source, importer, {
         skipSelf: true,
         ...options,
       });
-      if (
-        resolution &&
-        include.some((pattern) => minimatch(resolution.id, pattern))
-      ) {
+
+      if (resolution) {
         return { id: source, external: true };
       }
+
       return resolution;
     },
 

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -77,6 +77,7 @@ appScenarios
 
             addon.hbs(),
             addon.dependencies(),
+            addon.keepAssets(['**/*.css']),
 
             babel({ babelHelpers: 'bundled' }),
 
@@ -114,10 +115,14 @@ appScenarios
             'namespace-me.hbs': `
               namespaced component
             `,
+            'styles.css': `
+              button { text-transform: uppercase; }
+            `,
             'index.js': `
                 import Component from '@glimmer/component';
                 import { tracked } from '@glimmer/tracking';
 
+                import './styles.css';
                 import FlipButton from './button';
                 import Out from './out';
 
@@ -239,6 +244,8 @@ appScenarios
           expectFile('dist/_app_/components/demo/namespace/namespace-me.js').matches(
             'export { default } from "v2-addon/components/demo/namespace-me"'
           );
+
+          expectFile('dist/components/demo/styles.css').matches('button { text-transform: uppercase; }');
         });
 
         test('template transform was run', async function () {


### PR DESCRIPTION
Big project:
```
❯ tokei -t=TypeScript,JSON,JavaScript,SVG,Handlebars,CSS
===============================================================================
 Language            Files        Lines         Code     Comments       Blanks
===============================================================================
 CSS                    78         6857         5400          299         1158
 Handlebars             85         3702         3465           82          155
 JavaScript             10          553          427           47           79
 JSON                    2          456          456            0            0
 SVG                   164         1717         1717            0            0
 TypeScript            195        13396         9657         1476         2263
===============================================================================
 Total                 534        26681        21122         1904         3655
===============================================================================
```
With this in the rollup config:
```js
addon.keepAssets(['**/styles/*.css']), // resolves to only 5 files in the project
```

Before:
```
 → dist...
created dist in 28.7s
```

After:
```
 → dist...
created dist in 7.1s
```