### PR TITLE
Fix branch elimination for `macroDependencySatisfies`

### DIFF
--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -97,7 +97,9 @@ export function makeFirstTransform(opts: FirstTransformParams) {
             );
           }
           if (node.path.original === 'macroDependencySatisfies') {
-            return literal(dependencySatisfies(node, opts.packageRoot, moduleName, packageCache), env.syntax.builders);
+            return env.syntax.builders.sexpr('macroCondition', [
+              literal(dependencySatisfies(node, opts.packageRoot, moduleName, packageCache), env.syntax.builders),
+            ]);
           }
         },
         MustacheStatement(node: any) {

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -97,8 +97,6 @@ export function makeFirstTransform(opts: FirstTransformParams) {
             );
           }
           if (node.path.original === 'macroDependencySatisfies') {
-            console.log('parent', JSON.stringify(walker.parent, null, 2));
-            console.log('node', JSON.stringify(node, null, 2));
             const staticValue = literal(
               dependencySatisfies(node, opts.packageRoot, moduleName, packageCache),
               env.syntax.builders

--- a/packages/macros/tests/glimmer/dependency-satisfies.test.ts
+++ b/packages/macros/tests/glimmer/dependency-satisfies.test.ts
@@ -29,6 +29,14 @@ describe('dependency satisfies', () => {
       expect(result).toMatch(/@a=\{\{true\}\}/);
     });
 
+    test('in branch', () => {
+      let result = transform(
+        `{{#if (macroDependencySatisfies 'qunit' '^2.8.0')}}<div></div>{{else}}<span></span>{{/if}}`,
+        { filename }
+      );
+      expect(result).toEqual('<div></div>');
+    });
+
     test('emits false for out-of-range package', () => {
       let result = transform(`{{macroDependencySatisfies 'qunit' '^10.0.0'}}`, { filename });
       expect(result).toEqual('{{false}}');

--- a/packages/macros/tests/glimmer/dependency-satisfies.test.ts
+++ b/packages/macros/tests/glimmer/dependency-satisfies.test.ts
@@ -30,11 +30,8 @@ describe('dependency satisfies', () => {
     });
 
     test('in branch', () => {
-      let result = transform(
-        `{{#if (macroDependencySatisfies 'qunit' '^2.8.0')}}<div></div>{{else}}<span></span>{{/if}}`,
-        { filename }
-      );
-      expect(result).toEqual('<div></div>');
+      let result = transform(`{{#if (macroDependencySatisfies 'qunit' '^2.8.0')}}red{{else}}blue{{/if}}`, { filename });
+      expect(result).toEqual('red');
     });
 
     test('emits false for out-of-range package', () => {


### PR DESCRIPTION
This is a follow up to #1468, and should fix https://github.com/ember-animation/ember-animated/pull/647.

The problem is that #1468 only fixed branch elimination for non-runtime macros in JS/TS code via babel, but didn't fix it for templates via glimmer. This fixes `macroDependencySatisfies` by transforming it into a `macroCondition` in the first pass, which will eliminate the branch in the second pass when it's used as a sub-expression.

Writing code like `macroCondition (macroDependencySatisfies 'qunit' '^2.8.0')` will work, but is not ergonomic and is unfriendly.

I don't think this needs to be done for `macroGetConfig` or `macroGetOwnConfig`.