### PR TITLE
linkto routable engine path in host app

### DIFF
--- a/tests/fixtures/engines-host-app/app/templates/application.hbs
+++ b/tests/fixtures/engines-host-app/app/templates/application.hbs
@@ -1,6 +1,7 @@
 <nav>
   <LinkTo @route="use-eager-engine">Eager</LinkTo>
   <LinkTo @route="use-lazy-engine">Lazy</LinkTo>
+  <LinkTo @route="use-lazy-engine.inner-engine">Inner</LinkTo>
   <LinkTo @route="style-check">Style Check</LinkTo>
 </nav>
 

--- a/tests/fixtures/engines-host-app/ember-cli-build.js
+++ b/tests/fixtures/engines-host-app/ember-cli-build.js
@@ -27,5 +27,11 @@ module.exports = function (defaults) {
   }
 
   const Webpack = require('@embroider/webpack').Webpack;
-  return require('@embroider/compat').compatBuild(app, Webpack);
+  return require('@embroider/compat').compatBuild(app, Webpack, {
+    // staticAddonTestSupportTrees: true,
+    // staticAddonTrees: true,
+    // staticHelpers: true,
+    // staticModifiers: true,
+    // staticComponents: true,
+  });
 };

--- a/tests/fixtures/lazy-engine/addon/routes.js
+++ b/tests/fixtures/lazy-engine/addon/routes.js
@@ -1,3 +1,5 @@
 import buildRoutes from 'ember-engines/routes';
 
-export default buildRoutes(function() {});
+export default buildRoutes(function() {
+    this.route('inner-engine')
+});


### PR DESCRIPTION
this pr adds a failing test case for routable lazy engines