### PR TITLE
fix the release-stable CI job

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,12 +4,17 @@ inputs:
   use_lockfile:
     description: 'Whether to use the lockfile vs latest floating dependencies'
     required: false
-    default: true
+    default: "true"
+  use_pinned_node:
+    description: "Whether to use the node version defined in .npmrc"
+    required: false
+    default: "false"
 runs:
   using: 'composite'
   steps:
     - name: remove pinned node version
       run: echo "auto-install-peers=false" > .npmrc
+      if: inputs.use_pinned_node == 'false'
       shell: bash
     - uses: pnpm/action-setup@v2
       name: Install pnpm

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+        with:
+          use_pinned_node: "true"
       - name: Install Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
since #1594 we have been using pnpm to pin our node version [using `.npmrc` to set the `use-node-version` setting](https://github.com/embroider-build/embroider/pull/1594/files#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR2). 

This was fine for local development, but for CI we wanted to rely on a floating major for Node so that it was more in-line with our `--no-lockfile` policy and might show up some issues quicker. To achieve this we [overwrote the .npmrc file to remove the `use-node-version` setting](https://github.com/embroider-build/embroider/pull/1594/files#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530R12) 

This is what was getting picked up by the CI job as being an uncommitted change, so I made it possible to opt-out of this behaviour in our setup action 👍 