### PR TITLE
Add the ability to customise rollup-plugin-clean's config

### DIFF
--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -1,7 +1,7 @@
 import { default as hbs } from './rollup-hbs-plugin';
 import { default as publicEntrypoints } from './rollup-public-entrypoints';
 import { default as appReexports } from './rollup-app-reexports';
-import { default as clean } from 'rollup-plugin-delete';
+import { default as clean, Options as DelOptions } from 'rollup-plugin-delete';
 import { default as keepAssets } from './rollup-keep-assets';
 import { default as dependencies } from './rollup-addon-dependencies';
 import { default as publicAssets } from './rollup-public-assets';
@@ -47,8 +47,8 @@ export class Addon {
 
   // By default rollup does not clear the output directory between builds. This
   // does that.
-  clean() {
-    return clean({ targets: `${this.#destDir}/*` });
+  clean(options: DelOptions) {
+    return clean({ targets: `${this.#destDir}/*`, ...options });
   }
 
   // V2 Addons are allowed to contain imports of .css files. This tells rollup


### PR DESCRIPTION
Now that #1446 is merged this PR adds the ability to customise the config sent to addon.clean() using the available config on the underlying rollup-plugin-delete package

Essentially I think that changing the build step for everyone was a bit too aggressive a change and can cause issues (like accidentally deleting previously emitted files). If you have a specific use case where you want to clean the dist files late in the stack you can just add the hook config to our `clean()` call with this PR 👍 