### PR TITLE
Always load ember-testing package eagerly

### DIFF
--- a/packages/compat/src/compat-adapters/ember-source.ts
+++ b/packages/compat/src/compat-adapters/ember-source.ts
@@ -124,11 +124,16 @@ export default class extends V1Addon {
         meta['implicit-modules'] = [];
       }
       meta['implicit-modules'].push('./ember/index.js');
-
-      if (!meta['implicit-test-modules']) {
-        meta['implicit-test-modules'] = [];
+      // before 5.6, Ember uses the AMD loader to decide if it's test-only parts
+      // are present, so we must ensure they're registered. After that it's
+      // enough to evaluate ember-testing, which @embroider/core is hard-coded
+      // to do in the backward-compatible tests bundle.
+      if (!satisfies(this.packageJSON.version, '>= 5.6.0-alpha.0', { includePrerelease: true })) {
+        if (!meta['implicit-test-modules']) {
+          meta['implicit-test-modules'] = [];
+        }
+        meta['implicit-test-modules'].push('./ember-testing/index.js');
       }
-      meta['implicit-test-modules'].push('./ember-testing/index.js');
     }
     return meta;
   }

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -1338,6 +1338,7 @@ export class CompatAppBuilder {
     // packagers to understand. It's better to express it here as a direct
     // module dependency.
     let eagerModules: string[] = [
+      'ember-testing',
       explicitRelative(dirname(myName), this.topAppJSAsset(appFiles, prepared).relativePath),
     ];
 


### PR DESCRIPTION
In ember-source 5.6 (now in beta), we refactored the way Ember and its test-only pieces find each other to no longer be dependent on the AMD loader.

But this mean it's no longer sufficient to `define()` *and not evaluate* the `ember-testing` package in order to install the test support. It must actually get evaluted first.

Note that this bug does not manifest on embroider `main`, because there implicit-test-modules are eagerly evaluated. This is only a problem on stable, when using `staticEmberSource: true`.