### PR TITLE
fix this.import from node_modules in v1 addons

### DIFF
--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -49,10 +49,7 @@ export default class CompatAddons implements Stage {
     if (!this.treeSync) {
       this.treeSync = new TreeSync(
         addons,
-        resolve(locateEmbroiderWorkingDir(this.compatApp.root), 'rewritten-packages'),
-        {
-          ignore: ['**/node_modules'],
-        }
+        resolve(locateEmbroiderWorkingDir(this.compatApp.root), 'rewritten-packages')
       );
     }
 

--- a/tests/scenarios/compat-addon-import-test.ts
+++ b/tests/scenarios/compat-addon-import-test.ts
@@ -1,0 +1,60 @@
+import { expectFilesAt, ExpectFile } from '@embroider/test-support/file-assertions/qunit';
+import { PreparedApp } from 'scenario-tester';
+import { throwOnWarnings } from '@embroider/core';
+import { appScenarios, baseAddon } from './scenarios';
+import QUnit from 'qunit';
+import { merge } from 'lodash';
+const { module: Qmodule, test } = QUnit;
+
+appScenarios
+  .map('compat-addon-import', project => {
+    let addon1 = baseAddon();
+    addon1.pkg.name = 'my-addon1';
+
+    merge(addon1.files, {
+      'index.js': `
+        module.exports = {
+          name: require('./package.json').name,
+          included(app) {
+            this.import('node_modules/third-party1/index.js', {
+              using: [{ transformation: 'amd' }],
+              type: 'test'
+            });
+          }
+        }
+      `,
+    });
+
+    addon1.addDependency('third-party1', '1.2.3').files = {
+      'index.js': 'module.exports = function() { console.log("hello world"); }',
+    };
+
+    project.addDependency(addon1);
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      throwOnWarnings(hooks);
+
+      let app: PreparedApp;
+
+      let expectFile: ExpectFile;
+
+      hooks.before(async assert => {
+        app = await scenario.prepare();
+        let result = await app.execute('ember build', { env: { STAGE1_ONLY: 'true' } });
+        assert.equal(result.exitCode, 0, result.output);
+      });
+
+      hooks.beforeEach(assert => {
+        expectFile = expectFilesAt(app.dir, { qunit: assert });
+      });
+
+      test('synthesized-vendor has imported file in node modules', function () {
+        expectFile(
+          './node_modules/.embroider/rewritten-packages/@embroider/synthesized-vendor/node_modules/third-party1/index.js'
+        ).matches(`(function(define){
+module.exports = function() { console.log(\"hello world\"); }
+})((function(){ function newDefine(){ var args = Array.prototype.slice.call(arguments); return define.apply(null, args); }; newDefine.amd = true; return newDefine; })());`);
+      });
+    });
+  });


### PR DESCRIPTION
As part of #1435 we have moved all vendor code from addons to `./node_modules/.embroider/rewritten-packages/@embroider/synthesized-vendor/`, which works when you call `this.import()` from an addon's `included()` hook.

Perhaps as a copy & paste error we were ignoring the case where `this.import()` was called on a file in `node_modules`, this PR will fix that.

Note: I have committed and pushed a failing test that I will fix in a subsequent commit so that we can see that the issue exists on main and is fixed by the commit 👍 