### PR TITLE
Fix rewritten-package-cache when app has symlink to node_modules

### DIFF
--- a/packages/shared-internals/src/rewritten-package-cache.ts
+++ b/packages/shared-internals/src/rewritten-package-cache.ts
@@ -1,6 +1,6 @@
 import PackageCache from './package-cache';
 import Package from './package';
-import { existsSync, readJSONSync } from 'fs-extra';
+import { existsSync, readJSONSync, realpathSync } from 'fs-extra';
 import { resolve } from 'path';
 import { getOrCreate } from './get-or-create';
 import { locateEmbroiderWorkingDir } from './working-dir';
@@ -146,10 +146,16 @@ export class RewrittenPackageCache implements PublicAPI<PackageCache> {
     let { packages, extraResolutions } = readJSONSync(indexFile) as RewrittenPackageIndex;
     return {
       oldToNew: new Map(
-        Object.entries(packages).map(([oldRoot, newRoot]) => [resolve(addonsDir, oldRoot), resolve(addonsDir, newRoot)])
+        Object.entries(packages).map(([oldRoot, newRoot]) => [
+          realpathSync(resolve(addonsDir, oldRoot)),
+          realpathSync(resolve(addonsDir, newRoot)),
+        ])
       ),
       newToOld: new Map(
-        Object.entries(packages).map(([oldRoot, newRoot]) => [resolve(addonsDir, newRoot), resolve(addonsDir, oldRoot)])
+        Object.entries(packages).map(([oldRoot, newRoot]) => [
+          realpathSync(resolve(addonsDir, newRoot)),
+          realpathSync(resolve(addonsDir, oldRoot)),
+        ])
       ),
       extraResolutions: new Map(
         Object.entries(extraResolutions).map(([fromRoot, toRoots]) => [

--- a/packages/shared-internals/src/rewritten-package-cache.ts
+++ b/packages/shared-internals/src/rewritten-package-cache.ts
@@ -1,6 +1,6 @@
 import PackageCache from './package-cache';
 import Package from './package';
-import { existsSync, readJSONSync, realpathSync } from 'fs-extra';
+import { ensureDirSync, existsSync, readJSONSync, realpathSync } from 'fs-extra';
 import { resolve } from 'path';
 import { getOrCreate } from './get-or-create';
 import { locateEmbroiderWorkingDir } from './working-dir';
@@ -142,6 +142,12 @@ export class RewrittenPackageCache implements PublicAPI<PackageCache> {
         extraResolutions: new Map(),
       };
     }
+
+    // this directory is a bit special because RewrittenPackageCache needs to
+    // exist before this dir has been produced. But the dir appears preemptively
+    // in our index, and we don't want that to blow up during the realpath
+    // below.
+    ensureDirSync(resolve(addonsDir, '..', 'rewritten-app'));
 
     let { packages, extraResolutions } = readJSONSync(indexFile) as RewrittenPackageIndex;
     return {


### PR DESCRIPTION
This came up in ember-cli's test infrastructure, where the test apps have a symlink for `node_modules`. Without realpathSync, our index here doesn't match the actual package paths.