### PR TITLE
[vite] fix for duplicate modules with dep optimizer

### DIFF
--- a/tests/vite-app/app/app.js
+++ b/tests/vite-app/app/app.js
@@ -3,14 +3,6 @@ import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'vite-app/config/environment';
 
-// this is needed because of an issue with the dependency discovery in vite
-// where it is not picking up the dependencies of the gjs file because vite
-// never even asks the dependency discovery code to load this file. We
-// suspect that it has got something to do with the fact that the rewritten
-// app is in node_modules so we will revisit this once we have killed the
-// need for a rewritten_app
-import 'vite-app/components/fancy.gjs';
-
 export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;

--- a/tests/vite-app/vite.config.mjs
+++ b/tests/vite-app/vite.config.mjs
@@ -31,7 +31,6 @@ export default defineConfig({
   ],
   optimizeDeps: optimizeDeps(),
   server: {
-    hmr: false,
     port: 4200,
     watch: {
       ignored: ["!**/node_modules/.embroider/rewritten-app/**"],


### PR DESCRIPTION
Because we do imports from virtual modules, some imports gets rewritten to absolute paths. Those will then be ignored by depa optimizer, since the absolute path contains node_modules
https://github.com/vitejs/vite/issues/13538

https://github.com/vitejs/vite/blob/711dd807610b39538e9955970145d52e4ca1d8c0/packages/vite/src/node/plugins/resolve.ts#LL832C5-L832C44