### PR TITLE
Update macros README with v2 addon instructions

### DIFF
--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -57,6 +57,34 @@ module.exports = {
 };
 ```
 
+## Setting Configuration: from a v2 Ember Addon
+
+1. Add `@embroider/macros` as `dependency`.
+2. In `addon-main.js`, do:
+
+```js
+'use strict';
+
+const { addonV1Shim } = require('@embroider/addon-shim');
+
+module.exports = {
+  ...addonV1Shim(__dirname),
+  options: {
+    '@embroider/macros': {
+      setOwnConfig: {
+        // your config goes here
+      },
+      setConfig: {
+        'some-dependency': {
+          // config for some-dependency
+        },
+      },
+    },
+  },
+};
+
+```
+
 ## The Macros
 
 ### macroCondition


### PR DESCRIPTION
This clarifies where to put build-time options for v2 addons without a root `index.js` file.