### PR TITLE
Allow to pass additional config to addonV1Shim

### DIFF
--- a/packages/addon-shim/src/index.ts
+++ b/packages/addon-shim/src/index.ts
@@ -12,6 +12,7 @@ import { satisfies } from 'semver';
 
 export interface ShimOptions {
   disabled?: (options: any) => boolean;
+  additionalConfig?: object;
 }
 
 function addonMeta(pkgJSON: PackageInfo): AddonMeta {
@@ -167,6 +168,7 @@ export function addonV1Shim(directory: string, options: ShimOptions = {}) {
         (this.parent as EAI2Instance).registerV2Addon(name, root);
       }
     },
+    ...(options.additionalConfig || {}),
   };
 }
 


### PR DESCRIPTION
We're in the process of converting our internal addon to v2 and one thing that we're missing is a way to specify additional options for the ember-cli addon. This PR introduces a way to forward any custom stuff to the ember-cli addon config. In our case this would look like this:

```js
const bodyParser = require('body-parser');
const path = require('path');
const { addonV1Shim } = require('@embroider/addon-shim');

module.exports = addonV1Shim(__dirname, {
  additionalConfig: {
    options: {
      svgJar: {
        sourceDirs: [path.join(__dirname, 'src/assets/icons')],
      },
    },

    testemMiddleware(app) {
      app.post('/write-junit', bodyParser.text({ limit: '100mb' }), function (req, res) {
        // ...implementation omitted...
        res.end();
      });
    },
  },
});
```

One thing is `options` for the addons we're depend on - in this case it's telling `svgJar` to look for icons inside `src` so we can do both things: use icons in the addon and package them up to be used in the apps directly.

Another thing is `testemMiddleware` - there does not seem to be another way to have this middleware, because configuring it via `testem.js` in the apps does not work at all (ember-cli overrides middleware with delegation to the addons).

Not sure if there needs to be a test for this here, any guidance is appreciated. Cheers