### PR TITLE
Resolver refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "jest": {
     "projects": [
-      "<rootDir>/packages/*",
-      "<rootDir>/test-packages/"
+      "<rootDir>/packages/*"
     ],
     "testEnvironment": "node",
     "testMatch": [

--- a/packages/compat/src/standalone-addon-build.ts
+++ b/packages/compat/src/standalone-addon-build.ts
@@ -44,6 +44,10 @@ ${summarizePeerDepViolations(violations)}`
     return new Funnel(interior, { destDir: index.packages[pkg.root] });
   });
 
+  let fakeTargets = Object.values(index.packages).map(dir => {
+    return writeFile(join(dir, '..', 'moved-package-target.js'), '');
+  });
+
   return broccoliMergeTrees([
     ...exteriorTrees,
     new Funnel(compatApp.synthesizeStylesPackage(interiorTrees), {
@@ -53,6 +57,7 @@ ${summarizePeerDepViolations(violations)}`
       destDir: '@embroider/synthesized-vendor',
     }),
     writeFile('index.json', JSON.stringify(index, null, 2)),
+    ...fakeTargets,
   ]);
 }
 
@@ -62,7 +67,7 @@ function buildAddonIndex(compatApp: CompatApp, appPackage: Package, packages: Se
     extraResolutions: {},
   };
   for (let oldPkg of packages) {
-    let newRoot = `${oldPkg.name}.${hashed(oldPkg.root)}`;
+    let newRoot = `${oldPkg.name}.${hashed(oldPkg.root)}/node_modules/${oldPkg.name}`;
     content.packages[oldPkg.root] = newRoot;
     let nonResolvableDeps = oldPkg.nonResolvableDeps;
     if (nonResolvableDeps) {

--- a/packages/compat/tests/audit.test.ts
+++ b/packages/compat/tests/audit.test.ts
@@ -318,7 +318,7 @@ describe('audit', function () {
     });
     let result = await audit();
     expect(result.findings).toEqual([]);
-    expect(Object.keys(result.modules).length).toBe(3);
+    expect(Object.keys(result.modules).length).toBe(2);
   });
 
   test('finds missing component in standalone hbs', async function () {

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -829,7 +829,9 @@ export class Resolver {
       return request.rehome(resolve(pkg.root, 'package.json'));
     } else {
       // otherwise we need to just assume that internal naming is simple
-      return request.rehome(resolve(pkg.root, '..', 'moved-package-target.js'));
+      return request.rehome(resolve(pkg.root, '..', 'moved-package-target.js')).withMeta({
+        resolvedWithinPackage: pkg.root,
+      });
     }
   }
 
@@ -994,6 +996,13 @@ export class Resolver {
       // not a classic runtime thing. It's better to let it be a build error
       // here.
       return request;
+    }
+
+    if (fromFile.endsWith('moved-package-target.js')) {
+      if (!request.meta?.resolvedWithinPackage) {
+        throw new Error(`bug: embroider resolver's meta is not propagating`);
+      }
+      fromFile = resolve(request.meta?.resolvedWithinPackage as string, 'package.json');
     }
 
     let pkg = this.packageCache.ownerOfFile(fromFile);

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -829,7 +829,7 @@ export class Resolver {
       return request.rehome(resolve(pkg.root, 'package.json'));
     } else {
       // otherwise we need to just assume that internal naming is simple
-      return request.alias(request.specifier.replace(pkg.name, '.')).rehome(resolve(pkg.root, 'package.json'));
+      return request.rehome(resolve(pkg.root, '..', 'moved-package-target.js'));
     }
   }
 
@@ -954,7 +954,7 @@ export class Resolver {
         throw new Error(
           `A module tried to resolve "${request.specifier}" and didn't find it (${label}).
 
- - Maybe a dependency declaration is missing? 
+ - Maybe a dependency declaration is missing?
  - Remember that v1 addons can only import non-Ember-addon NPM dependencies if they include ember-auto-import in their dependencies.
  - If this dependency is available in the AMD loader (because someone manually called "define()" for it), you can configure a shim like:
 

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -815,24 +815,20 @@ export class Resolver {
       // packages get this help, v2 packages are natively supposed to make their
       // own modules resolvable, and we want to push them all to do that
       // correctly.
-      return logTransition(`v1 self-import`, request, this.resolveWithinPackage(request, pkg));
+      return logTransition(
+        `v1 self-import`,
+        request,
+        request.alias(request.specifier.replace(pkg.name, '.')).rehome(resolve(pkg.root, 'package.json'))
+      );
     }
 
     return request;
   }
 
   private resolveWithinPackage<R extends ModuleRequest>(request: R, pkg: Package): R {
-    // if ('exports' in pkg.packageJSON) {
-    //   // this is the easy case -- a package that uses exports can safely resolve
-    //   // its own name, so it's enough to let it resolve the (self-targeting)
-    //   // specifier from its own package root.
-    //   return request.rehome(resolve(pkg.root, 'package.json'));
-    // } else {
-    // otherwise we need to just assume that internal naming is simple
     return request.rehome(resolve(pkg.root, '..', 'moved-package-target.js')).withMeta({
       resolvedWithinPackage: pkg.root,
     });
-    // }
   }
 
   private preHandleExternal<R extends ModuleRequest>(request: R): R {

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -760,14 +760,15 @@ Scenarios.fromProject(() => new Project())
         test('app can resolve file in rewritten addon', async function () {
           let index: RewrittenPackageIndex = {
             packages: {
-              [resolve(app.dir, 'node_modules/my-addon')]: 'my-addon.1234',
+              [resolve(app.dir, 'node_modules/my-addon')]: 'my-addon.1234/node_modules/my-addon',
             },
             extraResolutions: {},
           };
           givenFiles({
             'node_modules/.embroider/rewritten-packages/index.json': JSON.stringify(index),
-            'node_modules/.embroider/rewritten-packages/my-addon.1234/hello-world.js': ``,
-            'node_modules/.embroider/rewritten-packages/my-addon.1234/package.json': addonPackageJSON(),
+            'node_modules/.embroider/rewritten-packages/my-addon.1234/node_modules/my-addon/hello-world.js': ``,
+            'node_modules/.embroider/rewritten-packages/my-addon.1234/node_modules/my-addon/package.json':
+              addonPackageJSON(),
             'app.js': `import "my-addon/hello-world"`,
           });
 
@@ -776,28 +777,29 @@ Scenarios.fromProject(() => new Project())
           expectAudit
             .module('./app.js')
             .resolves('my-addon/hello-world')
-            .to('./node_modules/.embroider/rewritten-packages/my-addon.1234/hello-world.js');
+            .to('./node_modules/.embroider/rewritten-packages/my-addon.1234/node_modules/my-addon/hello-world.js');
         });
 
         test('moved addon resolves dependencies from its original location', async function () {
           let index: RewrittenPackageIndex = {
             packages: {
-              [resolve(app.dir, 'node_modules/my-addon')]: 'my-addon.1234',
+              [resolve(app.dir, 'node_modules/my-addon')]: 'my-addon.1234/node_modules/my-addon',
             },
             extraResolutions: {},
           };
           givenFiles({
             'node_modules/my-addon/node_modules/inner-dep/index.js': '',
             'node_modules/.embroider/rewritten-packages/index.json': JSON.stringify(index),
-            'node_modules/.embroider/rewritten-packages/my-addon.1234/hello-world.js': `import "inner-dep"`,
-            'node_modules/.embroider/rewritten-packages/my-addon.1234/package.json': addonPackageJSON(),
+            'node_modules/.embroider/rewritten-packages/my-addon.1234/node_modules/my-addon/hello-world.js': `import "inner-dep"`,
+            'node_modules/.embroider/rewritten-packages/my-addon.1234/node_modules/my-addon/package.json':
+              addonPackageJSON(),
             'app.js': `import "my-addon/hello-world"`,
           });
 
           await configure({});
 
           expectAudit
-            .module('./node_modules/.embroider/rewritten-packages/my-addon.1234/hello-world.js')
+            .module('./node_modules/.embroider/rewritten-packages/my-addon.1234/node_modules/my-addon/hello-world.js')
             .resolves('inner-dep')
             .to('./node_modules/my-addon/node_modules/inner-dep/index.js');
         });


### PR DESCRIPTION
This PR started as an effort myself and @ef4 were pairing on to see if we can figure out how to teach vite and esbuild about our dependencies a bit better

It ended up being a nice refactor of the resolver so that we could remove some codepaths and simplify what the resolver was doing. It will also (hopefully) help esbuild understand what is going on a bit better, but I have split this PR so that it only contains the resolver refactor and the Vite/esbuild stuff will follow on in a new PR 👍 