### PR TITLE
fix single asterisk replacement in reverse-exports

### DIFF
--- a/packages/reverse-exports/package.json
+++ b/packages/reverse-exports/package.json
@@ -9,11 +9,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "devDependencies": {
-    "@types/minimatch": "^3.0.4"
-  },
   "dependencies": {
-    "minimatch": "^3.0.4",
     "resolve.exports": "^2.0.2"
   }
 }

--- a/packages/reverse-exports/tests/reverse-exports.test.ts
+++ b/packages/reverse-exports/tests/reverse-exports.test.ts
@@ -140,6 +140,24 @@ describe('reverse exports', function () {
       'You tried to reverse exports for the file `./foo.bar` in package `my-addon` but it does not match any of the exports rules defined in package.json. This means it should not be possible to access directly.'
     );
   });
+
+  it('breaks TODO rename this test to something better', function () {
+    const packageJson = {
+      name: 'my-v2-addon',
+      exports: {
+        '.': './dist/index.js',
+        './*': {
+          types: './dist/*.d.ts',
+          default: './dist/*.js',
+        },
+        './addon-main.js': './addon-main.js',
+      },
+    };
+
+    expect(reversePackageExports(packageJson, './dist/_app_/components/welcome-page.js')).toBe(
+      'my-v2-addon/_app_/components/welcome-page'
+    );
+  });
 });
 
 describe('_findKeyRecursively', function () {

--- a/packages/reverse-exports/tests/reverse-exports.test.ts
+++ b/packages/reverse-exports/tests/reverse-exports.test.ts
@@ -1,4 +1,4 @@
-import reversePackageExports, { _findPathRecursively } from '../src';
+import reversePackageExports, { _findPathRecursively, _prepareStringForRegex } from '../src';
 
 describe('reverse exports', function () {
   it('exports is missing', function () {
@@ -141,7 +141,7 @@ describe('reverse exports', function () {
     );
   });
 
-  it('breaks TODO rename this test to something better', function () {
+  it('conditional exports: using a single asterisk as glob for nested path', function () {
     const packageJson = {
       name: 'my-v2-addon',
       exports: {
@@ -276,5 +276,18 @@ describe('_findKeyRecursively', function () {
     };
 
     expect(_findPathRecursively(exports, str => str === './missing-path.js')).toBe(undefined);
+  });
+});
+
+describe('_prepareStringForRegex', function () {
+  [
+    { input: './foo', expected: '^\\.\\/foo$' },
+    { input: './foo.js', expected: '^\\.\\/foo\\.js$' },
+    { input: './foo/*.js', expected: '^\\.\\/foo\\/.*\\.js$' },
+    { input: './foo/', expected: '^\\.\\/foo\\/.*$' },
+  ].forEach(({ input, expected }) => {
+    it(input, function () {
+      expect(_prepareStringForRegex(input)).toStrictEqual(expected);
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,16 +568,9 @@ importers:
 
   packages/reverse-exports:
     dependencies:
-      minimatch:
-        specifier: ^3.0.4
-        version: 3.1.2
       resolve.exports:
         specifier: ^2.0.2
         version: 2.0.2
-    devDependencies:
-      '@types/minimatch':
-        specifier: ^3.0.4
-        version: 3.0.5
 
   packages/router:
     dependencies:


### PR DESCRIPTION
I took the reverse-exports package out for its first real-world spin today by combining https://github.com/embroider-build/embroider/pull/1648 https://github.com/embroider-build/embroider/pull/1650 and https://github.com/embroider-build/embroider/pull/1653 into one giant mega branch 💪 ... but it didn't work 😂 

I first looked at the error and thought "on no we need to update the blueprint because the exports are wrong" but thinking about it a bit better it looks like our reverse-exports could do with a little bit of love. This is totally expected in the dev process of the package since real-world examples will always beat lab-built ones 👍 

@lolmaus if you could take a look at this and get the test passing that would be super 🎉 