### PR TITLE
performance: avoid paying decodeFastbootSwitch regex cost unless needed

### DIFF
--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -150,6 +150,10 @@ export function fastbootSwitch(specifier: string, fromFile: string, names: Set<s
 }
 
 export function decodeFastbootSwitch(filename: string) {
+  // Performance: avoid paying regex exec cost unless needed
+  if (!filename.includes(fastbootSwitchSuffix)) {
+    return;
+  }
   let match = fastbootSwitchPattern.exec(filename);
   if (match) {
     let names = match.groups?.names?.split(',') ?? [];

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -124,6 +124,10 @@ export function virtualPairComponent(hbsModule: string, jsModule: string | null)
 function decodeVirtualPairComponent(
   filename: string
 ): { relativeHBSModule: string; relativeJSModule: string | null; debugName: string } | null {
+  // Performance: avoid paying regex exec cost unless needed
+  if (!filename.includes(pairComponentMarker)) {
+    return null;
+  }
   let match = pairComponentPattern.exec(filename);
   if (!match) {
     return null;
@@ -186,6 +190,10 @@ const implicitModulesPattern = /(?<filename>.*)[\\/]-embroider-implicit-(?<test>
 export function decodeImplicitModules(
   filename: string
 ): { type: 'implicit-modules' | 'implicit-test-modules'; fromFile: string } | undefined {
+  // Performance: avoid paying regex exec cost unless needed
+  if (!filename.includes('-embroider-implicit-')) {
+    return;
+  }
   let m = implicitModulesPattern.exec(filename);
   if (m) {
     return {


### PR DESCRIPTION
Ref https://github.com/embroider-build/embroider/issues/1610

Before this change, my large app was spending 20+ seconds on the regex:

<img width="849" alt="Screenshot 2023-09-25 at 9 58 19 AM" src="https://github.com/raycohen/embroider/assets/20404/29af0e7e-810c-4d26-885e-3b1397796030">

After this change, it spends no time here (my app does not use fastboot, so the condition is never met). I think this condition will be correct for users that do use fastboot.