### PR TITLE
use package paths instead of relative paths for app tree resolving

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -641,7 +641,16 @@ export class CompatAppBuilder {
       if (!child.isEngine()) {
         this.findActiveAddons(child, engine, true);
       }
-      engine.addons.set(child, resolvePath(pkg.root, 'package.json'));
+      let canResolveFrom: string;
+      if (pkg === this.appPackageWithMovedDeps) {
+        // we want canResolveFrom to always be a rewritten package path, and our
+        // app's package is not rewritten yet here.
+        canResolveFrom = resolvePath(this.root, 'package.json');
+      } else {
+        // whereas our addons are already moved
+        canResolveFrom = resolvePath(pkg.root, 'package.json');
+      }
+      engine.addons.set(child, canResolveFrom);
     }
     // ensure addons are applied in the correct order, if set (via @embroider/compat/v1-addon)
     if (!isChild) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
     "lodash": "^4.17.21",
     "resolve": "^1.20.0",
     "resolve-package-path": "^4.0.1",
+    "@embroider/reverse-exports": "workspace:*",
     "typescript-memoize": "^1.0.1",
     "walk-sync": "^3.0.0"
   },

--- a/packages/core/src/app-files.ts
+++ b/packages/core/src/app-files.ts
@@ -44,7 +44,7 @@ export class AppFiles {
       combinedFiles.add(f);
     }
 
-    for (let addon of engine.addons) {
+    for (let addon of engine.addons.keys()) {
       let appJS = addon.meta['app-js'];
       if (appJS) {
         for (let filename of Object.keys(appJS)) {
@@ -202,8 +202,8 @@ export class AppFiles {
 export interface Engine {
   // the engine's own package
   package: Package;
-  // the set of active addons in the engine
-  addons: Set<AddonPackage>;
+  // the set of active addons in the engine. For each one we keep track of a file that can resolve the addon, because we'll need that later.
+  addons: Map<AddonPackage, string>;
   // the parent engine, if any
   parent: Engine | undefined;
   // where the engine's own V2 code comes from

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       '@embroider/macros':
         specifier: workspace:*
         version: link:../macros
+      '@embroider/reverse-exports':
+        specifier: workspace:*
+        version: link:../reverse-exports
       '@embroider/shared-internals':
         specifier: workspace:*
         version: link:../shared-internals

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -105,10 +105,12 @@ Scenarios.fromProject(() => new Project())
                   {
                     name: 'my-addon',
                     root: resolve(app.dir, 'node_modules', 'my-addon'),
+                    canResolveFromFile: resolve(app.dir, 'package.json'),
                   },
                   {
                     name: 'a-v1-addon',
                     root: resolve(app.dir, 'node_modules', 'a-v1-addon'),
+                    canResolveFromFile: resolve(app.dir, 'package.json'),
                   },
                 ],
               },


### PR DESCRIPTION
This is blocked on https://github.com/embroider-build/embroider/issues/1651 because we can't really release code that depends on a shakey implementation of reverse-exports. We considered feature-flagging the change but it felt like a lot of work with very little gain 🤔 

~Edit: I made this PR draft since it's blocked on needing `reverse-exports` 👍~

Edit: reverse-exports was added in https://github.com/embroider-build/embroider/pull/1652 so this PR is good to go now