### PR TITLE
vite: fix hbs loading for virtual pair components

### DIFF
--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -1,8 +1,7 @@
 import { dirname, basename, resolve, posix, sep, join } from 'path';
-import { Resolver, AddonPackage, Package, cleanUrl } from '.';
+import type { Resolver, AddonPackage, Package } from '.';
 import { explicitRelative, extensionsPattern } from '.';
 import { compile } from './js-handlebars';
-import { cleanUrl } from '.';
 
 const externalESPrefix = '/@embroider/ext-es/';
 const externalCJSPrefix = '/@embroider/ext-cjs/';
@@ -139,12 +138,11 @@ const pairComponentMarker = '-embroider-pair-component';
 const pairComponentPattern = /^(?<hbsModule>.*)\/(?<jsModule>[^\/]*)-embroider-pair-component$/;
 
 export function virtualPairComponent(hbsModule: string, jsModule: string | undefined): string {
-  let clearHbsModule = cleanUrl(hbsModule);
   let relativeJSModule = '';
   if (jsModule) {
-    relativeJSModule = explicitRelative(clearHbsModule, jsModule);
+    relativeJSModule = explicitRelative(hbsModule, jsModule);
   }
-  return `${clearHbsModule}/${encodeURIComponent(relativeJSModule)}${pairComponentMarker}`;
+  return `${hbsModule}/${encodeURIComponent(relativeJSModule)}${pairComponentMarker}`;
 }
 
 function decodeVirtualPairComponent(

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -1,5 +1,5 @@
 import { dirname, basename, resolve, posix, sep, join } from 'path';
-import type { Resolver, AddonPackage, Package } from '.';
+import { Resolver, AddonPackage, Package, cleanUrl } from '.';
 import { explicitRelative, extensionsPattern } from '.';
 import { compile } from './js-handlebars';
 import { cleanUrl } from '.';

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -2,6 +2,7 @@ import { dirname, basename, resolve, posix, sep, join } from 'path';
 import type { Resolver, AddonPackage, Package } from '.';
 import { explicitRelative, extensionsPattern } from '.';
 import { compile } from './js-handlebars';
+import { cleanUrl } from '.';
 
 const externalESPrefix = '/@embroider/ext-es/';
 const externalCJSPrefix = '/@embroider/ext-cjs/';
@@ -138,11 +139,12 @@ const pairComponentMarker = '-embroider-pair-component';
 const pairComponentPattern = /^(?<hbsModule>.*)\/(?<jsModule>[^\/]*)-embroider-pair-component$/;
 
 export function virtualPairComponent(hbsModule: string, jsModule: string | undefined): string {
+  let clearHbsModule = cleanUrl(hbsModule);
   let relativeJSModule = '';
   if (jsModule) {
-    relativeJSModule = explicitRelative(hbsModule, jsModule);
+    relativeJSModule = explicitRelative(clearHbsModule, jsModule);
   }
-  return `${hbsModule}/${encodeURIComponent(relativeJSModule)}${pairComponentMarker}`;
+  return `${clearHbsModule}/${encodeURIComponent(relativeJSModule)}${pairComponentMarker}`;
 }
 
 function decodeVirtualPairComponent(

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -99,10 +99,13 @@ async function maybeSynthesizeComponentJS(context: PluginContext, source: string
     return null;
   }
 
-  const pkg = resolverLoader.resolver.packageCache.ownerOfFile(templateResolution.id);
-  const isInComponents = pkg?.isV2App() && templateResolution.id.slice(pkg?.root.length).startsWith('/components');
+  const resolvedId = templateResolution.id.split('?')[0];
+  templateResolution.id = resolvedId;
 
-  if (templateResolution.id.endsWith('/template.hbs' || !isInComponents)) {
+  const pkg = resolverLoader.resolver.packageCache.ownerOfFile(resolvedId);
+  const isInComponents = pkg?.isV2App() && resolvedId.slice(pkg?.root.length).startsWith('/components');
+
+  if (resolvedId.endsWith('/template.hbs' || !isInComponents)) {
     return {
       ...templateResolution,
       meta: {

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -1,4 +1,6 @@
 // TODO: I copied this from @embroider/addon-dev, it needs to be its own package
+// (or be in shared-internals or core)
+import { createFilter } from '@rollup/pluginutils';
 import type { PluginContext, ResolvedId } from 'rollup';
 import type { Plugin } from 'vite';
 import { hbsToJS, ResolverLoader } from '@embroider/core';
@@ -130,8 +132,10 @@ async function maybeSynthesizeComponentJS(context: PluginContext, source: string
   };
 }
 
+const hbsFilter = createFilter('**/*.hbs?(\\?)*');
+
 function maybeRewriteHBS(resolution: ResolvedId) {
-  if (!resolution.id.split('?')[0].endsWith('.hbs')) {
+  if (!hbsFilter(resolution.id)) {
     return null;
   }
   debug('emitting hbs rewrite: %s', resolution.id);

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -97,6 +97,18 @@ async function maybeSynthesizeComponentJS(context: PluginContext, source: string
   if (!templateResolution) {
     return null;
   }
+
+  if (templateResolution.id.endsWith('/template.hbs' || templateResolution.id.includes('/templates/'))) {
+    return {
+      ...templateResolution,
+      meta: {
+        'rollup-hbs-plugin': {
+          type: 'template',
+        },
+      },
+    };
+  }
+
   debug(`emitting template only component: %s`, templateResolution.id);
 
   // we're trying to resolve a JS module but only the corresponding HBS

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -105,7 +105,7 @@ async function maybeSynthesizeComponentJS(context: PluginContext, source: string
   const pkg = resolverLoader.resolver.packageCache.ownerOfFile(resolvedId);
   const isInComponents = pkg?.isV2App() && resolvedId.slice(pkg?.root.length).startsWith('/components');
 
-  if (resolvedId.endsWith('/template.hbs' || !isInComponents)) {
+  if (resolvedId.endsWith('/template.hbs') || !isInComponents) {
     return {
       ...templateResolution,
       meta: {

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -1,6 +1,4 @@
 // TODO: I copied this from @embroider/addon-dev, it needs to be its own package
-// (or be in shared-internals or core)
-import { createFilter } from '@rollup/pluginutils';
 import type { PluginContext, ResolvedId } from 'rollup';
 import type { Plugin } from 'vite';
 import { hbsToJS } from '@embroider/core';
@@ -113,10 +111,8 @@ async function maybeSynthesizeComponentJS(context: PluginContext, source: string
   };
 }
 
-const hbsFilter = createFilter('**/*.hbs?(\\?)*');
-
 function maybeRewriteHBS(resolution: ResolvedId) {
-  if (!hbsFilter(resolution.id)) {
+  if (!resolution.id.split('?')[0].endsWith('.hbs')) {
     return null;
   }
   debug('emitting hbs rewrite: %s', resolution.id);

--- a/tests/vite-app/app/components/old/component.js
+++ b/tests/vite-app/app/components/old/component.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class extends Component {
+  message = 'hi';
+}

--- a/tests/vite-app/app/components/old/template.hbs
+++ b/tests/vite-app/app/components/old/template.hbs
@@ -1,0 +1,1 @@
+<div>hey {{@message}} <Fancy /></div>

--- a/tests/vite-app/app/templates/application.hbs
+++ b/tests/vite-app/app/templates/application.hbs
@@ -1,6 +1,7 @@
 {{page-title "ViteApp"}}
 
 <Example @message={{this.model.message}} />
+<Old @message={{this.model.message}} />
 
 <WelcomePage />
 {{! Feel free to remove this! }}


### PR DESCRIPTION
it happens when embroider generates a virtual pair component, the resolved id then looks like `/template.hbs/component.ts-embroider-pair-component`