### PR TITLE
cache bust index html on arbitrary dom changes

### DIFF
--- a/packages/core/src/html-entrypoint.ts
+++ b/packages/core/src/html-entrypoint.ts
@@ -152,6 +152,11 @@ export class HTMLEntrypoint {
     }
     return this.dom.serialize();
   }
+
+  simpleRender(): string {
+    //used to cache bust during webpack build
+    return this.dom.serialize();
+  }
 }
 
 export interface BundleSummary {


### PR DESCRIPTION
what this pr introduces is a cache key in the form of a render on first cache of the appInfo
subsequent runs render the  html file before it would be processed and altered by webpack to contain all chunks this providing a stable key to check against
we also have a final check in place once webpack has built to not write a file if the final content is unchanged which is done as a file system check

@ef4 this seems to be caused by the way we check if appInfo is the same and if we need to set up a new webpack instance 
I did not find a better way to query at start of the build or at another point during the process