### PR TITLE
All addons may need emberVirtualPeerDep handling

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -842,19 +842,9 @@ export class Resolver {
       return external('beforeResolve emberVirtualPackages', request, specifier);
     }
 
-    if (!pkg.meta['auto-upgraded'] && emberVirtualPeerDeps.has(packageName)) {
-      // Native v2 addons are allowed to use the emberVirtualPeerDeps like
-      // `@glimmer/component`. And like all v2 addons, it's important that they
-      // see those dependencies after those dependencies have been converted to
-      // v2.
-      //
-      // But unlike auto-upgraded addons, native v2 addons are not necessarily
-      // copied out of their original place in node_modules. And from that
-      // original place they might accidentally resolve the emberVirtualPeerDeps
-      // that are present there in v1 format.
-      //
-      // So before we let normal resolving happen, we adjust these imports to
-      // point at the app's copies instead.
+    if (emberVirtualPeerDeps.has(packageName) && !pkg.hasDependency(packageName)) {
+      // addons (whether auto-upgraded or not) may use the app's
+      // emberVirtualPeerDeps, like "@glimmer/component" etc.
       if (!this.options.activeAddons[packageName]) {
         throw new Error(`${pkg.name} is trying to import the app's ${packageName} package, but it seems to be missing`);
       }


### PR DESCRIPTION
As the old comment here implied, this was relying on the assumption that auto-upgraded packages would never be at risk of accidentally resolving un-rewritten emberVirtualPeerDeps because they would necessarily resolve from our rewritten node_modules. But that is no longer true, so in complicated monorepo environments it is possible for them to see a copy of an emberVirtualPeerDep that isn't actually in use and therefore isn't rewritten to v2.

This change expands the behavior that we used to only use for native v2 addons to all addons.

Addons can still avoid being impacted by this compatbility feature if they declare their own dependencies explicity. That is, you have a dep or peerDep on `@glimmer/component` or `@ember/string`, etc, you will get exactly the range you asked for. If you don't have any such dependency, you can still use those packages but you get the app's active copy.