### PR TITLE
allow apps to disable the decorator transforms

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -241,7 +241,6 @@ export default class CompatApp {
         disableDebugTooling: false,
         disablePresetEnv: false,
         disableEmberModulesAPIPolyfill: false,
-        disableDecoratorTransforms: false,
       },
     });
 


### PR DESCRIPTION
Classic apps can use this setting to disable the decorator transforms, which is useful when we are experimenting with better transforms and the migration toward stage3 decorators. At the moment embroider overrides it, but I don't think that's necessary and we can let the option flow through.