### PR TITLE
Eagerly virtualize emberVirtualPackages

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -829,6 +829,10 @@ export class Resolver {
       return external('beforeResolve', request, specifier);
     }
 
+    if (emberVirtualPackages.has(packageName) && !pkg.hasDependency(packageName)) {
+      return external('beforeResolve emberVirtualPackages', request, specifier);
+    }
+
     if (!pkg.meta['auto-upgraded'] && emberVirtualPeerDeps.has(packageName)) {
       // Native v2 addons are allowed to use the emberVirtualPeerDeps like
       // `@glimmer/component`. And like all v2 addons, it's important that they

--- a/packages/shared-internals/src/ember-standard-modules.ts
+++ b/packages/shared-internals/src/ember-standard-modules.ts
@@ -37,6 +37,11 @@ emberVirtualPackages.add('@embroider/macros');
 // the modules-api-polyfill. Newer APIs need to be added here.
 emberVirtualPackages.add('@ember/owner');
 
+// these are not public API but they're included in ember-source, so for
+// correctness we still want to understand that they come from there.
+emberVirtualPackages.add('@glimmer/validator');
+emberVirtualPackages.add('@glimmer/manager');
+
 // These are the known names that people use to import template precomiplation
 // macros from.
 export const templateCompilationModules = Object.freeze([

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -1,5 +1,5 @@
 import { AddonMeta, AppMeta } from '@embroider/shared-internals';
-import { outputFileSync } from 'fs-extra';
+import { outputFileSync, readJsonSync, writeJSONSync } from 'fs-extra';
 import { resolve } from 'path';
 import QUnit from 'qunit';
 import { PreparedApp, Project, Scenarios } from 'scenario-tester';
@@ -551,6 +551,27 @@ Scenarios.fromProject(() => new Project())
             .module('./node_modules/my-addon/_app_/hello-world.js')
             .resolves('my-app/secondary')
             .to('./secondary.js');
+        });
+
+        test(`known ember-source-provided virtual packages are externalized even when accidentally resolvable`, async function () {
+          givenFiles({
+            'node_modules/rsvp/index.js': `export {}`,
+            'app.js': `import "rsvp"`,
+          });
+          await configure({});
+          expectAudit.module('./app.js').resolves('rsvp').to('/@embroider/external/rsvp');
+        });
+
+        test(`known ember-source-provided virtual packages are not externalized when explicitly included in deps`, async function () {
+          let pkg = readJsonSync(resolve(app.dir, 'package.json'));
+          pkg.dependencies['rsvp'] = '*';
+          writeJSONSync(resolve(app.dir, 'package.json'), pkg);
+          givenFiles({
+            'node_modules/rsvp/index.js': '',
+            'app.js': `import "rsvp"`,
+          });
+          await configure({});
+          expectAudit.module('./app.js').resolves('rsvp').to('./node_modules/rsvp/index.js');
         });
 
         test(`resolves addon fastboot-js`, async function () {

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -559,7 +559,7 @@ Scenarios.fromProject(() => new Project())
             'app.js': `import "rsvp"`,
           });
           await configure({});
-          expectAudit.module('./app.js').resolves('rsvp').to('/@embroider/external/rsvp');
+          expectAudit.module('./app.js').resolves('rsvp').to(resolve('/@embroider/external/rsvp'));
         });
 
         test(`known ember-source-provided virtual packages are not externalized when explicitly included in deps`, async function () {

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -1,6 +1,6 @@
 import { AddonMeta, AppMeta, RewrittenPackageIndex } from '@embroider/shared-internals';
 import { outputFileSync, readJsonSync, writeJSONSync } from 'fs-extra';
-import { resolve } from 'path';
+import { resolve, sep } from 'path';
 import QUnit from 'qunit';
 import { PreparedApp, Project, Scenarios } from 'scenario-tester';
 import { CompatResolverOptions } from '@embroider/compat/src/resolver-transform';
@@ -559,7 +559,7 @@ Scenarios.fromProject(() => new Project())
             'app.js': `import "rsvp"`,
           });
           await configure({});
-          expectAudit.module('./app.js').resolves('rsvp').to(resolve('/@embroider/external/rsvp'));
+          expectAudit.module('./app.js').resolves('rsvp').to(resolve('/@embroider/external/rsvp').replaceAll(sep, '/'));
         });
 
         test(`known ember-source-provided virtual packages are not externalized when explicitly included in deps`, async function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "./tests/scenarios/**/*.ts"
   ],
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2021",
     "module": "commonjs",
     "declaration": true,
     "typeRoots": ["types", "node_modules/@types"],
@@ -20,7 +20,7 @@
     "allowUnreachableCode": false,
     "strict": true,
     "skipLibCheck": true,
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
... and expand the list of virtual pacakges to includes some that are private-but-used-API.

Before this, we only provided these as fallbacks when normal resolving failed, and this mostly worked. But that was when we were also rewriting the entire node_modules graph on disk. Now that we don't do that, there are many more opportunities to accidentally resolve copies of packages that aren't really what you expected.