### PR TITLE
remove missing import from vite index

### DIFF
--- a/packages/vite/index.mjs
+++ b/packages/vite/index.mjs
@@ -3,5 +3,4 @@ export * from './src/esbuild-resolver.js';
 export * from './src/hbs.js';
 export * from './src/scripts.js';
 export * from './src/template-tag.js';
-export * from './src/addons.js';
 export * from './src/optimize-deps.js';


### PR DESCRIPTION
This was removed in https://github.com/embroider-build/embroider/pull/1686 but we forgot to remove this import 🙃 