### PR TITLE
Add semverRange <=4.11.0 for ember-data debug

### DIFF
--- a/packages/compat/src/compat-adapters/@ember-data/debug.ts
+++ b/packages/compat/src/compat-adapters/@ember-data/debug.ts
@@ -1,5 +1,6 @@
 import { AddonMeta } from '@embroider/core';
 import V1Addon from '../../v1-addon';
+import semver from 'semver';
 
 export default class EmberDataDebug extends V1Addon {
   get packageMeta(): Partial<AddonMeta> {
@@ -10,5 +11,9 @@ export default class EmberDataDebug extends V1Addon {
     meta.externals = [...(meta.externals ?? []), '@ember-data/store'];
 
     return meta;
+  }
+
+  static shouldApplyAdapter(addonInstance: any) {
+    return semver.lt(addonInstance.pkg.version, '4.11.1');
   }
 }


### PR DESCRIPTION
fix #1506
There is missing the `semverRange` rule for ember-data/debug in (https://github.com/embroider-build/embroider/pull/1435 - commit https://github.com/embroider-build/embroider/commit/0382837a2ccf74ad6e5f885bc399b9b31bdafd52)