### PR TITLE
stop ember-composable-helpers searching for babel configs

### DIFF
--- a/packages/compat/src/compat-adapters/ember-composable-helpers.ts
+++ b/packages/compat/src/compat-adapters/ember-composable-helpers.ts
@@ -33,6 +33,6 @@ class MatchHelpers extends Funnel {
     }
     let src = readFileSync(join(this.inputPaths[0], 'index.js'), 'utf8');
     let plugins = [stripBadReexportsPlugin({ resolveBase: this.outputPath })];
-    writeFileSync(join(this.outputPath, 'index.js'), transform(src, { plugins })!.code!);
+    writeFileSync(join(this.outputPath, 'index.js'), transform(src, { plugins, configFile: false })!.code!);
   }
 }


### PR DESCRIPTION
This replicates the fix that I did upstream https://github.com/DockYard/ember-composable-helpers/pull/449

TLDR on the issue: a vite app has a babel config in the root of the app, and we shouldn't search for babel configs from addons because it creates a chicken-and-the-egg situation 👍 