### PR TITLE
add a basic implementation of the gjs rollup plugin

### DIFF
--- a/packages/addon-dev/package.json
+++ b/packages/addon-dev/package.json
@@ -29,6 +29,7 @@
     "@embroider/core": "workspace:^",
     "@rollup/pluginutils": "^4.1.1",
     "assert-never": "^1.2.1",
+    "content-tag": "^1.0.0",
     "fs-extra": "^10.0.0",
     "minimatch": "^3.0.4",
     "rollup-plugin-copy-assets": "^2.0.3",

--- a/packages/addon-dev/src/rollup-gjs-plugin.ts
+++ b/packages/addon-dev/src/rollup-gjs-plugin.ts
@@ -1,0 +1,71 @@
+import { createFilter } from '@rollup/pluginutils';
+import type { Plugin, PluginContext, ResolvedId } from 'rollup';
+import { readFileSync } from 'fs';
+import { Preprocessor } from 'content-tag';
+
+const PLUGIN_NAME = 'rollup-gjs-plugin';
+
+const processor = new Preprocessor();
+// import { parse as pathParse } from 'path';
+
+export default function rollupGjsPlugin(): Plugin {
+  return {
+    name: PLUGIN_NAME,
+    async resolveId(source: string, importer: string | undefined, options) {
+      let resolution = await this.resolve(source, importer, {
+        skipSelf: true,
+        ...options,
+      });
+
+      if (resolution) {
+        return maybeRewriteGJS(resolution);
+      }
+    },
+
+    load(id: string) {
+      const meta = getMeta(this, id);
+      if (!meta) {
+        return;
+      }
+
+      this.addWatchFile(meta.originalId);
+      let input = readFileSync(meta.originalId, 'utf8');
+      let code = processor.process(input);
+      return {
+        code,
+      };
+    },
+  };
+}
+
+type Meta = {
+  originalId: string;
+};
+
+function getMeta(context: PluginContext, id: string): Meta | null {
+  const meta = context.getModuleInfo(id)?.meta?.[PLUGIN_NAME];
+  if (meta) {
+    return meta as Meta;
+  } else {
+    return null;
+  }
+}
+
+const gjsFilter = createFilter('**/*.gjs');
+
+function maybeRewriteGJS(resolution: ResolvedId) {
+  if (!gjsFilter(resolution.id)) {
+    return null;
+  }
+
+  // This creates an `*.gjs.js` that we will populate in `load()` hook.
+  return {
+    ...resolution,
+    id: resolution.id.replace(/\.gjs$/, '') + '.js',
+    meta: {
+      [PLUGIN_NAME]: {
+        originalId: resolution.id,
+      },
+    },
+  };
+}

--- a/packages/addon-dev/src/rollup-gjs-plugin.ts
+++ b/packages/addon-dev/src/rollup-gjs-plugin.ts
@@ -51,17 +51,29 @@ function getMeta(context: PluginContext, id: string): Meta | null {
   }
 }
 
-const gjsFilter = createFilter('**/*.gjs');
+const gjsFilter = createFilter('**/*.g{j,t}s');
 
 function maybeRewriteGJS(resolution: ResolvedId) {
   if (!gjsFilter(resolution.id)) {
     return null;
   }
 
-  // This creates an `*.gjs.js` that we will populate in `load()` hook.
+  let id;
+
+  if (resolution.id.endsWith('.gjs')) {
+    id = resolution.id.replace(/\.gjs$/, '.js');
+  } else if (resolution.id.endsWith('.gts')) {
+    id = resolution.id.replace(/\.gts$/, '.ts');
+  } else {
+    throw new Error(
+      'Unexpected issues in the plugin-rollup-gjs - an unexpected file made its way throught the pluginUtils filter'
+    );
+  }
+
+  // This creates an `*.js` or `*.ts` that **replaces** the .gjs or .gts file that we will populate in `load()` hook.
   return {
     ...resolution,
-    id: resolution.id.replace(/\.gjs$/, '') + '.js',
+    id,
     meta: {
       [PLUGIN_NAME]: {
         originalId: resolution.id,

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -1,4 +1,5 @@
 import { default as hbs } from './rollup-hbs-plugin';
+import { default as gjs } from './rollup-gjs-plugin';
 import { default as publicEntrypoints } from './rollup-public-entrypoints';
 import { default as appReexports } from './rollup-app-reexports';
 import { default as clean } from 'rollup-plugin-delete';
@@ -43,6 +44,10 @@ export class Addon {
   // required for javascript tooling to understand your package.
   hbs() {
     return hbs();
+  }
+
+  gjs() {
+    return gjs();
   }
 
   // By default rollup does not clear the output directory between builds. This

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       assert-never:
         specifier: ^1.2.1
         version: 1.2.1
+      content-tag:
+        specifier: ^1.0.0
+        version: 1.0.0
       fs-extra:
         specifier: ^10.0.0
         version: 10.0.0
@@ -1609,6 +1612,9 @@ importers:
       '@babel/plugin-transform-class-properties':
         specifier: ^7.16.7
         version: 7.22.0(@babel/core@7.22.6)
+      '@babel/plugin-transform-class-static-block':
+        specifier: ^7.22.5
+        version: 7.22.5(@babel/core@7.22.6)
       '@babel/plugin-transform-runtime':
         specifier: ^7.18.6
         version: 7.18.6(@babel/core@7.22.6)
@@ -1731,7 +1737,7 @@ importers:
         version: /ember-source@4.4.0(@babel/core@7.22.6)
       ember-source-beta:
         specifier: npm:ember-source@beta
-        version: /ember-source@5.2.0-beta.4(@babel/core@7.22.6)
+        version: /ember-source@5.2.0-beta.3(@babel/core@7.22.6)
       ember-source-latest:
         specifier: npm:ember-source@latest
         version: /ember-source@5.1.2(@babel/core@7.22.6)
@@ -2325,7 +2331,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4(supports-color@8.1.0)
       lodash.debounce: 4.0.8
-      resolve: 1.20.0
+      resolve: 1.22.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9567,7 +9573,7 @@ packages:
       wordwrap: 0.0.3
 
   /bower-endpoint-parser@0.2.2:
-    resolution: {integrity: sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=}
+    resolution: {integrity: sha512-YWZHhWkPdXtIfH3VRu3QIV95sa75O9vrQWBOHjexWCLBCTy5qJvRr36LXTqFwTchSXVlzy5piYJOjzHr7qhsNg==}
     engines: {node: '>=0.8.0'}
 
   /brace-expansion@1.1.11:
@@ -14752,8 +14758,8 @@ packages:
       - webpack
     dev: true
 
-  /ember-source@5.2.0-beta.4(@babel/core@7.22.6):
-    resolution: {integrity: sha512-b1Obm3gCkOk5KimtEoXTMbzxXemU8N+WT2mTTa4+9cMxv2qCO8ZVBpkyEmZvQl+W6BrF7tFVl+k6pUDQvuwWKA==}
+  /ember-source@5.2.0-beta.3(@babel/core@7.22.6):
+    resolution: {integrity: sha512-UuhLgcLKWGxTJKgx9fpDG5PV+kjUp707LA7blG9GClCrdgGgGiHlGP5IslPZrSx3oTQhg1KNPIyX/PzjTquwIg==}
     engines: {node: '>= 16.*'}
     dependencies:
       '@babel/helper-module-imports': 7.22.5

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -36,6 +36,7 @@
     "@babel/plugin-proposal-decorators": "^7.17.2",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-class-properties": "^7.16.7",
+    "@babel/plugin-transform-class-static-block": "^7.22.5",
     "@babel/plugin-transform-runtime": "^7.18.6",
     "@babel/plugin-transform-typescript": "^7.22.5",
     "@babel/preset-env": "^7.16.11",

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -34,6 +34,7 @@ appScenarios
           ],
           "plugins": [
             "@embroider/addon-dev/template-colocation-plugin",
+            "@babel/plugin-proposal-class-static-block",
             ["babel-plugin-ember-template-compilation", {
               targetFormat: 'hbs',
               compilerPath: 'ember-source/dist/ember-template-compiler',
@@ -67,15 +68,12 @@ appScenarios
               'components/**/*.js',
             ]),
 
-            addon.appReexports([
-              'components/demo/index.js',
-              'components/demo/out.js',
-              'components/demo/namespace-me.js',
-            ], {
+            addon.appReexports(['components/**/*.js'], {
               mapFilename: (name) => reexportMappings[name] || name,
             }),
 
             addon.hbs(),
+            addon.gjs(),
             addon.dependencies(),
 
             babel({ babelHelpers: 'bundled' }),
@@ -102,6 +100,10 @@ appScenarios
       },
       src: {
         components: {
+          'single-file-component.gjs': `import Component from '@glimmer/component';
+          export default class SingleFileComponent extends Component {
+            <template><div data-test-single-file-component>Hello {{@message}}</div></template>
+          }`,
           demo: {
             'button.hbs': `
               <button {{on 'click' @onClick}}>
@@ -176,6 +178,12 @@ appScenarios
               assert.dom('out').containsText('true');
             });
 
+            test('<SingleFileComponent @message="bob" />', async function(assert) {
+              await render(hbs\`<SingleFileComponent @message="bob" />\`);
+
+              assert.dom().containsText('hello bob');
+            })
+
             test('transform worked', async function (assert) {
               await render(hbs\`<Demo />\`);
               assert.dom('[data-test="should-transform"]').containsText('iWasTransformed');
@@ -222,6 +230,8 @@ appScenarios
 
         test('package.json is modified appropriately', async function () {
           expectFile('package.json').json('ember-addon.app-js').deepEquals({
+            './components/demo/button.js': './dist/_app_/components/demo/button.js',
+            './components/single-file-component.js': './dist/_app_/components/single-file-component.js',
             './components/demo/index.js': './dist/_app_/components/demo/index.js',
             './components/demo/out.js': './dist/_app_/components/demo/out.js',
             './components/demo/namespace/namespace-me.js': './dist/_app_/components/demo/namespace/namespace-me.js',
@@ -247,6 +257,23 @@ appScenarios
             /TEMPLATE = precompileTemplate\("Hello there/,
             'template is still in hbs format'
           );
+        });
+
+        test('gjs components compiled correctly', async function () {
+          expectFile(
+            'dist/components/single-file-component.js'
+          ).matches(`import templateOnly from '@ember/component/template-only';
+import { setComponentTemplate } from '@ember/component';
+import { precompileTemplate } from '@ember/template-compilation';
+import Component from '@glimmer/component';
+
+class SingleFileComponent extends Component {}
+setComponentTemplate(precompileTemplate(\"<div data-test-single-file-component>Hello {{@message}}</div>\", {
+  strictMode: true
+}), templateOnly());
+
+export { SingleFileComponent as default };
+//# sourceMappingURL=single-file-component.js.map`);
         });
       });
 

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -34,7 +34,7 @@ appScenarios
           ],
           "plugins": [
             "@embroider/addon-dev/template-colocation-plugin",
-            "@babel/plugin-proposal-class-static-block",
+            "@babel/plugin-transform-class-static-block",
             ["babel-plugin-ember-template-compilation", {
               targetFormat: 'hbs',
               compilerPath: 'ember-source/dist/ember-template-compiler',
@@ -149,6 +149,7 @@ appScenarios
     addon.linkDependency('@embroider/addon-dev', { baseDir: __dirname });
     addon.linkDependency('babel-plugin-ember-template-compilation', { baseDir: __dirname });
     addon.linkDevDependency('@babel/core', { baseDir: __dirname });
+    addon.linkDevDependency('@babel/plugin-transform-class-static-block', { baseDir: __dirname });
     addon.linkDevDependency('@babel/plugin-transform-class-properties', { baseDir: __dirname });
     addon.linkDevDependency('@babel/plugin-proposal-decorators', { baseDir: __dirname });
     addon.linkDevDependency('@babel/preset-env', { baseDir: __dirname });
@@ -181,7 +182,7 @@ appScenarios
             test('<SingleFileComponent @message="bob" />', async function(assert) {
               await render(hbs\`<SingleFileComponent @message="bob" />\`);
 
-              assert.dom().containsText('hello bob');
+              assert.dom().containsText('Hello bob');
             })
 
             test('transform worked', async function (assert) {
@@ -260,17 +261,14 @@ appScenarios
         });
 
         test('gjs components compiled correctly', async function () {
-          expectFile(
-            'dist/components/single-file-component.js'
-          ).matches(`import templateOnly from '@ember/component/template-only';
-import { setComponentTemplate } from '@ember/component';
+          expectFile('dist/components/single-file-component.js').equalsCode(`import Component from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
-import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
 
 class SingleFileComponent extends Component {}
 setComponentTemplate(precompileTemplate(\"<div data-test-single-file-component>Hello {{@message}}</div>\", {
   strictMode: true
-}), templateOnly());
+}), SingleFileComponent);
 
 export { SingleFileComponent as default };
 //# sourceMappingURL=single-file-component.js.map`);


### PR DESCRIPTION
This is just testing out an end-to-end implementation of the swc-based content-tag preprocessor

There are a number of things that need to be done before we can merge this: 

- [x] merge the content-tag PRs
- [x] decide exactly where the content-tag npm package will be deployed to (i.e. what name and potentially what scope)
- [x] figure out why babel isn't happy with the output of content-tag 🤔 
- [x] decide if this is an independent rollup plugin or if it's part of the hbs one
- [x] https://github.com/embroider-build/content-tag/issues/1
- [x] https://github.com/embroider-build/content-tag/issues/3

If anyone can think of anything else let me know ;) 