### PR TITLE
add files block to the vite package

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -23,5 +23,12 @@
     "@types/fs-extra": "^9.0.12",
     "rollup": "^3.23.0",
     "vite": "^4.3.9"
-  }
+  },
+  "files": [
+    "index.mjs",
+    "index.d.ts",
+    "src/**/*.js",
+    "src/**/*.d.ts",
+    "src/**/*.js.map"
+  ]
 }


### PR DESCRIPTION
I discovered today that npm defaults to use .gitignore files if there is no .npmignore 🙈 we need to specify a `files` block in the package.json to override this, I took a hint from `@embroider/webpack` package 👍 