### PR TITLE
Test if type=module is allowed for v2 addons

### DIFF
--- a/tests/scenarios/v2-addon-test.ts
+++ b/tests/scenarios/v2-addon-test.ts
@@ -9,6 +9,7 @@ appScenarios
   .map('v2-addon-basics', project => {
     let addon = baseV2Addon();
     addon.pkg.name = 'v2-addon';
+    addon.pkg.type = 'module';
     (addon.pkg as any)['ember-addon']['app-js']['./components/example-component.js'] =
       './app/components/example-component.js';
     merge(addon.files, {
@@ -32,9 +33,9 @@ appScenarios
         'example-component.css': '/* not empty */ h1 { color: red }',
       },
       'import-from-npm.js': `
-        export default async function() { 
+        export default async function() {
           let { message } = await import('third-party');
-          return message() 
+          return message()
         }
         `,
     });


### PR DESCRIPTION
Noticed an issue with a development `ember build` and got this error with type=module in the package.json of the v2 addon:
```
Build Error (PackagerRunner) in ../node_modules/.pnpm/file+ember-primitives_@glimmer+component@1.1.2_@glimmer+tracking@1.1.2_@glint+template@1.0.2__5flicjnelbvasblmzhqljcm6ai/node_modules/ember-primitives/dist/index.js

Module not found: Error: Can't resolve '<repo>/node_modules/.pnpm/@embroider+macros@1.11.0_@glint+template@1.0.2/node_modules/@embroider/macros/src/addon/es-compat' in '$TMPDIR/embroider/2194b3/node_modules/.pnpm/file+ember-primitives_@glimmer+component@1.1.2_@glimmer+tracking@1.1.2_@glint+template@1.0.2__5flicjnelbvasblmzhqljcm6ai/node_modules/ember-primitives/dist/index.js'
Did you mean 'es-compat.js'?
BREAKING CHANGE: The request '<repo>/node_modules/.pnpm/@embroider+macros@1.11.0_@glint+template@1.0.2/node_modules/@embroider/macros/src/addon/es-compat' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.


Stack Trace and Error Report: /tmp/error.dump.65d732fa1322ef93e4dcf03a11d342ce.log
```