### PR TITLE
Hide base path from public URL of rollup-public-assets

### DIFF
--- a/packages/addon-dev/src/rollup-public-assets.ts
+++ b/packages/addon-dev/src/rollup-public-assets.ts
@@ -20,7 +20,7 @@ export default function publicAssets(
       });
       const publicAssets: Record<string, string> = filenames.reduce(
         (acc: Record<string, string>, v): Record<string, string> => {
-          acc[`./${path}/${v}`] = ['/', pkg.name, '/', path, '/', v].join('');
+          acc[`./${path}/${v}`] = ['/', pkg.name, '/', v].join('');
           return acc;
         },
         {}


### PR DESCRIPTION
This change is to enable a v2 addon to expose its public assets (using `addon.publicAssets()`) under the same URL as a v1 addon would. But currently, the public URL would always include the base path that you pass into the rollup plugin. Say if your v1 addon `my-addon` had `public/foo/bar.jpg`, it would expose taht under the URL of `/my-addon/foo/bar.jpg`. But if converting that to v2 and putting the file into e.g. `src/public/foo/bar.jpg`, then using the rollup plugin it would be exposed as `/my-addon/src/public/foo/bar.jpg`, and no way to get rid off the path (`src/public`).

This change is removing that, which makes this strictly speaking a breaking one though! 🤔 