### PR TITLE
Bugfix: contextual staticHelpers in subexpression position

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -734,10 +734,12 @@ class TemplateResolver implements ASTPlugin {
         });
         return;
       }
-      let resolution = this.targetHelper(node.path.original);
-      this.emit(path, resolution, (node, newId) => {
-        node.path = newId;
-      });
+      if (node.path.tail.length === 0 && node.path.head.type === 'VarHead') {
+        let resolution = this.targetHelper(node.path.original);
+        this.emit(path, resolution, (node, newId) => {
+          node.path = newId;
+        });
+      }
     },
     MustacheStatement: {
       enter: (node, path) => {

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -647,6 +647,40 @@ Scenarios.fromProject(() => new Project())
         `);
       });
 
+      test('ignores dot-rule subexpression helper invocation', async function () {
+        givenFiles({
+          'templates/application.hbs': `{{#if (thing.is 1) }}{{/if}}`,
+        });
+        await configure({
+          staticComponents: true,
+          staticHelpers: true,
+          staticModifiers: true,
+        });
+        expectTranspiled('templates/application.hbs').equalsCode(`
+        import { precompileTemplate } from "@ember/template-compilation";
+        export default precompileTemplate("{{#if (thing.is 1)}}{{/if}}", {
+          moduleName: "my-app/templates/application.hbs"
+        });
+      `);
+      });
+
+      test('ignores at-rule subexpression helper invocation', async function () {
+        givenFiles({
+          'templates/application.hbs': `{{#if (@thing 1) }}{{/if}}`,
+        });
+        await configure({
+          staticComponents: true,
+          staticHelpers: true,
+          staticModifiers: true,
+        });
+        expectTranspiled('templates/application.hbs').equalsCode(`
+        import { precompileTemplate } from "@ember/template-compilation";
+        export default precompileTemplate("{{#if (@thing 1)}}{{/if}}", {
+          moduleName: "my-app/templates/application.hbs"
+        });
+      `);
+      });
+
       test('helper in component argument', async function () {
         givenFiles({
           'templates/application.hbs': `<Stuff @value={{myHelper 1}}/>`,


### PR DESCRIPTION
We were incorrectly trying to figure out the global resolutions for helpers in subexpression position whose path contains dots or starts with `@`. Both of these are only contextual lookups, never global lookups.

We already handled this case correctly in content-position.