### PR TITLE
performance: cache existsSync results in PackageCache.ownerOfFile

### DIFF
--- a/packages/shared-internals/src/package-cache.ts
+++ b/packages/shared-internals/src/package-cache.ts
@@ -17,6 +17,21 @@ function getCachedRealpath(path: string): string {
   return root;
 }
 
+const existsCache = new Map<string, boolean>();
+
+function getCachedExists(path: string): boolean {
+  if (existsCache.has(path)) {
+    const cachedExists = existsCache.get(path);
+    if (cachedExists !== undefined) {
+      return cachedExists;
+    }
+  }
+
+  const exists = existsSync(path);
+  existsCache.set(path, exists);
+  return exists;
+}
+
 export default class PackageCache {
   constructor(public appRoot: string) {}
 
@@ -68,7 +83,7 @@ export default class PackageCache {
       if (this.rootCache.has(candidate)) {
         return this.rootCache.get(candidate);
       }
-      if (existsSync([...usedSegments, 'package.json'].join(sep))) {
+      if (getCachedExists([...usedSegments, 'package.json'].join(sep))) {
         return this.get(candidate);
       }
     }


### PR DESCRIPTION
Similar to https://github.com/embroider-build/embroider/pull/1608

A lot of time is being spent in `PackageCache#ownerOfFile` and a good chunk of that is from the calls to `existsSync`:

Before:
<img width="839" alt="Screenshot 2023-09-25 at 11 17 06 PM" src="https://github.com/raycohen/embroider/assets/20404/50c4e7ad-7c41-48b2-ae22-43e6c2e6aa5f">

By caching, the amount of time in `existsSync` drops considerably in my large app, From ~12 seconds to under 500ms. The total time spent in `ownerOfFile` drops less, from 20 to 14 seconds.

After:
<img width="835" alt="Screenshot 2023-09-25 at 11 17 18 PM" src="https://github.com/raycohen/embroider/assets/20404/7b88d32b-6f91-4aee-8207-02255800f612">

Even with the caching, this path is still so hot that there's a good deal of time in `ownerOfFile` and the new `getCachedExistsSync` methods that isn't accounted for by `existsSync`. There's probably more that can be done here.