### PR TITLE
Ensure custom HTML attributes are passed-through

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -223,16 +223,15 @@ export class CompatAppBuilder {
         rootURL: this.rootURL(),
         prepare: (dom: JSDOM) => {
           let scripts = [...dom.window.document.querySelectorAll('script')];
-          let styles = [...dom.window.document.querySelectorAll('link[rel="stylesheet"]')] as HTMLLinkElement[];
-
+          let styles = [...dom.window.document.querySelectorAll('link[rel*="stylesheet"]')] as HTMLLinkElement[];
           return {
-            javascript: definitelyReplace(dom, this.compatApp.findAppScript(scripts, entrypoint)),
-            styles: definitelyReplace(dom, this.compatApp.findAppStyles(styles, entrypoint)),
-            implicitScripts: definitelyReplace(dom, this.compatApp.findVendorScript(scripts, entrypoint)),
-            implicitStyles: definitelyReplace(dom, this.compatApp.findVendorStyles(styles, entrypoint)),
-            testJavascript: maybeReplace(dom, this.compatApp.findTestScript(scripts)),
-            implicitTestScripts: maybeReplace(dom, this.compatApp.findTestSupportScript(scripts)),
-            implicitTestStyles: maybeReplace(dom, this.compatApp.findTestSupportStyles(styles)),
+            javascript: this.compatApp.findAppScript(scripts, entrypoint),
+            styles: this.compatApp.findAppStyles(styles, entrypoint),
+            implicitScripts: this.compatApp.findVendorScript(scripts, entrypoint),
+            implicitStyles: this.compatApp.findVendorStyles(styles, entrypoint),
+            testJavascript: this.compatApp.findTestScript(scripts),
+            implicitTestScripts: this.compatApp.findTestSupportScript(scripts),
+            implicitTestStyles: this.compatApp.findTestSupportStyles(styles),
           };
         },
       };
@@ -1363,18 +1362,6 @@ export class CompatAppBuilder {
     prepared.set(asset.relativePath, asset);
     return asset;
   }
-}
-
-function maybeReplace(dom: JSDOM, element: Element | undefined): Node | undefined {
-  if (element) {
-    return definitelyReplace(dom, element);
-  }
-}
-
-function definitelyReplace(dom: JSDOM, element: Element): Node {
-  let placeholder = dom.window.document.createTextNode('');
-  element.replaceWith(placeholder);
-  return placeholder;
 }
 
 function defaultAddonPackageRules(): PackageRules[] {

--- a/packages/core/src/html-entrypoint.ts
+++ b/packages/core/src/html-entrypoint.ts
@@ -66,7 +66,7 @@ export class HTMLEntrypoint {
   }
 
   private handledStyles() {
-    let styleTags = [...this.dom.window.document.querySelectorAll('link[rel="stylesheet"]')] as HTMLLinkElement[];
+    let styleTags = [...this.dom.window.document.querySelectorAll('link[rel*="stylesheet"]')] as HTMLLinkElement[];
     let [ignoredStyleTags, handledStyleTags] = partition(styleTags, styleTag => {
       return !styleTag.href || styleTag.hasAttribute('data-embroider-ignore') || isAbsoluteURL(styleTag.href);
     });

--- a/tests/scenarios/compat-app-html-attributes-test.ts
+++ b/tests/scenarios/compat-app-html-attributes-test.ts
@@ -1,0 +1,67 @@
+import type { ExpectFile } from '@embroider/test-support/file-assertions/qunit';
+import { expectFilesAt } from '@embroider/test-support/file-assertions/qunit';
+import { appScenarios } from './scenarios';
+import QUnit from 'qunit';
+const { module: Qmodule, test } = QUnit;
+
+appScenarios
+  .map('compat-app-script-attributes', app => {
+    let appFolder = app.files.app;
+
+    if (appFolder === null || typeof appFolder !== 'object') {
+      throw new Error('app folder unexpectedly missing');
+    }
+
+    let indexHtml = appFolder['index.html'];
+
+    if (typeof indexHtml !== 'string') {
+      throw new Error('index.html unexpectedly missing');
+    }
+
+    // <link ... href=".../app-template.css"> => <link ... href=".../app-template.css" data-original-filename="app-template.css">
+    indexHtml = indexHtml.replace('vendor.css">', 'vendor.css" data-original-filename="vendor.css">');
+    indexHtml = indexHtml.replace('app-template.css">', 'app-template.css" data-original-filename="app-template.css">');
+
+    // <link integrity="" rel="stylesheet" => <link integrity="" rel="stylesheet prefetch"
+    indexHtml = indexHtml.replace(
+      /<link integrity="" rel="stylesheet"/g,
+      '<link integrity="" rel="stylesheet prefetch"'
+    );
+
+    // <script ... src=".../vendor.js"> => <script ... src=".../vendor.js" data-original-filename="vendor.js">
+    indexHtml = indexHtml.replace('vendor.js">', 'vendor.js" data-original-filename="vendor.js">');
+    indexHtml = indexHtml.replace('app-template.js">', 'app-template.js" data-original-filename="app-template.js">');
+
+    // <script ... => <script defer ...
+    indexHtml = indexHtml.replace(/<script /g, '<script defer ');
+
+    app.mergeFiles({
+      app: {
+        'index.html': indexHtml,
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    let expectFile: ExpectFile;
+
+    Qmodule(scenario.name, function (hooks) {
+      hooks.beforeEach(async assert => {
+        let app = await scenario.prepare();
+        let result = await app.execute('ember build');
+        assert.equal(result.exitCode, 0, result.output);
+        expectFile = expectFilesAt(app.dir, { qunit: assert });
+      });
+
+      test('custom HTML attributes are passed through', () => {
+        expectFile('./dist/index.html').matches('<link integrity="" rel="stylesheet prefetch"');
+        expectFile('./dist/index.html').doesNotMatch('rel="stylesheet"');
+        expectFile('./dist/index.html').matches('<script defer');
+        expectFile('./dist/index.html').doesNotMatch('<script src');
+        // by default, there is no vendor CSS and the tag is omitted entirely
+        expectFile('./dist/index.html').doesNotMatch('data-original-filename="vendor.css">');
+        expectFile('./dist/index.html').matches('" data-original-filename="app-template.css">');
+        expectFile('./dist/index.html').matches('" data-original-filename="vendor.js">');
+        expectFile('./dist/index.html').matches('" data-original-filename="app-template.js">');
+      });
+    });
+  });


### PR DESCRIPTION
This ensures user-defined attributes on `<script>` and `<link>` tags in the compat `index.html` are propagated to the final HTML file. Replaces #588

Fixes #456