### PR TITLE
Perf: Only require.resolve the babel plugin cache busting file once

### DIFF
--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -70,6 +70,10 @@ function gatherAddonCacheKey(project: any): string {
   return cacheKey;
 }
 
+const babelCacheBustingPluginPath: string = require.resolve(
+  '@embroider/shared-internals/src/babel-plugin-cache-busting.js'
+);
+
 export default class MacrosConfig {
   static for(key: any, appRoot: string): MacrosConfig {
     let found = localSharedState.get(key);
@@ -370,11 +374,7 @@ export default class MacrosConfig {
 
     return [
       [join(__dirname, 'babel', 'macros-babel-plugin.js'), opts],
-      [
-        require.resolve('@embroider/shared-internals/src/babel-plugin-cache-busting.js'),
-        { version: cacheKey },
-        `@embroider/macros cache buster: ${owningPackageRoot}`,
-      ],
+      [babelCacheBustingPluginPath, { version: cacheKey }, `@embroider/macros cache buster: ${owningPackageRoot}`],
     ];
   }
 


### PR DESCRIPTION
This gets hit many times during the ember-cli startup phase where the addon graph is initialized, and then once per rebuild. The value shouldn't change, so we can just run it once.

Caching removes the cost highlighted:
<img width="852" alt="resolve-before" src="https://github.com/embroider-build/embroider/assets/20404/cfa834ae-8d6a-43dc-963f-4fbcab80afc6">
