### PR TITLE
Disable chokidar polling override in tests

### DIFF
--- a/tests/scenarios/helpers/v2-addon.ts
+++ b/tests/scenarios/helpers/v2-addon.ts
@@ -39,11 +39,6 @@ export class DevWatcher {
       configFile.options.map((options: RollupOptions) => {
         options.watch = {
           buildDelay: 20,
-          // Windows doesn't have a good file-watching mechanism (such as inotify),
-          // so we need to tell this `DevWatcher` tool to use chokidar's polling feature
-          chokidar: {
-            usePolling: true,
-          },
         };
         return options;
       })


### PR DESCRIPTION
Ran into bugs/issues with using polling mode when writing tests for #1696, specifically that on my macOS dev environment using polling, when watching a directory it doesn't seem to consistently emit the `added` event. 

Mainly I wanted to see which, if any, tests fail without this option. It also seemed a bit suspect since rollup/chokidar presumably works on windows out of the box? 

Even if this is necessary we may want to limit it to the windows test only (can just set `CHOKIDAR_USEPOLLING` on the job level), since this makes things _less_ realistic everywhere else.