### PR TITLE
Docs porting addons to v2 co location

### DIFF
--- a/docs/porting-addons-to-v2.md
+++ b/docs/porting-addons-to-v2.md
@@ -195,6 +195,8 @@ In this part, we address potential blockers before we actually switch to V2. Thi
 
 1. Make sure all the reexports in `addon/app` follow the default naming convention, such that `addon/app/components/whatever.js` contains only a reexport of `your-addon-name/components/whatever`. If the names don't align, move files around inside `addon/addon` until they do.
 
+1. Make sure your addon has [co-located templates](https://rfcs.emberjs.com/id/0481-component-templates-co-location/). By default, the build tools expect to find the component's `.js` and `.hbs` in the same folder. If your addon used to have an `addon/templates/components` folder, move to co-location. Note that a [codemod](https://www.npmjs.com/package/ember-component-template-colocation-migrator) has been released when co-location has become the recommended structure.
+
 1. Make sure your `addon/index.js` file isn't trying to do anything "interesting". Ideally it contains nothing other than your addon's name.
    - if it was using `app.import()` or `this.import()`, port those usages to `ember-auto-import` instead
    - if you're trying to modify your own source code based on the presence of other packages or based on development vs testing vs production, switch to `@embroider/macros` instead

--- a/docs/porting-addons-to-v2.md
+++ b/docs/porting-addons-to-v2.md
@@ -191,11 +191,11 @@ In this part, we address potential blockers before we actually switch to V2. Thi
 
 1. Make sure your test-app (and docs app if you have one) has `ember-auto-import` >= 2. Once you convert your addon to v2 format, it can only be consumed by apps that have ember-auto-import >= 2. This also means you should plan to make a semver major release to communicate this new requirement to your users.
 
-2. Make sure all the files in the `addon/app` contain _only_ reexport statements. If there's anything that's not a reexport statement, move that code into somewhere in the `addon/addon` directory and reexport it from `addon/app`. This was already best practice, but we're about to enforce it.
+1. Make sure all the files in the `addon/app` contain _only_ reexport statements. If there's anything that's not a reexport statement, move that code into somewhere in the `addon/addon` directory and reexport it from `addon/app`. This was already best practice, but we're about to enforce it.
 
-3. Make sure all the reexports in `addon/app` follow the default naming convention, such that `addon/app/components/whatever.js` contains only a reexport of `your-addon-name/components/whatever`. If the names don't align, move files around inside `addon/addon` until they do.
+1. Make sure all the reexports in `addon/app` follow the default naming convention, such that `addon/app/components/whatever.js` contains only a reexport of `your-addon-name/components/whatever`. If the names don't align, move files around inside `addon/addon` until they do.
 
-4. Make sure your `addon/index.js` file isn't trying to do anything "interesting". Ideally it contains nothing other than your addon's name.
+1. Make sure your `addon/index.js` file isn't trying to do anything "interesting". Ideally it contains nothing other than your addon's name.
    - if it was using `app.import()` or `this.import()`, port those usages to `ember-auto-import` instead
    - if you're trying to modify your own source code based on the presence of other packages or based on development vs testing vs production, switch to `@embroider/macros` instead
    - if you have other cases you're not sure what to do with, ask in an issue on this repo, or https://discuss.emberjs.com, or the #dev-embroider channel in the Ember community discord.


### PR DESCRIPTION
This PR is a proposal to add co-location to the list of pre-requisites to check before starting the conversion actions.

Although co-location has been the recommended structure for a while, there are popular addons still not using it (probably because it's not "essential" refactoring). I came across that case while migrating an addon, and in order to test the documentation, I decided to ignore my intuition and see what happens with a `templates/components` folder. The `.js` and `.hbs` seemed to be compiled as 2 different components, the second being template-only.