### PR TITLE
fix node version for @embroider/util

### DIFF
--- a/packages/util/ember-cli-build.js
+++ b/packages/util/ember-cli-build.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
-const { maybeEmbroider } = require('@embroider/test-setup');
 
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
@@ -15,13 +14,5 @@ module.exports = function (defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return maybeEmbroider(app, {
-    staticAddonTrees: true,
-    staticAddonTestSupportTrees: true,
-    skipBabel: [
-      {
-        package: 'qunit',
-      },
-    ],
-  });
+  return app.toTree();
 };

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -94,7 +94,7 @@
     "webpack": "^5.74.0"
   },
   "engines": {
-    "node": "14.* || >= 16"
+    "node": "12.* || 14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/tests/scenarios/util-test.ts
+++ b/tests/scenarios/util-test.ts
@@ -7,12 +7,35 @@ import { dirname } from 'path';
 const { module: Qmodule, test } = QUnit;
 
 supportMatrix(Scenarios.fromDir(dirname(require.resolve('@embroider/util/package.json'))))
-  .map('util', () => {})
+  .map('util', project => {
+    project.mergeFiles({
+      '.npmrc': 'use-node-version=12.22.1',
+      'test.js': `
+        const { module: QModule, test } = require("qunit");
+        const semver = require("semver");
+        const { PackageCache } = require("@embroider/shared-internals");
+
+        QModule("shared-internals", function () {
+          test("testing on node 12", function (assert) {
+            assert.ok(
+              semver.satisfies(process.version, "^12.0.0"),
+              \`\${process.version} should be what we expected\`
+            );
+          });
+        });
+      `,
+    });
+  })
   .forEachScenario(scenario => {
     Qmodule(scenario.name, function (hooks) {
       let app: PreparedApp;
       hooks.before(async () => {
         app = await scenario.prepare();
+      });
+
+      test('verify node version', async function (assert) {
+        let result = await app.execute(`pnpm ./node_modules/qunit/bin/qunit.js ./test.js`);
+        assert.equal(result.exitCode, 0, result.output);
       });
 
       test(`pnpm test:ember`, async function (assert) {

--- a/tests/scenarios/util-test.ts
+++ b/tests/scenarios/util-test.ts
@@ -7,6 +7,7 @@ import { dirname } from 'path';
 const { module: Qmodule, test } = QUnit;
 
 supportMatrix(Scenarios.fromDir(dirname(require.resolve('@embroider/util/package.json'))))
+  .only('lts_3_28')
   .map('util', project => {
     project.mergeFiles({
       '.npmrc': 'use-node-version=12.22.1',


### PR DESCRIPTION
I noticed while updating another ember app that `@embroider/util` accidentally dropped support for Node 12 in a minor version so this just fixes that 👍 