### PR TITLE
Module resolver: virtualize vendor.js

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -457,7 +457,7 @@ export class CompatAppBuilder {
     html.insertStyleLink(html.styles, `assets/${this.origAppPackage.name}.css`);
 
     // virtual-vendor entrypoint
-    html.insertScriptTag(html.implicitScripts, '@embroider/core/vendor');
+    html.insertScriptTag(html.implicitScripts, '@embroider/core/vendor.js');
 
     if (this.fastbootConfig) {
       // any extra fastboot vendor files get inserted into our

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -831,6 +831,7 @@ export class CompatAppBuilder {
     let resolverConfig = this.resolverConfig(appFiles);
     this.addResolverConfig(resolverConfig);
     this.addContentForConfig(this.contentForTree.readContents());
+    this.addEmberEnvConfig(this.configTree.readConfig().EmberENV);
     let babelConfig = await this.babelConfig(resolverConfig);
     this.addBabelConfig(babelConfig);
     writeFileSync(
@@ -930,6 +931,12 @@ export class CompatAppBuilder {
 
   private addContentForConfig(contentForConfig: any) {
     outputJSONSync(join(locateEmbroiderWorkingDir(this.compatApp.root), 'content-for.json'), contentForConfig, {
+      spaces: 2,
+    });
+  }
+
+  private addEmberEnvConfig(emberEnvConfig: any) {
+    outputJSONSync(join(locateEmbroiderWorkingDir(this.compatApp.root), 'ember-env.json'), emberEnvConfig, {
       spaces: 2,
     });
   }

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -948,12 +948,7 @@ export class Resolver {
 
   private handleVendor<R extends ModuleRequest>(request: R): R {
     //TODO move the extra forwardslash handling out into the vite plugin
-    const candidates = [
-      '#embroider/core/vendor',
-      '@embroider/core/vendor',
-      '/@embroider/core/vendor',
-      './@embroider/core/vendor',
-    ];
+    const candidates = ['@embroider/core/vendor.js', '/@embroider/core/vendor.js', './@embroider/core/vendor.js'];
 
     if (!candidates.includes(request.specifier)) {
       return request;
@@ -962,7 +957,7 @@ export class Resolver {
     let pkg = this.packageCache.ownerOfFile(request.fromFile);
     if (pkg?.root !== this.options.engines[0].root) {
       throw new Error(
-        `bug: found an import of ${request.specifier} in ${request.fromFile}, but this is not the top-level Ember app. The top-level Ember app is the only one that has support for @embroider/core/vendor. If you think something should be fixed in Embroider, please open an issue on https://github.com/embroider-build/embroider/issues.`
+        `bug: found an import of ${request.specifier} in ${request.fromFile}, but this is not the top-level Ember app. The top-level Ember app is the only one that has support for @embroider/core/vendor.js. If you think something should be fixed in Embroider, please open an issue on https://github.com/embroider-build/embroider/issues.`
       );
     }
 

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -4,6 +4,7 @@ import { explicitRelative, extensionsPattern } from '.';
 import { compile } from './js-handlebars';
 import { decodeImplicitTestScripts, renderImplicitTestScripts } from './virtual-test-support';
 import { decodeTestSupportStyles, renderTestSupportStyles } from './virtual-test-support-styles';
+import { decodeVirtualVendor, renderVendor } from './virtual-vendor';
 import { decodeVirtualVendorStyles, renderVendorStyles } from './virtual-vendor-styles';
 
 const externalESPrefix = '/@embroider/ext-es/';
@@ -41,6 +42,11 @@ export function virtualContent(filename: string, resolver: Resolver): VirtualCon
   let im = decodeImplicitModules(filename);
   if (im) {
     return renderImplicitModules(im, resolver);
+  }
+
+  let isVendor = decodeVirtualVendor(filename);
+  if (isVendor) {
+    return renderVendor(filename, resolver);
   }
 
   let isImplicitTestScripts = decodeImplicitTestScripts(filename);

--- a/packages/core/src/virtual-vendor.ts
+++ b/packages/core/src/virtual-vendor.ts
@@ -1,11 +1,9 @@
-import { type Package, extensionsPattern } from '@embroider/shared-internals';
+import { type Package } from '@embroider/shared-internals';
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { readFileSync } from 'fs';
 import { sortBy } from 'lodash';
-import { join } from 'path';
 import resolve from 'resolve';
-import walkSync from 'walk-sync';
-import { AppFiles } from './app-files';
+import type { Engine } from './app-files';
 import type { Resolver } from './module-resolver';
 import type { VirtualContentResult } from './virtual-content';
 
@@ -22,26 +20,19 @@ export function renderVendor(filename: string, resolver: Resolver): VirtualConte
 }
 
 function getVendor(owner: Package, resolver: Resolver): string {
-  let engine = resolver.owningEngine(owner);
-  let hasFastboot = Boolean(resolver.options.engines[0]!.activeAddons.find(a => a.name === 'ember-cli-fastboot'));
-  let appFiles = new AppFiles(
-    {
-      package: owner,
-      addons: new Map(
-        engine.activeAddons.map(addon => [
-          resolver.packageCache.get(addon.root) as V2AddonPackage,
-          addon.canResolveFromFile,
-        ])
-      ),
-      isApp: true,
-      modulePrefix: resolver.options.modulePrefix,
-      appRelativePath: 'NOT_USED_DELETE_ME',
-    },
-    getAppFiles(owner.root),
-    hasFastboot ? getFastbootFiles(owner.root) : new Set(),
-    extensionsPattern(resolver.options.resolvableExtensions),
-    resolver.options.podModulePrefix
-  );
+  let engineConfig = resolver.owningEngine(owner);
+  let engine: Engine = {
+    package: owner,
+    addons: new Map(
+      engineConfig.activeAddons.map(addon => [
+        resolver.packageCache.get(addon.root) as V2AddonPackage,
+        addon.canResolveFromFile,
+      ])
+    ),
+    isApp: true,
+    modulePrefix: resolver.options.modulePrefix,
+    appRelativePath: 'NOT_USED_DELETE_ME',
+  };
 
   // TODO - From where do we get this dynamically? in compat-app-builder:
   // let emberENV = this.configTree.readConfig().EmberENV;
@@ -54,23 +45,10 @@ function getVendor(owner: Package, resolver: Resolver): string {
     _TEMPLATE_ONLY_GLIMMER_COMPONENTS: true,
   };
 
-  return generateVendor(appFiles, emberENV);
+  return generateVendor(engine, emberENV);
 }
 
-function getAppFiles(appRoot: string): Set<string> {
-  const files: string[] = walkSync(appRoot, {
-    ignore: ['_babel_config_.js', '_babel_filter_.js', 'app.js', 'assets', 'testem.js', 'node_modules'],
-  });
-  return new Set(files);
-}
-
-function getFastbootFiles(appRoot: string): Set<string> {
-  const appDirPath = join(appRoot, '_fastboot_');
-  const files: string[] = walkSync(appDirPath);
-  return new Set(files);
-}
-
-function generateVendor(engine: AppFiles, emberENV?: unknown): string {
+function generateVendor(engine: Engine, emberENV?: unknown): string {
   // Add addons implicit-scripts
   let vendor: string[] = impliedAddonVendors(engine).map((sourcePath: string): string => {
     let source = readFileSync(sourcePath);
@@ -86,7 +64,7 @@ function generateVendor(engine: AppFiles, emberENV?: unknown): string {
   return vendor.join('') as string;
 }
 
-function impliedAddonVendors({ engine }: AppFiles): string[] {
+function impliedAddonVendors(engine: Engine): string[] {
   let result: Array<string> = [];
   for (let addon of sortBy(Array.from(engine.addons.keys()), pkg => {
     switch (pkg.name) {

--- a/packages/core/src/virtual-vendor.ts
+++ b/packages/core/src/virtual-vendor.ts
@@ -1,0 +1,210 @@
+import type { VirtualContentResult } from './virtual-content';
+import type { Resolver } from './module-resolver';
+import { explicitRelative, type Package, extensionsPattern } from '@embroider/shared-internals';
+import { AppFiles } from './app-files';
+import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
+import walkSync from 'walk-sync';
+import { join } from 'path';
+import type { InMemoryAsset, OnDiskAsset } from './asset';
+// import SourceMapConcat from 'fast-sourcemap-concat';
+import { readFileSync, statSync } from 'fs';
+import { sortBy } from 'lodash';
+import resolve from 'resolve';
+
+class ConcatenatedAsset {
+  kind: 'concatenated-asset' = 'concatenated-asset';
+  constructor(
+    public relativePath: string,
+    public sources: (OnDiskAsset | InMemoryAsset)[],
+    private resolvableExtensions: RegExp
+  ) {}
+  get sourcemapPath() {
+    return this.relativePath.replace(this.resolvableExtensions, '') + '.map';
+  }
+}
+
+export function decodeVirtualVendor(filename: string): boolean {
+  return filename.endsWith('-embroider-vendor.js');
+}
+
+export function renderVendor(filename: string, resolver: Resolver): VirtualContentResult {
+  const vendorScript = vendorContents(filename, resolver);
+  return { src: `${vendorScript}`, watches: [] };
+}
+
+function vendorContents(fromFile: string, resolver: Resolver) {
+  const owner = resolver.packageCache.ownerOfFile(fromFile);
+  if (!owner) {
+    throw new Error(`Failed to find a valid owner for ${fromFile}`);
+  }
+  // TODO: Rebuild the vendor generated in the rewritten-app instead of reading it
+  let asset = implicitScriptsAsset(owner, resolver);
+  if (asset) {
+    let finalAsset = updateImplicitScriptAssetSync(asset);
+    return finalAsset;
+  }
+  return undefined;
+}
+
+function implicitScriptsAsset(owner: Package, resolver: Resolver) {
+  let engine = resolver.owningEngine(owner);
+  let hasFastboot = Boolean(resolver.options.engines[0]!.activeAddons.find(a => a.name === 'ember-cli-fastboot'));
+  let appFiles = new AppFiles(
+    {
+      package: owner,
+      addons: new Map(
+        engine.activeAddons.map(addon => [
+          resolver.packageCache.get(addon.root) as V2AddonPackage,
+          addon.canResolveFromFile,
+        ])
+      ),
+      isApp: true,
+      modulePrefix: resolver.options.modulePrefix,
+      appRelativePath: 'NOT_USED_DELETE_ME',
+    },
+    getAppFiles(owner.root),
+    hasFastboot ? getFastbootFiles(owner.root) : new Set(),
+    extensionsPattern(resolver.options.resolvableExtensions),
+    resolver.options.podModulePrefix
+  );
+
+  // TODO - From where do I get this dynamically?
+  // let emberENV = this.configTree.readConfig().EmberENV;
+  const emberENV = {
+    EXTEND_PROTOTYPES: false,
+    FEATURES: {},
+    _APPLICATION_TEMPLATE_WRAPPER: false,
+    _DEFAULT_ASYNC_OBSERVERS: true,
+    _JQUERY_INTEGRATION: false,
+    _TEMPLATE_ONLY_GLIMMER_COMPONENTS: true,
+  };
+
+  let asset;
+  let implicitScripts = impliedAssets(appFiles, owner.root, emberENV);
+  if (implicitScripts.length > 0) {
+    asset = new ConcatenatedAsset('assets/vendor.js', implicitScripts, /\.js/);
+  }
+  return asset;
+}
+
+function getAppFiles(appRoot: string): Set<string> {
+  const files: string[] = walkSync(appRoot, {
+    ignore: ['_babel_config_.js', '_babel_filter_.js', 'app.js', 'assets', 'testem.js', 'node_modules'],
+  });
+  return new Set(files);
+}
+
+function getFastbootFiles(appRoot: string): Set<string> {
+  const appDirPath = join(appRoot, '_fastboot_');
+  const files: string[] = walkSync(appDirPath);
+  return new Set(files);
+}
+
+function impliedAssets(engine: AppFiles, root: string, emberENV?: unknown): (OnDiskAsset | InMemoryAsset)[] {
+  let result: (OnDiskAsset | InMemoryAsset)[] = impliedAddonAssets(engine).map((sourcePath: string): OnDiskAsset => {
+    let stats = statSync(sourcePath);
+    return {
+      kind: 'on-disk',
+      relativePath: explicitRelative(root, sourcePath),
+      sourcePath,
+      mtime: stats.mtimeMs,
+      size: stats.size,
+    };
+  });
+
+  result.unshift({
+    kind: 'in-memory',
+    relativePath: '_testing_prefix_.js',
+    source: `var runningTests=false;`,
+  });
+
+  result.unshift({
+    kind: 'in-memory',
+    relativePath: '_ember_env_.js',
+    source: `window.EmberENV={ ...(window.EmberENV || {}), ...${JSON.stringify(emberENV, null, 2)} };`,
+  });
+
+  result.push({
+    kind: 'in-memory',
+    relativePath: '_loader_.js',
+    source: `loader.makeDefaultExport=false;`,
+  });
+
+  return result;
+}
+
+function impliedAddonAssets({ engine }: AppFiles): string[] {
+  let result: Array<string> = [];
+  for (let addon of sortBy(Array.from(engine.addons.keys()) /*, scriptPriority.bind(this)*/)) {
+    let implicitScripts = addon.meta['implicit-scripts'];
+    if (implicitScripts) {
+      let options = { basedir: addon.root };
+      for (let mod of implicitScripts) {
+        result.push(resolve.sync(mod, options));
+      }
+    }
+  }
+  return result;
+}
+
+// function scriptPriority(pkg: Package) {
+//   switch (pkg.name) {
+//     case 'loader.js':
+//       return 0;
+//     case 'ember-source':
+//       return 10;
+//     default:
+//       return 1000;
+//   }
+// }
+
+// TODO - the initial function updateConcatenatedAsset is async and relies on SourceMapConcat
+// see commented function below
+function updateImplicitScriptAssetSync(asset: ConcatenatedAsset) {
+  let concat = '';
+  for (let source of asset.sources) {
+    switch (source.kind) {
+      case 'on-disk':
+        let content = readFileSync(source.sourcePath);
+        concat = `${concat}${content}`;
+        break;
+      case 'in-memory':
+        if (typeof source.source !== 'string') {
+          throw new Error(`attempted to concatenated a Buffer-backed in-memory asset`);
+        }
+        concat = `${concat}${source.source}`;
+        break;
+      // default:
+      //   assertNever(source);
+    }
+  }
+  return concat;
+}
+
+// async function updateImplicitScriptAsset(asset: ConcatenatedAsset, root: string, fromFile: string) {
+//   let concat = new SourceMapConcat({
+//     outputFile: fromFile,
+//     mapCommentType: asset.relativePath.endsWith('.js') ? 'line' : 'block',
+//     baseDir: root,
+//   });
+//   if (process.env.EMBROIDER_CONCAT_STATS) {
+//     let MeasureConcat = (await import('@embroider/core/src/measure-concat')).default;
+//     concat = new MeasureConcat(asset.relativePath, concat, root);
+//   }
+//   for (let source of asset.sources) {
+//     switch (source.kind) {
+//       case 'on-disk':
+//         concat.addFile(explicitRelative(root, source.sourcePath));
+//         break;
+//       case 'in-memory':
+//         if (typeof source.source !== 'string') {
+//           throw new Error(`attempted to concatenated a Buffer-backed in-memory asset`);
+//         }
+//         concat.addSpace(source.source);
+//         break;
+//       default:
+//         assertNever(source);
+//     }
+//   }
+//   await concat.end();
+// }

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -63,6 +63,14 @@ export function resolver(): Plugin {
     buildEnd() {
       this.emitFile({
         type: 'asset',
+        fileName: '@embroider/core/vendor.js',
+        source: virtualContent(
+          resolve(resolverLoader.resolver.options.engines[0].root, '-embroider-vendor.js'),
+          resolverLoader.resolver
+        ).src,
+      });
+      this.emitFile({
+        type: 'asset',
         fileName: '@embroider/core/test-support.js',
         source: virtualContent(
           resolve(resolverLoader.resolver.options.engines[0].root, '-embroider-test-support.js'),

--- a/test-packages/support/suite-setup-util.ts
+++ b/test-packages/support/suite-setup-util.ts
@@ -29,6 +29,7 @@ async function githubMatrix() {
     ...suites
       .filter(s => s.name !== 'jest-suites') // TODO: jest tests do not work under windows yet
       .filter(s => !s.name.includes('watch-mode')) // TODO: watch tests are far too slow on windows right now
+      .filter(s => !s.name.endsWith('compat-addon-classic-features-virtual-scripts')) // TODO: these tests are too slow on windows right now
       .map(s => ({
         name: `${s.name} windows`,
         os: 'windows',

--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -1,5 +1,5 @@
 import { throwOnWarnings } from '@embroider/core';
-import { readFileSync } from 'fs';
+import { lstatSync, readFileSync } from 'fs';
 import { merge } from 'lodash';
 import QUnit from 'qunit';
 import type { PreparedApp } from 'scenario-tester';
@@ -125,6 +125,46 @@ appScenarios
           let text = await response.text();
           assert.true(text.includes('<p>Content for body</p>'));
           assert.true(text.includes('<p>Content for custom</p>'));
+        } finally {
+          await server.shutdown();
+        }
+      });
+    });
+  });
+
+appScenarios
+  .map('compat-addon-classic-features-virtual-scripts', () => {})
+  .forEachScenario(scenario => {
+    let app: PreparedApp;
+
+    Qmodule(`${scenario.name} - build mode`, function (hooks) {
+      hooks.before(async assert => {
+        app = await scenario.prepare();
+        let result = await app.execute('pnpm build');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+
+      test('vendor.js script is emitted in the build', async function (assert) {
+        assert.true(lstatSync(`${app.dir}/dist/@embroider/core/vendor.js`).isFile());
+      });
+    });
+
+    Qmodule(`${scenario.name} - dev mode`, function (hooks) {
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test('vendor.js script is served', async function (assert) {
+        const server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+        try {
+          const [, url] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+          let response = await fetch(`${url}/@embroider/core/vendor.js`);
+          assert.strictEqual(response.status, 200);
+          // checking the response status 200 is not enough to assert vendor.js is served,
+          // because when the URL is not recognized, the response contains the index.html
+          // and has a 200 status (for index.html being returned correctly)
+          let text = await response.text();
+          assert.true(!text.includes('<!DOCTYPE html>'));
         } finally {
           await server.shutdown();
         }


### PR DESCRIPTION
Virtualization of the vendor endpoint. 

This PR replaces the script tag `src="assets/vendor.js"` with the virtual entry point `src="@embroider/core/vendor"` in the `index.html` of the rewritten app. The content that was previously written in `assets/vendor.js` is now generated by the `virtual-vendor`'s functions.

**How to test**
- On the main branch:
  - Start the vite-app
  - Visit http://127.0.0.1:4200/assets/vendor.js
- On the `virtual-vendor` branch:
  - Start the vite-app
  - Visit http://127.0.0.1:4200/@embroider/core/vendor.js
- 👀 both files should have the same content
- On the `virtual-vendor` branch, build the vite app
- 👀 There should be a file `dist/@embroider/core/vendor.js` with the same content