### PR TITLE
Fix looping for unchanged files

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -242,6 +242,13 @@ export class Resolver {
       // no additional fallback is available.
       return resolution;
     }
+
+    if (nextRequest.fromFile === request.fromFile && nextRequest.specifier === request.specifier) {
+      throw new Error(
+        'Bug Discovered! New request is not === original request but has the same fromFile and specifier. This will likely create a loop.'
+      );
+    }
+
     if (nextRequest.isVirtual) {
       // virtual requests are terminal, there is no more beforeResolve or
       // fallbackResolve around them. The defaultResolve is expected to know how


### PR DESCRIPTION
With https://github.com/embroider-build/embroider/pull/1627 we introduced a bug that might allow bundlers to get stuck in a loop.

This PR fixes that problem and adds a guard to the internalResolve function that should hopefully catch any regressions like this in the future 👍 