### PR TITLE
update the releasing CI job

### DIFF
--- a/.github/workflows/release-plan-preview.yml
+++ b/.github/workflows/release-plan-preview.yml
@@ -4,11 +4,6 @@ on:
     branches:
       - main
 
-env:
-  VOLTA_FEATURE_PNPM: 1
-  branch: "embroider-release-preview"
-  title: "Preview Release"
-
 jobs:
   prepare_release_notes:
     name: Prepare Release Notes
@@ -24,6 +19,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
+        with:
+          use_pinned_node: true
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
@@ -31,13 +28,12 @@ jobs:
           set -x
           # For an unknown reason the `pnpm embroider-release` bin is not
           # wired up as it is locally.
-          plan=$(node ./test-packages/release/src/cli.js explain-plan)
           node ./test-packages/release/src/cli.js prepare
           # Don't print this, because it can be very large
           set +x
           # Have to use this EOF syntax for multi-line strings.
           echo 'text<<EOF' >> $GITHUB_OUTPUT
-          echo "$plan" >> $GITHUB_OUTPUT
+          jq .description .release-plan.json -r >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
@@ -47,9 +43,8 @@ jobs:
           commit-message: "Prepare Release using 'embroider-release'"
           author: "github-actions[bot] <github-actions-bot@users.noreply.github.com>"
           labels: "internal"
-          draft: true
-          branch: ${{ env.branch }}
-          title: ${{ env.title }}
+          branch: embroider-release-preview
+          title: Prepare Release
           body: |
             Preview of the Release.
 


### PR DESCRIPTION
This improves the DX around using the release plan infra (from my learnings in extracting it into https://github.com/embroider-build/release-plan ) 👍 