### PR TITLE
use realpath of engine's route when building resolver.json

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -35,7 +35,7 @@ import mergeWith from 'lodash/mergeWith';
 import cloneDeep from 'lodash/cloneDeep';
 import { sync as resolveSync } from 'resolve';
 import bind from 'bind-decorator';
-import { outputJSONSync, readJSONSync, rmSync, statSync, unlinkSync, writeFileSync } from 'fs-extra';
+import { outputJSONSync, readJSONSync, rmSync, statSync, unlinkSync, writeFileSync, realpathSync } from 'fs-extra';
 import type { Options as EtcOptions } from 'babel-plugin-ember-template-compilation';
 import type { Options as ResolverTransformOptions } from './resolver-transform';
 import type { Options as AdjustImportsOptions } from './babel-plugin-adjust-imports';
@@ -285,7 +285,9 @@ export class CompatAppBuilder {
       appRoot: this.origAppPackage.root,
       engines: engines.map((appFiles, index) => ({
         packageName: appFiles.engine.package.name,
-        root: index === 0 ? this.root : appFiles.engine.package.root, // first engine is the app, which has been relocated to this.root
+        // first engine is the app, which has been relocated to this.root
+        // we need to use the real path here because webpack requests always use the real path i.e. follow symlinks
+        root: realpathSync(index === 0 ? this.root : appFiles.engine.package.root),
         fastbootFiles: appFiles.fastbootFiles,
         activeAddons: [...appFiles.engine.addons]
           .map(a => ({


### PR DESCRIPTION
This solves a problem that we face when we try to run embroider in an app where `node_modules` has been symlinked. The issue arises because all webpack requests normalise the path of a package using fs.realpath so when we're trying to find the [owningEngine](https://github.com/embroider-build/embroider/blob/main/packages/core/src/module-resolver.ts#L707C7-L707C7) of a package we will always get the wrong answer because package passed into that request will have the real path on disk (after removing symbolic link information)

I have tested this locally and it also seems to unblock https://github.com/ember-cli/ember-cli/pull/10370 because the ember-cli CI also does some shenanigans with linking node_modules