### PR TITLE
merge default options and the prebuild options provided in ember-cli-build

### DIFF
--- a/packages/compat/src/default-pipeline.ts
+++ b/packages/compat/src/default-pipeline.ts
@@ -58,11 +58,11 @@ const defaultPrebuildOptions = {
   },
 };
 
-export function prebuild(emberApp: EmberAppInstance, options: Options = defaultPrebuildOptions): Node {
+export function prebuild(emberApp: EmberAppInstance, options?: Options): Node {
   let outputPath: string;
   let addons;
 
-  let embroiderApp = new App(emberApp, options);
+  let embroiderApp = new App(emberApp, { ...defaultPrebuildOptions, ...options });
 
   addons = new CompatAddons(embroiderApp);
   addons.ready().then(result => {


### PR DESCRIPTION
Recently, the `prebuild` function has been written in the `default-pipeline` so we can run the build with Vite requirements by default:
```diff
// ember-cli-build.js

- return compatBuild(app, undefined, {
-     staticAddonTrees: true,
-     staticAddonTestSupportTrees: true,
-     staticComponents: true,
-     ...
-   });
+ return prebuild(app);
```

However, there was an issue with the way `prebuild` uses the options: If an options object was provided in `ember-cli-build.js`, this would replace entirely the `defaultPrebuildOptions` that Vite requires and options like `staticAddonTrees` and `staticEmberSource` would be `false` instead of `true`, resulting to breaking side effects.

This PR changes `prebuild` function to always use the `defaultPrebuildOptions` and extend them with the passed options.

**How to test manually**

- In `tests/vite-app/ember-cli-build.js`, do the following change:
```diff
- return prebuild(app);
+ return prebuild(app, {});
```
- Then run the vite-app. 
- 👀 The app should run correclty