### PR TITLE
Define local types for @embroider/core, since we have no guarantees of the consuming test environment

### DIFF
--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -35,6 +35,18 @@ export function warn(message: string, ...params: any[]) {
   }
 }
 
+/**
+ * This type is normally from QUnit as a global.
+ * But dependents on `@embroider/core` may not be testing with QUnit,
+ * so we can't rely on the global availability of the NestedHooks interface.
+ *
+ * Here, we define only what we use in a way that is compatible with QUnit's types.
+ */
+interface NestedHooks {
+  before: (callback: () => void | Promise<void>) => void;
+  after: (callback: () => void | Promise<void>) => void;
+}
+
 // for use in our test suites
 let hardFailMode = 0;
 export function throwOnWarnings(hooks?: NestedHooks) {
@@ -48,8 +60,14 @@ export function throwOnWarnings(hooks?: NestedHooks) {
     });
   } else {
     // Jest mode
-    beforeAll(() => hardFailMode++);
-    afterAll(() => hardFailMode--);
+    if ('beforeAll' in globalThis && 'afterAll' in globalThis) {
+      /**
+       * Like with QUnit's NestedHooks, we can't be certain that our
+       * consuming environment will provide types for beforeAll and afterAll
+       */
+      (globalThis as any).beforeAll(() => hardFailMode++);
+      (globalThis as any).afterAll(() => hardFailMode--);
+    }
   }
 }
 


### PR DESCRIPTION
This will help with ESM conversion because when our packages type check, they don't (and can't) know if they're going to be used in a Jest or QUnit test environment (or maybe an environment without either of those global types).

The approach here is that we define only what we use for when we receive args, and globals are accessed on `globalThis`, which we can cast to _any_, because we can't know what's on there.

If we want to generate _all_ types for `@embroider/addon-dev` in #1766, we'll need to make sure no package that `@embroider/addon-dev` depends on (nor sub-packages) rely on globally provided types.

This has worked historically for us so far due to a global and single type-checking command with every set of types available at once (which is representative of how our packages can be used :sweat_smile: )