### PR TITLE
Add `@glimmer/reference` as a virtual package

### DIFF
--- a/packages/shared-internals/src/ember-standard-modules.ts
+++ b/packages/shared-internals/src/ember-standard-modules.ts
@@ -40,6 +40,7 @@ emberVirtualPackages.add('@ember/owner');
 // these are not public API but they're included in ember-source, so for
 // correctness we still want to understand that they come from there.
 emberVirtualPackages.add('@glimmer/validator');
+emberVirtualPackages.add('@glimmer/reference');
 emberVirtualPackages.add('@glimmer/manager');
 
 // These are the known names that people use to import template precomiplation


### PR DESCRIPTION
Another fix to #1487

The fix in #1495 turned out to be incomplete and didn't solve my actual problem (which I reduced away in my report). The actual import in the app was for `@glimmer/reference`, which internally imports from `@glimmer/validator`. I think because in `@glimmer/reference`'s `package.json` it has its own dep on `@glimmer/validator` it escapes this rule and acquired the actual copy in `node_modules`, causing the duplication.

It seems like this would also be a problem if you, say, imported from `@glimmer/runtime` (which imports from `@glimmer/reference` and, in turns, `@glimmer/validator`)? I don't personally have that particular use case but I could see that happening. Do we just wait and see or is there something more targeted hard-coding that we should do specifically for `@glimmer/validator`?