### PR TITLE
Remove silent option from ember build in compatPrebuild

### DIFF
--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -4,7 +4,7 @@ import type { Plugin } from 'vite';
 export function emberBuild(mode: string): Promise<void> {
   if (mode === 'build') {
     return new Promise((resolve, reject) => {
-      const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--production'], { silent: true });
+      const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--production']);
       child.on('exit', code => (code === 0 ? resolve() : reject()));
     });
   }


### PR DESCRIPTION
Vite does not complete otherwise and no ember build output is shown.