### PR TITLE
don't run CI for all branches starting with v

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches:
       - main
-      - 'v*' # prior release branches (e.g. `v0.30.x` branch)
+      - 'v[0-9]+*' # prior release branches (e.g. `v0.30.x` branch)
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
We noticed that CI was originally running twice for https://github.com/embroider-build/embroider/pull/1653 because the branch name was `virtual-implicit-modules` 🤦 

This PR makes sure that branch pushes only run if it starts with a `v` that is immediately followed by at least one number, it's not a perfect solution but it's a lot better than what we had 😂 