### PR TITLE
Bump content-tag and add inline_source_map option for rollup and vite

### DIFF
--- a/packages/addon-dev/package.json
+++ b/packages/addon-dev/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@embroider/core": "workspace:^",
     "@rollup/pluginutils": "^4.1.1",
-    "content-tag": "^1.1.2",
+    "content-tag": "^2.0.1",
     "fs-extra": "^10.0.0",
     "minimatch": "^3.0.4",
     "rollup-plugin-copy-assets": "^2.0.3",

--- a/packages/addon-dev/src/rollup-gjs-plugin.ts
+++ b/packages/addon-dev/src/rollup-gjs-plugin.ts
@@ -8,7 +8,9 @@ const PLUGIN_NAME = 'rollup-gjs-plugin';
 const processor = new Preprocessor();
 // import { parse as pathParse } from 'path';
 
-export default function rollupGjsPlugin(): Plugin {
+export default function rollupGjsPlugin(
+  { inline_source_map } = { inline_source_map: false }
+): Plugin {
   return {
     name: PLUGIN_NAME,
 
@@ -17,7 +19,10 @@ export default function rollupGjsPlugin(): Plugin {
         return null;
       }
       let input = readFileSync(id, 'utf8');
-      let code = processor.process(input, id);
+      let code = processor.process(input, {
+        filename: id,
+        inline_source_map,
+      });
       return {
         code,
       };

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^4.1.1",
     "assert-never": "^1.2.1",
-    "content-tag": "^1.1.2",
+    "content-tag": "^2.0.1",
     "debug": "^4.3.2",
     "fs-extra": "^10.0.0",
     "jsdom": "^16.6.0",

--- a/packages/vite/src/template-tag.ts
+++ b/packages/vite/src/template-tag.ts
@@ -5,7 +5,7 @@ import { Preprocessor } from 'content-tag';
 
 const gjsFilter = createFilter('**/*.gjs');
 
-export function templateTag(): Plugin {
+export function templateTag({ inline_source_map } = { inline_source_map: false }): Plugin {
   let preprocessor = new Preprocessor();
 
   function candidates(id: string) {
@@ -44,7 +44,10 @@ export function templateTag(): Plugin {
       if (!gjsFilter(id)) {
         return null;
       }
-      return preprocessor.process(readFileSync(id, 'utf8'), id);
+      return preprocessor.process(readFileSync(id, 'utf8'), {
+        filename: id,
+        inline_source_map: inline_source_map,
+      });
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: ^4.1.1
         version: 4.2.1
       content-tag:
-        specifier: ^1.1.2
-        version: 1.2.2
+        specifier: ^2.0.1
+        version: 2.0.1
       fs-extra:
         specifier: ^10.0.0
         version: 10.1.0
@@ -900,8 +900,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       content-tag:
-        specifier: ^1.1.2
-        version: 1.2.2
+        specifier: ^2.0.1
+        version: 2.0.1
       debug:
         specifier: ^4.3.2
         version: 4.3.4(supports-color@8.1.1)
@@ -10067,8 +10067,8 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
-  /content-tag@1.2.2:
-    resolution: {integrity: sha512-9guqKIx2H+78N17otBpl8yLZbQGL5q1vBO/jDb3gF2JjixtcVpC62jDUNxjVMNoaZ09oxRX84ZOD6VX02qkVvg==}
+  /content-tag@2.0.1:
+    resolution: {integrity: sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==}
     dev: false
 
   /content-type@1.0.5:


### PR DESCRIPTION
Backport https://github.com/embroider-build/embroider/pull/1784 to `stable`