### PR TITLE
make sure @embroider/macros doesn't try to load a babel config

### DIFF
--- a/packages/macros/src/babel/evaluate-json.ts
+++ b/packages/macros/src/babel/evaluate-json.ts
@@ -473,7 +473,7 @@ export function buildLiterals(
   if (typeof value === 'undefined') {
     return babelContext.types.identifier('undefined');
   }
-  let statement = babelContext.parse(`a(${JSON.stringify(value)})`) as t.File;
+  let statement = babelContext.parse(`a(${JSON.stringify(value)})`, { configFile: false }) as t.File;
   let expression = (statement.program.body[0] as t.ExpressionStatement).expression as t.CallExpression;
   return expression.arguments[0] as t.ObjectExpression;
 }


### PR DESCRIPTION
this was causing some issues for us in the vite work because we now have a real babel config. This could have caused a bunch of other bugs, and it should never have tried to load a local babel config 🙈 