### PR TITLE
use transform babel plugins instead of proposal

### DIFF
--- a/docs/porting-addons-to-v2.md
+++ b/docs/porting-addons-to-v2.md
@@ -213,7 +213,7 @@ Now that we've separated the test-app and docs app concerns from the addon, we c
 4. `yarn add @embroider/addon-shim`. This is the only dependency a v2 addon needs (in order to interoperate with ember-cli.
 5. We're going to set up a default build pipeline for things like template colocation and decorator support. Install these dev dependencies:
 
-   `yarn add --dev @embroider/addon-dev rollup @rollup/plugin-babel @babel/core @babel/plugin-proposal-class-properties @babel/plugin-proposal-decorators`
+   `yarn add --dev @embroider/addon-dev rollup @rollup/plugin-babel @babel/core @babel/plugin-transform-class-properties @babel/plugin-proposal-decorators`
 
 6. Grab the [example babel config](https://github.com/embroider-build/embroider/blob/main/packages/addon-dev/sample-babel.config.json) and save it as `addon/babel.config.json`
    - If you addon requires template transforms in order to publish to a shareable format. Apply transforms using the `babel-plugin-ember-template-compilation`. View how to use this in the [example babel.config.js](https://github.com/embroider-build/embroider/blob/main/packages/addon-dev/sample-babel.config.js)

--- a/packages/addon-dev/sample-babel.config.js
+++ b/packages/addon-dev/sample-babel.config.js
@@ -18,6 +18,6 @@ module.exports = {
       },
     ],
     ['@babel/plugin-proposal-decorators', { legacy: true }],
-    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-transform-class-properties',
   ],
 };

--- a/packages/addon-dev/sample-babel.config.json
+++ b/packages/addon-dev/sample-babel.config.json
@@ -2,6 +2,6 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/packages/macros/tests/babel/macro-condition.test.ts
+++ b/packages/macros/tests/babel/macro-condition.test.ts
@@ -24,7 +24,7 @@ describe('macroCondition', function () {
     babelConfig(version: number) {
       let babelConfig = makeBabelConfig(version, config);
       if (version === 7) {
-        babelConfig.plugins.push('@babel/plugin-proposal-class-properties');
+        babelConfig.plugins.push('@babel/plugin-transform-class-properties');
       }
       babelConfig.filename = filename;
       return babelConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   browserslist: ^4.14.0
   qunit: ^2.14.1
@@ -607,7 +611,7 @@ importers:
         version: 7.2.1
       ember-source:
         specifier: ^4.12.0
-        version: 4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0)(webpack@5.78.0)
+        version: 4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.88.0)
       ember-template-lint:
         specifier: ^4.0.0
         version: 4.10.1
@@ -1041,7 +1045,7 @@ importers:
         version: 3.1.1
       '@ember/test-helpers':
         specifier: ^2.9.1
-        version: 2.9.3(@babel/core@7.19.6)(@glint/template@1.0.0)(ember-source@4.6.0)
+        version: 2.9.3(@babel/core@7.22.5)(ember-source@3.26.0)
       '@embroider/test-support':
         specifier: workspace:*
         version: link:../support
@@ -1086,7 +1090,7 @@ importers:
         version: 1.0.0
       ember-qunit:
         specifier: ^6.1.1
-        version: 6.2.0(@ember/test-helpers@2.9.3)(@glint/template@1.0.0)(ember-source@4.6.0)(qunit@2.14.1)(webpack@5.78.0)
+        version: 6.2.0(@ember/test-helpers@2.9.3)(ember-source@3.26.0)(qunit@2.14.1)(webpack@5.78.0)
       ember-resolver:
         specifier: ^10.1.0
         version: 10.1.0(@ember/string@3.1.1)(ember-source@3.26.0)
@@ -1514,7 +1518,7 @@ importers:
         version: 2.19.2
       ember-auto-import:
         specifier: ^2.6.3
-        version: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+        version: 2.6.3(webpack@5.88.0)
       fastboot:
         specifier: ^4.1.1
         version: 4.1.1
@@ -1555,15 +1559,15 @@ importers:
       '@babel/core':
         specifier: ^7.17.5
         version: 7.19.6(supports-color@8.1.0)
-      '@babel/plugin-proposal-class-properties':
-        specifier: ^7.16.7
-        version: 7.16.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-decorators':
         specifier: ^7.17.2
         version: 7.21.0(@babel/core@7.19.6)
       '@babel/plugin-syntax-dynamic-import':
         specifier: ^7.8.3
         version: 7.8.3(@babel/core@7.19.6)
+      '@babel/plugin-transform-class-properties':
+        specifier: ^7.16.7
+        version: 7.22.0(@babel/core@7.19.6)
       '@babel/plugin-transform-runtime':
         specifier: ^7.18.6
         version: 7.18.6(@babel/core@7.19.6)
@@ -1578,13 +1582,13 @@ importers:
         version: 7.18.6
       '@ember/legacy-built-in-components':
         specifier: ^0.4.1
-        version: 0.4.1(@glint/template@1.0.0)(ember-source@4.12.0)
+        version: 0.4.1(ember-source@5.2.0-beta.3)
       '@ember/string':
         specifier: ^3.0.0
         version: 3.0.1
       '@ember/test-helpers-3':
         specifier: npm:@ember/test-helpers@^3.2.0
-        version: /@ember/test-helpers@3.2.0(@glint/template@1.0.0)(ember-source@4.12.0)(webpack@5.78.0)
+        version: /@ember/test-helpers@3.2.0(ember-source@5.2.0-beta.3)(webpack@5.88.0)
       '@embroider/addon-shim':
         specifier: workspace:*
         version: link:../../packages/addon-shim
@@ -1653,7 +1657,7 @@ importers:
         version: 4.1.1
       ember-cli-latest:
         specifier: npm:ember-cli@latest
-        version: /ember-cli@5.0.0(lodash@4.17.21)
+        version: /ember-cli@5.1.0(lodash@4.17.21)
       ember-composable-helpers:
         specifier: ^4.4.1
         version: 4.4.1
@@ -1668,7 +1672,7 @@ importers:
         version: /ember-data@5.1.0(@babel/core@7.19.6)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.2.0-beta.3)
       ember-engines:
         specifier: ^0.8.23
-        version: 0.8.23(@ember/legacy-built-in-components@0.4.1)(@glint/template@1.0.0)(ember-source@4.12.0)
+        version: 0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.2.0-beta.3)
       ember-inline-svg:
         specifier: ^0.2.1
         version: 0.2.1(@babel/core@7.19.6)
@@ -1677,7 +1681,7 @@ importers:
         version: 4.1.0(ember-source@5.2.0-beta.3)
       ember-qunit-7:
         specifier: npm:ember-qunit@^7.0.0
-        version: /ember-qunit@7.0.0(@ember/test-helpers@3.2.0)(@glint/template@1.0.0)(ember-source@4.12.0)(qunit@2.14.1)(webpack@5.78.0)
+        version: /ember-qunit@7.0.0(@ember/test-helpers@3.2.0)(ember-source@5.2.0-beta.3)(qunit@2.14.1)(webpack@5.88.0)
       ember-source:
         specifier: ~3.28.11
         version: 3.28.11(@babel/core@7.19.6)
@@ -2041,7 +2045,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-    dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.21.5:
     resolution: {integrity: sha512-uNrjKztPLkUk7bpCNC0jEKDJzzkvel/W+HguzbN8krA+LPfC1CEobJEvAvGka2A/M+ViOqXdcRL0GqPUJSjx9g==}
@@ -2158,7 +2161,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-create-class-features-plugin@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-xkb58MyOYIslxu3gKmVXmjTtUPvBU4odYzbiIQbWwLKIHCsx6UGZGX6F1IznMFVnDdirseUZopzN+ZRt8Xb33Q==}
@@ -2178,7 +2180,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-create-regexp-features-plugin@7.21.8(@babel/core@7.19.6):
     resolution: {integrity: sha512-zGuSdedkFtsFHGbexAvNuipg1hbtitDLo2XE8/uf6Y9sOQV1xsYX/2pNbtedp/X0eU1pIt+kGvaqHCowkRbS5g==}
@@ -2277,7 +2278,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-    dev: true
 
   /@babel/helper-module-imports@7.21.4:
     resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
@@ -2332,7 +2332,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-    dev: true
 
   /@babel/helper-plugin-utils@7.21.5:
     resolution: {integrity: sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==}
@@ -2395,7 +2394,6 @@ packages:
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-simple-access@7.21.5:
     resolution: {integrity: sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==}
@@ -2420,7 +2418,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-    dev: true
 
   /@babel/helper-split-export-declaration@7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
@@ -2601,8 +2598,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6(supports-color@8.1.0)
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -2613,8 +2610,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -2666,8 +2663,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.21.5
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/plugin-syntax-decorators': 7.21.0(@babel/core@7.22.5)
@@ -3346,6 +3343,19 @@ packages:
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-transform-class-properties@7.22.0(@babel/core@7.19.6):
+    resolution: {integrity: sha512-m04PcP0S4OR+NpRQNIOEPHVdGcXqbOEn+pIYzrqRTXMlOjKy6s7s30MZ1WzglHQhD/X/yhngun4yG0FqPszZzw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.6(supports-color@8.1.0)
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/plugin-transform-classes@7.21.0(@babel/core@7.19.6):
     resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
@@ -4030,7 +4040,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6(supports-color@8.1.0)
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.19.6)
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.19.6)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.19.6)
     transitivePeerDependencies:
@@ -4517,7 +4527,7 @@ packages:
       '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.88.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-cli-typescript: 5.2.1
@@ -4608,7 +4618,7 @@ packages:
       '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-cli-typescript: 5.2.1
@@ -4751,7 +4761,7 @@ packages:
       '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.88.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.19.6)
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
@@ -4955,7 +4965,7 @@ packages:
       '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
       '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.88.0)
       '@ember/edition-utils': 1.2.0
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-cli-typescript: 5.2.1
@@ -5019,7 +5029,7 @@ packages:
     dependencies:
       '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
       '@ember-data/store': 4.4.0(@babel/core@7.19.6)(webpack@5.88.0)
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-cli-typescript: 5.2.1
@@ -5094,7 +5104,7 @@ packages:
       '@ember-data/private-build-infra': 4.4.0(@babel/core@7.19.6)
       '@ember/string': 3.1.1
       '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.19.6)
       ember-cli-babel: 7.26.11
       ember-cli-path-utils: 1.0.0
@@ -5219,7 +5229,23 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-typescript: 4.2.1
-      ember-source: 4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-source: 4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+    dev: true
+
+  /@ember/legacy-built-in-components@0.4.1(ember-source@5.2.0-beta.3):
+    resolution: {integrity: sha512-tLxiU1YR+A+002rkGfwyB4FK8bO5qqU/3c7cZ1z2j3XG+1T28Yg2iZuMxPwFJ0LsE//mhRFkWlGzO3tJUtMHbA==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      ember-source: '*'
+    dependencies:
+      '@embroider/macros': 1.12.1(@glint/template@1.0.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 5.7.2
+      ember-cli-typescript: 4.2.1
+      ember-source: 5.2.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.0)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -5318,6 +5344,27 @@ packages:
       - supports-color
     dev: true
 
+  /@ember/test-helpers@2.9.3(@babel/core@7.22.5)(ember-source@3.26.0):
+    resolution: {integrity: sha512-ejVg4Dj+G/6zyLvQsYOvmGiOLU6AS94tY4ClaO1E2oVvjjtVJIRmVLFN61I+DuyBg9hS3cFoPjQRTZB9MRIbxQ==}
+    engines: {node: 10.* || 12.* || 14.* || 15.* || >= 16.*}
+    peerDependencies:
+      ember-source: '>=3.8.0'
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/macros': 1.12.1(@glint/template@1.0.0)
+      '@embroider/util': 1.10.0(ember-source@3.26.0)
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 6.2.0
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.22.5)
+      ember-source: 3.26.0(@babel/core@7.22.5)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+    dev: true
+
   /@ember/test-helpers@3.2.0(@glint/template@1.0.0)(ember-source@4.12.0)(webpack@5.78.0):
     resolution: {integrity: sha512-3yWpPsK5O77tUdCwW3HayrAcdlRitIRYMvLIG69Pkal1JMIGdNYVTvJ2R1lenhQh2syd/WFmGM07vQuDAtotQw==}
     engines: {node: 16.* || >= 18}
@@ -5333,6 +5380,27 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.2.0
       ember-source: 4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0)(webpack@5.78.0)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+    dev: true
+
+  /@ember/test-helpers@3.2.0(ember-source@5.2.0-beta.3)(webpack@5.88.0):
+    resolution: {integrity: sha512-3yWpPsK5O77tUdCwW3HayrAcdlRitIRYMvLIG69Pkal1JMIGdNYVTvJ2R1lenhQh2syd/WFmGM07vQuDAtotQw==}
+    engines: {node: 16.* || >= 18}
+    peerDependencies:
+      ember-source: ^4.0.0 || ^5.0.0
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/macros': 1.12.1(@glint/template@1.0.0)
+      '@simple-dom/interface': 1.4.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      ember-auto-import: 2.6.3(webpack@5.88.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 6.2.0
+      ember-source: 5.2.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.0)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -5410,6 +5478,42 @@ packages:
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-source: 4.6.0(@babel/core@7.19.6)(@glint/template@1.0.0)(webpack@5.78.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@embroider/util@1.10.0(ember-source@3.26.0):
+    resolution: {integrity: sha512-utAFKoq6ajI27jyqjvX3PiGL4m+ZyGVlVNbSbE/nOqi2llRyAkh5ltH1WkIK7jhdwQFJouo1NpOSj9J3/HDa3A==}
+    engines: {node: 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0-beta.1
+      ember-source: '*'
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
+    dependencies:
+      '@embroider/macros': 1.12.1(@glint/template@1.0.0)
+      broccoli-funnel: 3.0.8
+      ember-cli-babel: 7.26.11
+      ember-source: 3.26.0(@babel/core@7.22.5)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@embroider/util@1.10.0(ember-source@5.2.0-beta.3):
+    resolution: {integrity: sha512-utAFKoq6ajI27jyqjvX3PiGL4m+ZyGVlVNbSbE/nOqi2llRyAkh5ltH1WkIK7jhdwQFJouo1NpOSj9J3/HDa3A==}
+    engines: {node: 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0-beta.1
+      ember-source: '*'
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
+    dependencies:
+      '@embroider/macros': 1.12.1(@glint/template@1.0.0)
+      broccoli-funnel: 3.0.8
+      ember-cli-babel: 7.26.11
+      ember-source: 5.2.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8017,7 +8121,6 @@ packages:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.88.0
-    dev: true
 
   /babel-messages@6.23.0:
     resolution: {integrity: sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==}
@@ -10444,7 +10547,6 @@ packages:
       schema-utils: 3.1.2
       semver: 7.5.3
       webpack: 5.88.0
-    dev: true
 
   /css-select-base-adapter@0.1.1:
     resolution: {integrity: sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==}
@@ -10949,6 +11051,47 @@ packages:
       - webpack
     dev: true
 
+  /ember-auto-import@2.6.3(@glint/template@1.0.0):
+    resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.22.5)
+      '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
+      '@babel/preset-env': 7.16.11(@babel/core@7.22.5)
+      '@embroider/macros': 1.12.1(@glint/template@1.0.0)
+      '@embroider/shared-internals': 2.2.1
+      babel-loader: 8.2.2(@babel/core@7.22.5)(webpack@5.78.0)
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-ember-template-compilation: 2.0.2
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.6(webpack@5.88.0)
+      debug: 4.3.2(supports-color@8.1.0)
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.7
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.5.3(webpack@5.78.0)
+      parse5: 6.0.1
+      resolve: 1.22.2
+      resolve-package-path: 4.0.3
+      semver: 7.5.3
+      style-loader: 2.0.0(webpack@5.78.0)
+      typescript-memoize: 1.0.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+    dev: true
+
   /ember-auto-import@2.6.3(@glint/template@1.0.0)(webpack@5.78.0):
     resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -10989,20 +11132,60 @@ packages:
       - supports-color
       - webpack
 
+  /ember-auto-import@2.6.3(webpack@5.88.0):
+    resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.22.5)
+      '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
+      '@babel/preset-env': 7.16.11(@babel/core@7.22.5)
+      '@embroider/macros': 1.12.1(@glint/template@1.0.0)
+      '@embroider/shared-internals': 2.2.1
+      babel-loader: 8.2.2(@babel/core@7.22.5)(webpack@5.88.0)
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-ember-template-compilation: 2.0.2
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.6(webpack@5.88.0)
+      debug: 4.3.2(supports-color@8.1.0)
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.7
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.5.3(webpack@5.88.0)
+      parse5: 6.0.1
+      resolve: 1.22.2
+      resolve-package-path: 4.0.3
+      semver: 7.5.3
+      style-loader: 2.0.0(webpack@5.88.0)
+      typescript-memoize: 1.0.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+
   /ember-bootstrap@5.0.0(@babel/core@7.19.6)(ember-source@5.2.0-beta.3)(webpack@5.88.0):
     resolution: {integrity: sha512-ocH7qJKikxDgLv1prWyYzDaH85of8/l0LeV2bnMCp3/ZdRak/vq4dWqm53hMQ0ifN4llfs1Q1bwlcra/BT7yCA==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
       '@ember/render-modifiers': 2.0.5(@babel/core@7.19.6)(ember-source@5.2.0-beta.3)
       '@embroider/macros': 1.12.1(@glint/template@1.0.0)
-      '@embroider/util': 1.10.0(@glint/template@1.0.0)(ember-source@4.6.0)
+      '@embroider/util': 1.10.0(ember-source@5.2.0-beta.3)
       '@glimmer/component': 1.1.2(@babel/core@7.19.6)
       '@glimmer/tracking': 1.1.2
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-build-config-editor: 0.5.1
       ember-cli-htmlbars: 6.2.0
@@ -12194,12 +12377,13 @@ packages:
       - whiskers
     dev: true
 
-  /ember-cli@5.0.0(lodash@4.17.21):
-    resolution: {integrity: sha512-poklpwf+GrDhkFRTYvYmpkSA5R0pNy4Vahxjvji5jUl82tot+J95ZY1QH1yx//QzQ7zb1XlcOnceieyd2j1Rbw==}
+  /ember-cli@5.1.0(lodash@4.17.21):
+    resolution: {integrity: sha512-TlnfO+V5lZqRQ7eGXt+P8q24Cu90GSXXAS/2NasaCtC1WY7eVzhfMsoNZiOw3Pe1CaB7i5fPDR8jAMsTwx8Tpg==}
     engines: {node: '>= 16'}
     hasBin: true
     dependencies:
       '@babel/core': 7.22.5
+      '@pnpm/find-workspace-dir': 6.0.2
       broccoli: 3.5.2
       broccoli-builder: 0.18.14
       broccoli-concat: 4.2.5
@@ -12508,6 +12692,20 @@ packages:
       - '@babel/core'
       - supports-color
 
+  /ember-compatibility-helpers@1.2.6(@babel/core@7.22.5):
+    resolution: {integrity: sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==}
+    engines: {node: 10.* || >= 12.*}
+    dependencies:
+      babel-plugin-debug-macros: 0.2.0(@babel/core@7.22.5)
+      ember-cli-version-checker: 5.1.2
+      find-up: 5.0.0
+      fs-extra: 9.1.0
+      semver: 5.7.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /ember-composable-helpers@4.4.1:
     resolution: {integrity: sha512-MVx4KGFL6JzsYfCf9OqLCCnr7DN5tG2jFW9EvosvfgCL7gRdNxLqewR4PWPYA882wetmJ9zvcIEUJhFzZ4deaw==}
     engines: {node: 10.* || >= 12.*}
@@ -12601,7 +12799,7 @@ packages:
       '@ember/string': 3.1.1
       '@glimmer/env': 0.1.7
       broccoli-merge-trees: 4.2.0
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
       ember-inflector: 4.0.2
@@ -12673,6 +12871,18 @@ packages:
       - supports-color
     dev: true
 
+  /ember-destroyable-polyfill@2.0.3(@babel/core@7.22.5):
+    resolution: {integrity: sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==}
+    engines: {node: 10.* || >= 12}
+    dependencies:
+      ember-cli-babel: 7.26.11
+      ember-cli-version-checker: 5.1.2
+      ember-compatibility-helpers: 1.2.6(@babel/core@7.22.5)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /ember-disable-prototype-extensions@1.1.3:
     resolution: {integrity: sha512-SB9NcZ27OtoUk+gfalsc3QU17+54OoqR668qHcuvHByk4KAhGxCKlkm9EBlKJcGr7yceOOAJqohTcCEBqfRw9g==}
     engines: {node: '>= 0.10.0'}
@@ -12684,7 +12894,7 @@ packages:
     peerDependencies:
       ember-source: ^3.8 || 4
     dependencies:
-      '@embroider/util': 1.10.0(@glint/template@1.0.0)(ember-source@4.6.0)
+      '@embroider/util': 1.10.0(ember-source@5.2.0-beta.3)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.2.0
       ember-source: 5.2.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.0)
@@ -12718,7 +12928,39 @@ packages:
       ember-cli-preprocess-registry: 3.3.0
       ember-cli-string-utils: 1.1.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-source: 4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0)
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+    dev: true
+
+  /ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.1)(ember-source@5.2.0-beta.3):
+    resolution: {integrity: sha512-rrvHUkZRNrf+9u/sCw7XYrITStjP/9Ypykk1nYQHoo+6Krp11e81QNVsGTXFpXtMHXbNtH5IcRyZvfSXqUOrUQ==}
+    engines: {node: 10.* || >= 12}
+    peerDependencies:
+      '@ember/legacy-built-in-components': '*'
+      ember-source: ^3.12 || 4
+    dependencies:
+      '@ember/legacy-built-in-components': 0.4.1(ember-source@5.2.0-beta.3)
+      '@embroider/macros': 1.12.1(@glint/template@1.0.0)
+      amd-name-resolver: 1.3.1
+      babel-plugin-compact-reexports: 1.1.0
+      broccoli-babel-transpiler: 7.8.1
+      broccoli-concat: 4.2.5
+      broccoli-debug: 0.6.5
+      broccoli-dependency-funnel: 2.1.2
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 2.0.2
+      broccoli-merge-trees: 3.0.2
+      broccoli-test-helper: 2.0.0
+      calculate-cache-key-for-tree: 2.0.0
+      ember-asset-loader: 0.6.1
+      ember-cli-babel: 7.26.11
+      ember-cli-preprocess-registry: 3.3.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-version-checker: 5.1.2
+      ember-source: 5.2.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - '@glint/template'
@@ -12933,7 +13175,7 @@ packages:
     engines: {node: 10.* || >= 12}
     dependencies:
       '@popperjs/core': 2.11.7
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.2.0
       ember-modifier: 3.2.7(@babel/core@7.19.6)
@@ -12970,6 +13212,32 @@ packages:
       - webpack
     dev: true
 
+  /ember-qunit@6.2.0(@ember/test-helpers@2.9.3)(ember-source@3.26.0)(qunit@2.14.1)(webpack@5.78.0):
+    resolution: {integrity: sha512-mC+0bp8DwWzJLn8SW3GS8KDZIkl4yLsNYwMi5Dw6+aFllq7FM2crd/dfY4MuOIHK7GKdjtmWJTMGnjSpeSayaw==}
+    engines: {node: 14.* || 16.* || >= 18}
+    peerDependencies:
+      '@ember/test-helpers': ^2.9.3
+      ember-source: '>=3.28'
+      qunit: ^2.13.0
+    dependencies:
+      '@ember/test-helpers': 2.9.3(@babel/core@7.22.5)(ember-source@3.26.0)
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 3.0.2
+      common-tags: 1.8.2
+      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-test-loader: 3.0.0
+      ember-source: 3.26.0(@babel/core@7.22.5)
+      qunit: 2.14.1
+      resolve-package-path: 4.0.3
+      silent-error: 1.1.1
+      validate-peer-dependencies: 2.2.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+    dev: true
+
   /ember-qunit@7.0.0(@ember/test-helpers@3.2.0)(@glint/template@1.0.0)(ember-source@4.12.0)(qunit@2.14.1)(webpack@5.78.0):
     resolution: {integrity: sha512-KhrndHYEXsHnXvmsGyJLJQ6VCudXaRs5dzPZBsdttZJIhsB6PmYAvq2Q+mh3GRDT/59T/sRDrB3FD3/lATS8aA==}
     engines: {node: 16.* || >= 18}
@@ -12986,6 +13254,32 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
       ember-source: 4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0)(webpack@5.78.0)
+      qunit: 2.14.1
+      resolve-package-path: 4.0.3
+      silent-error: 1.1.1
+      validate-peer-dependencies: 2.2.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+    dev: true
+
+  /ember-qunit@7.0.0(@ember/test-helpers@3.2.0)(ember-source@5.2.0-beta.3)(qunit@2.14.1)(webpack@5.88.0):
+    resolution: {integrity: sha512-KhrndHYEXsHnXvmsGyJLJQ6VCudXaRs5dzPZBsdttZJIhsB6PmYAvq2Q+mh3GRDT/59T/sRDrB3FD3/lATS8aA==}
+    engines: {node: 16.* || >= 18}
+    peerDependencies:
+      '@ember/test-helpers': '>=3.0.3'
+      ember-source: '>=4.0.0'
+      qunit: ^2.13.0
+    dependencies:
+      '@ember/test-helpers': 3.2.0(ember-source@5.2.0-beta.3)(webpack@5.88.0)
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 3.0.2
+      common-tags: 1.8.2
+      ember-auto-import: 2.6.3(webpack@5.88.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-test-loader: 3.0.0
+      ember-source: 5.2.0-beta.3(@babel/core@7.19.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.0)
       qunit: 2.14.1
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -13200,6 +13494,46 @@ packages:
       - supports-color
     dev: true
 
+  /ember-source@4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0):
+    resolution: {integrity: sha512-h0lV902A4Mny2eiqXPy15uXXoCc7BnUegE4axLAy4IoxEkJ1o5h0aLJFiB4Tzb1htx8vgHjJz//Y5Jig7NSDTw==}
+    engines: {node: '>= 14.*'}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
+    dependencies:
+      '@babel/helper-module-imports': 7.21.4
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.19.6)
+      '@ember/edition-utils': 1.2.0
+      '@glimmer/component': 1.1.2(@babel/core@7.19.6)
+      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.19.6)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.19.6)
+      babel-plugin-filter-imports: 4.0.0
+      broccoli-concat: 4.2.5
+      broccoli-debug: 0.6.5
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      chalk: 4.1.1
+      ember-auto-import: 2.6.3(@glint/template@1.0.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-get-component-path-option: 1.0.0
+      ember-cli-is-package-missing: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0
+      ember-cli-version-checker: 5.1.2
+      ember-router-generator: 2.0.0
+      inflection: 1.13.4
+      resolve: 1.22.2
+      semver: 7.3.8
+      silent-error: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+      - webpack
+    dev: true
+
   /ember-source@4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(@glint/template@1.0.0)(webpack@5.78.0):
     resolution: {integrity: sha512-h0lV902A4Mny2eiqXPy15uXXoCc7BnUegE4axLAy4IoxEkJ1o5h0aLJFiB4Tzb1htx8vgHjJz//Y5Jig7NSDTw==}
     engines: {node: '>= 14.*'}
@@ -13240,6 +13574,46 @@ packages:
       - webpack
     dev: true
 
+  /ember-source@4.12.0(@babel/core@7.19.6)(@glimmer/component@1.1.2)(webpack@5.88.0):
+    resolution: {integrity: sha512-h0lV902A4Mny2eiqXPy15uXXoCc7BnUegE4axLAy4IoxEkJ1o5h0aLJFiB4Tzb1htx8vgHjJz//Y5Jig7NSDTw==}
+    engines: {node: '>= 14.*'}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
+    dependencies:
+      '@babel/helper-module-imports': 7.21.4
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.19.6)
+      '@ember/edition-utils': 1.2.0
+      '@glimmer/component': 1.1.2(@babel/core@7.19.6)
+      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.19.6)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.19.6)
+      babel-plugin-filter-imports: 4.0.0
+      broccoli-concat: 4.2.5
+      broccoli-debug: 0.6.5
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      chalk: 4.1.1
+      ember-auto-import: 2.6.3(webpack@5.88.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-get-component-path-option: 1.0.0
+      ember-cli-is-package-missing: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0
+      ember-cli-version-checker: 5.1.2
+      ember-router-generator: 2.0.0
+      inflection: 1.13.4
+      resolve: 1.22.2
+      semver: 7.3.8
+      silent-error: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+      - webpack
+    dev: true
+
   /ember-source@4.4.0(@babel/core@7.19.6)(webpack@5.88.0):
     resolution: {integrity: sha512-o4jJko/2IRfGsyfje51nNYMQj+OusJph4CIGF+Yk9pmvoS0TbzKHKWlnFiIygTcnUiMHkG18FL9Z0LSd/Kgl5w==}
     engines: {node: '>= 12.*'}
@@ -13256,7 +13630,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -13349,7 +13723,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -13408,7 +13782,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.3(@glint/template@1.0.0)(webpack@5.78.0)
+      ember-auto-import: 2.6.3(webpack@5.88.0)
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -17952,7 +18326,6 @@ packages:
     dependencies:
       schema-utils: 4.0.1
       webpack: 5.88.0
-    dev: true
 
   /minimatch@3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
@@ -20575,7 +20948,6 @@ packages:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
       webpack: 5.88.0
-    dev: true
 
   /style-search@0.1.0:
     resolution: {integrity: sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==}
@@ -20849,7 +21221,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
       jest-worker: 27.5.1
-      schema-utils: 3.3.0
+      schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.4
       webpack: 5.88.0

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -33,9 +33,9 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.2",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+    "@babel/plugin-transform-class-properties": "^7.16.7",
     "@babel/plugin-transform-runtime": "^7.18.6",
     "@babel/plugin-transform-typescript": "^7.22.5",
     "@babel/preset-env": "^7.16.11",

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -42,7 +42,7 @@ appScenarios
               ],
             }],
             ["@babel/plugin-proposal-decorators", { "legacy": true }],
-            [ "@babel/plugin-proposal-class-properties" ]
+            [ "@babel/plugin-transform-class-properties" ]
           ]
         }
       `,
@@ -147,7 +147,7 @@ appScenarios
     addon.linkDependency('@embroider/addon-dev', { baseDir: __dirname });
     addon.linkDependency('babel-plugin-ember-template-compilation', { baseDir: __dirname });
     addon.linkDevDependency('@babel/core', { baseDir: __dirname });
-    addon.linkDevDependency('@babel/plugin-proposal-class-properties', { baseDir: __dirname });
+    addon.linkDevDependency('@babel/plugin-transform-class-properties', { baseDir: __dirname });
     addon.linkDevDependency('@babel/plugin-proposal-decorators', { baseDir: __dirname });
     addon.linkDevDependency('@babel/preset-env', { baseDir: __dirname });
     addon.linkDevDependency('@rollup/plugin-babel', { baseDir: __dirname });

--- a/tests/scenarios/v2-addon-dev-typescript-test.ts
+++ b/tests/scenarios/v2-addon-dev-typescript-test.ts
@@ -29,7 +29,7 @@ appScenarios
             "@babel/plugin-transform-typescript",
             "@embroider/addon-dev/template-colocation-plugin",
             ["@babel/plugin-proposal-decorators", { "legacy": true }],
-            ["@babel/plugin-proposal-class-properties"]
+            ["@babel/plugin-transform-class-properties"]
           ]
         }
       `,
@@ -117,7 +117,7 @@ appScenarios
           addon.clean(),
         ],
       };
-          
+
       `,
       src: {
         components: {
@@ -175,7 +175,7 @@ appScenarios
     addon.linkDependency('@babel/runtime', { baseDir: __dirname });
     addon.linkDevDependency('@babel/core', { baseDir: __dirname });
     addon.linkDevDependency('@babel/plugin-transform-typescript', { baseDir: __dirname });
-    addon.linkDevDependency('@babel/plugin-proposal-class-properties', { baseDir: __dirname });
+    addon.linkDevDependency('@babel/plugin-transform-class-properties', { baseDir: __dirname });
     addon.linkDevDependency('@babel/plugin-proposal-decorators', { baseDir: __dirname });
     addon.linkDevDependency('@rollup/plugin-babel', { baseDir: __dirname });
     addon.linkDevDependency('@rollup/plugin-typescript', { baseDir: __dirname });

--- a/tests/scenarios/v2-addon-dev-watch-test.ts
+++ b/tests/scenarios/v2-addon-dev-watch-test.ts
@@ -31,7 +31,7 @@ Scenarios.fromProject(() => baseV2Addon())
           "plugins": [
             "@embroider/addon-dev/template-colocation-plugin",
             ["@babel/plugin-proposal-decorators", { "legacy": true }],
-            [ "@babel/plugin-proposal-class-properties" ]
+            [ "@babel/plugin-transform-class-properties" ]
           ]
         }
       `,
@@ -101,7 +101,7 @@ Scenarios.fromProject(() => baseV2Addon())
     addon.linkDependency('@embroider/addon-dev', { baseDir: __dirname });
     addon.linkDependency('babel-plugin-ember-template-compilation', { baseDir: __dirname });
     addon.linkDevDependency('@babel/core', { baseDir: __dirname });
-    addon.linkDevDependency('@babel/plugin-proposal-class-properties', { baseDir: __dirname });
+    addon.linkDevDependency('@babel/plugin-transform-class-properties', { baseDir: __dirname });
     addon.linkDevDependency('@babel/plugin-proposal-decorators', { baseDir: __dirname });
     addon.linkDevDependency('@babel/preset-env', { baseDir: __dirname });
     addon.linkDevDependency('@rollup/plugin-babel', { baseDir: __dirname });


### PR DESCRIPTION
While working on #1518 we noticed that we were still using `@babel/plugin-proposal-class-properties` but it has since been renamed to `@babel/plugin-transform-class-properties` 

This PR extracts that change to its own PR because the gjs support might take a little while to get polished up 👍 