### PR TITLE
[bugfix] Set output.experimentalMinChunkSize to 0, to counter a change in rollup@3.22.0

### DIFF
--- a/packages/addon-dev/package.json
+++ b/packages/addon-dev/package.json
@@ -42,7 +42,7 @@
     "@types/fs-extra": "^9.0.12",
     "@types/minimatch": "^3.0.4",
     "@types/yargs": "^17.0.3",
-    "rollup": "^2.58.0",
+    "rollup": "^3.23.0",
     "tmp": "^0.1.0",
     "typescript": "^4.9.0"
   },

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -75,6 +75,7 @@ export class Addon {
     return {
       dir: this.#destDir,
       entryFileNames: '[name]',
+      experimentalMinChunkSize: 0,
       format: 'es',
       hoistTransitiveImports: false,
       sourcemap: true,

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -74,8 +74,8 @@ export class Addon {
   output() {
     return {
       dir: this.#destDir,
-      format: 'es',
       entryFileNames: '[name]',
+      format: 'es',
       hoistTransitiveImports: false,
       sourcemap: true,
     };

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -53,9 +53,9 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
-    "rollup": "^2.67.0",
+    "rollup": "^3.23.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "~3.0.2",
+    "rollup-plugin-ts": "^3.2.0",
     "typescript": "^4.9.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
         version: 3.0.4
       rollup-plugin-copy-assets:
         specifier: ^2.0.3
-        version: 2.0.3(rollup@2.69.1)
+        version: 2.0.3(rollup@3.23.0)
       rollup-plugin-delete:
         specifier: ^2.0.0
         version: 2.0.0
@@ -96,8 +96,8 @@ importers:
         specifier: ^17.0.3
         version: 17.0.3
       rollup:
-        specifier: ^2.58.0
-        version: 2.69.1
+        specifier: ^3.23.0
+        version: 3.23.0
       tmp:
         specifier: ^0.1.0
         version: 0.1.0
@@ -633,14 +633,14 @@ importers:
         specifier: ^2.5.1
         version: 2.8.7
       rollup:
-        specifier: ^2.67.0
-        version: 2.69.1
+        specifier: ^3.23.0
+        version: 3.23.0
       rollup-plugin-copy:
         specifier: ^3.4.0
         version: 3.4.0
       rollup-plugin-ts:
-        specifier: ~3.0.2
-        version: 3.0.2(@babel/core@7.19.6)(@babel/plugin-transform-runtime@7.18.6)(@babel/preset-env@7.16.11)(@babel/preset-typescript@7.18.6)(@babel/runtime@7.18.6)(rollup@2.69.1)(typescript@4.9.3)
+        specifier: ^3.2.0
+        version: 3.2.0(@babel/core@7.19.6)(@babel/plugin-transform-runtime@7.18.6)(@babel/preset-env@7.16.11)(@babel/preset-typescript@7.18.6)(@babel/runtime@7.18.6)(rollup@3.23.0)(typescript@4.9.3)
       typescript:
         specifier: ^4.9.0
         version: 4.9.3
@@ -1581,7 +1581,7 @@ importers:
         version: 7.18.6
       '@ember/legacy-built-in-components':
         specifier: ^0.4.1
-        version: 0.4.1(ember-source@5.0.0)
+        version: 0.4.1(ember-source@5.1.0-beta.1)
       '@ember/string':
         specifier: ^3.0.0
         version: 3.0.1
@@ -1599,7 +1599,7 @@ importers:
         version: link:../../packages/util
       '@rollup/plugin-babel':
         specifier: ^5.3.1
-        version: 5.3.1(@babel/core@7.19.6)(rollup@2.69.1)
+        version: 5.3.1(@babel/core@7.19.6)(rollup@3.23.0)
       '@tsconfig/ember':
         specifier: 1.0.1
         version: 1.0.1
@@ -1635,7 +1635,7 @@ importers:
         version: 3.0.0
       ember-bootstrap:
         specifier: ^5.0.0
-        version: 5.0.0(@babel/core@7.19.6)(ember-source@5.0.0)(webpack@5.78.0)
+        version: 5.0.0(@babel/core@7.19.6)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
       ember-cli:
         specifier: ~3.28.0
         version: 3.28.0(lodash@4.17.21)
@@ -1662,16 +1662,16 @@ importers:
         version: /ember-data@4.4.0(@babel/core@7.19.6)(webpack@5.78.0)
       ember-data-latest:
         specifier: npm:ember-data@latest
-        version: /ember-data@4.12.0(@babel/core@7.19.6)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)(webpack@5.78.0)
+        version: /ember-data@4.11.3(@babel/core@7.19.6)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
       ember-engines:
         specifier: ^0.8.23
-        version: 0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.0.0)
+        version: 0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.1.0-beta.1)
       ember-inline-svg:
         specifier: ^0.2.1
         version: 0.2.1(@babel/core@7.19.6)
       ember-modifier:
         specifier: ^4.0.0
-        version: 4.1.0(ember-source@5.0.0)
+        version: 4.1.0(ember-source@5.1.0-beta.1)
       ember-source:
         specifier: ~3.28.11
         version: 3.28.11(@babel/core@7.19.6)
@@ -1680,7 +1680,7 @@ importers:
         version: /ember-source@4.4.0(@babel/core@7.19.6)(webpack@5.78.0)
       ember-source-beta:
         specifier: npm:ember-source@beta
-        version: /ember-source@5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0)
+        version: /ember-source@5.1.0-beta.1(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
       ember-source-latest:
         specifier: npm:ember-source@latest
         version: /ember-source@5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0)
@@ -1688,11 +1688,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       rollup:
-        specifier: ^2.69.1
-        version: 2.69.1
+        specifier: ^3.23.0
+        version: 3.23.0
       rollup-plugin-ts:
-        specifier: ~3.0.0
-        version: 3.0.2(@babel/core@7.19.6)(@babel/plugin-transform-runtime@7.18.6)(@babel/preset-env@7.16.11)(@babel/preset-typescript@7.18.6)(@babel/runtime@7.18.6)(rollup@2.69.1)(typescript@4.9.3)
+        specifier: ^3.2.0
+        version: 3.2.0(@babel/core@7.19.6)(@babel/plugin-transform-runtime@7.18.6)(@babel/preset-env@7.16.11)(@babel/preset-typescript@7.18.6)(@babel/runtime@7.18.6)(rollup@3.23.0)(typescript@4.9.3)
       typescript:
         specifier: ^4.9.0
         version: 4.9.3
@@ -1933,7 +1933,7 @@ packages:
       '@babel/traverse': 7.21.5(supports-color@8.1.0)
       '@babel/types': 7.21.5
       convert-source-map: 1.9.0
-      debug: 4.3.2(supports-color@8.1.0)
+      debug: 4.3.4(supports-color@8.1.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -1948,14 +1948,14 @@ packages:
       '@babel/code-frame': 7.21.4
       '@babel/generator': 7.21.5
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helpers': 7.21.5
+      '@babel/helper-module-transforms': 7.21.5(supports-color@8.1.0)
+      '@babel/helpers': 7.21.5(supports-color@8.1.0)
       '@babel/parser': 7.21.8
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@8.1.0)
       '@babel/types': 7.21.5
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -2117,21 +2117,6 @@ packages:
     dependencies:
       '@babel/types': 7.21.5
 
-  /@babel/helper-module-transforms@7.21.5:
-    resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-simple-access': 7.21.5
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
-      '@babel/types': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
-
   /@babel/helper-module-transforms@7.21.5(supports-color@8.1.0):
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
     engines: {node: '>=6.9.0'}
@@ -2221,16 +2206,6 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.5(supports-color@8.1.0)
-      '@babel/types': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
-
-  /@babel/helpers@7.21.5:
-    resolution: {integrity: sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -3413,23 +3388,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/traverse@7.21.5:
-    resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.5
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.8
-      '@babel/types': 7.21.5
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   /@babel/traverse@7.21.5(supports-color@8.1.0):
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
     engines: {node: '>=6.9.0'}
@@ -3549,23 +3507,26 @@ packages:
       - supports-color
     dev: true
 
-  /@ember-data/adapter@4.12.0(@ember-data/store@4.12.0)(@ember/string@3.0.1)(ember-inflector@4.0.2):
-    resolution: {integrity: sha512-sY7Zm73LSN1x1jO+lTV0+Vtdis6rBFAuRD3sln1BOW0y9che5WK+qyQs8FhjC6m9D/FFIKqUucWvaPO4/GazuQ==}
-    engines: {node: 16.* || >= 18.*}
+  /@ember-data/adapter@4.11.3(@ember-data/store@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(webpack@5.78.0):
+    resolution: {integrity: sha512-G7dbaPnYMW8VYxIT75KAkzax2mkWTs2TYxS7+qbphs6esXpO9Y/iNp5fTqLaACb9JqUypwEA/rlfC7/zkcGbBw==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
-      '@ember-data/store': 4.12.0
+      '@ember-data/store': 4.11.3
       '@ember/string': ^3.0.1
       ember-inflector: ^4.0.2
     dependencies:
-      '@ember-data/private-build-infra': 4.12.0
-      '@ember-data/store': 4.12.0(@babel/core@7.19.6)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/model@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+      '@ember-data/private-build-infra': 4.11.3
+      '@ember-data/store': 4.11.3(@babel/core@7.19.6)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
+      '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
+      ember-auto-import: 2.6.3(webpack@5.78.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.2
     transitivePeerDependencies:
       - supports-color
+      - webpack
     dev: true
 
   /@ember-data/adapter@4.4.0(@babel/core@7.19.6)(webpack@5.78.0):
@@ -3596,6 +3557,16 @@ packages:
       - supports-color
     dev: true
 
+  /@ember-data/canary-features@4.11.3:
+    resolution: {integrity: sha512-RTLY2N9t1SXr4e90VBKi+3PIitwjTMBU8BcEhnKovT//sGlywohHq7T36H6nJuITRtki3On9PpbJOhhQZuyAlQ==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+    dependencies:
+      '@embroider/macros': 1.10.0
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@ember-data/canary-features@4.4.0:
     resolution: {integrity: sha512-PkizCdM5SXCWiAKwq9ybIfhsLtM596IXtBz0cRH+d4YV3sBIsQjnAf+IYsJpwxf+XKvzXnzPLeIcFd7+NL6YPw==}
     engines: {node: 12.* || >= 14.*}
@@ -3621,13 +3592,13 @@ packages:
       - supports-color
     dev: true
 
-  /@ember-data/debug@4.12.0(@ember/string@3.0.1)(webpack@5.78.0):
-    resolution: {integrity: sha512-6SNJjoV3zKnjjZEu9/tOjeWdN70mxmkvHd+0Y7kjasmjLBgIkZk20+B/nFm25MpmmpfZEsvdUY3HIfu+iPy+5A==}
-    engines: {node: 16.* || >= 18.*}
+  /@ember-data/debug@4.11.3(@ember/string@3.0.1)(webpack@5.78.0):
+    resolution: {integrity: sha512-3pA5u3qy+pjtwcoyMzs7WijRrSQz5z+Vgn9b5Y4cEOHn8loS9riLCMScnFaQT3HjxQgq+3NkNb52sJafHPzs4Q==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
       '@ember/string': ^3.0.1
     dependencies:
-      '@ember-data/private-build-infra': 4.12.0
+      '@ember-data/private-build-infra': 4.11.3
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
@@ -3655,59 +3626,6 @@ packages:
       - webpack
     dev: true
 
-  /@ember-data/graph@4.12.0(@ember-data/store@4.12.0):
-    resolution: {integrity: sha512-5crSekONC8cm/sPS4OnNNG1TrnCb4rqrM72Ux8i8xlomYpLq75R2gY4ibY1HRNstrEoAB09rzONTB0bRJHlTQw==}
-    engines: {node: 16.* || >= 18.*}
-    peerDependencies:
-      '@ember-data/store': 4.12.0
-    dependencies:
-      '@ember-data/private-build-infra': 4.12.0
-      '@ember-data/store': 4.12.0(@babel/core@7.19.6)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/model@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.10.0
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@ember-data/json-api@4.12.0(@ember-data/graph@4.12.0)(@ember-data/store@4.12.0):
-    resolution: {integrity: sha512-vtxuB7akuSfsEBvLX/8h4zGyIozynyq5Bf9I02ftIoIIwD21wN+g/ZG91KU6sNZzyeycTZEKpoYaITM84pLTTg==}
-    engines: {node: 16.* || >= 18.*}
-    peerDependencies:
-      '@ember-data/graph': 4.12.0
-      '@ember-data/store': 4.12.0
-    dependencies:
-      '@ember-data/graph': 4.12.0(@ember-data/store@4.12.0)
-      '@ember-data/private-build-infra': 4.12.0
-      '@ember-data/store': 4.12.0(@babel/core@7.19.6)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/model@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.10.0
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@ember-data/legacy-compat@4.12.0(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0):
-    resolution: {integrity: sha512-QVZczGMbTk8Ch+xiZt7KQk5UX2AdUsVdR3rSB/pJVZrWcUWo6ToAR2mPl97/cWd6VYFXBZgMamsxkeBO4q5HXA==}
-    engines: {node: 16.* || >= 18}
-    peerDependencies:
-      '@ember-data/graph': 4.12.0
-      '@ember-data/json-api': 4.12.0
-    peerDependenciesMeta:
-      '@ember-data/graph':
-        optional: true
-      '@ember-data/json-api':
-        optional: true
-    dependencies:
-      '@ember-data/graph': 4.12.0(@ember-data/store@4.12.0)
-      '@ember-data/json-api': 4.12.0(@ember-data/graph@4.12.0)(@ember-data/store@4.12.0)
-      '@ember-data/private-build-infra': 4.12.0
-      '@embroider/macros': 1.10.0
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@ember-data/model@3.28.0(@babel/core@7.19.6):
     resolution: {integrity: sha512-G4lK0eRVZ8IU6Jh6+Wk060qLgj5ziPAKXXIqDsiDHaoBSd0uKj5tU+lUxHBxVM2fU3+yRr1WK5HIBu9PiSPWmw==}
     engines: {node: 12.* || >= 14.*}
@@ -3729,46 +3647,40 @@ packages:
       - supports-color
     dev: true
 
-  /@ember-data/model@4.12.0(@babel/core@7.19.6)(@ember-data/debug@4.12.0)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/store@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.0.0):
-    resolution: {integrity: sha512-gE9LRmUkrJy9hJ+WeNns/GOMQC311R18SOvbsIVk5z/u2tgD5l0BjLSeqCaG/CjO+fCRsM8Ne/Ivm07c/CyezQ==}
-    engines: {node: 16.* || >= 18.*}
+  /@ember-data/model@4.11.3(@babel/core@7.19.6)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0):
+    resolution: {integrity: sha512-nkDru5TZmOp4J1xp65D1bR3hBJ3u5KhKKfDpWeGnHW2YDCVUdLORRwW7vfrPnnXDIoJij42DwDVCiTY25Xhrqw==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
-      '@ember-data/debug': 4.12.0
-      '@ember-data/graph': 4.12.0
-      '@ember-data/json-api': 4.12.0
-      '@ember-data/legacy-compat': 4.12.0
-      '@ember-data/store': 4.12.0
-      '@ember-data/tracking': 4.12.0
+      '@ember-data/record-data': 4.11.3
+      '@ember-data/store': 4.11.3
+      '@ember-data/tracking': 4.11.3
       '@ember/string': ^3.0.1
       ember-inflector: ^4.0.2
     peerDependenciesMeta:
-      '@ember-data/debug':
-        optional: true
-      '@ember-data/graph':
-        optional: true
-      '@ember-data/json-api':
+      '@ember-data/record-data':
         optional: true
     dependencies:
-      '@ember-data/debug': 4.12.0(@ember/string@3.0.1)(webpack@5.78.0)
-      '@ember-data/graph': 4.12.0(@ember-data/store@4.12.0)
-      '@ember-data/json-api': 4.12.0(@ember-data/graph@4.12.0)(@ember-data/store@4.12.0)
-      '@ember-data/legacy-compat': 4.12.0(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)
-      '@ember-data/private-build-infra': 4.12.0
-      '@ember-data/store': 4.12.0(@babel/core@7.19.6)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/model@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
-      '@ember-data/tracking': 4.12.0
+      '@ember-data/canary-features': 4.11.3
+      '@ember-data/private-build-infra': 4.11.3
+      '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(webpack@5.78.0)
+      '@ember-data/store': 4.11.3(@babel/core@7.19.6)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
+      '@ember-data/tracking': 4.11.3
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
-      ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.19.6)(ember-source@5.0.0)
+      ember-auto-import: 2.6.3(webpack@5.78.0)
+      ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.19.6)(ember-source@5.1.0-beta.1)
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
+      ember-compatibility-helpers: 1.2.6(@babel/core@7.19.6)
       ember-inflector: 4.0.2
       inflection: 2.0.1
     transitivePeerDependencies:
       - '@babel/core'
       - ember-source
       - supports-color
+      - webpack
     dev: true
 
   /@ember-data/model@4.4.0(@babel/core@7.19.6)(webpack@5.78.0):
@@ -3829,13 +3741,14 @@ packages:
       - supports-color
     dev: true
 
-  /@ember-data/private-build-infra@4.12.0:
-    resolution: {integrity: sha512-cBuEZhxV8uyIRr+9oUZ4smQb+6p6ryH89+WdrGMTeKgKP3XkdlK9w+6veQAYOqgWAulTwmAxX+YU/zoPq2ne7w==}
-    engines: {node: 16.* || >= 18.*}
+  /@ember-data/private-build-infra@4.11.3:
+    resolution: {integrity: sha512-bXFQMEegUc+vKn/vD7FmAkq7ECE0okZ2sbtv/0RXqYn7TLk44rvGzpqSUXUowpCaGI/87MmaW8JaZMMdqF9wuw==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
     dependencies:
       '@babel/core': 7.21.8
       '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.21.8)
       '@babel/runtime': 7.21.5
+      '@ember-data/canary-features': 4.11.3
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.10.0
       babel-import-util: 1.3.0
@@ -3854,8 +3767,10 @@ packages:
       ember-cli-string-utils: 1.1.0
       ember-cli-version-checker: 5.1.2
       git-repo-info: 2.1.1
-      glob: 9.3.5
+      glob: 8.1.0
       npm-git-info: 1.0.3
+      rimraf: 3.0.2
+      rsvp: 4.8.5
       semver: 7.3.8
       silent-error: 1.1.1
     transitivePeerDependencies:
@@ -3913,6 +3828,24 @@ packages:
       - supports-color
     dev: true
 
+  /@ember-data/record-data@4.11.3(@ember-data/store@4.11.3)(webpack@5.78.0):
+    resolution: {integrity: sha512-8NmeEZJ7or354NLZJgibJ1FuhWL70H6G24tGSEIzM8IV7wr6TreIyaWODaW372QwamWYgFIpfnFwWt5MTlY/gw==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
+    peerDependencies:
+      '@ember-data/store': 4.11.3
+    dependencies:
+      '@ember-data/canary-features': 4.11.3
+      '@ember-data/private-build-infra': 4.11.3
+      '@ember-data/store': 4.11.3(@babel/core@7.19.6)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.10.0
+      ember-auto-import: 2.6.3(webpack@5.78.0)
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
+      - supports-color
+      - webpack
+    dev: true
+
   /@ember-data/record-data@4.4.0(@babel/core@7.19.6)(webpack@5.78.0):
     resolution: {integrity: sha512-QBP8EMih2tvXMHUv8j/jWzOkW/d/OGfO22maOi9mh/MoCaX+EphupgdCFJL2SjQZYFPVioPosLQmQX4l5ChkDw==}
     engines: {node: 12.* || >= 14.*}
@@ -3929,18 +3862,6 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
-    dev: true
-
-  /@ember-data/request@4.12.0:
-    resolution: {integrity: sha512-n08NaFwJPq8TUj0F5M5Y88hZ8OhuzaeHjygnaumZtAnCbM9vRrJvrGCcTkfPp2XL3jfKOzeTHNzWzX8XY+efzQ==}
-    engines: {node: 16.* || >= 18}
-    dependencies:
-      '@ember-data/private-build-infra': 4.12.0
-      '@ember/test-waiters': 3.0.2
-      '@embroider/macros': 1.10.0
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@ember-data/rfc395-data@0.0.4:
@@ -3960,23 +3881,25 @@ packages:
       - supports-color
     dev: true
 
-  /@ember-data/serializer@4.12.0(@ember-data/store@4.12.0)(@ember/string@3.0.1)(ember-inflector@4.0.2):
-    resolution: {integrity: sha512-q6TJKrS95eFKm9fNm9UkwTQBJw5G+oj37lBPtsnLs6Sm05RCR8fvUX+WbkKi6CoqfKrn2zlZU8Z8mKg7DXc5nA==}
-    engines: {node: 16.* || >= 18.*}
+  /@ember-data/serializer@4.11.3(@ember-data/store@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(webpack@5.78.0):
+    resolution: {integrity: sha512-Qnzrowinz14/onQfwd4TPwNG0sMTAwTWE0RajYo2fysF3CKyAua0nIzmFtXKx0CogD7TYd0C5xf6nMjFesT09Q==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
-      '@ember-data/store': 4.12.0
+      '@ember-data/store': 4.11.3
       '@ember/string': ^3.0.1
       ember-inflector: ^4.0.2
     dependencies:
-      '@ember-data/private-build-infra': 4.12.0
-      '@ember-data/store': 4.12.0(@babel/core@7.19.6)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/model@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+      '@ember-data/private-build-infra': 4.11.3
+      '@ember-data/store': 4.11.3(@babel/core@7.19.6)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
+      ember-auto-import: 2.6.3(webpack@5.78.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.2
     transitivePeerDependencies:
       - supports-color
+      - webpack
     dev: true
 
   /@ember-data/serializer@4.4.0(@babel/core@7.19.6)(webpack@5.78.0):
@@ -4011,42 +3934,37 @@ packages:
       - supports-color
     dev: true
 
-  /@ember-data/store@4.12.0(@babel/core@7.19.6)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/model@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0):
-    resolution: {integrity: sha512-7zOxg363f8raqmJcQYiH6JAWWyBDLRQTWLZeyeJD3kgFV+MqWlHLjEvOFCDW2SnfIrVAyFH7oh7x7POxClw9mA==}
-    engines: {node: 16.* || >= 18.*}
+  /@ember-data/store@4.11.3(@babel/core@7.19.6)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0):
+    resolution: {integrity: sha512-ogwWy+VqMpkCGs4n30pzuB2vqv/dJRL6wdV3fdNKpXrDugffjuMPpLBQYF937qztDUZKxmnbWAZe5PbQOz8b1Q==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
-      '@ember-data/graph': 4.12.0
-      '@ember-data/json-api': 4.12.0
-      '@ember-data/legacy-compat': 4.12.0
-      '@ember-data/model': 4.12.0
-      '@ember-data/tracking': 4.12.0
+      '@ember-data/model': 4.11.3
+      '@ember-data/record-data': 4.11.3
+      '@ember-data/tracking': 4.11.3
       '@ember/string': ^3.0.1
       '@glimmer/tracking': ^1.1.2
     peerDependenciesMeta:
-      '@ember-data/graph':
-        optional: true
-      '@ember-data/json-api':
-        optional: true
-      '@ember-data/legacy-compat':
-        optional: true
       '@ember-data/model':
         optional: true
+      '@ember-data/record-data':
+        optional: true
     dependencies:
-      '@ember-data/graph': 4.12.0(@ember-data/store@4.12.0)
-      '@ember-data/json-api': 4.12.0(@ember-data/graph@4.12.0)(@ember-data/store@4.12.0)
-      '@ember-data/legacy-compat': 4.12.0(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)
-      '@ember-data/model': 4.12.0(@babel/core@7.19.6)(@ember-data/debug@4.12.0)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/store@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.0.0)
-      '@ember-data/private-build-infra': 4.12.0
-      '@ember-data/tracking': 4.12.0
+      '@ember-data/canary-features': 4.11.3
+      '@ember-data/model': 4.11.3(@babel/core@7.19.6)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
+      '@ember-data/private-build-infra': 4.11.3
+      '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(webpack@5.78.0)
+      '@ember-data/tracking': 4.11.3
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
       '@glimmer/tracking': 1.1.2
-      ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.19.6)(ember-source@5.0.0)
+      ember-auto-import: 2.6.3(webpack@5.78.0)
+      ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.19.6)(ember-source@5.1.0-beta.1)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@babel/core'
       - ember-source
       - supports-color
+      - webpack
     dev: true
 
   /@ember-data/store@4.4.0(@babel/core@7.19.6)(webpack@5.78.0):
@@ -4068,9 +3986,9 @@ packages:
       - webpack
     dev: true
 
-  /@ember-data/tracking@4.12.0:
-    resolution: {integrity: sha512-Jgg6ayR70HLdMqIuXgh/5bdD93Qxop4evSA/f0ltDyilTQ63Olw6GkaYBpjOf6rZbRxdAOwLOOITyoE04zVq+g==}
-    engines: {node: 16.* || >= 18}
+  /@ember-data/tracking@4.11.3:
+    resolution: {integrity: sha512-YZxFTMe2TBL8H8/GrnrvP7Wc/uuAijoSyiP2g6TMNRsL1e/3BWDT0EIl+B/5Wji+dchofY8iuMWfpY7VDvPIzA==}
+    engines: {node: 14.* || 16.* || >= 18}
     dependencies:
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -4147,7 +4065,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/legacy-built-in-components@0.4.1(ember-source@5.0.0):
+  /@ember/legacy-built-in-components@0.4.1(ember-source@5.1.0-beta.1):
     resolution: {integrity: sha512-tLxiU1YR+A+002rkGfwyB4FK8bO5qqU/3c7cZ1z2j3XG+1T28Yg2iZuMxPwFJ0LsE//mhRFkWlGzO3tJUtMHbA==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -4157,7 +4075,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-typescript: 4.2.1
-      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.1.0-beta.1(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4192,7 +4110,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/render-modifiers@2.0.5(@babel/core@7.19.6)(ember-source@5.0.0):
+  /@ember/render-modifiers@2.0.5(@babel/core@7.19.6)(ember-source@5.1.0-beta.1):
     resolution: {integrity: sha512-5cJ1niIdOJC6k6KtIn9HGbr1DATJQp4ZqMv1vbi6LKQWbVCQ3byvKONtUEi3H0wcewlrcaWCqXOgm0nACzCOQA==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -4201,7 +4119,7 @@ packages:
       '@embroider/macros': 1.10.0
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.19.6)
-      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.1.0-beta.1(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -4410,7 +4328,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.2
+      debug: 4.3.2(supports-color@8.1.0)
       espree: 9.5.2
       globals: 13.20.0
       ignore: 5.2.4
@@ -4425,6 +4343,16 @@ packages:
   /@eslint/js@8.40.0:
     resolution: {integrity: sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@glimmer/compiler@0.84.2:
+    resolution: {integrity: sha512-rU8qpqbqxIPwrEQH82yDDFi1hgv6ud1agYexmnmCXlaLS5uCVATJAqKsVozc7aHOgmmF4Ukd/LoF4NYfGr8X3w==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/syntax': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/wire-format': 0.84.2
+      '@simple-dom/interface': 1.4.0
     dev: true
 
   /@glimmer/component@1.1.2(@babel/core@7.19.6):
@@ -4449,8 +4377,25 @@ packages:
       - '@babel/core'
       - supports-color
 
+  /@glimmer/destroyable@0.84.2:
+    resolution: {integrity: sha512-74L4+jlGUhzhUe87lTxjFdYEEfcDWcza+jqLXoyIb/p4cS0hWsTGlyF+OcuUbHO4yqJd4bXchGOVocoajmSp6w==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.2
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
+    dev: true
+
   /@glimmer/di@0.1.11:
     resolution: {integrity: sha512-moRwafNDwHTnTHzyyZC9D+mUSvYrs1Ak0tRPjjmCghdoHHIvMshVbEnwKb/1WmW5CUlKc2eL9rlAV32n3GiItg==}
+
+  /@glimmer/encoder@0.84.2:
+    resolution: {integrity: sha512-599TMDNDHiw+PhNXy5/AnMjh83NBKy+tl2YmwSRY9qktx4DDOZenzgwZ5haLlzPaceejJ6ZNAoGyV5bBrDY5+w==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/vm': 0.84.2
+    dev: true
 
   /@glimmer/env@0.1.7:
     resolution: {integrity: sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==}
@@ -4491,6 +4436,61 @@ packages:
       '@simple-dom/interface': 1.4.0
     dev: true
 
+  /@glimmer/low-level@0.78.2:
+    resolution: {integrity: sha512-0S6TWOOd0fzLLysw1pWZN0TgasaHmYs1Sjz9Til1mTByIXU1S+1rhdyr2veSQPO/aRjPuEQyKXZQHvx23Zax6w==}
+    dev: true
+
+  /@glimmer/manager@0.84.2:
+    resolution: {integrity: sha512-cXOnRTH9nwAe/un8hK0x6z1m67Cv5ywAuK7KRxAFTWHgGX/i6BvoZCStr6zJD/U6Frna2c7RJK8JpleP94opEA==}
+    dependencies:
+      '@glimmer/destroyable': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.2
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/reference': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/validator': 0.84.2
+    dev: true
+
+  /@glimmer/node@0.84.2:
+    resolution: {integrity: sha512-kefGxH+0N0xNyb6QovdPzmIBefZwu8TID45qsASgVbFx7mfFiXjQiyaxbRUyam4MAEb8Nzzx1Byxn1FQCYyLdA==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/runtime': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@simple-dom/document': 1.4.0
+      '@simple-dom/interface': 1.4.0
+    dev: true
+
+  /@glimmer/opcode-compiler@0.84.2:
+    resolution: {integrity: sha512-KwTH9cWEW4Neu3jmD9ANMIQYBiEqPsLx+h55G+wYp5djyjiYwSJ7KhgMAB+wEHuvB6izp3XdSO6jDMgp3pp49A==}
+    dependencies:
+      '@glimmer/encoder': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/reference': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/vm': 0.84.2
+      '@glimmer/wire-format': 0.84.2
+    dev: true
+
+  /@glimmer/owner@0.84.2:
+    resolution: {integrity: sha512-maZn642eXRImp/hOSa4nQmzMLEIywXwgahS/ZMuzD4HTTsA2SlEdjXSrVbRQYarYF8LkiJ7fpcKHkyNCe8SHrQ==}
+    dependencies:
+      '@glimmer/util': 0.84.2
+    dev: true
+
+  /@glimmer/program@0.84.2:
+    resolution: {integrity: sha512-Ohx+7H3+CSVHbC08trUK7fXC6ti9x0SQDC2Lwd7BMXmMyoOZHxdaKNrTJ+CsQ8nV1JkLfXhnvRDG08TqD5VHJw==}
+    dependencies:
+      '@glimmer/encoder': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/manager': 0.84.2
+      '@glimmer/opcode-compiler': 0.84.2
+      '@glimmer/util': 0.84.2
+    dev: true
+
   /@glimmer/reference@0.65.4:
     resolution: {integrity: sha512-yuRVE4qyqrlCndDMrHKDWUbDmGDCjPzsFtlTmxxnhDMJAdQsnr2cRLITHvQRDm1tXfigVvyKnomeuYhRRbBqYQ==}
     dependencies:
@@ -4519,6 +4519,24 @@ packages:
       '@glimmer/interfaces': 0.84.3
       '@glimmer/util': 0.84.3
       '@glimmer/validator': 0.84.3
+    dev: true
+
+  /@glimmer/runtime@0.84.2:
+    resolution: {integrity: sha512-mUefYwq8l4df61iWYsRKVYQUqAeCgeZ3fuYNRNbvKDudnT9bQXayJLqr6ZxwTVaDoeKjg+7lMjkDSDSvqoxfsA==}
+    dependencies:
+      '@glimmer/destroyable': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.2
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/low-level': 0.78.2
+      '@glimmer/owner': 0.84.2
+      '@glimmer/program': 0.84.2
+      '@glimmer/reference': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/validator': 0.84.2
+      '@glimmer/vm': 0.84.2
+      '@glimmer/wire-format': 0.84.2
+      '@simple-dom/interface': 1.4.0
     dev: true
 
   /@glimmer/syntax@0.65.4:
@@ -4646,6 +4664,20 @@ packages:
       - '@babel/core'
     dev: true
 
+  /@glimmer/vm@0.84.2:
+    resolution: {integrity: sha512-IuQeDlh+AUOOX8QXc+ehPv5uFnqstQVZGplqqvPQRcKvsEalog88RC34dAEwFdB756SKjgRSw+N+nT3ZDNVlvA==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
+    dev: true
+
+  /@glimmer/wire-format@0.84.2:
+    resolution: {integrity: sha512-/FmbXSPFJAoIZ6qu28xVXpAdy2Ln++Ewe6mRHFpnudV1lUrBN+Q09A4j/RN/hpAkyz/8ai5W+5rHKuaWxoi4Dg==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
+    dev: true
+
   /@glint/environment-ember-loose@1.0.0-beta.3(@glimmer/component@1.1.2)(@glint/template@1.0.0)(ember-cli-htmlbars@6.2.0):
     resolution: {integrity: sha512-Aby8penf3PB2VJrp9Ni33ZAcmFz8OpZ3wA2rz9DirOQhGrdDoTxcvNli6wu0R/NBqjjgKhM2WGzbxJ8NRdfdxA==}
     peerDependencies:
@@ -4696,7 +4728,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.2
+      debug: 4.3.2(supports-color@8.1.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5007,8 +5039,8 @@ packages:
       upath: 2.0.1
     dev: true
 
-  /@mdn/browser-compat-data@4.2.1:
-    resolution: {integrity: sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==}
+  /@mdn/browser-compat-data@5.2.59:
+    resolution: {integrity: sha512-f7VxPGqVLCSe+0KdDas33JyGY+eHJTfBkgAsoiM1BSv7e238FYJMTFwfGLhjnhOwc33wUwsnjiHSfXukwzbqog==}
     dev: true
 
   /@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1:
@@ -5155,7 +5187,7 @@ packages:
     resolution: {integrity: sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==}
     dev: true
 
-  /@rollup/plugin-babel@5.3.1(@babel/core@7.19.6)(rollup@2.69.1):
+  /@rollup/plugin-babel@5.3.1(@babel/core@7.19.6)(rollup@3.23.0):
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -5168,11 +5200,11 @@ packages:
     dependencies:
       '@babel/core': 7.19.6(supports-color@8.1.0)
       '@babel/helper-module-imports': 7.21.4
-      '@rollup/pluginutils': 3.1.0(rollup@2.69.1)
-      rollup: 2.69.1
+      '@rollup/pluginutils': 3.1.0(rollup@3.23.0)
+      rollup: 3.23.0
     dev: true
 
-  /@rollup/pluginutils@3.1.0(rollup@2.69.1):
+  /@rollup/pluginutils@3.1.0(rollup@3.23.0):
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -5181,7 +5213,7 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.69.1
+      rollup: 3.23.0
     dev: true
 
   /@rollup/pluginutils@4.1.1:
@@ -5192,12 +5224,19 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /@rollup/pluginutils@4.2.1:
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
+  /@rollup/pluginutils@5.0.2(rollup@3.23.0):
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
     dependencies:
+      '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
+      rollup: 3.23.0
     dev: true
 
   /@simple-dom/document@1.4.0:
@@ -5713,7 +5752,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.59.5
       '@typescript-eslint/type-utils': 5.59.5(eslint@8.40.0)(typescript@4.9.3)
       '@typescript-eslint/utils': 5.59.5(eslint@8.40.0)(typescript@4.9.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.0)
       eslint: 8.40.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
@@ -5758,7 +5797,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.59.5
       '@typescript-eslint/types': 5.59.5
       '@typescript-eslint/typescript-estree': 5.59.5(typescript@4.9.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.0)
       eslint: 8.40.0
       typescript: 4.9.3
     transitivePeerDependencies:
@@ -5805,7 +5844,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.5(typescript@4.9.3)
       '@typescript-eslint/utils': 5.59.5(eslint@8.40.0)(typescript@4.9.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.0)
       eslint: 8.40.0
       tsutils: 3.21.0(typescript@4.9.3)
       typescript: 4.9.3
@@ -5829,7 +5868,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.5
       '@typescript-eslint/visitor-keys': 5.59.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
@@ -7223,6 +7262,10 @@ packages:
     dependencies:
       underscore: 1.13.6
 
+  /backburner.js@2.7.0:
+    resolution: {integrity: sha512-eBZC6r7wT+YYAOKeru8IqgzOimz3VgyspXiZ1k6MI8i10zUdU8cnNII56rlnItQ89cHgQO3C/nPuFW3V9di+zg==}
+    dev: true
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -7354,7 +7397,7 @@ packages:
       wordwrap: 0.0.3
 
   /bower-endpoint-parser@0.2.2:
-    resolution: {integrity: sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=}
+    resolution: {integrity: sha512-YWZHhWkPdXtIfH3VRu3QIV95sa75O9vrQWBOHjexWCLBCTy5qJvRr36LXTqFwTchSXVlzy5piYJOjzHr7qhsNg==}
     engines: {node: '>=0.8.0'}
 
   /brace-expansion@1.1.11:
@@ -8112,17 +8155,17 @@ packages:
   /browser-process-hrtime@1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
 
-  /browserslist-generator@1.0.66:
-    resolution: {integrity: sha512-aFDax4Qzh29DdyhHQBD2Yu2L5OvaDnvYFMbmpLrLwwaNK4H6dHEhC/Nxv93/+mfAA+a/t94ln0P2JZvHO6LZDA==}
-    engines: {node: '>=8.0.0'}
+  /browserslist-generator@2.0.3:
+    resolution: {integrity: sha512-3j8ogwvlBpOEDR3f5n1H2n5BWXqHPWi/Xm8EC1DPJy5BWl4WkSFisatBygH/L9AEmg0MtOfcR1QnMuM9XL28jA==}
+    engines: {node: '>=16.15.1', npm: '>=7.0.0', pnpm: '>=3.2.0', yarn: '>=1.13'}
     dependencies:
-      '@mdn/browser-compat-data': 4.2.1
+      '@mdn/browser-compat-data': 5.2.59
       '@types/object-path': 0.11.1
       '@types/semver': 7.5.0
       '@types/ua-parser-js': 0.7.36
       browserslist: 4.21.5
       caniuse-lite: 1.0.30001487
-      isbot: 3.4.5
+      isbot: 3.6.10
       object-path: 0.11.8
       semver: 7.3.8
       ua-parser-js: 1.0.35
@@ -8657,13 +8700,13 @@ packages:
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
-  /compatfactory@1.0.1(typescript@4.9.3):
-    resolution: {integrity: sha512-hR9u0HSZTKDNNchPtMHg6myeNx0XO+av7UZIJPsi4rPALJBHi/W5Mbwi19hC/xm6y3JkYpxVYjTqnSGsU5X/iw==}
+  /compatfactory@2.0.9(typescript@4.9.3):
+    resolution: {integrity: sha512-fvO+AWcmbO7P1S+A3mwm3IGr74eHMeq5ZLhNhyNQc9mVDNHT4oe0Gg0ksdIFFNXLK7k7Z/TYcLAUSQdRgh1bsA==}
     engines: {node: '>=14.9.0'}
     peerDependencies:
       typescript: '>=3.x || >= 4.x'
     dependencies:
-      helpertypes: 0.0.18
+      helpertypes: 0.0.19
       typescript: 4.9.3
     dev: true
 
@@ -9257,18 +9300,6 @@ packages:
     dependencies:
       ms: 2.1.3
 
-  /debug@4.3.2:
-    resolution: {integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-    dev: true
-
   /debug@4.3.2(supports-color@8.1.0):
     resolution: {integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==}
     engines: {node: '>=6.0'}
@@ -9280,17 +9311,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.0
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
 
   /debug@4.3.4(supports-color@8.1.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -9625,11 +9645,11 @@ packages:
       - supports-color
       - webpack
 
-  /ember-bootstrap@5.0.0(@babel/core@7.19.6)(ember-source@5.0.0)(webpack@5.78.0):
+  /ember-bootstrap@5.0.0(@babel/core@7.19.6)(ember-source@5.1.0-beta.1)(webpack@5.78.0):
     resolution: {integrity: sha512-ocH7qJKikxDgLv1prWyYzDaH85of8/l0LeV2bnMCp3/ZdRak/vq4dWqm53hMQ0ifN4llfs1Q1bwlcra/BT7yCA==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@ember/render-modifiers': 2.0.5(@babel/core@7.19.6)(ember-source@5.0.0)
+      '@ember/render-modifiers': 2.0.5(@babel/core@7.19.6)(ember-source@5.1.0-beta.1)
       '@embroider/macros': 1.10.0
       '@embroider/util': 1.10.0(@glint/template@1.0.0)(ember-source@4.12.0)
       '@glimmer/component': 1.1.2(@babel/core@7.19.6)
@@ -9645,7 +9665,7 @@ packages:
       ember-cli-version-checker: 5.1.2
       ember-concurrency: 2.3.7(@babel/core@7.19.6)
       ember-decorators: 6.1.1
-      ember-element-helper: 0.6.1(ember-source@5.0.0)
+      ember-element-helper: 0.6.1(ember-source@5.1.0-beta.1)
       ember-focus-trap: 1.0.2
       ember-in-element-polyfill: 1.0.1
       ember-named-blocks-polyfill: 0.2.5
@@ -9694,7 +9714,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.19.6)(ember-source@5.0.0):
+  /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.19.6)(ember-source@5.1.0-beta.1):
     resolution: {integrity: sha512-VDgrpIJ6rDDHIfkYrsFR1BM3fpcC0+zFWIOsX0qY44zPrIXjhQWVXs2iVXLIPHprSgf+tFQ3ESxwDscpeRe/0A==}
     engines: {node: 14.* || >= 16}
     peerDependencies:
@@ -9706,7 +9726,7 @@ packages:
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.19.6)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.1.0-beta.1(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -11034,23 +11054,20 @@ packages:
       - supports-color
     dev: true
 
-  /ember-data@4.12.0(@babel/core@7.19.6)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)(webpack@5.78.0):
-    resolution: {integrity: sha512-E1A94HOurihoaFzJmArhtXfp56WsLlbTyhnqWfZKgqWZz1qKF4GVbDuOsGIsy6u345LdUCp2jtodRO2s43k88Q==}
-    engines: {node: 16.* || >= 18.*}
+  /ember-data@4.11.3(@babel/core@7.19.6)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0):
+    resolution: {integrity: sha512-7vir6Re3M3M6yJoCHy6UxEg3oSY1JEnsuTByY3lJquWPaUamn7qbPQvNr16Tqh8EKrt+e/+X26czFm4kRGhpVg==}
+    engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
       '@ember/string': ^3.0.1
     dependencies:
-      '@ember-data/adapter': 4.12.0(@ember-data/store@4.12.0)(@ember/string@3.0.1)(ember-inflector@4.0.2)
-      '@ember-data/debug': 4.12.0(@ember/string@3.0.1)(webpack@5.78.0)
-      '@ember-data/graph': 4.12.0(@ember-data/store@4.12.0)
-      '@ember-data/json-api': 4.12.0(@ember-data/graph@4.12.0)(@ember-data/store@4.12.0)
-      '@ember-data/legacy-compat': 4.12.0(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)
-      '@ember-data/model': 4.12.0(@babel/core@7.19.6)(@ember-data/debug@4.12.0)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/store@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.0.0)
-      '@ember-data/private-build-infra': 4.12.0
-      '@ember-data/request': 4.12.0
-      '@ember-data/serializer': 4.12.0(@ember-data/store@4.12.0)(@ember/string@3.0.1)(ember-inflector@4.0.2)
-      '@ember-data/store': 4.12.0(@babel/core@7.19.6)(@ember-data/graph@4.12.0)(@ember-data/json-api@4.12.0)(@ember-data/legacy-compat@4.12.0)(@ember-data/model@4.12.0)(@ember-data/tracking@4.12.0)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
-      '@ember-data/tracking': 4.12.0
+      '@ember-data/adapter': 4.11.3(@ember-data/store@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(webpack@5.78.0)
+      '@ember-data/debug': 4.11.3(@ember/string@3.0.1)(webpack@5.78.0)
+      '@ember-data/model': 4.11.3(@babel/core@7.19.6)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
+      '@ember-data/private-build-infra': 4.11.3
+      '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(webpack@5.78.0)
+      '@ember-data/serializer': 4.11.3(@ember-data/store@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(webpack@5.78.0)
+      '@ember-data/store': 4.11.3(@babel/core@7.19.6)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.1.0-beta.1)(webpack@5.78.0)
+      '@ember-data/tracking': 4.11.3
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
@@ -11120,7 +11137,7 @@ packages:
     engines: {node: '>= 0.10.0'}
     dev: true
 
-  /ember-element-helper@0.6.1(ember-source@5.0.0):
+  /ember-element-helper@0.6.1(ember-source@5.1.0-beta.1):
     resolution: {integrity: sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -11129,7 +11146,7 @@ packages:
       '@embroider/util': 1.10.0(@glint/template@1.0.0)(ember-source@4.12.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.2.0
-      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.1.0-beta.1(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -11166,14 +11183,14 @@ packages:
       - supports-color
     dev: true
 
-  /ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.0.0):
+  /ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.1.0-beta.1):
     resolution: {integrity: sha512-rrvHUkZRNrf+9u/sCw7XYrITStjP/9Ypykk1nYQHoo+6Krp11e81QNVsGTXFpXtMHXbNtH5IcRyZvfSXqUOrUQ==}
     engines: {node: 10.* || >= 12}
     peerDependencies:
       '@ember/legacy-built-in-components': '*'
       ember-source: ^3.12 || 4
     dependencies:
-      '@ember/legacy-built-in-components': 0.4.1(ember-source@5.0.0)
+      '@ember/legacy-built-in-components': 0.4.1(ember-source@5.1.0-beta.1)
       '@embroider/macros': 1.10.0
       amd-name-resolver: 1.3.1
       babel-plugin-compact-reexports: 1.1.0
@@ -11191,7 +11208,7 @@ packages:
       ember-cli-preprocess-registry: 3.3.0
       ember-cli-string-utils: 1.1.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.1.0-beta.1(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -11356,7 +11373,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-modifier@4.1.0(ember-source@5.0.0):
+  /ember-modifier@4.1.0(ember-source@5.1.0-beta.1):
     resolution: {integrity: sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==}
     peerDependencies:
       ember-source: '*'
@@ -11367,7 +11384,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 5.0.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.1.0-beta.1(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11844,8 +11861,8 @@ packages:
       - webpack
     dev: true
 
-  /ember-source@5.0.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.78.0):
-    resolution: {integrity: sha512-NkPWXt7nYEvoSOzjJJ3JxYPGvvHoZ2ouPHqs1/Jf2ZahXY5SKJW3mTJql1zW5gMcUwNIoFx1cvlfHr3CJ6sQog==}
+  /ember-source@5.1.0-beta.1(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0):
+    resolution: {integrity: sha512-XJfLvC8OVheXSXcGZDEA+fFVHRPyHf6AvAL3YJO2lNKlVEqv3WK6YM69QfcFZEITLqNHBcKLMDYAXkykzoYusg==}
     engines: {node: '>= 16.*'}
     peerDependencies:
       '@glimmer/component': ^1.1.2
@@ -11853,10 +11870,24 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.19.6)
       '@ember/edition-utils': 1.2.0
+      '@glimmer/compiler': 0.84.2
       '@glimmer/component': 1.1.2(@babel/core@7.19.6)
+      '@glimmer/destroyable': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.3
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/manager': 0.84.2
+      '@glimmer/node': 0.84.2
+      '@glimmer/opcode-compiler': 0.84.2
+      '@glimmer/owner': 0.84.2
+      '@glimmer/program': 0.84.2
+      '@glimmer/reference': 0.84.2
+      '@glimmer/runtime': 0.84.2
+      '@glimmer/validator': 0.84.2
       '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.19.6)
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.19.6)
       babel-plugin-filter-imports: 4.0.0
+      backburner.js: 2.7.0
       broccoli-concat: 4.2.5
       broccoli-debug: 0.6.5
       broccoli-file-creator: 2.1.1
@@ -11875,10 +11906,13 @@ packages:
       ember-router-generator: 2.0.0
       inflection: 1.13.4
       resolve: 1.22.2
+      route-recognizer: 0.3.4
+      router_js: 8.0.3(route-recognizer@0.3.4)(rsvp@4.8.5)
       semver: 7.3.8
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
+      - rsvp
       - supports-color
       - webpack
     dev: true
@@ -12708,7 +12742,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.1
       cross-spawn: 7.0.3
-      debug: 4.3.2
+      debug: 4.3.2(supports-color@8.1.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -13855,16 +13889,6 @@ packages:
       once: 1.4.0
     dev: true
 
-  /glob@9.3.5:
-    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      fs.realpath: 1.0.0
-      minimatch: 8.0.4
-      minipass: 4.2.8
-      path-scurry: 1.9.1
-    dev: true
-
   /global-modules@1.0.0:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
     engines: {node: '>=0.10.0'}
@@ -14198,8 +14222,8 @@ packages:
     dependencies:
       rsvp: 3.2.1
 
-  /helpertypes@0.0.18:
-    resolution: {integrity: sha512-XRhfbSEmR+poXUC5/8AbmYNJb2riOT6qPzjGJZr0S9YedHiaY+/tzPYzWMUclYMEdCYo/1l8PDYrQFCj02v97w==}
+  /helpertypes@0.0.19:
+    resolution: {integrity: sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==}
     engines: {node: '>=10.0.0'}
     dev: true
 
@@ -14976,8 +15000,8 @@ packages:
     engines: {node: '>= 14.0.0'}
     dev: true
 
-  /isbot@3.4.5:
-    resolution: {integrity: sha512-+KD6q1BBtw0iK9aGBGSfxJ31/ZgizKRjhm8ebgJUBMx0aeeQuIJ1I72beCoIrltIZGrSm4vmrxRxrG5n1aUTtw==}
+  /isbot@3.6.10:
+    resolution: {integrity: sha512-+I+2998oyP4oW9+OTQD8TS1r9P6wv10yejukj+Ksj3+UR5pUhsZN3f8W7ysq0p1qxpOVNbl5mCuv0bCaF8y5iQ==}
     engines: {node: '>=12'}
     dev: true
 
@@ -15025,7 +15049,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.0)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -15378,7 +15402,7 @@ packages:
       '@babel/generator': 7.21.5
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.21.8)
       '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.21.8)
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@8.1.0)
       '@babel/types': 7.21.5
       '@jest/expect-utils': 29.5.0
       '@jest/transform': 29.5.0
@@ -15756,7 +15780,7 @@ packages:
     dev: true
 
   /leek@0.0.24:
-    resolution: {integrity: sha1-5ADlfw5g2O8r1NBo3EKKVDRdvNo=}
+    resolution: {integrity: sha512-6PVFIYXxlYF0o6hrAsHtGpTmi06otkwNrMcmQ0K96SeSRHPREPa9J3nJZ1frliVH7XT0XFswoJFQoXsDukzGNQ==}
     dependencies:
       debug: 2.6.9(supports-color@8.1.0)
       lodash.assign: 3.2.0
@@ -16072,11 +16096,6 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /lru-cache@9.1.1:
-    resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
-    engines: {node: 14 || >=16.14}
-    dev: true
-
   /magic-string@0.24.1:
     resolution: {integrity: sha512-YBfNxbJiixMzxW40XqJEIldzHyh5f7CZKalo1uZffevyrPEX8Qgo9s0dmcORLHdV47UyvJg8/zD+6hQG3qvJrA==}
     dependencies:
@@ -16088,11 +16107,11 @@ packages:
     dependencies:
       sourcemap-codec: 1.4.8
 
-  /magic-string@0.26.7:
-    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
+  /magic-string@0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
     dependencies:
-      sourcemap-codec: 1.4.8
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /make-dir@3.1.0:
@@ -16445,13 +16464,6 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimatch@8.0.4:
-    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
-
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
@@ -16472,16 +16484,6 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
       yallist: 3.1.1
-
-  /minipass@4.2.8:
-    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /minipass@6.0.1:
-    resolution: {integrity: sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
 
   /mississippi@3.0.0:
     resolution: {integrity: sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==}
@@ -17295,14 +17297,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       path-root-regex: 0.1.2
-
-  /path-scurry@1.9.1:
-    resolution: {integrity: sha512-UgmoiySyjFxP6tscZDgWGEAgsW5ok8W3F5CJDnnH2pozwSTGE6eH7vwTotMwATWA2r5xqdkKdxYPkwlJjAI/3g==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      lru-cache: 9.1.1
-      minipass: 6.0.1
-    dev: true
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=}
@@ -18155,13 +18149,13 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup-plugin-copy-assets@2.0.3(rollup@2.69.1):
+  /rollup-plugin-copy-assets@2.0.3(rollup@3.23.0):
     resolution: {integrity: sha512-ETShhQGb9SoiwcNrvb3BhUNSGR89Jao0+XxxfzzLW1YsUzx8+rMO4z9oqWWmo6OHUmfNQRvqRj0cAyPkS9lN9w==}
     peerDependencies:
       rollup: '>=1.1.2'
     dependencies:
       fs-extra: 7.0.1
-      rollup: 2.69.1
+      rollup: 3.23.0
     dev: false
 
   /rollup-plugin-copy@3.4.0:
@@ -18182,8 +18176,8 @@ packages:
       del: 5.1.0
     dev: false
 
-  /rollup-plugin-ts@3.0.2(@babel/core@7.19.6)(@babel/plugin-transform-runtime@7.18.6)(@babel/preset-env@7.16.11)(@babel/preset-typescript@7.18.6)(@babel/runtime@7.18.6)(rollup@2.69.1)(typescript@4.9.3):
-    resolution: {integrity: sha512-67qi2QTHewhLyKDG6fX3jpohWpmUPPIT/xJ7rsYK46X6MqmoWy64Ti0y8ygPfLv8mXDCdRZUofM3mTxDfCswRA==}
+  /rollup-plugin-ts@3.2.0(@babel/core@7.19.6)(@babel/plugin-transform-runtime@7.18.6)(@babel/preset-env@7.16.11)(@babel/preset-typescript@7.18.6)(@babel/runtime@7.18.6)(rollup@3.23.0)(typescript@4.9.3):
+    resolution: {integrity: sha512-KkTLVifkUexEiAXS9VtSjDrjKr0TyusmNJpb2ZTAzI9VuPumSu4AktIaVNnwv70iUEitHwZtET7OAM+5n1u1tg==}
     engines: {node: '>=14.9.0', npm: '>=7.0.0', pnpm: '>=3.2.0', yarn: '>=1.13'}
     peerDependencies:
       '@babel/core': '>=6.x || >=7.x'
@@ -18216,16 +18210,16 @@ packages:
       '@babel/preset-env': 7.16.11(@babel/core@7.19.6)
       '@babel/preset-typescript': 7.18.6(@babel/core@7.19.6)
       '@babel/runtime': 7.18.6
-      '@rollup/pluginutils': 4.2.1
+      '@rollup/pluginutils': 5.0.2(rollup@3.23.0)
       '@wessberg/stringutil': 1.0.19
       ansi-colors: 4.1.3
       browserslist: 4.21.5
-      browserslist-generator: 1.0.66
-      compatfactory: 1.0.1(typescript@4.9.3)
+      browserslist-generator: 2.0.3
+      compatfactory: 2.0.9(typescript@4.9.3)
       crosspath: 2.0.0
-      magic-string: 0.26.7
-      rollup: 2.69.1
-      ts-clone-node: 1.0.0(typescript@4.9.3)
+      magic-string: 0.27.0
+      rollup: 3.23.0
+      ts-clone-node: 2.0.4(typescript@4.9.3)
       tslib: 2.5.0
       typescript: 4.9.3
     dev: true
@@ -18268,6 +18262,30 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /rollup@3.23.0:
+    resolution: {integrity: sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /route-recognizer@0.3.4:
+    resolution: {integrity: sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==}
+    dev: true
+
+  /router_js@8.0.3(route-recognizer@0.3.4)(rsvp@4.8.5):
+    resolution: {integrity: sha512-lSgNMksk/wp8nspLX3Pn6QD499FUjwYMkgP99RxqKEScil4DKC/59YezpEZ318zGtkq8WR01VBhH+/u3InlLgg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      route-recognizer: ^0.3.4
+      rsvp: ^4.8.5
+    dependencies:
+      '@glimmer/env': 0.1.7
+      route-recognizer: 0.3.4
+      rsvp: 4.8.5
+    dev: true
 
   /rsvp@3.2.1:
     resolution: {integrity: sha512-Rf4YVNYpKjZ6ASAmibcwTNciQ5Co5Ztq6iZPEykHpkoflnD/K5ryE/rHehFsTm4NJj8nKDhbi3eKBWGogmNnkg==}
@@ -19705,13 +19723,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /ts-clone-node@1.0.0(typescript@4.9.3):
-    resolution: {integrity: sha512-/cDYbr2HAXxFNeTT41c/xs/2bhLJjqnYheHsmA3AoHSt+n4JA4t0FL9Lk5O8kWnJ6jeB3kPcUoXIFtwERNzv6Q==}
+  /ts-clone-node@2.0.4(typescript@4.9.3):
+    resolution: {integrity: sha512-eG6FAgmQsenhIJOIFhUcO6yyYejBKZIKcI3y21jiQmIOrth5pD6GElyPAyeihbPSyBs3u/9PVNXy+5I7jGy8jA==}
     engines: {node: '>=14.9.0'}
     peerDependencies:
       typescript: ^3.x || ^4.x
     dependencies:
-      compatfactory: 1.0.1(typescript@4.9.3)
+      compatfactory: 2.0.9(typescript@4.9.3)
       typescript: 4.9.3
     dev: true
 

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -75,8 +75,8 @@
     "ember-source-beta": "npm:ember-source@beta",
     "ember-source-latest": "npm:ember-source@latest",
     "ember-truth-helpers": "^3.0.0",
-    "rollup": "^2.69.1",
-    "rollup-plugin-ts": "~3.0.0",
+    "rollup": "^3.23.0",
+    "rollup-plugin-ts": "^3.2.0",
     "typescript": "^4.9.0"
   },
   "volta": {


### PR DESCRIPTION
## Background

### A few independent incidences

After updating `rollup` to `3.22.0`, the package [`embroider-css-modules`](https://github.com/ijlee2/embroider-css-modules/tree/0.1.6/packages/embroider-css-modules) worked, in the sense that [the consuming app](https://github.com/ijlee2/embroider-css-modules/tree/0.1.6/docs/embroider-css-modules) (a test app) continued to run and all tests for the test app continued to pass. I noticed, however, that the `lint:types` script of the test app failed because `embroider-css-modules` didn't create `dist/index.d.ts` in the same way as before.

<details>

<summary>Error messages</summary>

```sh
app/components/widgets/widget-4/memo/actions.gts:3:28 - error TS2306: File '/packages/embroider-css-modules/dist/index.d.ts' is not a module.

3 import { localClass } from 'embroider-css-modules';
                             ~~~~~~~~~~~~~~~~~~~~~~~

app/components/ui/form/field.gts:4:28 - error TS2306: File '/packages/embroider-css-modules/dist/index.d.ts' is not a module.

4 import { localClass } from 'embroider-css-modules';
```

</details>

<details>

<summary>What <code>dist</code> looked like before updating <code>rollup</code></summary>

<img width="800" alt="" src="https://github.com/ijlee2/embroider-css-modules/assets/16869656/49b16a13-cc97-4ee5-aea0-0d2fbc3ea39b">

</details>

<details>

<summary>What <code>dist</code> looked like after updating <code>rollup</code></summary>

<img width="800" alt="" src="https://github.com/ijlee2/embroider-css-modules/assets/16869656/13673a35-aca5-4f6e-b098-a937065be031">

</details>


After updating `rollup` to `3.22.0` in another package (in another repo), I noticed that a different file called `dist/template-registry.d.ts` had been created differently. The test app for that package also failed `lint:types` as a result.

<details>

<summary>What <code>dist/template-registry.d.ts</code> looked like before updating <code>rollup</code></summary>

```ts
import UiSpinnerComponent from "./components/ui/spinner.js";
interface UiSpinnerRegistry {
    'Ui::Spinner': typeof UiSpinnerComponent;
}
export { UiSpinnerRegistry as default };
```

</details>

<details>

<summary>What <code>dist/template-registry.d.ts</code> looked like after updating <code>rollup</code></summary>

```ts
export {};
```

</details>


Finally, on Discord, [`@jeffsawatzky` described encountering a similar issue](https://discord.com/channels/480462759797063690/491905849405472769/1111019357888319641).

> And it [Glint] is _mostly_ working, except that the registry that I define in `template-registry.ts` don't get saved in `template-registry.d.ts` after build. Instead that file is blank, and the code I put in `template-registry.ts` ends up in `index.d.ts`. I've looked at other examples, but I haven't been able to figure this out. 


## Possible root cause

I reported the issue to the maintainers of `rollup` in https://github.com/rollup/rollup/issues/5008.

@lukastaegert noticed, the problem seemed to be limited to `*.d.ts` files, e.g. `dist/index.d.ts`, `dist/template-registry.d.ts`. If so, `rollup-plugin-ts` (which we use to support TypeScript) or one of its dependencies, might have made an assumption about chunks that is not valid as of `rollup@3.22.0`.


## Proposed solution

Lukas (who maintains `rollup`) and I both think, a good option is for `@embroider/addon-dev` to explicitly set `output.experimentalMinChunkSize` to `0`.

> Maybe explicitly setting `output.experimentalMinChunkSize:0` in the shared config is not a bad idea for now. The reasoning for setting it to `1` was that there should not be adverse effects to users, but it should avoid some empty chunks. It would still be helpful if someone with more knowledge about the workings of `rollup-plugin-dts` could look into this and determine if the empty files are a bug in the plugin or in Rollup. In the worst case, we could change the default back to `0` until the next major version.

This way, an addon maintainer doesn't need to set the value themselves in `rollup.config.js`:

```js
/* rollup.config.{js,mjs} */

import { Addon } from '@embroider/addon-dev/rollup';
import typescript from 'rollup-plugin-ts';

const addon = new Addon({
  srcDir: 'src',
  destDir: 'dist',
});

export default {
  output: {
    ...addon.output(),
    experimentalMinChunkSize: 0,  // <-- Current workaround for addon developers
  },

  plugins: [ ... ],
};
```

At the same time, the maintainers of `rollup` could continue to iterate on the default value of `experimentalMinChunkSize` for `v3` and `v4`.


## Related links

- https://github.com/ijlee2/embroider-css-modules/pull/42#discussion_r1202018979
- https://rollupjs.org/configuration-options/#output-experimentalminchunksize
- https://github.com/rollup/rollup/issues/5008
