### PR TITLE
Make template-colocation-plugin idempotent

### DIFF
--- a/packages/shared-internals/src/template-colocation-plugin.ts
+++ b/packages/shared-internals/src/template-colocation-plugin.ts
@@ -93,6 +93,9 @@ export default function main(babel: typeof Babel) {
       },
 
       ExportDefaultDeclaration(path: NodePath<t.ExportDefaultDeclaration>, state: State) {
+        if (state.associate) {
+          return;
+        }
         let template = getTemplate(path, state);
         if (!template) {
           return;
@@ -131,6 +134,9 @@ export default function main(babel: typeof Babel) {
         }
       },
       ExportNamedDeclaration(path: NodePath<t.ExportNamedDeclaration>, state: State) {
+        if (state.associate) {
+          return;
+        }
         let template = getTemplate(path, state);
         if (!template) {
           return;


### PR DESCRIPTION
It's not possible to have more than one colocated template for a given JS file, so we never need to run again, even if another babel plugin subsequently alters the code.

Fixes https://github.com/ef4/decorator-transforms/issues/16