### PR TITLE
compat adapter to add re-export observer-manager service

### DIFF
--- a/packages/compat/src/compat-adapters/ember-scroll-modifiers.ts
+++ b/packages/compat/src/compat-adapters/ember-scroll-modifiers.ts
@@ -1,0 +1,18 @@
+import V1Addon from '../v1-addon';
+
+export default class extends V1Addon {
+  get packageMeta() {
+    let meta = super.packageMeta;
+    // observer-manager is injected with the undocumented package@service syntax without being app re-exported
+    // this makes sure that the service is always re-exported and injectable even when built with staticAddonTrees=true
+    if (
+      meta['implicit-modules'] &&
+      !meta['implicit-modules'].find(implicitModule => implicitModule === './services/observer-manager.js')
+    ) {
+      meta['implicit-modules'].push('./services/observer-manager.js');
+    } else if (!meta['implicit-modules']) {
+      meta['implicit-modules'] = ['./services/observer-manager.js'];
+    }
+    return meta;
+  }
+}


### PR DESCRIPTION
fixes https://github.com/embroider-build/embroider/issues/1498  (solution 2 from https://github.com/embroider-build/embroider/issues/1498#issuecomment-1614929481)

this pr fixes the problematic addon that uses a non standard way of injecting a service.
with this we get more compatibility when people turn on static flags without a big enhancement to detecting this edge case and automatically fixing it