### PR TITLE
add vite@5 to the peer deps of @embroider/vite

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -4,7 +4,7 @@
   "main": "index.mjs",
   "peerDependencies": {
     "@embroider/core": "workspace:^",
-    "vite": "^4.3.9"
+    "vite": "^4.3.9 || ^5.0.0"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
This just cleans up a warning when running with vite@5