### PR TITLE
Revert "Run the clean plugin of addon-dev as late as possible"

### DIFF
--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -48,7 +48,7 @@ export class Addon {
   // By default rollup does not clear the output directory between builds. This
   // does that.
   clean() {
-    return clean({ targets: `${this.#destDir}/*`, hook: 'generateBundle' });
+    return clean({ targets: `${this.#destDir}/*` });
   }
 
   // V2 Addons are allowed to contain imports of .css files. This tells rollup


### PR DESCRIPTION
This reverts the change made in https://github.com/embroider-build/embroider/pull/1229

Essentially if you have any plugins that are outputting files in the build phase (before generateBundle) then they will be deleted. This is too aggressive as a default and doesn't actually solve the issue of noisy rebuilds 😞 