### PR TITLE
Windvis/fix/resolve nested layout components

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -565,7 +565,7 @@ export class Resolver {
 
   private *componentJSCandidates(inPackageName: string) {
     yield { prefix: '/components/', suffix: '' };
-    // yield { prefix: '/components/', suffix: '/index' };
+    yield { prefix: '/components/', suffix: '/index' };
     yield { prefix: '/components/', suffix: '/component' };
 
     let pods = this.podPrefix(inPackageName);

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -565,6 +565,7 @@ export class Resolver {
 
   private *componentJSCandidates(inPackageName: string) {
     yield { prefix: '/components/', suffix: '' };
+    // yield { prefix: '/components/', suffix: '/index' };
     yield { prefix: '/components/', suffix: '/component' };
 
     let pods = this.podPrefix(inPackageName);
@@ -954,7 +955,7 @@ export class Resolver {
         throw new Error(
           `A module tried to resolve "${request.specifier}" and didn't find it (${label}).
 
- - Maybe a dependency declaration is missing? 
+ - Maybe a dependency declaration is missing?
  - Remember that v1 addons can only import non-Ember-addon NPM dependencies if they include ember-auto-import in their dependencies.
  - If this dependency is available in the AMD loader (because someone manually called "define()" for it), you can configure a shim like:
 

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -103,6 +103,7 @@ Scenarios.fromProject(() => new Project())
         renamePackages?: Record<string, string>;
         addonMeta?: Partial<AddonMeta>;
         fastbootFiles?: { [appName: string]: { localFilename: string; shadowedFilename: string | undefined } };
+        options?: Partial<CompatResolverOptions['options']>;
       }
 
       let configure: (opts?: ConfigureOpts) => Promise<void>;
@@ -164,6 +165,7 @@ Scenarios.fromProject(() => new Project())
               staticHelpers: false,
               staticModifiers: false,
               allowUnsafeDynamicComponents: false,
+              ...opts?.options,
             },
             activePackageRules: [
               {
@@ -440,7 +442,13 @@ Scenarios.fromProject(() => new Project())
             'app.js': 'import "#embroider_compat/components/local-nested-layout-component"',
           });
 
-          await configure();
+          await configure({
+            // options: {
+            //   staticHelpers: true,
+            //   staticComponents: true,
+            //   staticModifiers: true,
+            // },
+          });
 
           expectAudit
             .module('./app.js')
@@ -450,27 +458,39 @@ Scenarios.fromProject(() => new Project())
 
         test('nested layout (in v1 addon) component resolved', async function () {
           givenFiles({
-            'app.js': 'import "a-v1-addon/components/v1-nested-layout-component"',
+            'app.js': 'import "#embroider_compat/components/v1-nested-layout-component"',
           });
 
-          await configure();
+          await configure({
+            // options: {
+            //   staticHelpers: true,
+            //   staticComponents: true,
+            //   staticModifiers: true,
+            // },
+          });
 
           expectAudit
             .module('./app.js')
-            .resolves('a-v1-addon/components/v1-nested-layout-component')
-            .to('/@embroider/ext-cjs/a-v1-addon/components/v1-nested-layout-component');
+            .resolves('#embroider_compat/components/v1-nested-layout-component')
+            .to('/@embroider/ext-cjs/a-v1-addon/components/v1-nested-layout-component/index.js');
         });
 
         test('nested layout (in v2 addon) component resolved', async function () {
           givenFiles({
-            'app.js': 'import "v2-addon/components/v2-nested-layout-component"',
+            'app.js': 'import "#embroider_compat/components/v2-nested-layout-component"',
           });
 
-          await configure();
+          await configure({
+            // options: {
+            //   staticHelpers: true,
+            //   staticComponents: true,
+            //   staticModifiers: true,
+            // },
+          });
 
           expectAudit
             .module('./app.js')
-            .resolves('v2-addon/components/v2-nested-layout-component')
+            .resolves('#embroider_compat/components/v2-nested-layout-component')
             .to('./node_modules/v2-addon/components/v2-nested-layout-component/index.js');
         });
 


### PR DESCRIPTION
Building off of https://github.com/embroider-build/embroider/pull/1596/files
I thought I'd be able to add the core-resolver tests, but I can't get the components to resolve.

-----

The goal is to have loose-mode templates resolve `/index` components (nested structure).

Today, we get this error:
```
Build Error (PackagerRunner) in templates/application.hbs

Module not found: Error: Can't resolve '#embroider_compat/components/example' in '/home/nvp/Development$TMPDIR/stackblitz-starters-8ycj88/my-addon/test-app'
```

-----

so that may mean I've configured something wrong, or the suggested fix isn't sufficient (tho, I presume the fix is good since #1596 had is green) -- so it's likely I don't yet understand what's trying to happen with the setup of the resolver code.

Draft PR because I need to change tasks
