### PR TITLE
optional ES-module compatibility setting

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -292,6 +292,7 @@ export class CompatAppBuilder {
           // search, so first one wins.
           .reverse(),
       })),
+      amdCompatibility: this.options.amdCompatibility,
 
       // this is the additional stufff that @embroider/compat adds on top to do
       // global template resolving
@@ -1272,7 +1273,7 @@ export class CompatAppBuilder {
 
     // this is a backward-compatibility feature: addons can force inclusion of
     // modules.
-    eagerModules.push('./#embroider-implicit-modules');
+    eagerModules.push('./-embroider-implicit-modules.js');
 
     let params = { amdModules, fastbootOnlyAmdModules, lazyRoutes, lazyEngines, eagerModules, styles };
     if (entryParams) {
@@ -1337,7 +1338,7 @@ export class CompatAppBuilder {
     let amdModules: { runtime: string; buildtime: string }[] = [];
     // this is a backward-compatibility feature: addons can force inclusion of
     // test support modules.
-    eagerModules.push('./#embroider-implicit-test-modules');
+    eagerModules.push('./-embroider-implicit-test-modules.js');
 
     for (let relativePath of engine.tests) {
       amdModules.push(this.importPaths(engine, relativePath));
@@ -1396,6 +1397,10 @@ let d = w.define;
   }
 {{/if}}
 
+{{#each eagerModules as |eagerModule| ~}}
+  i("{{js-string-escape eagerModule}}");
+{{/each}}
+
 {{#each amdModules as |amdModule| ~}}
   d("{{js-string-escape amdModule.runtime}}", function(){ return i("{{js-string-escape amdModule.buildtime}}");});
 {{/each}}
@@ -1408,9 +1413,6 @@ let d = w.define;
   }
 {{/if}}
 
-{{#each eagerModules as |eagerModule| ~}}
-  i("{{js-string-escape eagerModule}}");
-{{/each}}
 
 {{#if lazyRoutes}}
 w._embroiderRouteBundles_ = [

--- a/packages/compat/tests/audit.test.ts
+++ b/packages/compat/tests/audit.test.ts
@@ -28,6 +28,7 @@ describe('audit', function () {
     const resolvableExtensions = ['.js', '.hbs'];
 
     let resolverConfig: CompatResolverOptions = {
+      amdCompatibility: 'cjs',
       appRoot: app.baseDir,
       modulePrefix: 'audit-this-app',
       options: {
@@ -113,7 +114,7 @@ describe('audit', function () {
       './index.html',
       './app.js',
       './hello.hbs',
-      '/@embroider/external/@ember/template-factory',
+      '/@embroider/ext-cjs/@ember/template-factory',
     ]);
   });
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -79,6 +79,49 @@ export default interface Options {
   // useMethod optionally lets you pick which property within the module to use.
   // If not provided, we use the module.exports itself.
   pluginHints?: { resolve: string[]; useMethod?: string }[];
+
+  // Ember classically used a runtime AMD module loader.
+  //
+  // Embroider *can* locate the vast majority of modules statically, but when an
+  // addon is doing something highly dynamic (like injecting AMD `define()`
+  // statements directly into a <script>), we still may not be able to locate
+  // them. So Embroider can emit a placeholder shim for the missing module that
+  // attempts to locate it at runtime in the classic AMD loader.
+  //
+  // This shim can be generated as commonJS (cjs) or an ES module (es). The
+  // default is cjs.
+  //
+  // CJS is useful when you're building in an environment that is tolerant of
+  // mixed CJS and ES modules (like Webpack), because the set of exported names
+  // from the module doesn't need to be known in advance. For this reason, CJS
+  // shims are generated on-demand and are fully-automatic. This is the default
+  // for maximum backward-compatibility.
+  //
+  // ES is useful when you're building in a strict ES module environment (like
+  // Vite). It's fully spec-defined and doesn't suffer interoperability
+  // complexities. The downside is, we can only emit a correct shim for a module
+  // if you tell embroider what set of names it exports. Example:
+
+  // emberExternals: {
+  //   es: [
+  //     // import { first, second  } from "my-library";
+  //     ['my-library', ['first', 'second']],
+  //     // import Example from "my-library/components/example";
+  //     ['my-library/components/example', ['default']]
+  //   ];
+  // }
+
+  // It is not recommended to use `es` mode without also using
+  // staticEmberSource, because without staticEmberSource ember itself needs
+  // many external shims.
+  //
+  // false means we don't do any external shimming.
+  amdCompatibility?:
+    | false
+    | 'cjs'
+    | {
+        es: [string, string[]][];
+      };
 }
 
 export function optionsWithDefaults(options?: Options): Required<Options> {
@@ -90,7 +133,7 @@ export function optionsWithDefaults(options?: Options): Required<Options> {
     staticAppPaths: [],
     skipBabel: [],
     pluginHints: [],
-    implicitModulesStrategy: 'relativePaths' as 'relativePaths',
+    amdCompatibility: 'cjs' as const,
   };
   if (options) {
     return Object.assign(defaults, options);

--- a/packages/macros/src/babel/state.ts
+++ b/packages/macros/src/babel/state.ts
@@ -2,7 +2,7 @@ import type { NodePath, Node } from '@babel/traverse';
 import cloneDeepWith from 'lodash/cloneDeepWith';
 import lodashCloneDeep from 'lodash/cloneDeep';
 import { join, dirname, resolve } from 'path';
-import { explicitRelative, Package, RewrittenPackageCache } from '@embroider/shared-internals';
+import { cleanUrl, explicitRelative, Package, RewrittenPackageCache } from '@embroider/shared-internals';
 import { ImportUtil } from 'babel-import-util';
 import type * as Babel from '@babel/core';
 
@@ -57,7 +57,7 @@ export function initState(t: typeof Babel.types, path: NodePath<Babel.types.Prog
   state.removed = new Set();
   state.calledIdentifiers = new Set();
   state.packageCache = RewrittenPackageCache.shared('embroider', state.opts.appPackageRoot);
-  state.sourceFile = state.opts.owningPackageRoot || (path.hub as any).file.opts.filename;
+  state.sourceFile = state.opts.owningPackageRoot || cleanUrl((path.hub as any).file.opts.filename);
   state.pathToOurAddon = pathToAddon;
   state.owningPackage = owningPackage;
   state.originalOwningPackage = originalOwningPackage;

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "babel-import-util": "^2.0.0",
+    "debug": "^4.3.2",
     "ember-rfc176-data": "^0.3.17",
     "js-string-escape": "^1.0.1",
     "resolve-package-path": "^4.0.1",
@@ -42,6 +43,7 @@
     "@embroider/test-support": "workspace:*",
     "@types/babel__core": "^7.1.14",
     "@types/babel__traverse": "^7.18.5",
+    "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.12",
     "@types/lodash": "^4.14.170",
     "@types/js-string-escape": "^1.0.0",

--- a/packages/shared-internals/src/index.ts
+++ b/packages/shared-internals/src/index.ts
@@ -1,5 +1,5 @@
 export { AppMeta, AddonMeta, PackageInfo } from './metadata';
-export { explicitRelative, extensionsPattern, unrelativize } from './paths';
+export { explicitRelative, extensionsPattern, unrelativize, cleanUrl } from './paths';
 export { getOrCreate } from './get-or-create';
 export { default as Package, V2AddonPackage as AddonPackage, V2AppPackage as AppPackage, V2Package } from './package';
 export { default as PackageCache } from './package-cache';

--- a/packages/shared-internals/src/paths.ts
+++ b/packages/shared-internals/src/paths.ts
@@ -41,3 +41,11 @@ export function unrelativize(pkg: Package, specifier: string, fromFile: string) 
   }
   return result;
 }
+
+const postfixRE = /[?#].*$/s;
+
+// this is the same implementation Vite uses internally to keep its
+// cache-busting query params from leaking where they shouldn't.
+export function cleanUrl(url: string): string {
+  return url.replace(postfixRE, '');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,6 +640,9 @@ importers:
       babel-import-util:
         specifier: ^2.0.0
         version: 2.0.0
+      debug:
+        specifier: ^4.3.2
+        version: 4.3.2(supports-color@8.1.0)
       ember-rfc176-data:
         specifier: ^0.3.17
         version: 0.3.17
@@ -671,6 +674,9 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.18.5
         version: 7.18.5
+      '@types/debug':
+        specifier: ^4.1.5
+        version: 4.1.5
       '@types/fs-extra':
         specifier: ^9.0.12
         version: 9.0.12
@@ -1679,7 +1685,7 @@ importers:
         version: /ember-source@4.4.0(@babel/core@7.19.6)
       ember-source-beta:
         specifier: npm:ember-source@beta
-        version: /ember-source@5.2.0-beta.3(@babel/core@7.19.6)
+        version: /ember-source@5.2.0-beta.4(@babel/core@7.19.6)
       ember-source-latest:
         specifier: npm:ember-source@latest
         version: /ember-source@5.1.2(@babel/core@7.19.6)
@@ -2090,7 +2096,7 @@ packages:
       '@babel/core': 7.19.6(supports-color@8.1.0)
       '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.2(supports-color@8.1.0)
+      debug: 4.3.4(supports-color@8.1.0)
       lodash.debounce: 4.0.8
       resolve: 1.20.0
       semver: 6.3.1
@@ -7593,7 +7599,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.2(supports-color@8.1.0)
+      debug: 4.3.4(supports-color@8.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7940,7 +7946,7 @@ packages:
     resolution: {integrity: sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.2(supports-color@8.1.0)
+      debug: 4.3.4(supports-color@8.1.0)
       heimdalljs: 0.2.6
       istextorbinary: 2.6.0
       mkdirp: 0.5.6
@@ -9027,7 +9033,7 @@ packages:
     resolution: {integrity: sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==}
     engines: {node: '>= 6'}
     dependencies:
-      '@babel/core': 7.19.6(supports-color@8.1.0)
+      '@babel/core': 7.22.9
       '@babel/polyfill': 7.12.1
       broccoli-funnel: 2.0.2
       broccoli-merge-trees: 3.0.2
@@ -11824,7 +11830,7 @@ packages:
     engines: {node: 10.* || >= 12.*}
     dependencies:
       resolve-package-path: 3.1.0
-      semver: 7.3.8
+      semver: 7.5.4
       silent-error: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -13757,8 +13763,8 @@ packages:
       - webpack
     dev: true
 
-  /ember-source@5.2.0-beta.3(@babel/core@7.19.6):
-    resolution: {integrity: sha512-UuhLgcLKWGxTJKgx9fpDG5PV+kjUp707LA7blG9GClCrdgGgGiHlGP5IslPZrSx3oTQhg1KNPIyX/PzjTquwIg==}
+  /ember-source@5.2.0-beta.4(@babel/core@7.19.6):
+    resolution: {integrity: sha512-b1Obm3gCkOk5KimtEoXTMbzxXemU8N+WT2mTTa4+9cMxv2qCO8ZVBpkyEmZvQl+W6BrF7tFVl+k6pUDQvuwWKA==}
     engines: {node: '>= 16.*'}
     dependencies:
       '@babel/helper-module-imports': 7.22.5
@@ -16217,7 +16223,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2(supports-color@8.1.0)
-      debug: 4.3.2(supports-color@8.1.0)
+      debug: 4.3.4(supports-color@8.1.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -16257,7 +16263,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2(supports-color@8.1.0)
-      debug: 4.3.2(supports-color@8.1.0)
+      debug: 4.3.4(supports-color@8.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21071,7 +21077,7 @@ packages:
     resolution: {integrity: sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.2(supports-color@8.1.0)
+      debug: 4.3.4(supports-color@8.1.0)
       heimdalljs: 0.2.6
       mkdirp: 0.5.6
       rimraf: 3.0.2
@@ -22283,7 +22289,7 @@ packages:
   /workerpool@3.1.2:
     resolution: {integrity: sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==}
     dependencies:
-      '@babel/core': 7.19.6(supports-color@8.1.0)
+      '@babel/core': 7.22.9
       object-assign: 4.1.1
       rsvp: 4.8.5
     transitivePeerDependencies:

--- a/tests/scenarios/compat-namespaced-app-test.ts
+++ b/tests/scenarios/compat-namespaced-app-test.ts
@@ -48,7 +48,7 @@ appScenarios
       test(`imports within app js`, function () {
         expectAudit
           .module('assets/@ef4/namespaced-app.js')
-          .resolves('./#embroider-implicit-modules')
+          .resolves('./-embroider-implicit-modules.js')
           .toModule()
           .resolves('my-addon/my-implicit-module.js')
           .to('./node_modules/my-addon/my-implicit-module.js');

--- a/tests/scenarios/compat-renaming-test.ts
+++ b/tests/scenarios/compat-renaming-test.ts
@@ -224,7 +224,10 @@ appScenarios
           .to('./node_modules/emits-multiple-packages/somebody-elses-package/utils/index.js');
       });
       test('renamed modules keep their classic runtime name when used as implicit-modules', function () {
-        expectAudit.module('assets/app-template.js').resolves('./#embroider-implicit-modules').toModule().codeContains(`
+        expectAudit
+          .module('assets/app-template.js')
+          .resolves('./-embroider-implicit-modules.js')
+          .toModule().codeContains(`
           d('somebody-elses-package/environment', function() {
             return i('emits-multiple-packages/somebody-elses-package/environment')
           });
@@ -234,12 +237,12 @@ appScenarios
         expectAudit
           .module('./components/import-somebody-elses-original.js')
           .resolves('somebody-elses-package')
-          .to(resolve('/@embroider/external/somebody-elses-package').split(sep).join('/'));
+          .to(resolve('/@embroider/ext-cjs/somebody-elses-package').split(sep).join('/'));
 
         expectAudit
           .module('./components/import-somebody-elses-original.js')
           .resolves('somebody-elses-package/deeper')
-          .to(resolve('/@embroider/external/somebody-elses-package/deeper').split(sep).join('/'));
+          .to(resolve('/@embroider/ext-cjs/somebody-elses-package/deeper').split(sep).join('/'));
       });
       test('single file package gets captured and renamed', function () {
         expectAudit

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -69,6 +69,7 @@ Scenarios.fromProject(() => new Project())
           };
 
           let resolverOptions: CompatResolverOptions = {
+            amdCompatibility: 'cjs',
             activeAddons: {},
             renameModules: {},
             renamePackages: {},


### PR DESCRIPTION
This introduces a new option that opts-in to stricter behavior when we're trying to help v1 addons access legacy AMD modules. Previously, we always depended on looseness in webpack that allows us to mix CJS (which could fully-match the runtime egacy AMD behaviors) and ES modules. We would emit a CJS shim for each unknown module that would locate the module in the AMD loadeder at runtime.

With this new setting `amdCompatibility: { es }`, no automatic shims get emitted for missing modules. Instead you must manually list specific shims that you need (because the ES modules shims need their exports known statically in advance).

This setting is only recommended when also setting `staticEmberSource: true`, because otherwise ember itself needs a whole lof shimming.

In addition, this PR includes some defensive improvements to our rollup and babel plugins so that they filter query params off of filenames. This makes them more robust in build systems like vite that like to tack cache-busting query params onto everything.