### PR TITLE
refactor: change isProduction check strategy

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -65,6 +65,10 @@ export default class CompatApp {
     return this.legacyEmberAppInstance.env;
   }
 
+  get isProduction(): boolean {
+    return this.legacyEmberAppInstance.isProduction;
+  }
+
   @Memoize()
   get root(): string {
     if (this.isDummy) {
@@ -754,7 +758,7 @@ export default class CompatApp {
     this.options = optionsWithDefaults(_options);
 
     this.macrosConfig = MacrosConfig.for(legacyEmberAppInstance, this.root);
-    if (this.env !== 'production') {
+    if (!this.isProduction) {
       this.macrosConfig.enablePackageDevelopment(this.root);
       this.macrosConfig.enableRuntimeMode();
       if (this.isDummy) {

--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -57,7 +57,7 @@ function hasFastboot(emberApp: EmberAppInstance | EmberAppInstance) {
 
 function defaultVariants(emberApp: EmberAppInstance): Variant[] {
   let variants: Variant[] = [];
-  if (emberApp.env === 'production') {
+  if (emberApp.isProduction) {
     variants.push({
       name: 'browser',
       runtime: 'browser',

--- a/packages/macros/src/ember-addon-main.ts
+++ b/packages/macros/src/ember-addon-main.ts
@@ -30,7 +30,7 @@ export = {
       }
     }
 
-    if (appInstance.env !== 'production') {
+    if (!appInstance.isProduction) {
       // tell the macros our app is under development
       macrosConfig.enablePackageDevelopment(getAppRoot(appInstance));
       // also tell them our root project is under development. This can be

--- a/packages/shared-internals/src/ember-cli-models.ts
+++ b/packages/shared-internals/src/ember-cli-models.ts
@@ -39,6 +39,7 @@ export interface EmberCliPreprocessRegistry {
 
 export interface EmberAppInstance {
   env: 'development' | 'test' | 'production';
+  isProduction: boolean;
   name: string;
   _scriptOutputFiles: OutputFileToInputFileMap;
   _styleOutputFiles: OutputFileToInputFileMap;


### PR DESCRIPTION
In this PR I aim to essentially change the way Embroider checks whether we're building for `production`. In an `EmberApp` there's a `isProduction` which basically does a `environment === 'production'`. This shouldn't affect anything really.
It's just that we aim to override this `isProduction` in our app because we have a different notion of `isProduction`. We have environment === 'staging', environment === 'native-app' for which we still want Embroider to run it's production optimization logic.