### PR TITLE
fix publish for stable branch

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -49,7 +49,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: npm publish
-        run: pnpm release-plan publish
+        run: pnpm release-plan publish --publish-branch=stable
 
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.2.1",
     "prettier": "^2.3.1",
-    "release-plan": "^0.5.1",
+    "release-plan": "^0.6.0",
     "typescript": "^5.1.6"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         specifier: ^2.3.1
         version: 2.8.8
       release-plan:
-        specifier: ^0.5.1
-        version: 0.5.1
+        specifier: ^0.6.0
+        version: 0.6.0
       typescript:
         specifier: ^5.1.6
         version: 5.2.2
@@ -19549,8 +19549,8 @@ packages:
     dependencies:
       jsesc: 0.5.0
 
-  /release-plan@0.5.1:
-    resolution: {integrity: sha512-3GebglBmiCXjkUYETOvWhKttpyufDn+khkW/DAuCRA3dUwbRA/f7Yd5r37kluOgeJ+FSSWM0lYyoYCqV+UKB8Q==}
+  /release-plan@0.6.0:
+    resolution: {integrity: sha512-5c4JdHXPtVDEbC/aNCaTAr+NrVm1NST3rCFSVkdGInXfJ8KLPFWBZ9/AtIniTRb+E6vjJwy33N9DTnuW76iRpQ==}
     hasBin: true
     dependencies:
       '@ef4/lerna-changelog': 2.0.0


### PR DESCRIPTION
we [needed to update relase-plan](https://github.com/embroider-build/release-plan/pull/38) to add an option `--publish-branch` because by default pnpm only allows you to run `pnpm publish` on [main or master](https://pnpm.io/cli/publish#--publish-branch-branch). We are running it on `stable` and it was hanging in CI because it was prompting to know if you wanted to continue.

This PR prevents that from happening again 👍 