### PR TITLE
Use optional peer deps in @embroider/test-setup

### DIFF
--- a/packages/test-setup/package.json
+++ b/packages/test-setup/package.json
@@ -16,10 +16,26 @@
     "resolve": "^1.20.0"
   },
   "devDependencies": {
-    "@embroider/compat": "workspace:*",
-    "@embroider/core": "workspace:*",
-    "@embroider/webpack": "workspace:*",
+    "@embroider/compat": "workspace:^",
+    "@embroider/core": "workspace:^",
+    "@embroider/webpack": "workspace:^",
     "@types/lodash": "^4.14.170"
+  },
+  "peerDependencies": {
+    "@embroider/compat": "workspace:^",
+    "@embroider/core": "workspace:^",
+    "@embroider/webpack": "workspace:^"
+  },
+  "peerDependenciesMeta": {
+    "@embroider/compat": {
+      "optional": true
+    },
+    "@embroider/core": {
+      "optional": true
+    },
+    "@embroider/webpack": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"

--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -5,7 +5,15 @@ import type { Webpack } from '@embroider/webpack';
 type EmberWebpackOptions = typeof Webpack extends PackagerConstructor<infer Options> ? Options : never;
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const currentEmbroiderVersion = `^${require('../package.json').version}`;
+const ourPeerDeps = require('../package.json').peerDependencies;
+
+const embroiderDevDeps = {
+  '@embroider/core': `^${ourPeerDeps['@embroider/core']}`,
+  '@embroider/webpack': `^${ourPeerDeps['@embroider/webpack']}`,
+  '@embroider/compat': `^${ourPeerDeps['@embroider/compat']}`,
+  // Webpack is a peer dependency of `@embroider/webpack`
+  webpack: '^5.0.0',
+};
 
 /*
   Use this instead of `app.toTree()` in your ember-cli-build.js:
@@ -49,14 +57,7 @@ export function embroiderSafe(extension?: object) {
     {
       name: 'embroider-safe',
       npm: {
-        devDependencies: {
-          '@embroider/core': currentEmbroiderVersion,
-          '@embroider/webpack': currentEmbroiderVersion,
-          '@embroider/compat': currentEmbroiderVersion,
-
-          // Webpack is a peer dependency of `@embroider/webpack`
-          webpack: '^5.0.0',
-        },
+        devDependencies: embroiderDevDeps,
       },
       env: {
         EMBROIDER_TEST_SETUP_OPTIONS: 'safe',
@@ -71,14 +72,7 @@ export function embroiderOptimized(extension?: object) {
     {
       name: 'embroider-optimized',
       npm: {
-        devDependencies: {
-          '@embroider/core': currentEmbroiderVersion,
-          '@embroider/webpack': currentEmbroiderVersion,
-          '@embroider/compat': currentEmbroiderVersion,
-
-          // Webpack is a peer dependency of `@embroider/webpack`
-          webpack: '^5.0.0',
-        },
+        devDependencies: embroiderDevDeps,
       },
       env: {
         EMBROIDER_TEST_SETUP_OPTIONS: 'optimized',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -725,13 +725,13 @@ importers:
         version: 1.20.0
     devDependencies:
       '@embroider/compat':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../compat
       '@embroider/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@embroider/webpack':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../webpack
       '@types/lodash':
         specifier: ^4.14.170
@@ -1496,7 +1496,7 @@ importers:
         version: 7.3.8
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@20.1.3)(typescript@4.9.3)
+        version: 10.9.1(@types/node@15.12.2)(typescript@4.9.3)
     devDependencies:
       '@babel/core':
         specifier: ^7.17.5
@@ -1524,7 +1524,7 @@ importers:
         version: 7.18.6
       '@ember/legacy-built-in-components':
         specifier: ^0.4.1
-        version: 0.4.1(ember-source@5.0.0-beta.3)
+        version: 0.4.1(ember-source@5.0.0)
       '@ember/string':
         specifier: ^3.0.0
         version: 3.0.1
@@ -1578,7 +1578,7 @@ importers:
         version: 3.0.0
       ember-bootstrap:
         specifier: ^5.0.0
-        version: 5.0.0(@babel/core@7.19.6)(ember-source@5.0.0-beta.3)(webpack@5.82.1)
+        version: 5.0.0(@babel/core@7.19.6)(ember-source@5.0.0)(webpack@5.82.1)
       ember-cli:
         specifier: ~3.28.0
         version: 3.28.0(lodash@4.17.21)
@@ -1602,19 +1602,19 @@ importers:
         version: 3.28.0(@babel/core@7.19.6)
       ember-data-4.4:
         specifier: npm:ember-data@~4.4.0
-        version: /ember-data@4.4.1(@babel/core@7.19.6)(webpack@5.82.1)
+        version: /ember-data@4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
       ember-data-latest:
         specifier: npm:ember-data@4.4.1
         version: /ember-data@4.4.1(@babel/core@7.19.6)(webpack@5.82.1)
       ember-engines:
         specifier: ^0.8.23
-        version: 0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.0.0-beta.3)
+        version: 0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.0.0)
       ember-inline-svg:
         specifier: ^0.2.1
         version: 0.2.1(@babel/core@7.19.6)
       ember-modifier:
         specifier: ^4.0.0
-        version: 4.1.0(ember-source@5.0.0-beta.3)
+        version: 4.1.0(ember-source@5.0.0)
       ember-source:
         specifier: ~3.28.11
         version: 3.28.11(@babel/core@7.19.6)
@@ -1626,7 +1626,7 @@ importers:
         version: /ember-source@5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
       ember-source-latest:
         specifier: npm:ember-source@latest
-        version: /ember-source@4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
+        version: /ember-source@5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
       ember-truth-helpers:
         specifier: ^3.0.0
         version: 3.0.0
@@ -2036,7 +2036,7 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
       debug: 4.3.4(supports-color@8.1.0)
       lodash.debounce: 4.0.8
-      resolve: 1.20.0
+      resolve: 1.22.2
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -4361,6 +4361,24 @@ packages:
       - webpack
     dev: true
 
+  /@ember-data/adapter@4.4.0(@babel/core@7.19.6)(webpack@5.82.1):
+    resolution: {integrity: sha512-idHwfa29/Ki33FhTKUITvg2q2f2JEc7OqRyxCot+/BDJD8tj2AVToqs34wEXAFDCWua4lmR/KAGHLckMG4Eq+g==}
+    engines: {node: 12.* || >= 14.*}
+    dependencies:
+      '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
+      '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember/edition-utils': 1.2.0
+      '@ember/string': 3.0.1
+      ember-auto-import: 2.6.3(webpack@5.82.1)
+      ember-cli-babel: 7.26.11
+      ember-cli-test-info: 1.0.0
+      ember-cli-typescript: 5.2.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+
   /@ember-data/adapter@4.4.1(@babel/core@7.19.6)(webpack@5.82.1):
     resolution: {integrity: sha512-VIEusESLxpe/M7DGcmb7KTFLB3Joi+x5fbx6mywvYDhzTzsq/U5RCuIkxs9G/PNSlXD3z691GnZVd4T8GtcJXA==}
     engines: {node: 12.* || >= 14.*}
@@ -4441,6 +4459,23 @@ packages:
       - webpack
     dev: true
 
+  /@ember-data/debug@4.4.0(@babel/core@7.19.6)(webpack@5.82.1):
+    resolution: {integrity: sha512-gulLWVIIISG5o67fGxGraPI1ByYpR0LRRyU5+UROWweppVSf5zictKyyZwlxkfI8XvqC6rWRlCU0f3CstR7HWw==}
+    engines: {node: 12.* || >= 14.*}
+    dependencies:
+      '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
+      '@ember/edition-utils': 1.2.0
+      '@ember/string': 3.0.1
+      ember-auto-import: 2.6.3(webpack@5.82.1)
+      ember-cli-babel: 7.26.11
+      ember-cli-test-info: 1.0.0
+      ember-cli-typescript: 5.2.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+
   /@ember-data/debug@4.4.1(@babel/core@7.19.6)(webpack@5.82.1):
     resolution: {integrity: sha512-x5LeVyYSPZQkieJUU26c9mP4Y2Jo+kTBehh6+RgLOkCuNLfJdU5/YIB56IgWPFV0SmEMSoZtWh1rB+SBWAHWgg==}
     engines: {node: 12.* || >= 14.*}
@@ -4489,6 +4524,29 @@ packages:
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       ember-auto-import: 2.6.3(webpack@5.78.0)
+      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.19.6)
+      ember-cli-babel: 7.26.11
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      ember-cli-typescript: 5.2.1
+      ember-compatibility-helpers: 1.2.6(@babel/core@7.19.6)
+      inflection: 1.13.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+
+  /@ember-data/model@4.4.0(@babel/core@7.19.6)(webpack@5.82.1):
+    resolution: {integrity: sha512-lv8KhICjccDGu2/20dOcftpSI2V9bgfoOXXB3/7V+3Qxj75ws9U4jEqEZPc5rNQneufMUKVz/VBPgh9q3MJGQQ==}
+    engines: {node: 12.* || >= 14.*}
+    dependencies:
+      '@ember-data/canary-features': 4.4.0
+      '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
+      '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember/edition-utils': 1.2.0
+      '@ember/string': 3.0.1
+      ember-auto-import: 2.6.3(webpack@5.82.1)
       ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.19.6)
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
@@ -4553,7 +4611,7 @@ packages:
       npm-git-info: 1.0.3
       rimraf: 3.0.2
       rsvp: 4.8.5
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -4588,7 +4646,7 @@ packages:
       npm-git-info: 1.0.3
       rimraf: 3.0.2
       rsvp: 4.8.5
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -4623,7 +4681,7 @@ packages:
       npm-git-info: 1.0.3
       rimraf: 3.0.2
       rsvp: 4.8.5
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -4655,6 +4713,24 @@ packages:
       '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.78.0)
       '@ember/edition-utils': 1.2.0
       ember-auto-import: 2.6.3(webpack@5.78.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-test-info: 1.0.0
+      ember-cli-typescript: 5.2.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+
+  /@ember-data/record-data@4.4.0(@babel/core@7.19.6)(webpack@5.82.1):
+    resolution: {integrity: sha512-QBP8EMih2tvXMHUv8j/jWzOkW/d/OGfO22maOi9mh/MoCaX+EphupgdCFJL2SjQZYFPVioPosLQmQX4l5ChkDw==}
+    engines: {node: 12.* || >= 14.*}
+    dependencies:
+      '@ember-data/canary-features': 4.4.0
+      '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
+      '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember/edition-utils': 1.2.0
+      ember-auto-import: 2.6.3(webpack@5.82.1)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-cli-typescript: 5.2.1
@@ -4715,6 +4791,22 @@ packages:
       - webpack
     dev: true
 
+  /@ember-data/serializer@4.4.0(@babel/core@7.19.6)(webpack@5.82.1):
+    resolution: {integrity: sha512-lmNT+Zg+6onR/d0OSBcj/AMbI6XdquUZLahYwElKxG/NWD8TqhVu/uPHTDjmT3tr66JlX7CHvd1zbQahgy4uaA==}
+    engines: {node: 12.* || >= 14.*}
+    dependencies:
+      '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
+      '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      ember-auto-import: 2.6.3(webpack@5.82.1)
+      ember-cli-babel: 7.26.11
+      ember-cli-test-info: 1.0.0
+      ember-cli-typescript: 5.2.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+
   /@ember-data/serializer@4.4.1(@babel/core@7.19.6)(webpack@5.82.1):
     resolution: {integrity: sha512-ffzHcWDJlX5epM8SzQMirRkBU2/N/enJwnJV28DzcxQcrbVfUWZqaPgQWpg8wADLETfumERzy7WIJlcSCGR5ow==}
     engines: {node: 12.* || >= 14.*}
@@ -4756,6 +4848,25 @@ packages:
       '@ember/string': 3.0.1
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.6.3(webpack@5.78.0)
+      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.19.6)
+      ember-cli-babel: 7.26.11
+      ember-cli-path-utils: 1.0.0
+      ember-cli-typescript: 5.2.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+
+  /@ember-data/store@4.4.0(@babel/core@7.19.6)(webpack@5.82.1):
+    resolution: {integrity: sha512-jugE0yPxrxA5O5jUf3pGUXnuXQG07HnXUd3CXOQ1jSdkGcjJXOrWgNyNgFEOIC9Z8I6iwG7QIC7KIKF4nm3j0Q==}
+    engines: {node: 12.* || >= 14.*}
+    dependencies:
+      '@ember-data/canary-features': 4.4.0
+      '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
+      '@ember/string': 3.0.1
+      '@glimmer/tracking': 1.1.2
+      ember-auto-import: 2.6.3(webpack@5.82.1)
       ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.19.6)
       ember-cli-babel: 7.26.11
       ember-cli-path-utils: 1.0.0
@@ -4840,7 +4951,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/legacy-built-in-components@0.4.1(ember-source@5.0.0-beta.3):
+  /@ember/legacy-built-in-components@0.4.1(ember-source@5.0.0):
     resolution: {integrity: sha512-tLxiU1YR+A+002rkGfwyB4FK8bO5qqU/3c7cZ1z2j3XG+1T28Yg2iZuMxPwFJ0LsE//mhRFkWlGzO3tJUtMHbA==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -4850,7 +4961,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-typescript: 4.2.1
-      ember-source: 5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
+      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4900,7 +5011,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/render-modifiers@2.0.5(@babel/core@7.19.6)(ember-source@5.0.0-beta.3):
+  /@ember/render-modifiers@2.0.5(@babel/core@7.19.6)(ember-source@5.0.0):
     resolution: {integrity: sha512-5cJ1niIdOJC6k6KtIn9HGbr1DATJQp4ZqMv1vbi6LKQWbVCQ3byvKONtUEi3H0wcewlrcaWCqXOgm0nACzCOQA==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -4909,7 +5020,7 @@ packages:
       '@embroider/macros': 1.10.0
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.19.6)
-      ember-source: 5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
+      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -5006,8 +5117,8 @@ packages:
       ember-cli-babel: 7.26.11
       find-up: 5.0.0
       lodash: 4.17.21
-      resolve: 1.20.0
-      semver: 7.3.8
+      resolve: 1.22.2
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5020,8 +5131,8 @@ packages:
       fs-extra: 9.1.0
       js-string-escape: 1.0.1
       lodash: 4.17.21
-      resolve-package-path: 4.0.1
-      semver: 7.3.8
+      resolve-package-path: 4.0.3
+      semver: 7.5.1
       typescript-memoize: 1.0.1
 
   /@embroider/util@1.10.0(@glint/template@1.0.0)(ember-source@4.12.0):
@@ -6418,10 +6529,6 @@ packages:
   /@types/node@17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
     dev: true
-
-  /@types/node@20.1.3:
-    resolution: {integrity: sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA==}
-    dev: false
 
   /@types/node@9.6.61:
     resolution: {integrity: sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ==}
@@ -8447,7 +8554,7 @@ packages:
       wordwrap: 0.0.3
 
   /bower-endpoint-parser@0.2.2:
-    resolution: {integrity: sha512-YWZHhWkPdXtIfH3VRu3QIV95sa75O9vrQWBOHjexWCLBCTy5qJvRr36LXTqFwTchSXVlzy5piYJOjzHr7qhsNg==}
+    resolution: {integrity: sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=}
     engines: {node: '>=0.8.0'}
 
   /brace-expansion@1.1.11:
@@ -9058,7 +9165,7 @@ packages:
       ensure-posix-path: 1.1.1
       fs-extra: 5.0.0
       minimatch: 3.1.2
-      resolve: 1.20.0
+      resolve: 1.22.2
       rsvp: 4.8.5
       symlink-or-copy: 1.3.1
       walk-sync: 0.3.4
@@ -9223,7 +9330,7 @@ packages:
       caniuse-lite: 1.0.30001486
       isbot: 3.4.5
       object-path: 0.11.8
-      semver: 7.3.8
+      semver: 7.5.1
       ua-parser-js: 1.0.35
     dev: true
 
@@ -9265,7 +9372,7 @@ packages:
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.3.8
+      semver: 7.5.1
     dev: true
 
   /bytes@1.0.0:
@@ -10287,7 +10394,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.23)
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.2
-      semver: 7.3.8
+      semver: 7.5.1
       webpack: 5.82.1
 
   /css-select-base-adapter@0.1.1:
@@ -10865,7 +10972,7 @@ packages:
       parse5: 6.0.1
       resolve: 1.22.2
       resolve-package-path: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.1
       style-loader: 2.0.0(webpack@5.78.0)
       typescript-memoize: 1.0.1
       walk-sync: 3.0.0
@@ -10904,7 +11011,7 @@ packages:
       parse5: 6.0.1
       resolve: 1.22.2
       resolve-package-path: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.1
       style-loader: 2.0.0(webpack@5.82.1)
       typescript-memoize: 1.0.1
       walk-sync: 3.0.0
@@ -10912,11 +11019,11 @@ packages:
       - supports-color
       - webpack
 
-  /ember-bootstrap@5.0.0(@babel/core@7.19.6)(ember-source@5.0.0-beta.3)(webpack@5.82.1):
+  /ember-bootstrap@5.0.0(@babel/core@7.19.6)(ember-source@5.0.0)(webpack@5.82.1):
     resolution: {integrity: sha512-ocH7qJKikxDgLv1prWyYzDaH85of8/l0LeV2bnMCp3/ZdRak/vq4dWqm53hMQ0ifN4llfs1Q1bwlcra/BT7yCA==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@ember/render-modifiers': 2.0.5(@babel/core@7.19.6)(ember-source@5.0.0-beta.3)
+      '@ember/render-modifiers': 2.0.5(@babel/core@7.19.6)(ember-source@5.0.0)
       '@embroider/macros': 1.10.0
       '@embroider/util': 1.10.0(@glint/template@1.0.0)(ember-source@4.12.0)
       '@glimmer/component': 1.1.2(@babel/core@7.19.6)
@@ -10932,7 +11039,7 @@ packages:
       ember-cli-version-checker: 5.1.2
       ember-concurrency: 2.3.7(@babel/core@7.19.6)
       ember-decorators: 6.1.1
-      ember-element-helper: 0.6.1(ember-source@5.0.0-beta.3)
+      ember-element-helper: 0.6.1(ember-source@5.0.0)
       ember-focus-trap: 1.0.2
       ember-in-element-polyfill: 1.0.1
       ember-named-blocks-polyfill: 0.2.5
@@ -11204,7 +11311,7 @@ packages:
       hash-for-dep: 1.5.1
       heimdalljs-logger: 0.1.10
       json-stable-stringify: 1.0.2
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
       strip-bom: 4.0.0
       walk-sync: 2.2.0
@@ -11389,9 +11496,9 @@ packages:
       debug: 4.3.4(supports-color@8.1.0)
       execa: 4.1.0
       fs-extra: 9.1.0
-      resolve: 1.20.0
+      resolve: 1.22.2
       rsvp: 4.8.5
-      semver: 7.3.8
+      semver: 7.5.1
       stagehand: 1.0.1
       walk-sync: 2.2.0
     transitivePeerDependencies:
@@ -11407,9 +11514,9 @@ packages:
       debug: 4.3.4(supports-color@8.1.0)
       execa: 4.1.0
       fs-extra: 9.1.0
-      resolve: 1.20.0
+      resolve: 1.22.2
       rsvp: 4.8.5
-      semver: 7.3.8
+      semver: 7.5.1
       stagehand: 1.0.1
       walk-sync: 2.2.0
     transitivePeerDependencies:
@@ -11457,7 +11564,7 @@ packages:
     engines: {node: 10.* || >= 12.*}
     dependencies:
       resolve-package-path: 3.1.0
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -11702,7 +11809,7 @@ packages:
       resolve-package-path: 4.0.3
       safe-stable-stringify: 2.4.3
       sane: 5.0.1
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
@@ -11779,8 +11886,8 @@ packages:
     engines: {node: '>= 12'}
     hasBin: true
     dependencies:
-      '@babel/core': 7.19.6(supports-color@8.1.0)
-      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.19.6)
+      '@babel/core': 7.21.8
+      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.21.8)
       amd-name-resolver: 1.3.1
       babel-plugin-module-resolver: 4.1.0
       bower-config: 1.4.3
@@ -11854,11 +11961,11 @@ packages:
       promise.hash.helper: 1.0.8
       quick-temp: 0.1.8
       remove-types: 1.0.0
-      resolve: 1.20.0
+      resolve: 1.22.2
       resolve-package-path: 3.1.0
       safe-stable-stringify: 2.4.3
       sane: 5.0.1
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
@@ -12166,7 +12273,7 @@ packages:
       resolve-package-path: 4.0.3
       safe-stable-stringify: 2.4.3
       sane: 5.0.1
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
@@ -12328,6 +12435,31 @@ packages:
       - webpack
     dev: true
 
+  /ember-data@4.4.0(@babel/core@7.19.6)(webpack@5.82.1):
+    resolution: {integrity: sha512-Ak/CyffnGuaGv7y1TZJFPmHuCNf11cvcPICBGbe9nw5rbTJawakqsxCJ6TaPb9vR+KqE52uzWRcgz4c5HmfLsw==}
+    engines: {node: 12.* || >= 14.*}
+    dependencies:
+      '@ember-data/adapter': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember-data/debug': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember-data/model': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
+      '@ember-data/record-data': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember-data/serializer': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.82.1)
+      '@ember/edition-utils': 1.2.0
+      '@ember/string': 3.0.1
+      '@glimmer/env': 0.1.7
+      broccoli-merge-trees: 4.2.0
+      ember-auto-import: 2.6.3(webpack@5.82.1)
+      ember-cli-babel: 7.26.11
+      ember-cli-typescript: 5.2.1
+      ember-inflector: 4.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+
   /ember-data@4.4.1(@babel/core@7.19.6)(webpack@5.82.1):
     resolution: {integrity: sha512-Jc8a2OTX3rcnbmVwBjdeOYPSKUHWYRH+RMyDSLN3fpLp/A8pZp1Lkn3b5/ZEi9DmBRirxIDSSSPPZ6RDTMBYlQ==}
     engines: {node: 12.* || >= 14.*}
@@ -12381,7 +12513,7 @@ packages:
     engines: {node: '>= 0.10.0'}
     dev: true
 
-  /ember-element-helper@0.6.1(ember-source@5.0.0-beta.3):
+  /ember-element-helper@0.6.1(ember-source@5.0.0):
     resolution: {integrity: sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -12390,20 +12522,20 @@ packages:
       '@embroider/util': 1.10.0(@glint/template@1.0.0)(ember-source@4.12.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.2.0
-      ember-source: 5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
+      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
     dev: true
 
-  /ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.0.0-beta.3):
+  /ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.0.0):
     resolution: {integrity: sha512-rrvHUkZRNrf+9u/sCw7XYrITStjP/9Ypykk1nYQHoo+6Krp11e81QNVsGTXFpXtMHXbNtH5IcRyZvfSXqUOrUQ==}
     engines: {node: 10.* || >= 12}
     peerDependencies:
       '@ember/legacy-built-in-components': '*'
       ember-source: ^3.12 || 4
     dependencies:
-      '@ember/legacy-built-in-components': 0.4.1(ember-source@5.0.0-beta.3)
+      '@ember/legacy-built-in-components': 0.4.1(ember-source@5.0.0)
       '@embroider/macros': 1.10.0
       amd-name-resolver: 1.3.1
       babel-plugin-compact-reexports: 1.1.0
@@ -12421,7 +12553,7 @@ packages:
       ember-cli-preprocess-registry: 3.3.0
       ember-cli-string-utils: 1.1.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
+      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -12617,7 +12749,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-modifier@4.1.0(ember-source@5.0.0-beta.3):
+  /ember-modifier@4.1.0(ember-source@5.0.0):
     resolution: {integrity: sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==}
     peerDependencies:
       ember-source: '*'
@@ -12628,7 +12760,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
+      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12973,7 +13105,7 @@ packages:
       broccoli-file-creator: 2.1.1
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
-      chalk: 4.1.1
+      chalk: 4.1.2
       ember-auto-import: 2.6.3(webpack@5.78.0)
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
@@ -13061,7 +13193,7 @@ packages:
       ember-router-generator: 2.0.0
       inflection: 1.13.4
       resolve: 1.22.2
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -13105,6 +13237,45 @@ packages:
       - webpack
     dev: true
 
+  /ember-source@5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1):
+    resolution: {integrity: sha512-zy0iU3Mf9HZXVQacqWLAfHCbQge8Ysi2EpU6XTgrdf2PX5ILdWTbSPklxuTlkGV7NrG5PkIfGW8hfimwY6I/tw==}
+    engines: {node: '>= 16.*'}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
+    dependencies:
+      '@babel/helper-module-imports': 7.21.4
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.19.6)
+      '@ember/edition-utils': 1.2.0
+      '@glimmer/component': 1.1.2(@babel/core@7.19.6)
+      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.19.6)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.19.6)
+      babel-plugin-filter-imports: 4.0.0
+      broccoli-concat: 4.2.5
+      broccoli-debug: 0.6.5
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      chalk: 4.1.2
+      ember-auto-import: 2.6.3(webpack@5.82.1)
+      ember-cli-babel: 7.26.11
+      ember-cli-get-component-path-option: 1.0.0
+      ember-cli-is-package-missing: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0
+      ember-cli-version-checker: 5.1.2
+      ember-router-generator: 2.0.0
+      inflection: 1.13.4
+      resolve: 1.22.2
+      semver: 7.5.1
+      silent-error: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+      - webpack
+    dev: true
+
   /ember-source@5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.82.1):
     resolution: {integrity: sha512-NkPWXt7nYEvoSOzjJJ3JxYPGvvHoZ2ouPHqs1/Jf2ZahXY5SKJW3mTJql1zW5gMcUwNIoFx1cvlfHr3CJ6sQog==}
     engines: {node: '>= 16.*'}
@@ -13136,7 +13307,7 @@ packages:
       ember-router-generator: 2.0.0
       inflection: 1.13.4
       resolve: 1.22.2
-      semver: 7.3.8
+      semver: 7.5.1
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -13270,7 +13441,7 @@ packages:
       lodash: 4.17.21
       package-json: 6.5.0
       remote-git-tags: 3.0.0
-      semver: 7.3.8
+      semver: 7.5.1
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -15518,7 +15689,7 @@ packages:
       heimdalljs: 0.2.6
       heimdalljs-logger: 0.1.10
       path-root: 0.1.1
-      resolve: 1.20.0
+      resolve: 1.22.2
       resolve-package-path: 1.2.7
     transitivePeerDependencies:
       - supports-color
@@ -16172,7 +16343,7 @@ packages:
   /is-language-code@3.1.0:
     resolution: {integrity: sha512-zJdQ3QTeLye+iphMeK3wks+vXSRFKh68/Pnlw7aOfApFSEIOhYa8P9vwwa6QrImNNBMJTiL1PpYF0f4BxDuEgA==}
     dependencies:
-      '@babel/runtime': 7.18.6
+      '@babel/runtime': 7.21.5
     dev: true
 
   /is-map@2.0.2:
@@ -16857,7 +17028,7 @@ packages:
     dependencies:
       '@types/node': 15.12.2
       merge-stream: 2.0.0
-      supports-color: 8.1.0
+      supports-color: 8.1.1
 
   /jest-worker@29.5.0:
     resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
@@ -18323,7 +18494,7 @@ packages:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.3.8
+      semver: 7.5.1
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -18441,7 +18612,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
-      semver: 7.3.8
+      semver: 7.5.1
       validate-npm-package-name: 5.0.0
     dev: true
 
@@ -18450,7 +18621,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.3.8
+      semver: 7.5.1
       validate-npm-package-name: 3.0.0
 
   /npm-package-arg@9.1.2:
@@ -18459,7 +18630,7 @@ packages:
     dependencies:
       hosted-git-info: 5.2.1
       proc-log: 2.0.1
-      semver: 7.3.8
+      semver: 7.5.1
       validate-npm-package-name: 4.0.0
     dev: true
 
@@ -19864,9 +20035,9 @@ packages:
   /remove-types@1.0.0:
     resolution: {integrity: sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==}
     dependencies:
-      '@babel/core': 7.19.6(supports-color@8.1.0)
-      '@babel/plugin-syntax-decorators': 7.21.0(@babel/core@7.19.6)
-      '@babel/plugin-transform-typescript': 7.21.3(@babel/core@7.19.6)
+      '@babel/core': 7.21.8
+      '@babel/plugin-syntax-decorators': 7.21.0(@babel/core@7.21.8)
+      '@babel/plugin-transform-typescript': 7.21.3(@babel/core@7.21.8)
       prettier: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -19956,20 +20127,21 @@ packages:
     engines: {node: 8.* || 10.* || >= 12}
     dependencies:
       path-root: 0.1.1
-      resolve: 1.20.0
+      resolve: 1.22.2
 
   /resolve-package-path@3.1.0:
     resolution: {integrity: sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==}
     engines: {node: 10.* || >= 12}
     dependencies:
       path-root: 0.1.1
-      resolve: 1.20.0
+      resolve: 1.22.2
 
   /resolve-package-path@4.0.1:
     resolution: {integrity: sha512-2gb/yU2fSfX22pjDYyevzyOKK9q72XKUFqlAsrfPzZArM4JkIH/Qcme4n3EbaZttObWm/fIFLbPxrXIyiL8wdQ==}
     engines: {node: '>= 12'}
     dependencies:
       path-root: 0.1.1
+    dev: false
 
   /resolve-package-path@4.0.3:
     resolution: {integrity: sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==}
@@ -20369,7 +20541,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -21193,7 +21364,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-hyperlinks@3.0.0:
     resolution: {integrity: sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==}
@@ -21743,7 +21913,7 @@ packages:
       typescript: 4.9.3
     dev: true
 
-  /ts-node@10.9.1(@types/node@20.1.3)(typescript@4.9.3):
+  /ts-node@10.9.1(@types/node@15.12.2)(typescript@4.9.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -21762,7 +21932,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.1.3
+      '@types/node': 15.12.2
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -22190,7 +22360,7 @@ packages:
     engines: {node: '>= 12'}
     dependencies:
       resolve-package-path: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.1
     dev: true
 
   /vary@1.1.2:
@@ -22567,7 +22737,7 @@ packages:
   /workerpool@3.1.2:
     resolution: {integrity: sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==}
     dependencies:
-      '@babel/core': 7.19.6(supports-color@8.1.0)
+      '@babel/core': 7.21.8
       object-assign: 4.1.1
       rsvp: 4.8.5
     transitivePeerDependencies:


### PR DESCRIPTION
This makes it clearer to the release infrastructure why test-setup needs to get bumped when a package like `@embroider/core` gets a major.

