### PR TITLE
Upgrade changeset-recover to support label-based changelog management

### DIFF
--- a/.github/workflows/prepare-changelog.yml
+++ b/.github/workflows/prepare-changelog.yml
@@ -12,7 +12,7 @@ on:
       - main
 
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: prepare-changelog-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/prepare-changelog.yml
+++ b/.github/workflows/prepare-changelog.yml
@@ -1,8 +1,20 @@
 name: 'Prepare Changelog'
 on:
+  # Use labels on PRs to update the changelog
+  # - patch
+  # - minor
+  # - major
+  pull_request:
+    types:
+      - labeled
   push:
     branches:
       - main
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   VOLTA_FEATURE_PNPM: 1
   branch: "sync-changelog"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/jest": "^29.2.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
-    "changeset-recover": "0.1.0-beta.10",
+    "changeset-recover": "0.1.0-beta.11",
     "concurrently": "^7.2.1",
     "cross-env": "^7.0.3",
     "eslint": "^7.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(eslint@7.32.0)(typescript@4.4.2)
       changeset-recover:
-        specifier: 0.1.0-beta.10
-        version: 0.1.0-beta.10
+        specifier: 0.1.0-beta.11
+        version: 0.1.0-beta.11
       concurrently:
         specifier: ^7.2.1
         version: 7.2.1
@@ -9801,8 +9801,8 @@ packages:
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
-  /changeset-recover@0.1.0-beta.10:
-    resolution: {integrity: sha512-x+2+rHZafTEMbOXc7FlIDx2QxtoWTCL6GwAt9ZiRvmZ6Zp1woqJZQjKQ9SNlBR7kU6TFmOkKhhmDIqgL4eDYFg==}
+  /changeset-recover@0.1.0-beta.11:
+    resolution: {integrity: sha512-Qze+pi+yW4jD4UhFC/70nKJkdAUhoxH0bDWIaYtxXvZm/LQ509Yalb3ix1RVPRKWFIiaPlXpZAI5idn1gj/pWw==}
     engines: {node: ^16.0.0 || >= 18.0.0}
     hasBin: true
     dependencies:
@@ -16333,7 +16333,7 @@ packages:
       has-symbols: 1.0.3
 
   /is-type@0.0.1:
-    resolution: {integrity: sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=}
+    resolution: {integrity: sha512-YwJh/zBVrcJ90aAnPBM0CbHvm7lG9ao7lIFeqTZ1UQj4iFLpM5CikdaU+dGGesrMJwxLqPGmjjrUrQ6Kn3Zh+w==}
     dependencies:
       core-util-is: 1.0.3
 
@@ -21057,7 +21057,7 @@ packages:
       webpack: 5.74.0
 
   /styled_string@0.0.1:
-    resolution: {integrity: sha1-0ieCvYEpVFm8Tx3xjEutjpTdEko=}
+    resolution: {integrity: sha512-DU2KZiB6VbPkO2tGSqQ9n96ZstUPjW7X4sGO6V2m1myIQluX0p1Ol8BrA/l6/EesqhMqXOIXs3cJNOy1UuU2BA==}
 
   /sum-up@1.0.3:
     resolution: {integrity: sha512-zw5P8gnhiqokJUWRdR6F4kIIIke0+ubQSGyYUY506GCbJWtV7F6Xuy0j6S125eSX2oF+a8KdivsZ8PlVEH0Mcw==}


### PR DESCRIPTION
Changes to the workflow
 - re-runs the changeset generation on label change
 - only allow one run at a time, cancelling old or pending runs 
 
 Changes to `changeset-recover`
 - supports setting `patch` / `minor` / `major` via PR labels (like release-it)
 - better changed-package detection

This should allow the entire release process to be managed in the GitHub UI without needing to have git credentials or anything (ie: phone-based maintenance) 