### PR TITLE
Support route templates in addons

### DIFF
--- a/packages/addon-dev/src/rollup-app-reexports.ts
+++ b/packages/addon-dev/src/rollup-app-reexports.ts
@@ -22,14 +22,21 @@ export default function appReexports(opts: {
           !minimatch(addonFilename, '**/*.d.ts')
         ) {
           appJS[`./${appFilename}`] = `./dist/_app_/${appFilename}`;
-          this.emitFile({
-            type: 'asset',
-            fileName: `_app_/${appFilename}`,
-            source: `export { default } from "${pkg.name}/${addonFilename.slice(
-              0,
-              -extname(addonFilename).length
-            )}";\n`,
-          });
+          if (extname(appFilename) === '.hbs') {
+            this.emitFile({
+              type: 'asset',
+              fileName: `_app_/${appFilename}`,
+              source: (bundle[appFilename] as any).source,
+            });
+          } else {
+            this.emitFile({
+              type: 'asset',
+              fileName: `_app_/${appFilename}`,
+              source: `export { default } from "${
+                pkg.name
+              }/${addonFilename.slice(0, -extname(addonFilename).length)}";\n`,
+            });
+          }
         }
       }
       let originalAppJS = pkg['ember-addon']?.['app-js'];

--- a/packages/addon-dev/src/rollup-public-entrypoints.ts
+++ b/packages/addon-dev/src/rollup-public-entrypoints.ts
@@ -79,7 +79,7 @@ function isTemplateOnly(matches: string[], filePath: string) {
 
   let correspondingFileGlob = path.join(
     path.dirname(filePath),
-    path.basename(filePath).replace(/hbs$/, '*')
+    `{${path.basename(filePath).replace(/hbs$/, '*')},route.*,controller.*}`
   );
 
   let relatedFiles = matches.filter((match) =>


### PR DESCRIPTION
This adds support for route/controller templates within a v2 addon, which allows an ember-engine type setup using just an ember addon!

This is described in a little more detail in this [discord conversation](https://discord.com/channels/480462759797063690/1156970204820144188).

This narrows the definition of what a template-only component is, by also looking for route and/or controller files alongside the template file. This also expands the reexport plugin to simply copy over template files to the `_app_` directory during the build process so that it can be picked up by the parent app using the addon during the merge process.