### PR TITLE
Docs(addon-author-guide)/ remove ewp as an example of …

### DIFF
--- a/docs/addon-author-guide.md
+++ b/docs/addon-author-guide.md
@@ -67,7 +67,7 @@ Another good way to learn about v2 addons is to look at some examples:
 - [ember-stargate](https://github.com/simonihmig/ember-stargate)
 - [glimmer-apollo](https://github.com/josemarluedke/glimmer-apollo)
 
-Several of these examples use a monorepo as a way to keep a clean separation between the addon and the application that holds their test suite. If you're comfortable working with monorepos this is a good solution. On the other hand, monorepos have some tradeoffs and are not always well-supported by all tools, so it's also OK to keep your test app in a subdirectory of your addon. This is closer to how V1 addons work, where `tests/dummy` serves this purpose. See [ember-welcome-page](https://github.com/ember-cli/ember-welcome-page) for an example of not using a monorepo -- instead it has a `test-app` subdirectory and uses the `addon-dev` command from `@embroider/addon-dev` to manage linkage between the addon and the test-app and to manage combining of dependencies from both into a single top-level package.json
+These examples use a monorepo as a way to keep a clean separation between the addon and the application that holds their test suite. This is currently the recommended solution.
 
 We support some tools to make v2 addon development more convenient:
 


### PR DESCRIPTION
Closes #1754

This PR removes the out-of-date paragraph presenting an alternative to monorepos in `addon-author-guide`, with `ember-welcome-page` as an example. `ember-welcome-page` is now a monorepo.