### PR TITLE
Move @embroider/macros from emberVirtualPackages to emberVirtualPeerDeps

### DIFF
--- a/packages/shared-internals/src/ember-standard-modules.ts
+++ b/packages/shared-internals/src/ember-standard-modules.ts
@@ -31,7 +31,10 @@ emberVirtualPeerDeps.add('@ember/string');
 // (like snowpack) not to worry about these packages.
 emberVirtualPackages.add('@glimmer/env');
 emberVirtualPackages.add('ember');
-emberVirtualPackages.add('@embroider/macros');
+
+// this is a real package and even though most of its primary API is implemented
+// as transforms, it does include some runtime code.
+emberVirtualPeerDeps.add('@embroider/macros');
 
 // rfc176-data only covers things up to the point where Ember stopped needing
 // the modules-api-polyfill. Newer APIs need to be added here.


### PR DESCRIPTION
I noticed that `@embroider/macros/runtime` was getting force-externalized in an app. Which would make sense if it were really an emberVirtualPackage, but it's a real package so it should be listed in emberVirtualPeerDeps instead.

(It's true that most of what it exposes is "virtual" in the sense of having babel implementation, but the package does provide some runtime implementation too and that should be resolved to the real package)