### PR TITLE
Fix failing addon-dev-js test on main

### DIFF
--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -282,11 +282,11 @@ import Button from "./demo/button.js";
 import Another from "./another.js";
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@ember/component';
-var _class;
+var _SingleFileComponent;
 class SingleFileComponent extends Component {
   doIt() {}
 }
-_class = SingleFileComponent;
+_SingleFileComponent = SingleFileComponent;
 setComponentTemplate(
   precompileTemplate(
   "<div data-test-single-file-component>Hello {{@message}}</div><div data-test-another><Another /></div><Button data-test-button @onClick={{this.doIt}} />",
@@ -296,7 +296,7 @@ setComponentTemplate(
     Button,
   }),
   strictMode: true
-}), _class);
+}), _SingleFileComponent);
 
 export { SingleFileComponent as default };
 //# sourceMappingURL=single-file-component.js.map`);


### PR DESCRIPTION
Seems some dependency version update caused the compilation output to change slightly, making our (brittle!) test fail.

I first saw this on #1777 which is targeting `stable`, but then it also popped up today in this [scheduled CI job on `main`](https://github.com/embroider-build/embroider/actions/runs/7737478347/job/21096585986#step:4:27)