### PR TITLE
reorder extension precedence when searching app-js and fastboot-js trees

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1130,7 +1130,7 @@ export class Resolver {
     if (filename.match(/\.(hbs|js|hbs\.js)$/)) {
       yield filename;
     } else {
-      for (let ext of ['.hbs', '.js', '.hbs.js']) {
+      for (let ext of ['.js', '.hbs.js', '.hbs']) {
         yield `${filename}${ext}`;
       }
     }


### PR DESCRIPTION
As far as I can tell, this should always have been .js before .hbs and we just missed it when adding this.