### PR TITLE
Backport #1760 to stable: Add exclude option to appReexports and publicEntrypoints rollup plugins

### DIFF
--- a/packages/addon-dev/src/rollup-app-reexports.ts
+++ b/packages/addon-dev/src/rollup-app-reexports.ts
@@ -7,6 +7,7 @@ export default function appReexports(opts: {
   from: string;
   to: string;
   include: string[];
+  exclude?: string[];
   mapFilename?: (filename: string) => string;
   exports?: (filename: string) => string[] | string | undefined;
 }): Plugin {
@@ -26,7 +27,8 @@ export default function appReexports(opts: {
 
         if (
           opts.include.some((glob) => minimatch(addonFilename, glob)) &&
-          !minimatch(addonFilename, '**/*.d.ts')
+          !minimatch(addonFilename, '**/*.d.ts') &&
+          opts.exclude?.some((glob) => minimatch(addonFilename, glob)) !== true
         ) {
           appJS[`./${appFilename}`] = `./dist/_app_/${appFilename}`;
           this.emitFile({

--- a/packages/addon-dev/src/rollup-public-entrypoints.ts
+++ b/packages/addon-dev/src/rollup-public-entrypoints.ts
@@ -11,6 +11,7 @@ function normalizeFileExt(fileName: string) {
 export default function publicEntrypoints(args: {
   srcDir: string;
   include: string[];
+  exclude?: string[];
 }): Plugin {
   return {
     name: 'addon-modules',
@@ -19,6 +20,7 @@ export default function publicEntrypoints(args: {
 
       let matches = walkSync(args.srcDir, {
         globs: [...args.include, '**/*.hbs', '**/*.ts', '**/*.gts', '**/*.gjs'],
+        ignore: args.exclude,
       });
 
       for (let name of matches) {

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -42,8 +42,12 @@ export class Addon {
   // This configures rollup to emit public entrypoints for each module in your
   // srcDir that matches one of the given globs. Typical addons will want to
   // match patterns like "components/**/*.js", "index.js", and "test-support.js".
-  publicEntrypoints(patterns: string[]) {
-    return publicEntrypoints({ srcDir: this.#srcDir, include: patterns });
+  publicEntrypoints(patterns: string[], opts: { exclude?: string[] } = {}) {
+    return publicEntrypoints({
+      srcDir: this.#srcDir,
+      include: patterns,
+      exclude: opts.exclude,
+    });
   }
 
   // This wraps standalone .hbs files as Javascript files using inline

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -26,6 +26,7 @@ export class Addon {
     opts: {
       mapFilename?: (fileName: string) => string;
       exports?: (filename: string) => string[] | string | undefined;
+      exclude?: string[];
     } = {}
   ): Plugin {
     return appReexports({
@@ -34,6 +35,7 @@ export class Addon {
       include: patterns,
       mapFilename: opts.mapFilename,
       exports: opts.exports,
+      exclude: opts.exclude,
     });
   }
 

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -62,7 +62,9 @@ appScenarios
           plugins: [
             addon.publicEntrypoints([
               'components/**/*.js',
-            ]),
+            ], {
+              exclude: ['**/-excluded/**/*'],
+            }),
 
             addon.appReexports(['components/**/*.js'], {
               mapFilename: (name) => reexportMappings[name] || name,
@@ -247,11 +249,17 @@ appScenarios
           });
         });
 
-        test('the addon was built successfully', async function () {
+        test('the addon has expected public entrypoints', async function () {
+          expectFile('dist/components/demo/index.js').exists();
+          expectFile('dist/components/demo/out.js').exists();
+          expectFile('dist/components/demo/namespace-me.js').exists();
+          expectFile('dist/components/-excluded/never-import-this.js').doesNotExist();
+        });
+
+        test('the addon has expected app-reexports', async function () {
           expectFile('dist/_app_/components/demo/index.js').matches(
             'export { default } from "v2-addon/components/demo/index"'
           );
-
           expectFile('dist/_app_/components/demo/out.js').matches(
             'export { default } from "v2-addon/components/demo/out"'
           );

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -66,6 +66,7 @@ appScenarios
 
             addon.appReexports(['components/**/*.js'], {
               mapFilename: (name) => reexportMappings[name] || name,
+              exclude: ['**/-excluded/**/*'],
             }),
 
             addon.hbs(),
@@ -139,6 +140,11 @@ appScenarios
               <this.Button @onClick={{this.flip}} />
 
               <div data-test="should-transform">{{transformMe}}</div>
+            `,
+          },
+          '-excluded': {
+            'never-import-this.js': `
+              throw new Exception('This should never have been imported!');
             `,
           },
         },


### PR DESCRIPTION
Get the changes from #1760 into `stable`