### PR TITLE
Increase CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     needs: ['preflight']
     name: ${{ matrix.name }}
     runs-on: '${{ matrix.os }}-latest'
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     needs: ['preflight']
     name: ${{ matrix.name }}
     runs-on: '${{ matrix.os }}-latest'
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The windows watch mode tests takes just about 20 minutes and often get killed when they are just about to finish