### PR TITLE
vite: fix initializers not running

### DIFF
--- a/tests/vite-app/app/app.js
+++ b/tests/vite-app/app/app.js
@@ -7,6 +7,8 @@ export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
+  init() {
+    loadInitializers(App, config.modulePrefix);
+    super.init();
+  }
 }
-
-loadInitializers(App, config.modulePrefix);

--- a/tests/vite-app/app/app.js
+++ b/tests/vite-app/app/app.js
@@ -7,8 +7,8 @@ export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
-  init() {
+  constructor(...args) {
+    super(...args);
     loadInitializers(App, config.modulePrefix);
-    super.init();
   }
 }

--- a/tests/vite-app/app/initializers/test-init.js
+++ b/tests/vite-app/app/initializers/test-init.js
@@ -1,0 +1,6 @@
+export default {
+  name: 'test-init',
+  initialize(application) {
+    application.__test_init = true;
+  },
+};

--- a/tests/vite-app/app/instance-initializers/test-instance-init.js
+++ b/tests/vite-app/app/instance-initializers/test-instance-init.js
@@ -1,0 +1,6 @@
+export default {
+  name: 'test-instance-initializers',
+  initialize(instance) {
+    instance.__instance_test_init = true;
+  },
+};

--- a/tests/vite-app/tests/acceptance/app-init-test.js
+++ b/tests/vite-app/tests/acceptance/app-init-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { getApplication } from '@ember/test-helpers';
+import { setupApplicationTest } from 'vite-app/tests/helpers';
+
+module('Acceptance | app route', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('loaded initializers /', async function (assert) {
+    const app = getApplication();
+    assert.true([...app._applicationInstances][0].__instance_test_init);
+    assert.true(app.__test_init);
+  });
+});


### PR DESCRIPTION
loadInitializers was called before initalizers where registered via define.
So initializers where not able to run