### PR TITLE
Fix rewritten package cache encapsulation

### DIFF
--- a/packages/babel-loader-8/package.json
+++ b/packages/babel-loader-8/package.json
@@ -12,6 +12,9 @@
     "@babel/core": "^7.14.5",
     "babel-loader": "8"
   },
+  "devDependencies": {
+    "@embroider/core": "workspace:^"
+  },
   "peerDependencies": {
     "@embroider/core": "workspace:^"
   },

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -748,13 +748,13 @@ export class Resolver {
     let originalRequestingPkg = this.packageCache.original(requestingPkg);
     let originalTargetPkg = targetPkg ? this.packageCache.original(targetPkg) : undefined;
 
-    if (targetPkg && originalTargetPkg) {
+    if (targetPkg && originalTargetPkg !== targetPkg) {
       // in this case it doesn't matter whether or not the requesting package
       // was moved. RewrittenPackageCache.resolve already took care of finding
       // the right target, and we redirect the request so it will look inside
       // that target.
       return logTransition('request targets a moved package', request, this.resolveWithinPackage(request, targetPkg));
-    } else if (originalRequestingPkg) {
+    } else if (originalRequestingPkg !== requestingPkg) {
       // in this case, the requesting package is moved but its destination is
       // not, so we need to rehome the request back to the original location.
       return logTransition(

--- a/packages/macros/src/babel/get-config.ts
+++ b/packages/macros/src/babel/get-config.ts
@@ -84,7 +84,7 @@ function targetPackage(
   }
   try {
     let target = packageCache.resolve(packageName, us);
-    return packageCache.original(target) || target;
+    return packageCache.original(target);
   } catch (err) {
     return null;
   }

--- a/packages/macros/src/babel/state.ts
+++ b/packages/macros/src/babel/state.ts
@@ -93,7 +93,7 @@ function owningPackage(this: State): Package {
 
 function originalOwningPackage(this: State): Package {
   let pkg = this.owningPackage();
-  return this.packageCache.original(pkg) || pkg;
+  return this.packageCache.original(pkg);
 }
 
 function cloneDeep(this: State, node: Node): Node {

--- a/packages/macros/src/glimmer/get-config.ts
+++ b/packages/macros/src/glimmer/get-config.ts
@@ -24,7 +24,7 @@ export default function getConfig(
   }
 
   if (own) {
-    us = packageCache.original(us) || us;
+    us = packageCache.original(us);
     targetConfig = userConfigs[us.root];
   } else {
     let packageName = params.shift();
@@ -32,7 +32,7 @@ export default function getConfig(
       throw new Error(`macroGetConfig requires at least one argument`);
     }
     let targetPkg = packageCache.resolve(packageName.value, us);
-    targetPkg = packageCache.original(targetPkg) || targetPkg;
+    targetPkg = packageCache.original(targetPkg);
     targetConfig = userConfigs[targetPkg.root];
   }
   while (typeof targetConfig === 'object' && targetConfig && params.length > 0) {

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -287,7 +287,7 @@ export default class MacrosConfig {
       }
       // our configs all deal in the original locations of packages, even if
       // embroider is rewriting some of them
-      let pkg = this.packageCache.original(maybePkg) || maybePkg;
+      let pkg = this.packageCache.original(maybePkg);
       return {
         get name() {
           return pkg.name;
@@ -439,9 +439,9 @@ export default class MacrosConfig {
     }
     if (packageName) {
       let target = this.packageCache.resolve(packageName, us);
-      return this.packageCache.original(target) || target;
+      return this.packageCache.original(target);
     } else {
-      return this.packageCache.original(us) || us;
+      return this.packageCache.original(us);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,10 @@ importers:
       babel-loader:
         specifier: '8'
         version: 8.2.2(@babel/core@7.22.6)(webpack@5.78.0)
+    devDependencies:
+      '@embroider/core':
+        specifier: workspace:^
+        version: link:../core
 
   packages/compat:
     dependencies:
@@ -9572,7 +9576,7 @@ packages:
       wordwrap: 0.0.3
 
   /bower-endpoint-parser@0.2.2:
-    resolution: {integrity: sha512-YWZHhWkPdXtIfH3VRu3QIV95sa75O9vrQWBOHjexWCLBCTy5qJvRr36LXTqFwTchSXVlzy5piYJOjzHr7qhsNg==}
+    resolution: {integrity: sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=}
     engines: {node: '>=0.8.0'}
 
   /brace-expansion@1.1.11:


### PR DESCRIPTION
Fixes https://github.com/embroider-build/embroider/issues/1514

A v2 addon with a v1 addon dependency was not resolving its dependencies correctly, in two places.
 - in virtual-content.ts where we emit implicit-modules
 - in compat-app-builder.ts when doing partitionEngines

The fix to both is adjusting the meaning of RewrittenPackageCache so that it always provides packages that see moved dependencies, even when a given package *itself* has not moved (because it's a v2 addon).

Along with that I took the opportunity to make `packageCache.original()` more like `maybeMoved()` in that returns its argument if no change was needed, which simplified things for the majority of callers.