### PR TITLE
disable lint for scenarios since scenarios are not published

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,7 +47,7 @@ module.exports = {
       },
     },
     {
-      files: ['test-packages/**/*.[jt]s'],
+      files: ['test-packages/**/*.[jt]s', 'tests/scenarios/**/*.{js,ts}'],
       rules: {
         'import/no-extraneous-dependencies': 'off',
       },


### PR DESCRIPTION
Ran in to this here: https://github.com/embroider-build/embroider/pull/1624

needing to put execa in `dependencies` didn't make sense