### PR TITLE
unpin json-stable-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "overrides": {
       "browserslist": "^4.14.0",
       "graceful-fs": "^4.0.0",
-      "@types/eslint": "^8.37.0",
-      "json-stable-stringify": "1.0.2"
+      "@types/eslint": "^8.37.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,6 @@ overrides:
   browserslist: ^4.14.0
   graceful-fs: ^4.0.0
   '@types/eslint': ^8.37.0
-  json-stable-stringify: 1.0.2
 
 importers:
 


### PR DESCRIPTION
This PR essentially reverts https://github.com/embroider-build/embroider/pull/1662 now that a new ember-cli-fastboot verison has been released that fixes the problem: https://github.com/ember-fastboot/ember-cli-fastboot/pull/929