### PR TITLE
Fix relative import path of assets for non-entrypoint modules

### DIFF
--- a/packages/addon-dev/src/rollup-keep-assets.ts
+++ b/packages/addon-dev/src/rollup-keep-assets.ts
@@ -1,7 +1,7 @@
 import walkSync from 'walk-sync';
 import type { Plugin } from 'rollup';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import minimatch from 'minimatch';
 
 export default function keepAssets({
@@ -23,9 +23,10 @@ export default function keepAssets({
       });
       if (
         resolution &&
+        importer &&
         include.some((pattern) => minimatch(resolution.id, pattern))
       ) {
-        return { id: source, external: true };
+        return { id: resolve(dirname(importer), source), external: 'relative' };
       }
       return resolution;
     },


### PR DESCRIPTION
When modules reference static assets added to the build via the `keepAssets` rollup plugin, and those modules are not entrypoints and as such moved into a bundle at a different location, the relative path to that asset would not get rewritten, leading to broken references.

Fixes https://github.com/embroider-build/addon-blueprint/issues/192

Successfully tested in a local project. We don't have unit tests for rollup plugins here. And I haven't found scenarios that implicitly test the behavior of `keepAssets`, but maybe I missed that. Do we have an easy way to add tests, or is this good as-is?