### PR TITLE
don't force a utf8 encoding when reading the app HTML

### DIFF
--- a/packages/core/src/html-entrypoint.ts
+++ b/packages/core/src/html-entrypoint.ts
@@ -20,7 +20,9 @@ export class HTMLEntrypoint {
     private publicAssetURL: string,
     public filename: string
   ) {
-    this.dom = new JSDOM(readFileSync(join(this.pathToVanillaApp, this.filename), 'utf8'));
+    // https://github.com/jsdom/jsdom/issues/1898
+    // Omit hte encoding and let JSDOM handle it so that we can handle when a BOM is present
+    this.dom = new JSDOM(readFileSync(join(this.pathToVanillaApp, this.filename)));
 
     for (let tag of this.handledStyles()) {
       let styleTag = tag as HTMLLinkElement;


### PR DESCRIPTION
Resolves: https://github.com/embroider-build/embroider/issues/1402
NOTE: CI is borked until https://github.com/embroider-build/embroider/pull/1424

TODO: 
 - figure out how to make a BOM and add it to one of the scenarios for test coverage (and then test via temporary revert of this proposed fix)
    - at the moment, every time I copy a BOM character and try to paste it, my editor says my clipboard is empty and there is nothing to paste 😅 (or in VSCode, no change to the file occurs)