### PR TITLE
Skip checking optional peer deps during dependency-validatior

### DIFF
--- a/packages/shared-internals/src/dep-validation.ts
+++ b/packages/shared-internals/src/dep-validation.ts
@@ -50,6 +50,10 @@ export function validatePeerDependencies(appPackage: Package): PeerDepViolation[
   for (let [pkg, consumptions] of crawlDeps(appPackage)) {
     for (let dep of pkg.dependencies) {
       if (pkg.categorizeDependency(dep.name) === 'peerDependencies') {
+        if (pkg.packageJSON.peerDependenciesMeta?.[dep.name]?.optional) {
+          continue;
+        }
+
         for (let ancestors of consumptions) {
           for (let ancestor of ancestors.slice().reverse()) {
             if (ancestor.hasDependency(dep.name)) {

--- a/packages/shared-internals/src/metadata.ts
+++ b/packages/shared-internals/src/metadata.ts
@@ -53,6 +53,7 @@ export interface PackageInfo {
   module?: string;
   exports?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   devDependencies?: Record<string, string>;
   dependencies?: Record<string, string>;
   'ember-addon':


### PR DESCRIPTION
Draft because I'm still debugging

Most immediately, this affects ember-data 4.12.5.

I don't know if this is _the_ solve, as I don't really know haw to reason about checking if an optional peer declaration is correct or not. Feels like it may depend on runtime -- like if module loading _happens_ pull on the optional peer deps -- so maybe skipping optional peers here is the best we can do?

Open to suggestions

