### PR TITLE
Fix source map option not being passed to plugin

### DIFF
--- a/packages/addon-dev/src/rollup-gjs-plugin.ts
+++ b/packages/addon-dev/src/rollup-gjs-plugin.ts
@@ -9,7 +9,7 @@ const processor = new Preprocessor();
 // import { parse as pathParse } from 'path';
 
 export default function rollupGjsPlugin(
-  { inline_source_map } = { inline_source_map: false }
+  { inline_source_map } = { inline_source_map: true }
 ): Plugin {
   return {
     name: PLUGIN_NAME,

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -57,8 +57,8 @@ export class Addon {
     return hbs();
   }
 
-  gjs() {
-    return gjs();
+  gjs(options?: { inline_source_map: boolean }) {
+    return gjs(options);
   }
 
   // By default rollup does not clear the output directory between builds. This


### PR DESCRIPTION
Sorry about that, checked and now it works 100%
Missed it in https://github.com/embroider-build/embroider/pull/1786 thought plugin was just getting re-exported, my mistake