### PR TITLE
Fix html clearing on rebuild

### DIFF
--- a/packages/core/src/ember-html.ts
+++ b/packages/core/src/ember-html.ts
@@ -62,11 +62,8 @@ class Placeholder {
 
   clear() {
     let { start, end, parent } = this;
-    let target = start.nextSibling;
-
-    while (target && target !== end) {
-      parent.removeChild(target);
-      target = target.nextSibling;
+    while (start.nextSibling && start.nextSibling !== end) {
+      parent.removeChild(start.nextSibling);
     }
   }
 


### PR DESCRIPTION
There was a regression in #1605 that broke html clearing on rebuilds, which would cause all assets to get duplicated in the DOM.

(After `removeChild(target)`, `target.nextSibling` goes undefined.)

Fixes #1660.