### PR TITLE
docs: Update addon-author-guide.md

### DIFF
--- a/docs/addon-author-guide.md
+++ b/docs/addon-author-guide.md
@@ -1,6 +1,6 @@
 # Addon Author Guide
 
-This document lays out the recommended best practices for addon authors who want their addons to work in apps built with Embroider.
+This document lays out the recommended best practices for addon authors who want their addons to work in apps built with Embroider. For a step by step guide on how to convert an addon from v1 to v2, see [Guide: Porting an Addon to V2](https://github.com/embroider-build/embroider/blob/main/docs/porting-addons-to-v2.md)
 
 ## Give me the tl;dr: what should I do?
 

--- a/docs/addon-author-guide.md
+++ b/docs/addon-author-guide.md
@@ -1,6 +1,6 @@
 # Addon Author Guide
 
-This document lays out the recommended best practices for addon authors who want their addons to work in apps built with Embroider. For a step by step guide on how to convert an addon from v1 to v2, see [Guide: Porting an Addon to V2](https://github.com/embroider-build/embroider/blob/main/docs/porting-addons-to-v2.md)
+This document lays out the recommended best practices for addon authors who want their addons to work in apps built with Embroider. For a step by step guide on how to convert an addon from v1 to v2, see [Guide: Porting an Addon to V2](./porting-addons-to-v2.md)
 
 ## Give me the tl;dr: what should I do?
 


### PR DESCRIPTION
There is an overlap in concerns between `addon-author-guide.md` and `porting-addons-to-v2.md`

After having mixed the two, I felt a need to link to the detailed step-by-step guide `addon-author-guide.md`, since a lot of the addon-author-guide already mentions strategies to on how to convert.