### PR TITLE
Replace content-for using a Vite plugin

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -49,6 +49,7 @@ import assertNever from 'assert-never';
 import { Memoize } from 'typescript-memoize';
 import { join, dirname } from 'path';
 import resolve from 'resolve';
+import type ContentForConfig from './content-for-config';
 import type { V1Config } from './v1-config';
 import type { AddonMeta, Package, PackageInfo } from '@embroider/core';
 import { ensureDirSync, copySync, readdirSync, pathExistsSync } from 'fs-extra';
@@ -74,6 +75,7 @@ export class CompatAppBuilder {
     private options: Required<Options>,
     private compatApp: CompatApp,
     private configTree: V1Config,
+    private contentForTree: ContentForConfig,
     private synthVendor: Package,
     private synthStyles: Package
   ) {}
@@ -896,6 +898,7 @@ export class CompatAppBuilder {
 
     let resolverConfig = this.resolverConfig(appFiles);
     this.addResolverConfig(resolverConfig);
+    this.addContentForConfig(this.contentForTree.readContents());
     let babelConfig = await this.babelConfig(resolverConfig);
     this.addBabelConfig(babelConfig);
     writeFileSync(
@@ -991,6 +994,12 @@ export class CompatAppBuilder {
 
   private addResolverConfig(config: CompatResolverOptions) {
     outputJSONSync(join(locateEmbroiderWorkingDir(this.compatApp.root), 'resolver.json'), config, { spaces: 2 });
+  }
+
+  private addContentForConfig(contentForConfig: any) {
+    outputJSONSync(join(locateEmbroiderWorkingDir(this.compatApp.root), 'content-for.json'), contentForConfig, {
+      spaces: 2,
+    });
   }
 
   private shouldSplitRoute(routeName: string) {

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -150,10 +150,13 @@ export default class CompatApp {
 
   @Memoize()
   private get contentFor(): ContentForConfig {
-    const configPath = join('environments', `${this.legacyEmberAppInstance.env}.json`);
+    const configPaths = [
+      { file: '/index.html', path: join('environments', `${this.legacyEmberAppInstance.env}.json`) },
+    ];
+    if (this.shouldBuildTests) configPaths.push({ file: '/tests/index.html', path: join('environments', `test.json`) });
     return new ContentForConfig(this.configTree, {
       availableContentForTypes: this.options.availableContentForTypes,
-      configPath,
+      configPaths,
       pattern: this.filteredPatternsByContentFor.contentFor,
     });
   }

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -180,6 +180,14 @@ export default class CompatApp {
     });
   }
 
+  private get filteredPatternsByContentFor() {
+    const filter = '/{{content-for [\'"](.+?)["\']}}/g';
+    return {
+      contentFor: this.configReplacePatterns.find((pattern: any) => filter.includes(pattern.match.toString())),
+      others: this.configReplacePatterns.filter((pattern: any) => !filter.includes(pattern.match.toString())),
+    };
+  }
+
   private get htmlTree() {
     if (this.legacyEmberAppInstance.tests) {
       return mergeTrees([this.indexTree, this.testIndexTree]);
@@ -199,7 +207,7 @@ export default class CompatApp {
     return new this.configReplace(index, this.configTree, {
       configPath: join('environments', `${this.legacyEmberAppInstance.env}.json`),
       files: [indexFilePath],
-      patterns: this.configReplacePatterns,
+      patterns: this.filteredPatternsByContentFor.others,
       annotation: 'ConfigReplace/indexTree',
     });
   }
@@ -214,7 +222,7 @@ export default class CompatApp {
     return new this.configReplace(index, this.configTree, {
       configPath: join('environments', `test.json`),
       files: ['tests/index.html'],
-      patterns: this.configReplacePatterns,
+      patterns: this.filteredPatternsByContentFor.others,
       annotation: 'ConfigReplace/testIndexTree',
     });
   }

--- a/packages/compat/src/content-for-config.ts
+++ b/packages/compat/src/content-for-config.ts
@@ -1,0 +1,49 @@
+import Plugin from 'broccoli-plugin';
+import type { Node } from 'broccoli-node-api';
+
+export default class ContentForConfig extends Plugin {
+  // The object keys are the content types and each value is the HTML
+  // code that should replace the corresponding {{content-for}}
+  // Example: { body: '<p>This snippet replaces content-for \"body\" in the app index.html</p>' }
+  private contentFor: any;
+
+  private defaultContentForTypes = [
+    'head',
+    'test-head',
+    'head-footer',
+    'test-head-footer',
+    'body',
+    'test-body',
+    'body-footer',
+    'test-body-footer',
+    'config-module',
+    'app-boot',
+  ];
+
+  constructor(configTree: Node, private options: any) {
+    super([configTree], {
+      annotation: 'embroider:content-for-config',
+      persistentOutput: true,
+      needsCache: false,
+    });
+  }
+
+  readContents() {
+    if (!this.contentFor) {
+      throw new Error(`ContentForConfig not available until after the build`);
+    }
+    return this.contentFor;
+  }
+
+  build() {
+    if (!this.contentFor) this.contentFor = {};
+    const availableContentForTypes = this.options.availableContentForTypes ?? [];
+    const extendedContentTypes = new Set([...this.defaultContentForTypes, ...availableContentForTypes]);
+
+    extendedContentTypes.forEach(contentType => {
+      if (!this.contentFor[contentType]) {
+        this.contentFor[contentType] = `<p>Placeholder for "${contentType}" in the app index.html</p>`;
+      }
+    });
+  }
+}

--- a/packages/compat/src/content-for-config.ts
+++ b/packages/compat/src/content-for-config.ts
@@ -1,5 +1,7 @@
 import Plugin from 'broccoli-plugin';
 import type { Node } from 'broccoli-node-api';
+import { readFileSync } from 'fs-extra';
+import { join } from 'path';
 
 export default class ContentForConfig extends Plugin {
   // The object keys are the content types and each value is the HTML
@@ -41,9 +43,16 @@ export default class ContentForConfig extends Plugin {
     const extendedContentTypes = new Set([...this.defaultContentForTypes, ...availableContentForTypes]);
 
     extendedContentTypes.forEach(contentType => {
+      const matchExp = this.options.pattern.match;
       if (!this.contentFor[contentType]) {
-        this.contentFor[contentType] = `<p>Placeholder for "${contentType}" in the app index.html</p>`;
+        let contents = this.options.pattern.replacement.call(null, this.getAppConfig(), matchExp, contentType);
+        this.contentFor[contentType] = contents;
       }
     });
+  }
+
+  getAppConfig() {
+    let config = readFileSync(join(this.inputPaths[0], this.options.configPath), { encoding: 'utf8' });
+    return JSON.parse(config);
   }
 }

--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -95,6 +95,13 @@ export default interface Options extends CoreOptions {
   // it on in production. But it can be helpful when testing how much of your
   // app is able to work with staticComponents enabled.
   allowUnsafeDynamicComponents?: boolean;
+
+  // Allows you to customize the list of content types addons use to provide HTML
+  // to {{content-for}}. By default, the following content types are expected:
+  // 'head', 'test-head', 'head-footer', 'test-head-footer', 'body', 'test-body',
+  // 'body-footer', 'test-body-footer'. You need to use this config only to extend
+  // this list.
+  availableContentForTypes?: string[];
 }
 
 const defaults = Object.assign(coreWithDefaults(), {
@@ -106,6 +113,7 @@ const defaults = Object.assign(coreWithDefaults(), {
   workspaceDir: null,
   packageRules: [],
   allowUnsafeDynamicComponents: false,
+  availableContentForTypes: [],
 });
 
 export function optionsWithDefaults(options?: Options): Required<Options> {

--- a/packages/vite/index.mjs
+++ b/packages/vite/index.mjs
@@ -6,3 +6,4 @@ export * from './src/template-tag.js';
 export * from './src/optimize-deps.js';
 export * from './src/build.js';
 export * from './src/assets.js';
+export * from './src/content-for.js';

--- a/packages/vite/src/content-for.ts
+++ b/packages/vite/src/content-for.ts
@@ -1,0 +1,18 @@
+import type { Plugin } from 'vite';
+import { readJSONSync } from 'fs-extra';
+import { join } from 'path';
+import { locateEmbroiderWorkingDir } from '@embroider/core';
+
+export function contentFor(): Plugin {
+  return {
+    name: 'embroider-content-for',
+
+    transformIndexHtml(html) {
+      let config: any = readJSONSync(join(locateEmbroiderWorkingDir(process.cwd()), 'content-for.json'));
+      for (const [contentType, htmlContent] of Object.entries(config)) {
+        html = html.replace(`{{content-for "${contentType}"}}`, `${htmlContent}`);
+      }
+      return html;
+    },
+  };
+}

--- a/packages/vite/src/content-for.ts
+++ b/packages/vite/src/content-for.ts
@@ -7,9 +7,10 @@ export function contentFor(): Plugin {
   return {
     name: 'embroider-content-for',
 
-    transformIndexHtml(html) {
+    transformIndexHtml(html, { path }) {
       let config: any = readJSONSync(join(locateEmbroiderWorkingDir(process.cwd()), 'content-for.json'));
-      for (const [contentType, htmlContent] of Object.entries(config)) {
+      let contentsForConfig = config[path];
+      for (const [contentType, htmlContent] of Object.entries(contentsForConfig)) {
         html = html.replace(`{{content-for "${contentType}"}}`, `${htmlContent}`);
       }
       return html;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1971,159 +1971,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/addon-shim
 
-  tests/vite-app:
-    devDependencies:
-      '@babel/core':
-        specifier: ^7.23.6
-        version: 7.23.9
-      '@babel/eslint-parser':
-        specifier: ^7.22.5
-        version: 7.23.10(@babel/core@7.23.9)(eslint@8.57.0)
-      '@babel/plugin-proposal-decorators':
-        specifier: ^7.23.6
-        version: 7.23.9(@babel/core@7.23.9)
-      '@ember/optional-features':
-        specifier: ^2.0.0
-        version: 2.1.0
-      '@ember/string':
-        specifier: ^3.1.1
-        version: 3.1.1
-      '@ember/test-helpers':
-        specifier: ^3.0.3
-        version: 3.3.0(ember-source@5.7.0-beta.1)
-      '@embroider/compat':
-        specifier: workspace:*
-        version: link:../../packages/compat
-      '@embroider/core':
-        specifier: workspace:*
-        version: link:../../packages/core
-      '@embroider/vite':
-        specifier: workspace:*
-        version: link:../../packages/vite
-      '@glimmer/component':
-        specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.23.9)
-      '@glimmer/tracking':
-        specifier: ^1.1.2
-        version: 1.1.2
-      '@rollup/plugin-babel':
-        specifier: ^5.3.1
-        version: 5.3.1(@babel/core@7.23.9)(rollup@3.29.4)
-      broccoli-asset-rev:
-        specifier: ^3.0.0
-        version: 3.0.0
-      concurrently:
-        specifier: ^8.2.0
-        version: 8.2.2
-      ember-auto-import:
-        specifier: ^2.6.3
-        version: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
-      ember-cli:
-        specifier: ~5.0.0
-        version: 5.0.0
-      ember-cli-app-version:
-        specifier: ^6.0.0
-        version: 6.0.1(ember-source@5.7.0-beta.1)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.23.9)
-      ember-cli-clean-css:
-        specifier: ^2.0.0
-        version: 2.0.1
-      ember-cli-dependency-checker:
-        specifier: ^3.3.1
-        version: 3.3.2(ember-cli@5.0.0)
-      ember-cli-htmlbars:
-        specifier: ^6.2.0
-        version: 6.3.0
-      ember-cli-inject-live-reload:
-        specifier: ^2.1.0
-        version: 2.1.0
-      ember-cli-sri:
-        specifier: ^2.1.1
-        version: 2.1.1
-      ember-cli-terser:
-        specifier: ^4.0.2
-        version: 4.0.2
-      ember-load-initializers:
-        specifier: ^2.1.2
-        version: 2.1.2(@babel/core@7.23.9)
-      ember-modifier:
-        specifier: ^4.1.0
-        version: 4.1.0(ember-source@5.7.0-beta.1)
-      ember-page-title:
-        specifier: ^7.0.0
-        version: 7.0.0
-      ember-qunit:
-        specifier: ^7.0.0
-        version: 7.0.0(@ember/test-helpers@3.3.0)(ember-source@5.7.0-beta.1)(qunit@2.20.1)
-      ember-resolver:
-        specifier: ^10.1.0
-        version: 10.1.1(@ember/string@3.1.1)(ember-source@5.7.0-beta.1)
-      ember-source:
-        specifier: 5.7.0-beta.1
-        version: 5.7.0-beta.1(@babel/core@7.23.9)(@glimmer/component@1.1.2)
-      ember-template-lint:
-        specifier: ^5.10.3
-        version: 5.13.0
-      ember-welcome-page:
-        specifier: ^7.0.2
-        version: 7.0.2
-      eslint:
-        specifier: ^8.42.0
-        version: 8.57.0
-      eslint-config-prettier:
-        specifier: ^8.8.0
-        version: 8.10.0(eslint@8.57.0)
-      eslint-plugin-ember:
-        specifier: ^11.8.0
-        version: 11.12.0(eslint@8.57.0)
-      eslint-plugin-n:
-        specifier: ^16.0.0
-        version: 16.6.2(eslint@8.57.0)
-      eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
-      eslint-plugin-qunit:
-        specifier: ^7.3.4
-        version: 7.3.4(eslint@8.57.0)
-      js-reporters:
-        specifier: ^2.1.0
-        version: 2.1.0
-      loader.js:
-        specifier: ^4.7.0
-        version: 4.7.0
-      prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
-      puppeteer-chromium-resolver:
-        specifier: ^21.0.0
-        version: 21.0.0
-      qunit:
-        specifier: ^2.19.4
-        version: 2.20.1
-      qunit-dom:
-        specifier: ^2.0.0
-        version: 2.0.0
-      stylelint:
-        specifier: ^15.7.0
-        version: 15.11.0(typescript@5.2.2)
-      stylelint-config-standard:
-        specifier: ^33.0.0
-        version: 33.0.0(stylelint@15.11.0)
-      stylelint-prettier:
-        specifier: ^3.0.0
-        version: 3.0.0(prettier@2.8.8)(stylelint@15.11.0)
-      tracked-built-ins:
-        specifier: ^3.1.1
-        version: 3.3.0
-      typescript:
-        specifier: ^5.1.6
-        version: 5.2.2
-      vite:
-        specifier: ^5.0.9
-        version: 5.1.4
-
   types/broccoli: {}
 
   types/broccoli-concat:
@@ -5661,28 +5508,6 @@ packages:
       - webpack
     dev: true
 
-  /@ember/test-helpers@3.3.0(ember-source@5.7.0-beta.1):
-    resolution: {integrity: sha512-HEI28wtjnQuEj9+DstHUEEKPtqPAEVN9AAVr4EifVCd3DyEDy0m6hFT4qbap1WxAIktLja2QXGJg50lVWzZc5g==}
-    engines: {node: 16.* || >= 18}
-    peerDependencies:
-      ember-source: ^4.0.0 || ^5.0.0
-    dependencies:
-      '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.13.5(@glint/template@1.3.0)
-      '@simple-dom/interface': 1.4.0
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      dom-element-descriptors: 0.5.0
-      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 6.3.0
-      ember-source: 5.7.0-beta.1(@babel/core@7.23.9)(@glimmer/component@1.1.2)
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-      - webpack
-    dev: true
-
   /@ember/test-waiters@3.1.0:
     resolution: {integrity: sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==}
     engines: {node: 10.* || 12.* || >= 14.*}
@@ -8539,22 +8364,6 @@ packages:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: true
 
-  /@puppeteer/browsers@1.9.1:
-    resolution: {integrity: sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==}
-    engines: {node: '>=16.3.0'}
-    hasBin: true
-    dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
-      extract-zip: 2.0.1
-      progress: 2.0.3
-      proxy-agent: 6.3.1
-      tar-fs: 3.0.4
-      unbzip2-stream: 1.4.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@rollup/plugin-babel@5.3.1(@babel/core@7.23.9)(rollup@3.29.4):
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
@@ -8914,10 +8723,6 @@ packages:
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
-
-  /@tootallnate/quickjs-emscripten@0.23.0:
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-    dev: true
 
   /@tsconfig/ember@1.0.1:
     resolution: {integrity: sha512-aPzLw5BfQxsFPrh5fNDOK4SbSkp2q5fMlrKVeniVjMz1lAcyOh2eH5THkKKcBi1YN1/fbMdAWN/dKGW6lg2+8g==}
@@ -9307,14 +9112,6 @@ packages:
     resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
     dependencies:
       '@types/yargs-parser': 21.0.3
-
-  /@types/yauzl@2.10.3:
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-    requiresBuild: true
-    dependencies:
-      '@types/node': 15.14.9
-    dev: true
-    optional: true
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.2.2):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -9759,15 +9556,6 @@ packages:
       - supports-color
     dev: false
 
-  /agent-base@7.1.0:
-    resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
-    engines: {node: '>= 14'}
-    dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /agentkeepalive@4.5.0:
     resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
     engines: {node: '>= 8.0.0'}
@@ -10142,13 +9930,6 @@ packages:
     resolution: {integrity: sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==}
     engines: {node: '>=4'}
 
-  /ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
-    dependencies:
-      tslib: 2.6.2
-    dev: true
-
   /astral-regex@1.0.0:
     resolution: {integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==}
     engines: {node: '>=4'}
@@ -10219,10 +10000,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       possible-typed-array-names: 1.0.0
-
-  /b4a@1.6.6:
-    resolution: {integrity: sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==}
-    dev: true
 
   /babel-code-frame@6.26.0:
     resolution: {integrity: sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==}
@@ -11040,12 +10817,6 @@ packages:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
     dev: true
 
-  /bare-events@2.2.0:
-    resolution: {integrity: sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
@@ -11071,11 +10842,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       safe-buffer: 5.1.2
-
-  /basic-ftp@5.0.4:
-    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
-    engines: {node: '>=10.0.0'}
-    dev: true
 
   /before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
@@ -11938,10 +11704,6 @@ packages:
     dependencies:
       node-int64: 0.4.0
 
-  /buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-    dev: true
-
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -12174,16 +11936,6 @@ packages:
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
-
-  /chromium-bidi@0.5.8(devtools-protocol@0.0.1232444):
-    resolution: {integrity: sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==}
-    peerDependencies:
-      devtools-protocol: '*'
-    dependencies:
-      devtools-protocol: 0.0.1232444
-      mitt: 3.0.1
-      urlpattern-polyfill: 10.0.0
-    dev: true
 
   /ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
@@ -12866,14 +12618,6 @@ packages:
       cross-spawn: 7.0.3
     dev: true
 
-  /cross-fetch@4.0.0:
-    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
   /cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
@@ -13012,11 +12756,6 @@ packages:
 
   /data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
-    dev: true
-
-  /data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
     dev: true
 
   /data-urls@2.0.0:
@@ -13187,15 +12926,6 @@ packages:
       is-descriptor: 1.0.3
       isobject: 3.0.1
 
-  /degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
-    dev: true
-
   /del@5.1.0:
     resolution: {integrity: sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==}
     engines: {node: '>=8'}
@@ -13264,10 +12994,6 @@ packages:
 
   /dettle@1.0.1:
     resolution: {integrity: sha512-/oD3At60ZfhgzpofJtyClNTrIACyMdRe+ih0YiHzAniN0IZnLdLpEzgR6RtGs3kowxUkTnvV/4t1FBxXMUdusQ==}
-    dev: true
-
-  /devtools-protocol@0.0.1232444:
-    resolution: {integrity: sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==}
     dev: true
 
   /diff-sequences@29.6.3:
@@ -13378,10 +13104,6 @@ packages:
 
   /ee-first@1.1.1:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
-
-  /eight-colors@1.3.0:
-    resolution: {integrity: sha512-hVoK898cR71ADj7L1LZWaECLaSkzzPtqGXIaKv4K6Pzb72QgjLVsQaNI+ELDQQshzFvgp5xTPkaYkPGqw3YR+g==}
-    dev: true
 
   /electron-to-chromium@1.4.681:
     resolution: {integrity: sha512-1PpuqJUFWoXZ1E54m8bsLPVYwIVCRzvaL+n5cjigGga4z854abDnFRc+cTa2th4S79kyGqya/1xoR7h+Y5G5lg==}
@@ -13543,19 +13265,6 @@ packages:
     dependencies:
       ember-cli-babel: 7.26.11
       ember-source: 5.3.0(@babel/core@7.23.9)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
-      git-repo-info: 2.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /ember-cli-app-version@6.0.1(ember-source@5.7.0-beta.1):
-    resolution: {integrity: sha512-XA1FwkWA5QytmWF0jcJqEr3jcZoiCl9Fb33TZgOVfClL7Voxe+/RwzISEprBRQgbf7j8z1xf8/RJCKfclUy3rQ==}
-    engines: {node: 14.* || 16.* || >= 18}
-    peerDependencies:
-      ember-source: ^3.28.0 || >= 4.0.0
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-source: 5.7.0-beta.1(@babel/core@7.23.9)(@glimmer/component@1.1.2)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -15647,22 +15356,6 @@ packages:
       - supports-color
     dev: true
 
-  /ember-modifier@4.1.0(ember-source@5.7.0-beta.1):
-    resolution: {integrity: sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==}
-    peerDependencies:
-      ember-source: '*'
-    peerDependenciesMeta:
-      ember-source:
-        optional: true
-    dependencies:
-      '@embroider/addon-shim': 1.8.7
-      ember-cli-normalize-entity-name: 1.0.0
-      ember-cli-string-utils: 1.1.0
-      ember-source: 5.7.0-beta.1(@babel/core@7.23.9)(@glimmer/component@1.1.2)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /ember-named-blocks-polyfill@0.2.5:
     resolution: {integrity: sha512-OVMxzkfqJrEvmiky7gFzmuTaImCGm7DOudHWTdMBPO7E+dQSunrcRsJMgO9ZZ56suqBIz/yXbEURrmGS+avHxA==}
     engines: {node: 10.* || >= 12}
@@ -15850,32 +15543,6 @@ packages:
       - webpack
     dev: true
 
-  /ember-qunit@7.0.0(@ember/test-helpers@3.3.0)(ember-source@5.7.0-beta.1)(qunit@2.20.1):
-    resolution: {integrity: sha512-KhrndHYEXsHnXvmsGyJLJQ6VCudXaRs5dzPZBsdttZJIhsB6PmYAvq2Q+mh3GRDT/59T/sRDrB3FD3/lATS8aA==}
-    engines: {node: 16.* || >= 18}
-    peerDependencies:
-      '@ember/test-helpers': '>=3.0.3'
-      ember-source: '>=4.0.0'
-      qunit: ^2.13.0
-    dependencies:
-      '@ember/test-helpers': 3.3.0(ember-source@5.7.0-beta.1)
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 3.0.2
-      common-tags: 1.8.2
-      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
-      ember-cli-babel: 7.26.11
-      ember-cli-test-loader: 3.1.0
-      ember-source: 5.7.0-beta.1(@babel/core@7.23.9)(@glimmer/component@1.1.2)
-      qunit: 2.20.1
-      resolve-package-path: 4.0.3
-      silent-error: 1.1.1
-      validate-peer-dependencies: 2.2.0
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-      - webpack
-    dev: true
-
   /ember-qunit@8.0.2(@ember/test-helpers@3.3.0)(@glint/template@1.3.0)(ember-source@5.3.0)(qunit@2.20.1):
     resolution: {integrity: sha512-Rf60jeUTWNsF3Imf/FLujW/B/DFmKVXKmXO1lirTXjpertKfwRhp/3MnN8a/U/WyodTIsERkInGT1IqTtphCdQ==}
     peerDependencies:
@@ -15963,23 +15630,6 @@ packages:
       '@ember/string': 3.1.1
       ember-cli-babel: 7.26.11
       ember-source: 5.0.0(@babel/core@7.23.9)(@glimmer/component@1.1.2)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /ember-resolver@10.1.1(@ember/string@3.1.1)(ember-source@5.7.0-beta.1):
-    resolution: {integrity: sha512-y1zzn6C4YGJui+tJzcCKlsf1oSOSVAkRrvmg8OwqVIKnALKKb9ihx2qLCslHg8x0wJvJgMtDMXgrczvQrZW0Lw==}
-    engines: {node: 14.* || 16.* || >= 18}
-    peerDependencies:
-      '@ember/string': ^3.0.1
-      ember-source: ^4.8.3 || >= 5.0.0
-    peerDependenciesMeta:
-      ember-source:
-        optional: true
-    dependencies:
-      '@ember/string': 3.1.1
-      ember-cli-babel: 7.26.11
-      ember-source: 5.7.0-beta.1(@babel/core@7.23.9)(@glimmer/component@1.1.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16406,67 +16056,6 @@ packages:
       - webpack
     dev: true
 
-  /ember-source@5.7.0-beta.1(@babel/core@7.23.9)(@glimmer/component@1.1.2):
-    resolution: {integrity: sha512-r8Leu1ZbxiZAxmonRiZNBlvMaxhW0MR2Om97KfppRc82wAMAvqa3Qz+vyNHL2F4b00ckjNNLfanp7gO08Lq2GA==}
-    engines: {node: '>= 16.*'}
-    peerDependencies:
-      '@glimmer/component': ^1.1.2
-    dependencies:
-      '@babel/helper-module-imports': 7.22.15
-      '@ember/edition-utils': 1.2.0
-      '@glimmer/compiler': 0.87.1
-      '@glimmer/component': 1.1.2(@babel/core@7.23.9)
-      '@glimmer/destroyable': 0.87.1
-      '@glimmer/env': 0.1.7
-      '@glimmer/global-context': 0.87.1
-      '@glimmer/interfaces': 0.87.1
-      '@glimmer/manager': 0.87.1
-      '@glimmer/node': 0.87.1
-      '@glimmer/opcode-compiler': 0.87.1
-      '@glimmer/owner': 0.87.1
-      '@glimmer/program': 0.87.1
-      '@glimmer/reference': 0.87.1
-      '@glimmer/runtime': 0.87.1
-      '@glimmer/syntax': 0.87.1
-      '@glimmer/util': 0.87.1
-      '@glimmer/validator': 0.87.1
-      '@glimmer/vm': 0.87.1
-      '@glimmer/vm-babel-plugins': 0.87.1(@babel/core@7.23.9)
-      '@simple-dom/interface': 1.4.0
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.23.9)
-      babel-plugin-ember-template-compilation: 2.2.1
-      babel-plugin-filter-imports: 4.0.0
-      backburner.js: 2.8.0
-      broccoli-concat: 4.2.5
-      broccoli-debug: 0.6.5
-      broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      chalk: 4.1.2
-      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
-      ember-cli-babel: 7.26.11
-      ember-cli-get-component-path-option: 1.0.0
-      ember-cli-is-package-missing: 1.0.0
-      ember-cli-normalize-entity-name: 1.0.0
-      ember-cli-path-utils: 1.0.0
-      ember-cli-string-utils: 1.1.0
-      ember-cli-typescript-blueprint-polyfill: 0.1.0
-      ember-cli-version-checker: 5.1.2
-      ember-router-generator: 2.0.0
-      inflection: 2.0.1
-      route-recognizer: 0.3.4
-      router_js: 8.0.3(route-recognizer@0.3.4)
-      semver: 7.6.0
-      silent-error: 1.1.1
-      simple-html-tokenizer: 0.5.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - rsvp
-      - supports-color
-      - webpack
-    dev: true
-
   /ember-source@5.7.0-beta.2(@babel/core@7.23.9)(webpack@5.90.3):
     resolution: {integrity: sha512-Ep/oOmkYhtV/xv4lhqH+XucU6ioKEcaR7BWzaCGzjG2S4ly+yJwfm8hwticBFGGpDxxm4WZrSABvwe87SHA5zQ==}
     engines: {node: '>= 16.*'}
@@ -16730,15 +16319,6 @@ packages:
       walk-sync: 2.2.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
-    dev: true
-
-  /ember-welcome-page@7.0.2:
-    resolution: {integrity: sha512-TyaKxFIRXhODW5BTbqD/by0Gu8Z9B9AA1ki3Bzzm6fOj2b30Qlprtt+XUG52kS0zVNmxYj/WWoT0TsKiU61VOw==}
-    engines: {node: 14.* || 16.* || >= 18}
-    dependencies:
-      '@embroider/addon-shim': 1.8.7
-    transitivePeerDependencies:
       - supports-color
     dev: true
 
@@ -17904,29 +17484,11 @@ packages:
     resolution: {integrity: sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==}
     engines: {node: '>=8'}
 
-  /extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-    dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-    dev: true
-
-  /fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
     dev: true
 
   /fast-glob@3.3.2:
@@ -18042,12 +17604,6 @@ packages:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
     dependencies:
       bser: 2.1.1
-
-  /fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-    dependencies:
-      pend: 1.2.0
-    dev: true
 
   /figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -18606,20 +18162,6 @@ packages:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
 
-  /gauge@5.0.1:
-    resolution: {integrity: sha512-CmykPMJGuNan/3S4kZOpvvPYSNqSHANiWnh9XcMU2pSjtBfF0XzZ2p1bFAxTbnFxyBuPxQYHhzwaoOmUdqzvxQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      aproba: 2.0.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      signal-exit: 4.1.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    dev: true
-
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -18697,18 +18239,6 @@ packages:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
     dependencies:
       resolve-pkg-maps: 1.0.0
-    dev: true
-
-  /get-uri@6.0.3:
-    resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
-    engines: {node: '>= 14'}
-    dependencies:
-      basic-ftp: 5.0.4
-      data-uri-to-buffer: 6.0.2
-      debug: 4.3.4(supports-color@9.4.0)
-      fs-extra: 11.2.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /get-value@2.0.6:
@@ -19261,16 +18791,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
-    dependencies:
-      agent-base: 7.1.0
-      debug: 4.3.4(supports-color@9.4.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
@@ -19299,16 +18819,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /https-proxy-agent@7.0.4:
-    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
-    engines: {node: '>= 14'}
-    dependencies:
-      agent-base: 7.1.0
-      debug: 4.3.4(supports-color@9.4.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /https@1.0.0:
     resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
@@ -20403,11 +19913,6 @@ packages:
 
   /jquery@3.7.1:
     resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
-
-  /js-reporters@2.1.0:
-    resolution: {integrity: sha512-Q4GcEcPSb6ovhqp91claM3WPbSntQxbIn+3JiJgEXturys2ttWgs31VC60Yja+2unpNOH2A2qyjWFU2thCQ8sg==}
-    engines: {node: '>=10'}
-    dev: true
 
   /js-string-escape@1.0.1:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
@@ -21542,20 +21047,12 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /mitt@3.0.1:
-    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-    dev: true
-
   /mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
-
-  /mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-    dev: true
 
   /mkdirp-infer-owner@2.0.0:
     resolution: {integrity: sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==}
@@ -21690,11 +21187,6 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  /netmask@2.0.2:
-    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
-    engines: {node: '>= 0.4.0'}
-    dev: true
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -22258,30 +21750,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  /pac-proxy-agent@7.0.1:
-    resolution: {integrity: sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==}
-    engines: {node: '>= 14'}
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.0
-      debug: 4.3.4(supports-color@9.4.0)
-      get-uri: 6.0.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.4
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.0.2
-    dev: true
-
   /package-json@6.5.0:
     resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==}
     engines: {node: '>=8'}
@@ -22440,10 +21908,6 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-
-  /pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-    dev: true
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -22783,26 +22247,6 @@ packages:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  /proxy-agent@6.3.1:
-    resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
-    engines: {node: '>= 14'}
-    dependencies:
-      agent-base: 7.1.0
-      debug: 4.3.4(supports-color@9.4.0)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.4
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.0.1
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
-
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
 
@@ -22815,38 +22259,6 @@ packages:
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  /puppeteer-chromium-resolver@21.0.0:
-    resolution: {integrity: sha512-sjOX4ACPz4KgYuoHBPEwpDlcFY6W4n13dXhJh+cV449YzeO0diNpLgAQqTfaTJr/GFA6sLt4eNb0h+VJkuvGgg==}
-    requiresBuild: true
-    dependencies:
-      '@puppeteer/browsers': 1.9.1
-      eight-colors: 1.3.0
-      gauge: 5.0.1
-      puppeteer-core: 21.11.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /puppeteer-core@21.11.0:
-    resolution: {integrity: sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==}
-    engines: {node: '>=16.13.2'}
-    dependencies:
-      '@puppeteer/browsers': 1.9.1
-      chromium-bidi: 0.5.8(devtools-protocol@0.0.1232444)
-      cross-fetch: 4.0.0
-      debug: 4.3.4(supports-color@9.4.0)
-      devtools-protocol: 0.0.1232444
-      ws: 8.16.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
 
   /pure-rand@6.0.4:
     resolution: {integrity: sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==}
@@ -22883,10 +22295,6 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  /queue-tick@1.0.1:
-    resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
-    dev: true
 
   /quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
@@ -23984,17 +23392,6 @@ packages:
       - supports-color
     dev: true
 
-  /socks-proxy-agent@8.0.2:
-    resolution: {integrity: sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==}
-    engines: {node: '>= 14'}
-    dependencies:
-      agent-base: 7.1.0
-      debug: 4.3.4(supports-color@9.4.0)
-      socks: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /socks@2.8.1:
     resolution: {integrity: sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -24213,15 +23610,6 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
-
-  /streamx@2.16.1:
-    resolution: {integrity: sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==}
-    dependencies:
-      fast-fifo: 1.3.2
-      queue-tick: 1.0.1
-    optionalDependencies:
-      bare-events: 2.2.0
-    dev: true
 
   /strict-uri-encode@1.1.0:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
@@ -24670,22 +24058,6 @@ packages:
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
-
-  /tar-fs@3.0.4:
-    resolution: {integrity: sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==}
-    dependencies:
-      mkdirp-classic: 0.5.3
-      pump: 3.0.0
-      tar-stream: 3.1.7
-    dev: true
-
-  /tar-stream@3.1.7:
-    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-    dependencies:
-      b4a: 1.6.6
-      fast-fifo: 1.3.2
-      streamx: 2.16.1
-    dev: true
 
   /tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
@@ -25272,13 +24644,6 @@ packages:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  /unbzip2-stream@1.4.3:
-    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
-    dependencies:
-      buffer: 5.7.1
-      through: 2.3.8
-    dev: true
-
   /underscore.string@3.3.6:
     resolution: {integrity: sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==}
     dependencies:
@@ -25411,10 +24776,6 @@ packages:
   /url-to-options@1.0.1:
     resolution: {integrity: sha512-0kQLIzG4fdk/G5NONku64rSH/x32NOA39LVQqlK8Le6lvTF6GGRJpqaQFGgU+CLwySIqBSMdwYM0sYcW9f6P4A==}
     engines: {node: '>= 4'}
-    dev: true
-
-  /urlpattern-polyfill@10.0.0:
-    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
     dev: true
 
   /use@3.1.1:
@@ -26151,13 +25512,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  /yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
-    dev: true
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}

--- a/tests/addon-template/vite.config.mjs
+++ b/tests/addon-template/vite.config.mjs
@@ -7,6 +7,7 @@ import {
   optimizeDeps,
   compatPrebuild,
   assets,
+  contentFor,
 } from "@embroider/vite";
 import { resolve } from "path";
 import { babel } from "@rollup/plugin-babel";
@@ -26,6 +27,7 @@ export default defineConfig(({ mode }) => {
       resolver(),
       compatPrebuild(),
       assets(),
+      contentFor(),
 
       babel({
         babelHelpers: "runtime",

--- a/tests/app-template/vite.config.mjs
+++ b/tests/app-template/vite.config.mjs
@@ -7,6 +7,7 @@ import {
   optimizeDeps,
   compatPrebuild,
   assets,
+  contentFor,
 } from "@embroider/vite";
 import { resolve } from "path";
 import { babel } from "@rollup/plugin-babel";
@@ -26,6 +27,7 @@ export default defineConfig(({ mode }) => {
       resolver(),
       compatPrebuild(),
       assets(),
+      contentFor(),
 
       babel({
         babelHelpers: "runtime",

--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -1,0 +1,133 @@
+import { throwOnWarnings } from '@embroider/core';
+import { readFileSync } from 'fs';
+import { merge } from 'lodash';
+import QUnit from 'qunit';
+import type { PreparedApp } from 'scenario-tester';
+import fetch from 'node-fetch';
+
+import { appScenarios, baseAddon } from './scenarios';
+import CommandWatcher from './helpers/command-watcher';
+
+const { module: Qmodule, test } = QUnit;
+
+appScenarios
+  .map('compat-addon-classic-features-content-for', project => {
+    let myAddon = baseAddon();
+    myAddon.pkg.name = 'my-addon';
+    merge(myAddon.files, {
+      'index.js': `
+        module.exports = {
+          name: require('./package.json').name,
+          contentFor: function (type) {
+            switch (type) {
+              case 'body':
+                return '<p>Content for body</p>';
+              case 'custom':
+                return '<p>Content for custom</p>';
+              default:
+                return '';
+            }
+          }
+        }
+      `,
+    });
+    project.addDependency(myAddon);
+
+    merge(project.files, {
+      'ember-cli-build.js': `
+        'use strict';
+
+        const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+        const { maybeEmbroider } = require('@embroider/test-setup');
+        
+        module.exports = function (defaults) {
+          let app = new EmberApp(defaults, {
+            ...(process.env.FORCE_BUILD_TESTS ? {
+              tests: true,
+            } : undefined),
+          });
+        
+          return maybeEmbroider(app, {
+            availableContentForTypes: ['custom'],
+            skipBabel: [
+              {
+                package: 'qunit',
+              },
+            ],
+          });
+        };
+      `,
+      app: {
+        'index.html': `
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8">
+              <title>AppTemplate</title>
+              <meta name="description" content="">
+              <meta name="viewport" content="width=device-width, initial-scale=1">
+          
+              {{content-for "head"}}
+          
+              <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+              <link integrity="" rel="stylesheet" href="{{rootURL}}assets/app-template.css">
+          
+              {{content-for "head-footer"}}
+            </head>
+            <body>
+              {{content-for "body"}}
+              {{content-for "custom"}}
+          
+              <script src="{{rootURL}}assets/vendor.js"></script>
+              <script src="{{rootURL}}assets/app-template.js"></script>
+          
+              {{content-for "body-footer"}}
+            </body>
+          </html>
+        `,
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      throwOnWarnings(hooks);
+
+      let app: PreparedApp;
+
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test('content-for are replaced: build mode', async function (assert) {
+        let result = await app.execute(`pnpm build`, {
+          env: {
+            // Force building tests so we can check the content of /tests/index.html
+            // and assert it can be different from index.html
+            FORCE_BUILD_TESTS: 'true',
+          },
+        });
+        assert.equal(result.exitCode, 0, result.output);
+
+        let content = readFileSync(`${app.dir}/dist/index.html`).toString();
+        assert.true(content.includes('<p>Content for body</p>'));
+        assert.true(content.includes('<p>Content for custom</p>'));
+
+        content = readFileSync(`${app.dir}/dist/tests/index.html`).toString();
+        assert.true(content.includes('<p>Content for body</p>'));
+        assert.true(!content.includes('<p>Content for custom</p>'));
+      });
+
+      test('content-for are replaced: dev mode', async function (assert) {
+        const server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+        try {
+          const [, url] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+          let response = await fetch(`${url}/`);
+          let text = await response.text();
+          assert.true(text.includes('<p>Content for body</p>'));
+          assert.true(text.includes('<p>Content for custom</p>'));
+        } finally {
+          await server.shutdown();
+        }
+      });
+    });
+  });

--- a/tests/ts-app-template/vite.config.mjs
+++ b/tests/ts-app-template/vite.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import { resolver, hbs, scripts, templateTag, optimizeDeps, compatPrebuild } from '@embroider/vite';
+import { resolver, hbs, scripts, templateTag, optimizeDeps, compatPrebuild, contentFor } from '@embroider/vite';
 import { resolve } from 'path';
 import { babel } from '@rollup/plugin-babel';
 
@@ -16,6 +16,7 @@ export default defineConfig({
     scripts(),
     resolver(),
     compatPrebuild(),
+    contentFor(),
 
     babel({
       babelHelpers: 'runtime',


### PR DESCRIPTION
This PR moves `{{content-for}}` from stage 2 to stage 3: 

We no longer replace the `{{content-for}}` snippets in the `index.html` during the build of the rewritten app. Instead, we leave the `{{content-for}}` in place and it's a new Vite plugin that performs the replacement. To do so, the Vite plugin relies on a new file `content-for.json` output during the pre-build. 

**Breaking change**

The new approach supposes that Embroider knows in advance what types of `{{content-for}}` are provided by the addons, because the Broccoli plugin that builds the dictionary needs to be agnostic from `rewritten-app/index.html` if we don't want to be tied with stage 2.

The new build option `availableContentForTypes` allows to extend the list of `{{content-for}}` types in case an addon provides something custom. For instance, let's suppose your app relies on a classic addon that provides `{{content-for  "custom"}}`, you should add the following build option so the content can be replaced:
```js
// ember-cli-build.js
const EmberApp = require('ember-cli/lib/broccoli/ember-app');
const { prebuild } = require('@embroider/compat');

module.exports = function (defaults) {
  const app = new EmberApp(defaults, {});
  return prebuild(app, {
    availableContentForTypes: ['custom'],
  });
};
```
