### PR TITLE
improved resolver logging

### DIFF
--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -25,6 +25,10 @@ export class EsBuildModuleRequest implements ModuleRequest {
     readonly isVirtual: boolean
   ) {}
 
+  get debugType() {
+    return 'esbuild';
+  }
+
   alias(newSpecifier: string) {
     return new EsBuildModuleRequest(newSpecifier, this.fromFile, this.meta, this.isVirtual) as this;
   }

--- a/packages/vite/src/request.ts
+++ b/packages/vite/src/request.ts
@@ -36,6 +36,10 @@ export class RollupModuleRequest implements ModuleRequest {
     readonly meta: Record<string, any> | undefined
   ) {}
 
+  get debugType() {
+    return 'rollup';
+  }
+
   get isVirtual(): boolean {
     return this.specifier.startsWith(virtualPrefix);
   }

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -157,6 +157,10 @@ class WebpackModuleRequest implements ModuleRequest {
     this.meta = state.contextInfo._embroiderMeta ? { ...state.contextInfo._embroiderMeta } : undefined;
   }
 
+  get debugType() {
+    return 'webpack';
+  }
+
   alias(newSpecifier: string) {
     this.state.request = newSpecifier;
     return new WebpackModuleRequest(this.babelLoaderPrefix, this.appRoot, this.state) as this;


### PR DESCRIPTION
 - distinguish the different Request implementations
 - opportunistically shorten filenames
 - use newlines and indents to try to make it more readable