### PR TITLE
use meta tag to set global EmberENV

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -359,7 +359,7 @@ export class CompatAppBuilder {
               return e
           }
           var metaName = '${appName}' + '/config/environment';
-          var metaTag = typeof document !== 'undefined && document.querySelector('meta[name="' + metaName + '"]');
+          var metaTag = typeof document !== 'undefined' && document.querySelector('meta[name="' + metaName + '"]');
           if (metaTag) {
             try {
               var rawConfig = document.querySelector('meta[name="' + metaName + '"]').getAttribute('content');

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -358,10 +358,10 @@ export class CompatAppBuilder {
                   e[r] = t[r]
               return e
           }
-          var metaTag = document.querySelector('meta[name="' + metaName + '"]');
+          var metaName = '${appName}' + '/config/environment';
+          var metaTag = typeof document !== 'undefined && document.querySelector('meta[name="' + metaName + '"]');
           if (metaTag) {
             try {
-              var metaName = '${appName}' + '/config/environment';
               var rawConfig = document.querySelector('meta[name="' + metaName + '"]').getAttribute('content');
               var config = JSON.parse(decodeURIComponent(rawConfig));
               window.EmberENV = merge(window.EmberENV || {}, config.EmberENV);


### PR DESCRIPTION
have a single source for ember env.
same as https://github.com/ember-cli/ember-cli/blob/master/lib/broccoli/app-config-from-meta.js

it could also help with rebuilds, as an edit to the config only needs to rebuild the html file