### PR TITLE
Rehome moved requests to real on-disk files

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -107,28 +107,38 @@ type MergeMap = Map</* engine root dir */ string, Map</* withinEngineModuleName 
 const compatPattern = /#embroider_compat\/(?<type>[^\/]+)\/(?<rest>.*)/;
 
 export interface ModuleRequest {
-  specifier: string;
-  fromFile: string;
-  isVirtual: boolean;
+  readonly specifier: string;
+  readonly fromFile: string;
+  readonly isVirtual: boolean;
+  readonly meta: Record<string, unknown> | undefined;
   alias(newSpecifier: string): this;
   rehome(newFromFile: string): this;
   virtualize(virtualFilename: string): this;
+  withMeta(meta: Record<string, any> | undefined): this;
 }
 
 class NodeModuleRequest implements ModuleRequest {
-  constructor(readonly specifier: string, readonly fromFile: string, readonly isVirtual = false) {}
+  constructor(
+    readonly specifier: string,
+    readonly fromFile: string,
+    readonly isVirtual: boolean,
+    readonly meta: Record<string, any> | undefined
+  ) {}
   alias(specifier: string): this {
-    return new NodeModuleRequest(specifier, this.fromFile) as this;
+    return new NodeModuleRequest(specifier, this.fromFile, false, this.meta) as this;
   }
   rehome(fromFile: string): this {
     if (this.fromFile === fromFile) {
       return this;
     } else {
-      return new NodeModuleRequest(this.specifier, fromFile) as this;
+      return new NodeModuleRequest(this.specifier, fromFile, false, this.meta) as this;
     }
   }
-  virtualize(filename: string) {
-    return new NodeModuleRequest(filename, this.fromFile, true) as this;
+  virtualize(filename: string): this {
+    return new NodeModuleRequest(filename, this.fromFile, true, this.meta) as this;
+  }
+  withMeta(meta: Record<string, any> | undefined): this {
+    return new NodeModuleRequest(this.specifier, this.fromFile, this.isVirtual, meta) as this;
   }
 }
 
@@ -247,7 +257,7 @@ export class Resolver {
     | { type: 'virtual'; filename: string; content: string }
     | { type: 'real'; filename: string }
     | { type: 'not_found'; err: Error } {
-    let resolution = this.resolveSync(new NodeModuleRequest(specifier, fromFile), request => {
+    let resolution = this.resolveSync(new NodeModuleRequest(specifier, fromFile, false, undefined), request => {
       if (request.isVirtual) {
         return {
           type: 'found',
@@ -744,7 +754,7 @@ export class Resolver {
       return logTransition(
         'outbound request from moved package',
         request,
-        request.rehome(resolve(originalRequestingPkg.root, request.fromFile.slice(requestingPkg.root.length + 1)))
+        request.withMeta({ wasMovedTo: request.fromFile }).rehome(resolve(originalRequestingPkg.root, 'package.json'))
       );
     }
 
@@ -953,7 +963,10 @@ export class Resolver {
     // isV2Ember()
     let movedPkg = this.packageCache.maybeMoved(pkg);
     if (movedPkg !== pkg) {
-      fromFile = resolve(movedPkg.root, request.fromFile.slice(pkg.root.length + 1));
+      if (!request.meta?.wasMovedTo) {
+        throw new Error(`bug: embroider resolver's meta is not propagating`);
+      }
+      fromFile = request.meta.wasMovedTo as string;
       pkg = movedPkg;
     }
 


### PR DESCRIPTION
When we're about to do default resolving outbound from a moved package, we need to rehome the request to the original location of the moved package. Previously, we did this by just replacing the moved package root with the original package root, leaving the within-package part of the part unchanged.

In general, this path doesn't actually exist on disk, but that didn't really matter to webpack. Unfortunately it does matter to vite, which for dubious reasons checks that the importing file actually exists before being willing to use it as the base for resolution.

So instead we need to rehome to a file that exists, so we'll use `package.json` like we generally do when we want to mean "from this package".

However, we also need to *undo* this rehoming if the request falls through to our own fallback. Previously that was easy because we still had the true within-package path in the module specifier. Now we can't do that because we threw away the within-package part and replaced it with `package.json`, so instead we need to introduce a general mechanism for attaching metadata to requests.

