### PR TITLE
expanding EmptyPackage contents

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -34,7 +34,7 @@ export default function buildCompatAddon(originalPackage: Package, v1Cache: V1In
     // because that whole process only depends on looking at all the
     // package.json files on disk -- it can't know which ones are going to end
     // up unused at this point.
-    return new EmptyPackageTree(originalPackage.name);
+    return new EmptyPackageTree(originalPackage);
   }
 
   let needsSmooshing = oldPackages.length > 1 && oldPackages[0].hasAnyTrees();

--- a/packages/compat/src/empty-package-tree.ts
+++ b/packages/compat/src/empty-package-tree.ts
@@ -1,3 +1,4 @@
+import { Package } from '@embroider/core';
 import Plugin from 'broccoli-plugin';
 import { writeJSONSync } from 'fs-extra';
 import { join } from 'path';
@@ -5,7 +6,7 @@ import { join } from 'path';
 export default class extends Plugin {
   private built = false;
 
-  constructor(private name: string) {
+  constructor(private originalPackage: Package) {
     super([], {
       annotation: 'empty-package-tree',
       persistentOutput: true,
@@ -15,7 +16,9 @@ export default class extends Plugin {
   build() {
     if (!this.built) {
       writeJSONSync(join(this.outputPath, 'package.json'), {
-        name: this.name,
+        name: this.originalPackage.name,
+        version: this.originalPackage.version,
+        '//': 'This empty package was created by embroider. See https://github.com/embroider-build/embroider/blob/main/docs/empty-package-output.md',
       });
     }
   }


### PR DESCRIPTION
This incorporates https://github.com/embroider-build/embroider/pull/1350 as well as the suggestion in https://github.com/embroider-build/embroider/issues/1338#issuecomment-1453524143 to include the version so that `dependencySatisfies` will still work correctly.