### PR TITLE
add --access=public to npm publish unstable

### DIFF
--- a/test-packages/unstable-release/publish.js
+++ b/test-packages/unstable-release/publish.js
@@ -10,7 +10,7 @@ async function publish() {
   for (let workspace of publicWorkspaces) {
     console.info(`Publishing ${workspace}`);
     try {
-      await execaCommand('npm publish --tag=unstable --verbose', { cwd: dirname(workspace) });
+      await execaCommand('npm publish --tag=unstable --verbose --access=public', { cwd: dirname(workspace) });
     } catch (err) {
       console.info(`Publishing ${workspace} has failed. A full list of errors will be printed at the end of this run`);
       errors.push(err);


### PR DESCRIPTION
This is only relevant for new packages and came up because #1550 was merged 🎉 

Fixes #1551 