### PR TITLE
Generate per-package implicit-modules imports

### DIFF
--- a/packages/compat/src/babel-plugin-adjust-imports.ts
+++ b/packages/compat/src/babel-plugin-adjust-imports.ts
@@ -182,7 +182,7 @@ function lazyPackageLookup(config: InternalConfig, filename: string) {
   return {
     get owningPackage() {
       if (!owningPackage) {
-        owningPackage = { result: config.resolver.owningPackage(filename) };
+        owningPackage = { result: config.resolver.packageCache.ownerOfFile(filename) };
       }
       return owningPackage.result;
     },

--- a/packages/compat/src/dependency-rules.ts
+++ b/packages/compat/src/dependency-rules.ts
@@ -230,7 +230,7 @@ export function activePackageRules(
 }
 
 export function appTreeRulesDir(root: string, resolver: Resolver) {
-  let pkg = resolver.owningPackage(root);
+  let pkg = resolver.packageCache.ownerOfFile(root);
   if (pkg?.isV2Addon()) {
     // in general v2 addons can keep their app tree stuff in other places than
     // "_app_" and we would need to check their package.json to see. But this code

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
   ResolverFunction,
   SyncResolverFunction,
 } from './module-resolver';
+export { ResolverLoader } from './resolver-loader';
 export { virtualContent } from './virtual-content';
 export type { Engine } from './app-files';
 

--- a/packages/core/src/resolver-loader.ts
+++ b/packages/core/src/resolver-loader.ts
@@ -1,0 +1,32 @@
+import { readJSONSync } from 'fs-extra';
+import { Resolver, Options } from './module-resolver';
+import { locateEmbroiderWorkingDir } from '@embroider/shared-internals';
+import { join } from 'path';
+import { watch as fsWatch, FSWatcher } from 'fs';
+
+export class ResolverLoader {
+  #resolver: Resolver | undefined;
+  #configFile: string;
+  #watcher: FSWatcher | undefined;
+
+  constructor(readonly appRoot: string, watch = false) {
+    this.#configFile = join(locateEmbroiderWorkingDir(this.appRoot), 'resolver.json');
+    if (watch) {
+      this.#watcher = fsWatch(this.#configFile, { persistent: false }, () => {
+        this.#resolver = undefined;
+      });
+    }
+  }
+
+  close() {
+    this.#watcher?.close();
+  }
+
+  get resolver(): Resolver {
+    if (!this.#resolver) {
+      let config: Options = readJSONSync(join(locateEmbroiderWorkingDir(this.appRoot), 'resolver.json'));
+      this.#resolver = new Resolver(config);
+    }
+    return this.#resolver;
+  }
+}

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -139,19 +139,16 @@ export const {{name}} = mod.{{name}};
 {{/each}}
 `) as (params: { names: string[]; hasDefaultExport: boolean }) => string;
 
+const implicitModulesPattern = /(?<filename>.*)[\\/]#embroider-implicit-(?<test>test-)?modules$/;
+
 export function decodeImplicitModules(
   filename: string
 ): { type: 'implicit-modules' | 'implicit-test-modules'; fromFile: string } | undefined {
-  if (filename.endsWith('/#embroider-implicit-modules')) {
+  let m = implicitModulesPattern.exec(filename);
+  if (m) {
     return {
-      type: 'implicit-modules',
-      fromFile: filename.slice(0, -1 * '/#embroider-implicit-modules'.length),
-    };
-  }
-  if (filename.endsWith('/#embroider-implicit-test-modules')) {
-    return {
-      type: 'implicit-test-modules',
-      fromFile: filename.slice(0, -1 * '/#embroider-implicit-test-modules'.length),
+      type: m.groups!.test ? 'implicit-test-modules' : 'implicit-modules',
+      fromFile: m.groups!.filename,
     };
   }
 }

--- a/packages/shared-internals/src/rewritten-package-cache.ts
+++ b/packages/shared-internals/src/rewritten-package-cache.ts
@@ -324,4 +324,8 @@ class WrappedPackage implements PackageTheGoodParts {
     // package.json.ß
     return this.plainPkg.hasDependency(name);
   }
+
+  categorizeDependency(name: string): 'dependencies' | 'devDependencies' | 'peerDependencies' | undefined {
+    return this.plainPkg.categorizeDependency(name);
+  }
 }

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -14,15 +14,17 @@ export { EmbroiderResolverOptions as Options };
 
 const virtualLoaderName = '@embroider/webpack/src/virtual-loader';
 const virtualLoaderPath = resolve(__dirname, './virtual-loader.js');
-const virtualRequestPattern = new RegExp(`${escapeRegExp(virtualLoaderPath)}\\?(?<filename>.+)!`);
+const virtualRequestPattern = new RegExp(`${escapeRegExp(virtualLoaderPath)}\\?(?<query>.+)!`);
 
 export class EmbroiderPlugin {
   #resolver: EmbroiderResolver;
   #babelLoaderPrefix: string;
+  #appRoot: string;
 
   constructor(opts: EmbroiderResolverOptions, babelLoaderPrefix: string) {
     this.#resolver = new EmbroiderResolver(opts);
     this.#babelLoaderPrefix = babelLoaderPrefix;
+    this.#appRoot = opts.appRoot;
   }
 
   #addLoaderAlias(compiler: Compiler, name: string, alias: string) {
@@ -46,7 +48,7 @@ export class EmbroiderPlugin {
       let adaptedResolve = getAdaptedResolve(defaultResolve);
 
       nmf.hooks.resolve.tapAsync({ name: '@embroider/webpack', stage: 50 }, (state: unknown, callback: CB) => {
-        let request = WebpackModuleRequest.from(state, this.#babelLoaderPrefix);
+        let request = WebpackModuleRequest.from(state, this.#babelLoaderPrefix, this.#appRoot);
         if (!request) {
           defaultResolve(state, callback);
           return;
@@ -109,7 +111,7 @@ class WebpackModuleRequest implements ModuleRequest {
   specifier: string;
   fromFile: string;
 
-  static from(state: any, babelLoaderPrefix: string): WebpackModuleRequest | undefined {
+  static from(state: any, babelLoaderPrefix: string, appRoot: string): WebpackModuleRequest | undefined {
     // when the files emitted from our virtual-loader try to import things,
     // those requests show in webpack as having no issuer. But we can see here
     // which requests they are and adjust the issuer so they resolve things from
@@ -118,7 +120,7 @@ class WebpackModuleRequest implements ModuleRequest {
       for (let dep of state.dependencies) {
         let match = virtualRequestPattern.exec(dep._parentModule?.userRequest);
         if (match) {
-          state.contextInfo.issuer = match.groups!.filename;
+          state.contextInfo.issuer = new URLSearchParams(match.groups!.query).get('f');
           state.context = dirname(state.contextInfo.issuer);
         }
       }
@@ -132,12 +134,13 @@ class WebpackModuleRequest implements ModuleRequest {
       !state.request.includes(virtualLoaderName) && // prevents recursion on requests we have already sent to our virtual loader
       !state.request.startsWith('!') // ignores internal webpack resolvers
     ) {
-      return new WebpackModuleRequest(babelLoaderPrefix, state);
+      return new WebpackModuleRequest(babelLoaderPrefix, appRoot, state);
     }
   }
 
   constructor(
     private babelLoaderPrefix: string,
+    private appRoot: string,
     public state: {
       request: string;
       context: string;
@@ -158,7 +161,7 @@ class WebpackModuleRequest implements ModuleRequest {
 
   alias(newSpecifier: string) {
     this.state.request = newSpecifier;
-    return new WebpackModuleRequest(this.babelLoaderPrefix, this.state) as this;
+    return new WebpackModuleRequest(this.babelLoaderPrefix, this.appRoot, this.state) as this;
   }
   rehome(newFromFile: string) {
     if (this.fromFile === newFromFile) {
@@ -166,11 +169,14 @@ class WebpackModuleRequest implements ModuleRequest {
     } else {
       this.state.contextInfo.issuer = newFromFile;
       this.state.context = dirname(newFromFile);
-      return new WebpackModuleRequest(this.babelLoaderPrefix, this.state) as this;
+      return new WebpackModuleRequest(this.babelLoaderPrefix, this.appRoot, this.state) as this;
     }
   }
   virtualize(filename: string) {
-    let next = this.alias(`${this.babelLoaderPrefix}${virtualLoaderName}?${filename}!`);
+    let params = new URLSearchParams();
+    params.set('f', filename);
+    params.set('a', this.appRoot);
+    let next = this.alias(`${this.babelLoaderPrefix}${virtualLoaderName}?${params.toString()}!`);
     next.isVirtual = true;
     return next;
   }

--- a/test-packages/support/audit-assertions.ts
+++ b/test-packages/support/audit-assertions.ts
@@ -116,6 +116,14 @@ export class ExpectModule {
     this.expectAudit.assert.codeEqual(this.module.content, expectedSource);
   }
 
+  codeContains(expectedSource: string) {
+    if (!this.module) {
+      this.emitMissingModule();
+      return;
+    }
+    this.expectAudit.assert.codeContains(this.module.content, expectedSource);
+  }
+
   resolves(specifier: string): PublicAPI<ExpectResolution> {
     if (!this.module) {
       this.emitMissingModule();

--- a/test-packages/support/audit-assertions.ts
+++ b/test-packages/support/audit-assertions.ts
@@ -210,6 +210,8 @@ type PublicAPI<T> = { [K in keyof T]: T[K] };
 class EmptyExpectModule implements PublicAPI<ExpectModule> {
   doesNotExist() {}
   codeEquals() {}
+  codeContains() {}
+
   resolves(): PublicAPI<ExpectResolution> {
     return new EmptyExpectResolution() as PublicAPI<ExpectResolution>;
   }

--- a/test-packages/support/index.ts
+++ b/test-packages/support/index.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import 'jest';
 import { transform as transform7, TransformOptions as Options7 } from '@babel/core';
-import escapeRegExp from 'lodash/escapeRegExp';
 import { createContext, Script } from 'vm';
 
 interface RunDefaultOptions {
@@ -100,14 +99,6 @@ export function emberTemplateCompiler() {
     path: join(__dirname, 'vendor', 'ember-template-compiler.js'),
     version: '4.8.1',
   };
-}
-
-export function definesPattern(runtimeName: string, buildTimeName: string): RegExp {
-  runtimeName = escapeRegExp(runtimeName);
-  buildTimeName = escapeRegExp(buildTimeName);
-  return new RegExp(
-    `d\\(['"]${runtimeName}['"], *function *\\(\\) *\\{[\\s\\n]*return i\\(['"]${buildTimeName}['"]\\);?[\\s\\n]*\\}\\)`
-  );
 }
 
 export { ExpectFile } from './file-assertions';

--- a/tests/scenarios/compat-renaming-test.ts
+++ b/tests/scenarios/compat-renaming-test.ts
@@ -4,7 +4,6 @@ import QUnit from 'qunit';
 import { resolve, sep } from 'path';
 const { module: Qmodule, test } = QUnit;
 
-import { definesPattern } from '@embroider/test-support';
 import { ExpectFile, expectRewrittenFilesAt } from '@embroider/test-support/file-assertions/qunit';
 
 import { throwOnWarnings } from '@embroider/core';
@@ -225,13 +224,11 @@ appScenarios
           .to('./node_modules/emits-multiple-packages/somebody-elses-package/utils/index.js');
       });
       test('renamed modules keep their classic runtime name when used as implicit-modules', function () {
-        let assertFile = expectFile('assets/app-template.js');
-        assertFile.matches(
-          definesPattern(
-            'somebody-elses-package/environment',
-            'emits-multiple-packages/somebody-elses-package/environment'
-          )
-        );
+        expectAudit.module('assets/app-template.js').resolves('./#embroider-implicit-modules').toModule().codeContains(`
+          d('somebody-elses-package/environment', function() {
+            return i('emits-multiple-packages/somebody-elses-package/environment')
+          });
+        `);
       });
       test('rewriting one module does not capture entire package namespace', function () {
         expectAudit


### PR DESCRIPTION
Previously, all implicit-modules got imported by their containing engine (normally the app). This makes some sense, because they are getting AMD-defined into one flat namespace anyway for compatibility reasons. If there are multiple versions of a package in the transitive deps, only one can be present in the AMD loader.

However, this assumes there will be resolvability from the app all the way to the transitive deps, which is not true in general. And it also means that if there is a mismatch between the list of implicit-modules provided by different copies of a package you could run into failures where you try to find them in the wrong copy.

So instead, this PR moves the importing of implicit modules into per-package virtual modules. Each package imports its own direct dependencies' implicit modules, as well as the virtual implicit-module entrypoints for those dependencies.

If you have vast webs of addons, this change might make your code bigger. But the solution to that is enabling `staticAddonTrees`, which cuts the set of implicit-modules down to approximately zero.