### PR TITLE
prevent double ^ when using embroider test-setup

### DIFF
--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -8,9 +8,9 @@ type EmberWebpackOptions = typeof Webpack extends PackagerConstructor<infer Opti
 const ourPeerDeps = require('../package.json').peerDependencies;
 
 const embroiderDevDeps = {
-  '@embroider/core': `^${ourPeerDeps['@embroider/core']}`,
-  '@embroider/webpack': `^${ourPeerDeps['@embroider/webpack']}`,
-  '@embroider/compat': `^${ourPeerDeps['@embroider/compat']}`,
+  '@embroider/core': `${ourPeerDeps['@embroider/core']}`,
+  '@embroider/webpack': `${ourPeerDeps['@embroider/webpack']}`,
+  '@embroider/compat': `${ourPeerDeps['@embroider/compat']}`,
   // Webpack is a peer dependency of `@embroider/webpack`
   webpack: '^5.0.0',
 };


### PR DESCRIPTION
After the last release `@embroider/test-setup` was outputting a double `^` for the embroider versions like this: 

```
"@embroider/core": "^^3.0.0",
"@embroider/webpack": "^^3.0.0",
"@embroider/compat": "^^3.0.0"
```

I don't know if any other packagers are more lenient about this but pnpm is very unhappy, so we should remove the extra carat 👍 