### PR TITLE
support packages that use modules

### DIFF
--- a/packages/shared-internals/src/babel-filter.ts
+++ b/packages/shared-internals/src/babel-filter.ts
@@ -26,9 +26,9 @@ export default function babelFilter(skipBabel: { package: string; semverRange?: 
 }
 
 function babelCanHandle(filename: string) {
-  // we can handle .js and .ts files with babel. If typescript is enabled, .ts
-  // files become resolvable and stage3 will be asking us if they should get
+  // we can handle .mjs, .js and .ts files with babel. If typescript is enabled,
+  // .ts files become resolvable and stage3 will be asking us if they should get
   // transpiled and the answer is yes. If typescript is not enbled, they will
   // not be resolvable, so stage3 won't ask us about them.
-  return /\.[jt]s$/i.test(filename);
+  return /\.m?[jt]s$/i.test(filename);
 }


### PR DESCRIPTION
.mjs files can be imported directly by an app
we should allow babel to handle any features the library is using to match the targets set in the app

babel is more than capable of transpiling .mjs files as it's an unambiguous extension that could use features the user is not targeting like private fields or the next hottest ecma script proposal.

this change optionally matches those files as well for processing by babel when stage3 asks about it.