### PR TITLE
fix vite auto reload on windows

### DIFF
--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -30,10 +30,10 @@ export function compatPrebuild(): Plugin {
   return {
     name: 'embroider-builder',
     enforce: 'pre',
-    configureServer() {
-      mode = 'development';
-    },
-    async buildStart() {
+    async configResolved(config) {
+      if (config.command === 'serve') {
+        mode = 'development';
+      }
       await emberBuild(mode);
     },
   };


### PR DESCRIPTION
ember build needs to be done before vite starts the server.
that is because vite already starts watching .embroider dir on server start. 

But its a problem for windows if the dir does not exist at that moment or if it gets deleted/replaced. Which is what an ember build does. Windows ends up not receiving updates for files in that directory...