### PR TITLE
Support engine's lazyLoading boolean config

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -1041,7 +1041,7 @@ export default class V1Addon {
     let built = new IntermediateBuild();
     built.staticMeta['order-index'] = this.orderIdx;
 
-    if (this.options.lazyLoading && this.options.lazyLoading.enabled) {
+    if (this.options.lazyLoading === true || (this.options.lazyLoading && this.options.lazyLoading.enabled)) {
       built.staticMeta['lazy-engine'] = true;
     }
 


### PR DESCRIPTION
Engine's lazyLoading previously used boolean configs `lazyLoading: true`. This re-enables the backwards compatibility inside embroider.

Source: https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/lib/utils/ensure-lazy-loading-hash.js