### PR TITLE
Make the package-json path repo-relative

### DIFF
--- a/test-packages/release/src/interdep.ts
+++ b/test-packages/release/src/interdep.ts
@@ -1,5 +1,5 @@
 import glob from 'globby';
-import { resolve } from 'path';
+import { resolve, relative } from 'path';
 import { readFileSync, readJSONSync } from 'fs-extra';
 import yaml from 'js-yaml';
 
@@ -21,15 +21,15 @@ export function publishedInterPackageDeps(): Map<string, PkgEntry> {
   for (let pattern of (yaml.load(readFileSync(resolve(__dirname, '../../../pnpm-workspace.yaml'), 'utf8')) as any)
     .packages) {
     for (let dir of glob.sync(pattern, { cwd: rootDir, expandDirectories: false, onlyDirectories: true })) {
-      let pkgJSONPath = resolve(rootDir, dir, 'package.json');
-      let pkg = readJSONSync(pkgJSONPath);
+      let absolutePkgJSONPath = resolve(rootDir, dir, 'package.json');
+      let pkg = readJSONSync(absolutePkgJSONPath);
       if (pkg.private) {
         continue;
       }
       pkgJSONS.set(pkg.name, pkg);
       packages.set(pkg.name, {
         version: pkg.version,
-        pkgJSONPath,
+        pkgJSONPath: dir,
         isDependencyOf: new Map(),
         isPeerDependencyOf: new Map(),
       });

--- a/test-packages/release/src/interdep.ts
+++ b/test-packages/release/src/interdep.ts
@@ -1,5 +1,5 @@
 import glob from 'globby';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
 import { readFileSync, readJSONSync } from 'fs-extra';
 import yaml from 'js-yaml';
 
@@ -29,7 +29,7 @@ export function publishedInterPackageDeps(): Map<string, PkgEntry> {
       pkgJSONS.set(pkg.name, pkg);
       packages.set(pkg.name, {
         version: pkg.version,
-        pkgJSONPath: dir,
+        pkgJSONPath: join(dir, 'package.json'),
         isDependencyOf: new Map(),
         isPeerDependencyOf: new Map(),
       });

--- a/test-packages/release/src/interdep.ts
+++ b/test-packages/release/src/interdep.ts
@@ -1,5 +1,5 @@
 import glob from 'globby';
-import { resolve, relative } from 'path';
+import { resolve } from 'path';
 import { readFileSync, readJSONSync } from 'fs-extra';
 import yaml from 'js-yaml';
 

--- a/test-packages/release/src/prepare.ts
+++ b/test-packages/release/src/prepare.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { planVersionBumps, saveSolution, Solution } from './plan';
 import { readJSONSync, writeJSONSync } from 'fs-extra';
+import { relativeToAbsolute } from './utils';
 
 const changelogPreamble = `# Embroider Changelog
 `;
@@ -36,9 +37,9 @@ function versionSummary(solution: Solution): string {
 function updateVersions(solution: Solution) {
   for (let entry of solution.values()) {
     if (entry.impact) {
-      let pkg = readJSONSync(entry.pkgJSONPath);
+      let pkg = readJSONSync(relativeToAbsolute(entry.pkgJSONPath));
       pkg.version = entry.newVersion;
-      writeJSONSync(entry.pkgJSONPath, pkg, { spaces: 2 });
+      writeJSONSync(relativeToAbsolute(entry.pkgJSONPath), pkg, { spaces: 2 });
     }
   }
 }

--- a/test-packages/release/src/publish.ts
+++ b/test-packages/release/src/publish.ts
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import { loadSolution, Solution } from './plan';
-import { dirname } from 'path';
 import { Octokit } from '@octokit/rest';
+import { absoluteDirname } from './utils';
 
 async function hasCleanRepo(): Promise<boolean> {
   let result = await execa('git', ['status', '--porcelain=v1'], { cwd: __dirname });
@@ -27,7 +27,7 @@ async function makeTags(solution: Solution, reporter: IssueReporter): Promise<vo
     }
     try {
       await execa('git', ['tag', tagFor(pkgName, entry)], {
-        cwd: dirname(entry.pkgJSONPath),
+        cwd: absoluteDirname(entry.pkgJSONPath),
         stderr: 'inherit',
         stdout: 'inherit',
       });
@@ -81,7 +81,7 @@ async function pnpmPublish(solution: Solution, reporter: IssueReporter): Promise
     }
     try {
       await execa('pnpm', ['publish', '--access=public'], {
-        cwd: dirname(entry.pkgJSONPath),
+        cwd: absoluteDirname(entry.pkgJSONPath),
         stderr: 'inherit',
         stdout: 'inherit',
       });

--- a/test-packages/release/src/utils.ts
+++ b/test-packages/release/src/utils.ts
@@ -1,0 +1,11 @@
+import { dirname, join, resolve } from 'path';
+
+export const root = resolve(__dirname, '../../../');
+
+export function relativeToAbsolute(repoRelative: string) {
+  return join(root, repoRelative);
+}
+
+export function absoluteDirname(repoRelative: string) {
+  return dirname(relativeToAbsolute(repoRelative));
+}


### PR DESCRIPTION
Unblocks: https://github.com/embroider-build/embroider/pull/1492

Today, in the release-plan.json, the pkgJSONPath is the absolute path to each package.json _on the machine that ran the command last_.

To allow for anyone to generate and interpret a release-plan, we need to move to repo-relative paths.

All the tools that I saw that read the pkgJSONPath will respect the current working directory -- but that would mean that the `embroider-release` tool can only be ran from the repo root -- so whenever the relative path is read, I converted it to an absolute path.

To test:
- merge a pr, but don't release yet
- run `pnpm i`
- run `pnpm compile --watch` (or without watch)
- run `export GITHUB_AUTH=xyz` (I used a classic token with repo permissions that I've since deleted)
- run `pnpm exec embroider-release explain-plan` (to see what to expect in the .release-plan.json)
- run `pnpm exec embroider-release prepare` (to generate / update the .release-plan.json)

Diff should look something like this:
![image](https://github.com/embroider-build/embroider/assets/199018/c04c6d47-2cc6-4be7-8b3b-044cf8249a3b)
