### PR TITLE
Don't over-serialize options into `resolver.json`

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -354,6 +354,13 @@ class CompatAppAdapter implements AppAdapter<TreeNames, CompatResolverOptions> {
       activeAddons[addon.name] = addon.root;
     }
 
+    let options: CompatResolverOptions['options'] = {
+      staticHelpers: this.options.staticHelpers,
+      staticModifiers: this.options.staticModifiers,
+      staticComponents: this.options.staticComponents,
+      allowUnsafeDynamicComponents: this.options.allowUnsafeDynamicComponents,
+    };
+
     let config: CompatResolverOptions = {
       // this part is the base ModuleResolverOptions as required by @embroider/core
       activeAddons,
@@ -379,8 +386,8 @@ class CompatAppAdapter implements AppAdapter<TreeNames, CompatResolverOptions> {
       // global template resolving
       modulePrefix: this.modulePrefix(),
       podModulePrefix: this.podModulePrefix(),
-      options: this.options,
       activePackageRules: this.activeRules(),
+      options,
     };
 
     return config;


### PR DESCRIPTION
`this.options` can contain arbitrary unserializable data (such as Broccoli trees, Webpack plugins, etc).

Fixes #1441

Optionally, we can change the type of the `AppBuilder`:

```patch
diff --git a/packages/core/src/app.ts b/packages/core/src/app.ts
index 5ab0844a..b46bcf0f 100644
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -223,14 +223,14 @@ class ConcatenatedAsset {

 type InternalAsset = OnDiskAsset | InMemoryAsset | BuiltEmberAsset | ConcatenatedAsset;

-export class AppBuilder<TreeNames> {
+export class AppBuilder<TreeNames, SpecificResolverConfig extends ResolverConfig = ResolverConfig> {
   // for each relativePath, an Asset we have already emitted
   private assets: Map<string, InternalAsset> = new Map();

   constructor(
     private root: string,
     private app: Package,
-    private adapter: AppAdapter<TreeNames>,
+    private adapter: AppAdapter<TreeNames, SpecificResolverConfig>,
     private options: Required<Options>,
     private macrosConfig: MacrosConfig
   ) {
@@ -994,7 +994,7 @@ export class AppBuilder<TreeNames> {
     );
   }

-  private addResolverConfig(config: ResolverConfig) {
+  private addResolverConfig(config: SpecificResolverConfig) {
     outputJSONSync(join(this.root, '.embroider', 'resolver.json'), config);
   }

```

Didn't commit it because I'm not sure if it's worth propagating the generic, and it wouldn't have detected this issue anyway, but it does document the intent of the `resolver.json` more correctly.

Happy to add a test if I can get some pointers.