### PR TITLE
Perf: cache macros lockfile lookup and read operations

### DIFF
--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -303,6 +303,40 @@ export default class MacrosConfig {
     };
   }
 
+  private static lockFilePathForAppRoot: Map<string, string | undefined> = new Map();
+  private static getLockFilePath(appRoot: string): string | undefined {
+    if (this.lockFilePathForAppRoot.has(appRoot)) {
+      return this.lockFilePathForAppRoot.get(appRoot);
+    }
+    let path = findUp.sync(['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml'], { cwd: appRoot });
+    this.lockFilePathForAppRoot.set(appRoot, path);
+    return path;
+  }
+
+  private static packageJsonPathForAppPackageRoot: Map<string, string | undefined> = new Map();
+  private static getPackageJsonPath(appPackageRoot: string): string | undefined {
+    if (this.packageJsonPathForAppPackageRoot.has(appPackageRoot)) {
+      return this.packageJsonPathForAppPackageRoot.get(appPackageRoot);
+    }
+    let path = findUp.sync('package.json', { cwd: appPackageRoot });
+    this.packageJsonPathForAppPackageRoot.set(appPackageRoot, path);
+    return path;
+  }
+
+  private static lockFileContentsForPath: Map<string, Buffer> = new Map();
+  private static getLockFileContents(lockFilePath: string): Buffer {
+    let buffer: Buffer | undefined;
+    if (this.lockFileContentsForPath.has(lockFilePath)) {
+      buffer = this.lockFileContentsForPath.get(lockFilePath);
+      if (buffer) {
+        return buffer;
+      }
+    }
+    buffer = fs.readFileSync(lockFilePath);
+    this.lockFileContentsForPath.set(lockFilePath, buffer);
+    return buffer;
+  }
+
   // to be called from within your build system. Returns the thing you should
   // push into your babel plugins list.
   //
@@ -342,13 +376,13 @@ export default class MacrosConfig {
       importSyncImplementation: this.importSyncImplementation,
     };
 
-    let lockFilePath = findUp.sync(['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml'], { cwd: self.appRoot });
+    let lockFilePath = MacrosConfig.getLockFilePath(self.appRoot);
 
     if (!lockFilePath) {
-      lockFilePath = findUp.sync('package.json', { cwd: opts.appPackageRoot });
+      lockFilePath = MacrosConfig.getPackageJsonPath(opts.appPackageRoot);
     }
 
-    let lockFileBuffer = lockFilePath ? fs.readFileSync(lockFilePath) : 'no-cache-key';
+    let lockFileBuffer = lockFilePath ? MacrosConfig.getLockFileContents(lockFilePath) : 'no-cache-key';
 
     // @embroider/macros provides a macro called dependencySatisfies which checks if a given
     // package name satisfies a given semver version range. Due to the way babel caches this can


### PR DESCRIPTION
This shaves about 2 seconds off of the total time spent in `babelPluginConfig` in my large app. 

Follow-up ideas:
 - There's also about 400ms from the use of `resolve` in `babelPluginConfig` which seems like it could be done once
 - It looks safe to cache the result of `hash.digest` which is currently taking 4s in my build



Before:

<img width="852" alt="Screenshot 2023-10-09 at 8 51 38 PM" src="https://github.com/embroider-build/embroider/assets/20404/d9118957-9f86-449c-8194-6c5ecebb8e65">


After:

<img width="852" alt="Screenshot 2023-10-09 at 9 06 09 PM" src="https://github.com/embroider-build/embroider/assets/20404/693d2584-5b72-4f0c-b40a-59abe51d0c02">
