### PR TITLE
Backport #1642 to stable:  Allow for more flexible addon-dev appReexports

### DIFF
--- a/packages/addon-dev/src/rollup-app-reexports.ts
+++ b/packages/addon-dev/src/rollup-app-reexports.ts
@@ -8,6 +8,7 @@ export default function appReexports(opts: {
   to: string;
   include: string[];
   mapFilename?: (filename: string) => string;
+  defaultExport?: string;
 }): Plugin {
   return {
     name: 'app-reexports',
@@ -25,21 +26,21 @@ export default function appReexports(opts: {
           this.emitFile({
             type: 'asset',
             fileName: `_app_/${appFilename}`,
-            source: `export { default } from "${pkg.name}/${addonFilename.slice(
-              0,
-              -extname(addonFilename).length
-            )}";\n`,
+            source: `export ${opts.defaultExport} from "${
+              pkg.name
+            }/${addonFilename.slice(0, -extname(addonFilename).length)}";\n`,
           });
         }
       }
       let originalAppJS = pkg['ember-addon']?.['app-js'];
-
-      let hasChanges = JSON.stringify(originalAppJS) !== JSON.stringify(appJS);
+      let newAppJs = Object.assign({}, originalAppJS || {}, appJS);
+      let hasChanges =
+        JSON.stringify(originalAppJS) !== JSON.stringify(newAppJs);
 
       // Don't cause a file i/o event unless something actually changed
       if (hasChanges) {
         pkg['ember-addon'] = Object.assign({}, pkg['ember-addon'], {
-          'app-js': appJS,
+          'app-js': newAppJs,
         });
         writeJsonSync('package.json', pkg, { spaces: 2 });
       }

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -1,4 +1,3 @@
-import { readJsonSync, writeJsonSync } from 'fs-extra';
 import { default as hbs } from './rollup-hbs-plugin';
 import { default as gjs } from './rollup-gjs-plugin';
 import { default as publicEntrypoints } from './rollup-public-entrypoints';
@@ -17,10 +16,6 @@ export class Addon {
   constructor(params: { srcDir?: string; destDir?: string } = {}) {
     this.#srcDir = params.srcDir ?? 'src';
     this.#destDir = params.destDir ?? 'dist';
-
-    let pkg = readJsonSync('package.json');
-    delete pkg['ember-addon']['app-js'];
-    writeJsonSync('package.json', pkg, { spaces: 2 });
   }
 
   // Given a list of globs describing modules in your srcDir, this generates
@@ -30,7 +25,7 @@ export class Addon {
     patterns: string[],
     opts: {
       mapFilename?: (fileName: string) => string;
-      defaultExport?: string;
+      exports?: (filename: string) => string[] | string | undefined;
     } = {}
   ): Plugin {
     return appReexports({
@@ -38,7 +33,7 @@ export class Addon {
       to: this.#destDir,
       include: patterns,
       mapFilename: opts.mapFilename,
-      defaultExport: opts.defaultExport || '{ default }',
+      exports: opts.exports,
     });
   }
 

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -1,3 +1,4 @@
+import { readJsonSync, writeJsonSync } from 'fs-extra';
 import { default as hbs } from './rollup-hbs-plugin';
 import { default as gjs } from './rollup-gjs-plugin';
 import { default as publicEntrypoints } from './rollup-public-entrypoints';
@@ -16,6 +17,10 @@ export class Addon {
   constructor(params: { srcDir?: string; destDir?: string } = {}) {
     this.#srcDir = params.srcDir ?? 'src';
     this.#destDir = params.destDir ?? 'dist';
+
+    let pkg = readJsonSync('package.json');
+    delete pkg['ember-addon']['app-js'];
+    writeJsonSync('package.json', pkg, { spaces: 2 });
   }
 
   // Given a list of globs describing modules in your srcDir, this generates
@@ -23,13 +28,17 @@ export class Addon {
   // package.json metadata to list them all.
   appReexports(
     patterns: string[],
-    opts: { mapFilename?: (fileName: string) => string } = {}
+    opts: {
+      mapFilename?: (fileName: string) => string;
+      defaultExport?: string;
+    } = {}
   ): Plugin {
     return appReexports({
       from: this.#srcDir,
       to: this.#destDir,
       include: patterns,
       mapFilename: opts.mapFilename,
+      defaultExport: opts.defaultExport || '{ default }',
     });
   }
 

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -73,8 +73,7 @@
   "ember-addon": {
     "version": 2,
     "type": "addon",
-    "main": "addon-main.js",
-    "app-js": {}
+    "main": "addon-main.js"
   },
   "exports": {
     ".": "./dist/index.js",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -73,7 +73,8 @@
   "ember-addon": {
     "version": 2,
     "type": "addon",
-    "main": "addon-main.js"
+    "main": "addon-main.js",
+    "app-js": {}
   },
   "exports": {
     ".": "./dist/index.js",

--- a/tests/scenarios/v2-addon-dev-typescript-test.ts
+++ b/tests/scenarios/v2-addon-dev-typescript-test.ts
@@ -95,17 +95,24 @@ appScenarios
           addon.publicEntrypoints([
             'components/**/*.js',
             'initializers/**/*.js',
+            'utils/**/*.js',
           ]),
 
           addon.appReexports([
             'components/demo/index.js',
             'components/demo/out.js',
             'components/demo/namespace-me.js',
+            'initializers/**/*.js',
+            'utils/**/*.js',
           ], {
             mapFilename: (name) => reexportMappings[name] || name,
-          }),
-          addon.appReexports(['initializers/**/*.js'], {
-            defaultExport: '{ default, initialize }',
+            exports: (name) => {
+              if (name.startsWith('initializers/')) {
+                return ['default', 'initialize'];
+              } else if (name.startsWith('utils/')) {
+                return '*';
+              }
+            }
           }),
 
           addon.dependencies(),
@@ -184,6 +191,13 @@ appScenarios
               name: 'demo',
               initialize,
             };
+          `,
+        },
+        utils: {
+          'demo-util.js': `
+            export function demoUtil() {
+              return 42;
+            }
           `,
         },
       },
@@ -270,6 +284,7 @@ appScenarios
             './components/demo/out.js': './dist/_app_/components/demo/out.js',
             './components/demo/namespace/namespace-me.js': './dist/_app_/components/demo/namespace/namespace-me.js',
             './initializers/demo.js': './dist/_app_/initializers/demo.js',
+            './utils/demo-util.js': './dist/_app_/utils/demo-util.js',
           });
         });
 
@@ -281,6 +296,7 @@ appScenarios
             './dist/_app_/components/demo/namespace/namespace-me.js':
               'export { default } from "v2-addon/components/demo/namespace-me";\n',
             './dist/_app_/initializers/demo.js': 'export { default, initialize } from "v2-addon/initializers/demo";\n',
+            './dist/_app_/utils/demo-util.js': 'export * from "v2-addon/utils/demo-util";\n',
           };
 
           assert.strictEqual(

--- a/tests/scenarios/v2-addon-dev-typescript-test.ts
+++ b/tests/scenarios/v2-addon-dev-typescript-test.ts
@@ -21,6 +21,9 @@ appScenarios
     addon.pkg.scripts = {
       build: 'node ./node_modules/rollup/dist/bin/rollup -c ./rollup.config.mjs',
     };
+    addon.pkg['ember-addon']['app-js'] = {
+      './components/previously-added.js': './dist/_app_/components/previously-added.js',
+    };
 
     merge(addon.files, {
       'babel.config.json': `
@@ -91,6 +94,7 @@ appScenarios
         plugins: [
           addon.publicEntrypoints([
             'components/**/*.js',
+            'initializers/**/*.js',
           ]),
 
           addon.appReexports([
@@ -99,6 +103,9 @@ appScenarios
             'components/demo/namespace-me.js',
           ], {
             mapFilename: (name) => reexportMappings[name] || name,
+          }),
+          addon.appReexports(['initializers/**/*.js'], {
+            defaultExport: '{ default, initialize }',
           }),
 
           addon.dependencies(),
@@ -166,6 +173,18 @@ appScenarios
               <this.Button @onClick={{this.flip}} />
             `,
           },
+        },
+        initializers: {
+          'demo.js': `
+            export function initialize() {
+              // Wow, we're doing the init in the app
+            }
+
+            export default {
+              name: 'demo',
+              initialize,
+            };
+          `,
         },
       },
     });
@@ -250,6 +269,7 @@ appScenarios
             './components/demo/index.js': './dist/_app_/components/demo/index.js',
             './components/demo/out.js': './dist/_app_/components/demo/out.js',
             './components/demo/namespace/namespace-me.js': './dist/_app_/components/demo/namespace/namespace-me.js',
+            './initializers/demo.js': './dist/_app_/initializers/demo.js',
           });
         });
 
@@ -260,6 +280,7 @@ appScenarios
             './dist/_app_/components/demo/out.js': 'export { default } from "v2-addon/components/demo/out";\n',
             './dist/_app_/components/demo/namespace/namespace-me.js':
               'export { default } from "v2-addon/components/demo/namespace-me";\n',
+            './dist/_app_/initializers/demo.js': 'export { default, initialize } from "v2-addon/initializers/demo";\n',
           };
 
           assert.strictEqual(


### PR DESCRIPTION
Get the changes from https://github.com/embroider-build/embroider/pull/1642 into `stable`