### PR TITLE
Fix release script

### DIFF
--- a/test-packages/release/src/cli.ts
+++ b/test-packages/release/src/cli.ts
@@ -32,6 +32,10 @@ yargs(process.argv.slice(2))
           description:
             'Allows you to run "publish" even if there are uncommitted changes in your repo. Useful only for developing "publish" itself.',
         })
+        .option('otp', {
+          type: 'string',
+          description: 'This is an OTP that will be passed to npm publish',
+        })
         .option('dryRun', {
           type: 'boolean',
           description: 'Run through the release, but log to stdout instead of tagging/pushing/publishing',

--- a/test-packages/release/src/publish.ts
+++ b/test-packages/release/src/publish.ts
@@ -53,7 +53,7 @@ async function makeTags(solution: Solution, reporter: IssueReporter, dryRun: boo
 
       if (dryRun) {
         info(`--dryRun active. Skipping \`git tag ${tag}\``);
-        return;
+        continue;
       }
 
       await execa('git', ['tag', tag], {
@@ -165,7 +165,7 @@ async function pnpmPublish(solution: Solution, reporter: IssueReporter, dryRun: 
       info(
         `--dryRun active. Skipping \`pnpm publish --access=public\` for ${pkgName}, which would publish version ${entry.newVersion}`
       );
-      return;
+      continue;
     }
 
     try {


### PR DESCRIPTION
I've had a chance to play with #1492 and I saw a few places where it could be improved: 

- the things that are checking github and npm should not be noisy if there is an **expected** 404 error
- --dryRun should not stop after the first package 🙈 
- we need a way to pass --otp=something to the publish stage

This PR fixes all of those 🎉 