### PR TITLE
fix keepAssets corrupting image files

### DIFF
--- a/packages/addon-dev/src/rollup-keep-assets.ts
+++ b/packages/addon-dev/src/rollup-keep-assets.ts
@@ -40,7 +40,7 @@ export default function keepAssets({
         this.emitFile({
           type: 'asset',
           fileName: name,
-          source: readFileSync(join(from, name), 'utf8'),
+          source: readFileSync(join(from, name)),
         });
       }
     },


### PR DESCRIPTION
We noticed that png files were getting corrupted when passing through the keepAssets plugin. We patched it locally and this change seems to make it work 👍 I'm just assuming that some png files don't survive being read as utf8 and then re-written back as utf8 🤷 