### PR TITLE
Support postcss-loader through postcssLoaderOptions

### DIFF
--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -60,6 +60,11 @@ export interface Options {
   babelLoaderOptions?: BabelLoaderOptions;
 
   /**
+   * Options for [`postcss-loader`](https://webpack.js.org/loaders/postcss-loader)
+   */
+  postcssLoaderOptions?: object;
+
+  /**
    * Options for [`css-loader`](https://webpack.js.org/loaders/css-loader)
    */
   cssLoaderOptions?: object;


### PR DESCRIPTION
Added a new postcssLoaderOptions to packagerOptions.  When these are supplied the postcss-loader is added and the options are passed through.  This seems necessary to support TailwindCSS.

This is an effort to resolve #668 .  It's rather unclear how to develop on Embroider using the monorepo and we're not sure this is the way you'd like to see this supported.  Local hacks do show the approach works.  We did not manage to install our branch through a github dependency on our app, help with that would be much appreciated.

co-author: @erikap