### PR TITLE
update deprecated (and removed) blacklist config in test app

### DIFF
--- a/tests/fixtures/blacklisted-addon-build-options/ember-cli-build.js
+++ b/tests/fixtures/blacklisted-addon-build-options/ember-cli-build.js
@@ -6,7 +6,7 @@ module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     // Add options here
     addons: {
-      blacklist: ['blacklisted-in-repo-addon'],
+      exclude: ['blacklisted-in-repo-addon'],
     },
   });
 


### PR DESCRIPTION
It turns out that ember-cli@5.0 has merged https://github.com/ember-cli/ember-cli/pull/10175 which removes the blacklist key for addons and replaces it with `exclude`. 

I have a feeling we might need to use the right one based on a version but I'm trying this PR just updating it for now 👍 