### PR TITLE
fix inter-package relative imports in addon's app-js

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -802,6 +802,15 @@ export class Resolver {
       // a compat adapter). In the metadata, they would be listed in
       // package-relative form, so we need to convert this specifier to that.
       let absoluteSpecifier = resolve(dirname(fromFile), specifier);
+
+      if (!absoluteSpecifier.startsWith(pkg.root)) {
+        // this relative path escape its package. So it's not really using
+        // normal inter-package resolving and we should leave it alone. This
+        // case comes up especially when babel transforms are trying to insert
+        // references to runtime utilities, like we do in @embroider/macros.
+        return logTransition('beforeResolve: relative path escapes its package', request);
+      }
+
       let packageRelativeSpecifier = explicitRelative(pkg.root, absoluteSpecifier);
       if (isExplicitlyExternal(packageRelativeSpecifier, pkg)) {
         let publicSpecifier = absoluteSpecifier.replace(pkg.root, pkg.name);

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -479,6 +479,25 @@ Scenarios.fromProject(() => new Project())
             .to('./node_modules/my-addon/_app_/hello-world.js');
         });
 
+        test('app-js module in addon can still do relative imports that escape its package', async function () {
+          givenFiles({
+            'node_modules/extra.js': '',
+            'node_modules/my-addon/_app_/hello-world.js': 'import "../../extra.js"',
+            'app.js': `import "my-app/hello-world"`,
+          });
+
+          await configure({
+            addonMeta: {
+              'app-js': { './hello-world.js': './_app_/hello-world.js' },
+            },
+          });
+
+          expectAudit
+            .module('./node_modules/my-addon/_app_/hello-world.js')
+            .resolves('../../extra.js')
+            .to('./node_modules/extra.js');
+        });
+
         test('hbs in addon is found', async function () {
           givenFiles({
             'node_modules/my-addon/_app_/templates/hello-world.hbs': '',


### PR DESCRIPTION
When relative imports escape their containing package, they shouldn't be understood as subject to our package-level rules. They should be left alone to keep them valid.

This happens particularly when babel transforms are inserting references to runtime utilities.

Fixes #1501 