### PR TITLE
[vite] use transform instead of load for gjs & hbs files

### DIFF
--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -3,7 +3,6 @@
 import { createFilter } from '@rollup/pluginutils';
 import type { PluginContext, ResolvedId } from 'rollup';
 import type { Plugin } from 'vite';
-import { readFileSync } from 'fs';
 import { hbsToJS } from '@embroider/core';
 import assertNever from 'assert-never';
 import { parse as pathParse } from 'path';
@@ -27,7 +26,7 @@ export function hbs(): Plugin {
       }
     },
 
-    load(id: string) {
+    transform(source: string, id: string) {
       const meta = getMeta(this, id);
       if (!meta) {
         return;
@@ -35,8 +34,7 @@ export function hbs(): Plugin {
 
       switch (meta.type) {
         case 'template':
-          let input = readFileSync(id.replace(/\.hbs\?.*/, '.hbs'), 'utf8');
-          let code = hbsToJS(input);
+          let code = hbsToJS(source);
           return {
             code,
           };

--- a/packages/vite/src/template-tag.ts
+++ b/packages/vite/src/template-tag.ts
@@ -2,13 +2,13 @@ import { createFilter } from '@rollup/pluginutils';
 import type { Plugin } from 'vite';
 import { Preprocessor } from 'content-tag';
 
-const gjsFilter = createFilter('**/*.{gjs,gts}?(\\?)*');
+const gjsFilter = createFilter('**/*.gjs?(\\?)*');
 
 export function templateTag(): Plugin {
   let preprocessor = new Preprocessor();
 
   function candidates(id: string) {
-    return [id + '.gjs', id + '.gts'];
+    return [id + '.gjs'];
   }
 
   return {

--- a/packages/vite/src/template-tag.ts
+++ b/packages/vite/src/template-tag.ts
@@ -1,15 +1,14 @@
 import { createFilter } from '@rollup/pluginutils';
 import type { Plugin } from 'vite';
-import { readFileSync } from 'fs';
 import { Preprocessor } from 'content-tag';
 
-const gjsFilter = createFilter('**/*.gjs?(\\?)*');
+const gjsFilter = createFilter('**/*.{gjs,gts}?(\\?)*');
 
 export function templateTag(): Plugin {
   let preprocessor = new Preprocessor();
 
   function candidates(id: string) {
-    return [id + '.gjs'];
+    return [id + '.gjs', id + '.gts'];
   }
 
   return {
@@ -40,11 +39,11 @@ export function templateTag(): Plugin {
       }
     },
 
-    load(id: string) {
+    transform(code: string, id: string) {
       if (!gjsFilter(id)) {
         return null;
       }
-      return preprocessor.process(readFileSync(id.replace(/\.gjs\?.*/, '.gjs'), 'utf8'), id);
+      return preprocessor.process(code, id);
     },
   };
 }


### PR DESCRIPTION
use transform function, this simplifies loading of those files without the need to handle paths