### PR TITLE
Allow v1 addons to rely on renaming system even when they have an exp…

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -789,7 +789,7 @@ export class Resolver {
     // ember-source might provide backburner via module renaming, but if you
     // have an explicit dependency on backburner you should still get that real
     // copy.
-    if (!pkg.hasDependency(packageName)) {
+    if (!reliablyResolvable(pkg, packageName)) {
       for (let [candidate, replacement] of Object.entries(this.options.renameModules)) {
         if (candidate === request.specifier) {
           return logTransition(`renameModules`, request, request.alias(replacement));
@@ -1275,6 +1275,11 @@ function isExplicitlyExternal(specifier: string, fromPkg: V2Package): boolean {
 // work because of the symlinking) without setting up "exports" (which makes
 // your own name reliably resolvable)
 function reliablyResolvable(pkg: V2Package, packageName: string) {
+  if (pkg.meta['auto-upgraded'] && !pkg.hasDependency('ember-auto-import')) {
+    // v1 addons without ember-auto-import cannot resolve NPM dependencies
+    return false;
+  }
+
   if (pkg.hasDependency(packageName)) {
     return true;
   }

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -58,13 +58,20 @@ Scenarios.fromProject(() => new Project())
         podModulePrefix?: string;
         renamePackages?: Record<string, string>;
         addonMeta?: Partial<AddonMeta>;
+        addonDependencies?: Record<string, string>;
         fastbootFiles?: { [appName: string]: { localFilename: string; shadowedFilename: string | undefined } };
       }
 
       let configure: (opts?: ConfigureOpts) => Promise<void>;
       let app: PreparedApp;
 
-      function addonPackageJSON(name = 'my-addon', addonMeta?: Partial<AddonMeta>) {
+      function addonPackageJSON(
+        name = 'my-addon',
+        addonMeta?: Partial<AddonMeta>,
+        dependencies: Record<string, string> = {
+          'ember-auto-import': '^2.0.0',
+        }
+      ) {
         return JSON.stringify(
           (() => {
             let meta: AddonMeta = { type: 'addon', version: 2, 'auto-upgraded': true, ...(addonMeta ?? {}) };
@@ -72,9 +79,7 @@ Scenarios.fromProject(() => new Project())
               name,
               keywords: ['ember-addon'],
               'ember-addon': meta,
-              dependencies: {
-                'ember-auto-import': '^2.0.0',
-              },
+              dependencies,
             };
           })(),
           null,
@@ -143,7 +148,11 @@ Scenarios.fromProject(() => new Project())
               module.exports = function(filename) { return true }
             `,
             'node_modules/.embroider/resolver.json': JSON.stringify(resolverOptions),
-            'node_modules/my-addon/package.json': addonPackageJSON('my-addon', opts?.addonMeta),
+            'node_modules/my-addon/package.json': addonPackageJSON(
+              'my-addon',
+              opts?.addonMeta,
+              opts?.addonDependencies
+            ),
           });
 
           expectAudit = await assert.audit({ app: app.dir, 'reuse-build': true });
@@ -837,6 +846,63 @@ Scenarios.fromProject(() => new Project())
               './node_modules/.embroider/rewritten-packages/a-v1-addon.1234/node_modules/a-v1-addon/_app_/components/i-am-implicit.js'
             );
         });
+
+        test('v1 package without auto-import gets renaming support even when it has a dependency', async function () {
+          givenFiles({
+            'node_modules/my-addon/index.js': 'import "renamed-interior"',
+            'node_modules/interior/index.js': '',
+            'node_modules/interior/package.json': addonPackageJSON('interior'),
+            'node_modules/renamed-interior/index.js': '',
+            'node_modules/renamed-interior/package.json': addonPackageJSON('renamed-interior'),
+            'app.js': `import "my-addon"`,
+          });
+
+          await configure({
+            renamePackages: {
+              'renamed-interior': 'interior',
+            },
+            addonDependencies: {
+              interior: '^1.0.0',
+              'renamed-interior': '^1.0.0',
+            },
+          });
+
+          expectAudit
+            .module('./app.js')
+            .resolves('my-addon')
+            .toModule()
+            .resolves('renamed-interior')
+            .to('./node_modules/interior/index.js');
+        });
+      });
+
+      test('v1 package with auto-import does not get renaming support for a dependency', async function () {
+        givenFiles({
+          'node_modules/my-addon/index.js': 'import "renamed-interior"',
+          'node_modules/interior/index.js': '',
+          'node_modules/interior/package.json': addonPackageJSON('interior'),
+          'node_modules/renamed-interior/index.js': '',
+          'node_modules/renamed-interior/package.json': addonPackageJSON('renamed-interior'),
+          'app.js': `import "my-addon"`,
+        });
+
+        await configure({
+          renamePackages: {
+            'renamed-interior': 'interior',
+          },
+          addonDependencies: {
+            interior: '^1.0.0',
+            'renamed-interior': '^1.0.0',
+            'ember-auto-import': '^2.0.0',
+          },
+        });
+
+        expectAudit
+          .module('./app.js')
+          .resolves('my-addon')
+          .toModule()
+          .resolves('renamed-interior')
+          .to('./node_modules/renamed-interior/index.js');
       });
     });
   });


### PR DESCRIPTION
…licit dep

An explicit dependency in package.json is supposed to take precedence over the package renaming system. But v1 addons without ember-auto-import don't actually get to access their explicit package.json dependencies from runtime code, so in that particular situation the renaming rules should still apply.

This was essentialy an asymetry between the check we do here in handleRenaming and the later "v1 package without auto-import" check in prehandleExternal. If an import is going to hit that `external`, it should also have the chance to first hit the renaming rules, avoiding the external entirely in many cases.