### PR TITLE
Allow route templates to be used in v2 addons

### DIFF
--- a/packages/addon-dev/src/rollup-hbs-plugin.ts
+++ b/packages/addon-dev/src/rollup-hbs-plugin.ts
@@ -76,6 +76,18 @@ async function maybeSynthesizeComponentJS(
   if (!templateResolution) {
     return null;
   }
+  // A rather primivite approach that will probably need to be refined.
+  // If an `hbs` file has `templates` in its path, it's considered a route template.
+  if (source.includes('templates')) {
+    return {
+      id: templateResolution.id.replace(/\.hbs$/, '.js'),
+      meta: {
+        'rollup-ember-route-templates-plugin': {
+          type: 'route-template',
+        },
+      },
+    };
+  }
   // we're trying to resolve a JS module but only the corresponding HBS
   // file exists. Synthesize the template-only component JS.
   return {


### PR DESCRIPTION
When compiling `hbs` files, the `rollup-hbs-plugin` in `@embroider/addon-dev` creates a template-only module definition (it “synthesises a module”) when a JS module is attempted to be resolved and no module exists yet:

https://github.com/embroider-build/embroider/blob/289f83d80d133da3de2b342e63f937986248c07d/packages/addon-dev/src/rollup-hbs-plugin.ts#L79-L88

This makes a lot of sense if the only kind of `hbs` file we can encounter is a component template.

Unfortunately, this rules out using route templates which are also `hbs` files: they don't have a corresponding `.js` file and so will be considered a template-only component making them unusable.

I believe that on the long term, the current route templates where the corresponding controller is considered the backing JS class and the route provides the `@model` property will give way to something else (something like [ember-route-template](https://github.com/discourse/ember-route-template)) but that's still some way off and it'd be nice to have an interim solution.

----

I'm aware the PR as it is currently is not mergeable: the assumption that if the import path (the source) has `templates` in the name is too rigid. The PR aims to serve more as a conversation starter as we need this feature in a project and I'd like to explore the correct way to do this.

And this is just one piece of the puzzle: it'd need a "rollup-ember-route-template" Rollup plugin which looks like this:

```js
import { readFileSync } from 'fs';
import { hbsToJS } from '@embroider/core';

function getMeta(context, id) {
  const meta =
    context.getModuleInfo(id)?.meta?.['rollup-ember-route-templates-plugin'];
  if (meta) {
    return meta;
  } else {
    return null;
  }
}

export default function routeTemplates() {
  return {
    name: 'rollup-ember-route-templates-plugin',
    load(id) {
      if (getMeta(this, id)) {
        const hbsFile = id.replace(/\.js$/, '.hbs');
        let input = readFileSync(hbsFile, 'utf8');
        let code = hbsToJS(input);
        return {
          code,
        };
      }
    },
  };
}
```

With this change, Embroider emits a file like this for a route template:

```js
import { precompileTemplate } from '@ember/template-compilation';
import { setComponentTemplate } from '@ember/component';

var TEMPLATE = precompileTemplate("The Caro-Kann Opening\n\n<div class=\"image-container\">\n  <img src=\"/grand-prix/assets/images/caro-kann.webp\" alt=\"Caro Kann Opening\" />\n</div>");

var caroKann = setComponentTemplate(TEMPLATE, precompileTemplate("The Caro-Kann Opening\n\n<div class=\"image-container\">\n  <img src=\"/grand-prix/assets/images/caro-kann.webp\" alt=\"Caro Kann Opening\" />\n</div>"));

export { caroKann as default };
//# sourceMappingURL=caro-kann.js.map
```

You'll notice that a call a`setComponentTemplate` call is inserted by [the Babel template-colocation-plugin](https://github.com/embroider-build/embroider/blob/main/packages/shared-internals/src/template-colocation-plugin.ts) which is incorrect. I'm not exactly sure what should be exported for route templates (maybe just the result of `precompileTemplate`?) but for some reason, the above, incorrect build output works fine 🤷🏼‍♂️ so finding out how to make it right is a next, bonus step :)