### PR TITLE
control ember build through vite

### DIFF
--- a/packages/vite/index.d.ts
+++ b/packages/vite/index.d.ts
@@ -4,3 +4,4 @@ export * from './src/hbs.js';
 export * from './src/scripts.js';
 export * from './src/template-tag.js';
 export * from './src/optimize-deps.js';
+export * from './src/build.js';

--- a/packages/vite/index.mjs
+++ b/packages/vite/index.mjs
@@ -4,3 +4,4 @@ export * from './src/hbs.js';
 export * from './src/scripts.js';
 export * from './src/template-tag.js';
 export * from './src/optimize-deps.js';
+export * from './src/build.js';

--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -1,0 +1,40 @@
+import { fork } from 'child_process';
+import type { Plugin } from 'vite';
+
+export function emberBuild(mode: string): Promise<void> {
+  if (mode === 'build') {
+    return new Promise((resolve, reject) => {
+      const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--production'], { silent: true });
+      child.on('exit', code => (code === 0 ? resolve() : reject()));
+    });
+  }
+  return new Promise((resolve, reject) => {
+    const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--watch'], { silent: true });
+    child.on('exit', code => (code === 0 ? resolve() : reject(new Error('ember build --watch failed'))));
+    child.on('spawn', () => {
+      child.stderr?.on('data', data => {
+        console.error(data.toString());
+      });
+      child.stdout!.on('data', data => {
+        console.log(data.toString());
+        if (data.toString().includes('Build successful')) {
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+export function compatPrebuild(): Plugin {
+  let mode = 'build';
+  return {
+    name: 'embroider-builder',
+    enforce: 'pre',
+    configureServer() {
+      mode = 'development';
+    },
+    async buildStart() {
+      await emberBuild(mode);
+    },
+  };
+}

--- a/tests/scenarios/vite-app-test.ts
+++ b/tests/scenarios/vite-app-test.ts
@@ -100,11 +100,6 @@ viteAppScenarios
         });
       }
 
-      test(`pnpm build:ember`, async function (assert) {
-        let result = await app.execute('pnpm build:ember');
-        assert.equal(result.exitCode, 0, result.output);
-      });
-
       test(`pnpm test:ember`, async function (assert) {
         // this will only hang if there is an issue
         assert.timeout(5 * 60 * 1000);
@@ -114,9 +109,7 @@ viteAppScenarios
         assert.ok(result.output.includes('should have Yay for gjs!'), 'should have tested');
         assert.ok(result.output.includes(' -- from gjs test file'), 'should have tested with gjs file');
         assert.ok(result.output.includes(' -- from gts test file'), 'should have tested with gts file');
-        const depCache = readdirSync(
-          join(app.dir, 'node_modules', '.embroider', 'rewritten-app', 'node_modules', '.vite', 'deps')
-        );
+        const depCache = readdirSync(join(app.dir, 'node_modules', '.vite', 'deps'));
         assert.ok(depCache.length > 0, 'should have created cached deps');
       });
     });

--- a/tests/vite-app/package.json
+++ b/tests/vite-app/package.json
@@ -11,7 +11,6 @@
     "test": "tests"
   },
   "scripts": {
-    "build:ember": "ember b",
     "build": "vite build",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:css": "stylelint \"**/*.css\"",
@@ -21,7 +20,6 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "start:prebuild": "ember build --watch",
     "start:dev": "vite",
     "start:test": "vite --open /tests/",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",

--- a/tests/vite-app/package.json
+++ b/tests/vite-app/package.json
@@ -20,7 +20,7 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "start:dev": "vite",
+    "start": "vite",
     "start:test": "vite --open /tests/",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
     "test:ember": "node ./scripts/run-tests.mjs"

--- a/tests/vite-app/vite.config.mjs
+++ b/tests/vite-app/vite.config.mjs
@@ -5,6 +5,7 @@ import {
   scripts,
   templateTag,
   optimizeDeps,
+  compatPrebuild,
 } from "@embroider/vite";
 import { resolve } from "path";
 import { babel } from "@rollup/plugin-babel";
@@ -15,11 +16,13 @@ export default defineConfig({
   root,
   // esbuild in vite does not support decorators
   esbuild: false,
+  cacheDir: resolve("node_modules", ".vite"),
   plugins: [
     hbs(),
     templateTag(),
     scripts(),
     resolver(),
+    compatPrebuild(),
 
     babel({
       babelHelpers: "runtime",


### PR DESCRIPTION
and also force optimizer rebundle when lock file changed.
this also solves an issue where the watcher did not detect changes if embroider build --watch was called after starting vite