### PR TITLE
add correct extensions to optimizeDeps() config

### DIFF
--- a/packages/vite/src/optimize-deps.ts
+++ b/packages/vite/src/optimize-deps.ts
@@ -8,6 +8,7 @@ export interface OptimizeDeps {
 export function optimizeDeps(): OptimizeDeps {
   return {
     exclude: ['@embroider/macros'],
+    extensions: ['.hbs', '.gjs'],
     esbuildOptions: {
       plugins: [esBuildResolver()],
     },

--- a/packages/vite/tests/optimize-deps.test.ts
+++ b/packages/vite/tests/optimize-deps.test.ts
@@ -6,7 +6,6 @@ describe('optimizeDeps', function () {
 
     expect(actual).toMatchInlineSnapshot(
       {
-        exclude: ['@embroider/macros'],
         esbuildOptions: {
           plugins: [expect.any(Object)],
         },
@@ -20,6 +19,10 @@ describe('optimizeDeps', function () {
         },
         "exclude": [
           "@embroider/macros",
+        ],
+        "extensions": [
+          ".hbs",
+          ".gjs",
         ],
       }
     `


### PR DESCRIPTION
I had done most of the work necessary to use esbuild to correctly load `hbs` or `gjs` files in #1650 but I forgot to add the correct config to the `optimizeDeps()` helper function. 

This PR fixes that 💪 