### PR TITLE
[bugfix] Ensured that normalizeFileExt ignores .css.d.ts files

### DIFF
--- a/packages/addon-dev/src/rollup-public-entrypoints.ts
+++ b/packages/addon-dev/src/rollup-public-entrypoints.ts
@@ -5,14 +5,7 @@ import minimatch from 'minimatch';
 import type { Plugin } from 'rollup';
 
 function normalizeFileExt(fileName: string) {
-  if (fileName.endsWith('.ts')) {
-    // Match .ts but not .d.ts
-    const regex = /(^.?|\.[^d]|[^.]d|[^.][^d])\.ts$/;
-
-    return fileName.replace(regex, '$1.js');
-  }
-
-  return fileName.replace(/\.hbs|\.gts|\.gjs$/, '.js');
+  return fileName.replace(/(?<!\.d)\.ts|\.hbs|\.gts|\.gjs$/, '.js');
 }
 
 export default function publicEntrypoints(args: {

--- a/packages/addon-dev/src/rollup-public-entrypoints.ts
+++ b/packages/addon-dev/src/rollup-public-entrypoints.ts
@@ -5,7 +5,11 @@ import minimatch from 'minimatch';
 import type { Plugin } from 'rollup';
 
 function normalizeFileExt(fileName: string) {
-  return fileName.replace(/\.ts|\.hbs|\.gts|\.gjs$/, '.js');
+  if (fileName.endsWith('.ts')) {
+    return fileName.replace(/\.ts$/, '.js');
+  }
+
+  return fileName.replace(/\.hbs|\.gts|\.gjs$/, '.js');
 }
 
 export default function publicEntrypoints(args: {

--- a/packages/addon-dev/src/rollup-public-entrypoints.ts
+++ b/packages/addon-dev/src/rollup-public-entrypoints.ts
@@ -6,7 +6,10 @@ import type { Plugin } from 'rollup';
 
 function normalizeFileExt(fileName: string) {
   if (fileName.endsWith('.ts')) {
-    return fileName.replace(/\.ts$/, '.js');
+    // Match .ts but not .d.ts
+    const regex = /(^.?|\.[^d]|[^.]d|[^.][^d])\.ts$/;
+
+    return fileName.replace(regex, '$1.js');
   }
 
   return fileName.replace(/\.hbs|\.gts|\.gjs$/, '.js');


### PR DESCRIPTION
## Background

I created [`sample-v2-addon`](https://github.com/ijlee2/embroider-css-modules/tree/0.1.6/docs/sample-v2-addon) to investigate how we can introduce CSS modules to v2 addons (while supporting Glint). The key is, for each CSS file `*.css`, to create the corresponding declaration file `*.css.d.ts`.

```sh
sample-v2-addon
├── src
│   └── components
│       ├── navigation-menu.css
│       ├── navigation-menu.css.d.ts
│       ├── navigation-menu.hbs
│       └── navigation-menu.ts
...
```

When the addon's `publicEntrypoints` and `appReexports` include the "normal" wildcard pattern `components/**/*.js`, the resulting `dist` will include files that are not supposed to be present:

```sh
sample-v2-addon
├── dist
│   └── components
│       ├── navigation-menu.css.d.d.ts ❌
│       ├── navigation-menu.css.d.d.ts.map ❌
│       ├── navigation-menu.css.d.js ❌
│       ├── navigation-menu.css.d.js.map ❌
│       ├── navigation-menu.d.ts
│       ├── navigation-menu.js
│       └── navigation-menu.js.map
...
```

I worked around the problem by providing the pattern `components/**/!(*.css.d).js`, but find the additional complexity in regular expression to be a tech risk (not easy to understand—_what is `.css.d.js`?_—and maintain):

```sh
sample-v2-addon
├── dist
│   └── components
│       ├── navigation-menu.d.ts
│       ├── navigation-menu.d.ts.map
│       ├── navigation-menu.js
│       └── navigation-menu.js.map
...
```


## Proposed solution

I suspect, the [current implementation of `normalizeFileExt`](https://github.com/embroider-build/embroider/blob/v3.1.0-addon-dev/packages/addon-dev/src/rollup-public-entrypoints.ts#L7-L9) didn't consider file extensions that include `.ts` as a substring.

```ts
function normalizeFileExt(fileName: string) {
  return fileName.replace(/\.ts|\.hbs|\.gts|\.gjs$/, '.js');
}
```

By making an early exit, we can consider `*.ts` cases and define a more specific rule that ignores `.css.d.ts`.

```ts
function normalizeFileExt(fileName: string) {
  if (fileName.endsWith('.ts')) {
    // Match .ts but not .d.ts
    const regex = /(^.?|\.[^d]|[^.]d|[^.][^d])\.ts$/;

    return fileName.replace(regex, '$1.js');
  }

  return fileName.replace(/\.hbs|\.gts|\.gjs$/, '.js');
}
```

Admittedly, the regular expression `/(^.?|\.[^d]|[^.]d|[^.][^d])\.ts$/`, copied from [StackOverflow](https://stackoverflow.com/a/43493203), is complex and forms another tech risk. Ideally, unit tests for `normalizeFileExt` would be present to document its input and output. (I didn't know in which package such tests can be written.)