### PR TITLE
Extract proposed test scenario to main to prove it's broken there and is a valid way to test /tests

### DIFF
--- a/tests/scenarios/app-config-environment-test.ts
+++ b/tests/scenarios/app-config-environment-test.ts
@@ -1,0 +1,91 @@
+import merge from 'lodash/merge';
+import { appScenarios } from './scenarios';
+import { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+
+const { module: Qmodule, test } = QUnit;
+
+appScenarios
+  .only('release')
+  .map('app-config-environment', project => {
+    merge(project.files, {
+      'ember-cli-build.js': `
+        'use strict';
+
+        const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+        const { maybeEmbroider } = require('@embroider/test-setup');
+
+        module.exports = function (defaults) {
+          let app = new EmberApp(defaults, {
+            tests: true,
+            storeConfigInMeta: false,
+          });
+          return maybeEmbroider(app, {});
+        };
+      `,
+      config: {
+        'environment.js': `module.exports = function(environment) {
+          // DEFAULT config/environment.js
+          let ENV = {
+            modulePrefix: 'my-app',
+            environment,
+            rootURL: '/',
+            // locationType: 'history',
+            //
+            // REQUIRED ONLY FOR THE TDD REPRODUCTION PROVING THIS IS BROKEN ON MAIN
+            locationType: 'none',
+            EmberENV: {
+              EXTEND_PROTOTYPES: false,
+              FEATURES: {},
+            },
+            APP: {},
+          };
+
+          if (environment === 'test') {
+            ENV.locationType = 'none';
+            ENV.APP.LOG_ACTIVE_GENERATION = false;
+            ENV.APP.LOG_VIEW_LOOKUPS = false;
+            ENV.APP.rootElement = '#ember-testing';
+            ENV.APP.autoboot = false;
+
+            // CUSTOM
+            ENV.someCustomField = true;
+          };
+
+          return ENV;
+        };`,
+      },
+      tests: {
+        unit: {
+          'store-config-in-meta-test.js': `
+            import { module, test } from 'qunit';
+            import ENV from 'app-template/config/environment';
+
+            module('Unit | storeConfigInMeta', function (hooks) {
+              test('it has loaded the correct config values', async function (assert) {
+                assert.equal(ENV.someCustomField, true);
+              });
+            });`,
+        },
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test(`yarn test ran against dev build with custom unit test`, async function (assert) {
+        // build the app with environment set to dev so that we can use this build output
+        // directory as the input to an `ember test` run later. This difference in build
+        // environment is important as it's the only way to test ember-cli-build.js'
+        // `tests: true` behavior, and is equivalent to visiting the app's /tests page
+        let devBuildResult = await app.execute(`yarn build --environment=development`);
+        assert.equal(devBuildResult.exitCode, 0, devBuildResult.output);
+        let testRunResult = await app.execute(`yarn test --path dist`);
+        assert.equal(testRunResult.exitCode, 0, testRunResult.output);
+      });
+    });
+  });


### PR DESCRIPTION
This PR pulls the test scenario proposed in https://github.com/embroider-build/embroider/pull/1412 out to main (away from our storeConfigInMeta bugfix) to prove that it fails here, and to prove that this method of `yarn build --environment=development` into `yarn test --path dist` is a valid way of reproducing the runtime environment present in the /tests page of a local development build.

To save you clicking through GitHub action logs, here's the test output:
```
~/s/embroider 22a/prove-this-spec-fails *3 ?1 ❯ yarn test --filter app-config                  16s
yarn run v1.22.19
$ cd tests/scenarios && yarn test --filter app-config
$ qunit --require ts-node/register *-test.ts --filter app-config
TAP version 13
not ok 1 release-app-config-environment > yarn test ran against dev build with custom unit test
  ---
  message: |
    $ ember test --path dist
    not ok 1 Chrome 113.0 - [3 ms] - Unit | storeConfigInMeta: it has loaded the correct config values
        ---
            expected: >
                true
            stack: >
                    at Object.eval (webpack://app-template/./tests/unit/store-config-in-meta-test.js?:9:12)
            negative: >
                false
            browser log: |
        ...
    ok 2 Chrome 113.0 - [0 ms] - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

    1..2
    # tests 2
    # pass  1
    # skip  0
    # todo  0
    # fail  1
    Testem finished with non-zero exit code. Tests failed.

    error Command failed with exit code 1.
    info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
  severity: failed
  actual  : 1
  expected: 0
  stack: |
        at Assert.equal (/Users/petermeehan/src/embroider/node_modules/qunit/qunit/qunit.js:1562:14)
  ...
1..1
# pass 0
# skip 0
# todo 0
# fail 1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```