### PR TITLE
Prevent query-params added by vite to be passed to core logic

### DIFF
--- a/packages/shared-internals/src/index.ts
+++ b/packages/shared-internals/src/index.ts
@@ -1,5 +1,12 @@
 export { AppMeta, AddonMeta, PackageInfo } from './metadata';
-export { explicitRelative, extensionsPattern, unrelativize, cleanUrl } from './paths';
+export {
+  explicitRelative,
+  extensionsPattern,
+  unrelativize,
+  cleanUrl,
+  cleanUrlQueryParams,
+  getUrlQueryParams,
+} from './paths';
 export { getOrCreate } from './get-or-create';
 export { default as Package, V2AddonPackage as AddonPackage, V2AppPackage as AppPackage, V2Package } from './package';
 export { default as PackageCache } from './package-cache';

--- a/packages/shared-internals/src/index.ts
+++ b/packages/shared-internals/src/index.ts
@@ -1,12 +1,5 @@
 export { AppMeta, AddonMeta, PackageInfo } from './metadata';
-export {
-  explicitRelative,
-  extensionsPattern,
-  unrelativize,
-  cleanUrl,
-  cleanUrlQueryParams,
-  getUrlQueryParams,
-} from './paths';
+export { explicitRelative, extensionsPattern, unrelativize, cleanUrl, getUrlQueryParams } from './paths';
 export { getOrCreate } from './get-or-create';
 export { default as Package, V2AddonPackage as AddonPackage, V2AppPackage as AppPackage, V2Package } from './package';
 export { default as PackageCache } from './package-cache';

--- a/packages/shared-internals/src/paths.ts
+++ b/packages/shared-internals/src/paths.ts
@@ -49,3 +49,15 @@ const postfixRE = /[?#].*$/s;
 export function cleanUrl(url: string): string {
   return url.replace(postfixRE, '');
 }
+
+// this pattern includes URL query params (ex: ?direct)
+// but excludes specifiers starting with # (ex: #embroider_compats/components/fancy)
+const postfixQueryParams = /[?].*$/s;
+
+export function cleanUrlQueryParams(url: string): string {
+  return url.replace(postfixQueryParams, '');
+}
+
+export function getUrlQueryParams(url: string): string {
+  return url.match(postfixQueryParams)?.[0] ?? '';
+}

--- a/packages/shared-internals/src/paths.ts
+++ b/packages/shared-internals/src/paths.ts
@@ -44,20 +44,22 @@ export function unrelativize(pkg: Package, specifier: string, fromFile: string) 
 
 const postfixRE = /[?#].*$/s;
 
-// this is the same implementation Vite uses internally to keep its
-// cache-busting query params from leaking where they shouldn't.
-export function cleanUrl(url: string): string {
-  return url.replace(postfixRE, '');
-}
-
 // this pattern includes URL query params (ex: ?direct)
 // but excludes specifiers starting with # (ex: #embroider_compats/components/fancy)
-const postfixQueryParams = /[?].*$/s;
+// so when using this pattern, #embroider_compat/fancy would be consider a pathname
+// without any params.
+const postfixREQueryParams = /[?].*$/s;
 
-export function cleanUrlQueryParams(url: string): string {
-  return url.replace(postfixQueryParams, '');
+// this is the same implementation Vite uses internally to keep its
+// cache-busting query params from leaking where they shouldn't.
+// includeHashSign true means #my-specifier is considered part of the pathname
+export function cleanUrl(url: string, includeHashSign = false): string {
+  const regexp = includeHashSign ? postfixREQueryParams : postfixRE;
+  return url.replace(regexp, '');
 }
 
-export function getUrlQueryParams(url: string): string {
-  return url.match(postfixQueryParams)?.[0] ?? '';
+// includeHashSign true means #my-specifier is considered part of the pathname
+export function getUrlQueryParams(url: string, includeHashSign = false): string {
+  const regexp = includeHashSign ? postfixREQueryParams : postfixRE;
+  return url.match(regexp)?.[0] ?? '';
 }

--- a/packages/vite/src/request.ts
+++ b/packages/vite/src/request.ts
@@ -30,6 +30,8 @@ export class RollupModuleRequest implements ModuleRequest {
       let fromFile = cleanUrl(nonVirtual);
 
       // strip query params off the source but keep track of them
+      // we use regexp-based methods over a URL object because the
+      // source can be a relative path.
       let cleanSource = cleanUrlQueryParams(source);
       let queryParams = getUrlQueryParams(source);
 
@@ -130,7 +132,7 @@ export class RollupModuleRequest implements ModuleRequest {
     if (this.isVirtual) {
       return {
         type: 'found',
-        filename: this.specifierWithQueryParams,
+        filename: this.specifier,
         result: { id: this.specifierWithQueryParams, resolvedBy: this.fromFile },
         isVirtual: this.isVirtual,
       };
@@ -152,7 +154,8 @@ export class RollupModuleRequest implements ModuleRequest {
       },
     });
     if (result) {
-      return { type: 'found', filename: result.id, result, isVirtual: this.isVirtual };
+      let { pathname } = new URL(result.id, 'http://example.com');
+      return { type: 'found', filename: pathname, result, isVirtual: this.isVirtual };
     } else {
       return { type: 'not_found', err: undefined };
     }

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -1,5 +1,5 @@
 import type { Plugin, ViteDevServer } from 'vite';
-import { virtualContent, ResolverLoader } from '@embroider/core';
+import { cleanUrlQueryParams, virtualContent, ResolverLoader } from '@embroider/core';
 import { RollupModuleRequest, virtualPrefix } from './request';
 import assertNever from 'assert-never';
 import makeDebug from 'debug';
@@ -52,7 +52,10 @@ export function resolver(): Plugin {
     },
     load(id) {
       if (id.startsWith(virtualPrefix)) {
-        let { src, watches } = virtualContent(id.slice(virtualPrefix.length), resolverLoader.resolver);
+        let { src, watches } = virtualContent(
+          cleanUrlQueryParams(id.slice(virtualPrefix.length)),
+          resolverLoader.resolver
+        );
         virtualDeps.set(id, watches);
         server?.watcher.add(watches);
         return src;

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -1,5 +1,5 @@
 import type { Plugin, ViteDevServer } from 'vite';
-import { cleanUrlQueryParams, virtualContent, ResolverLoader } from '@embroider/core';
+import { virtualContent, ResolverLoader } from '@embroider/core';
 import { RollupModuleRequest, virtualPrefix } from './request';
 import assertNever from 'assert-never';
 import makeDebug from 'debug';
@@ -52,10 +52,8 @@ export function resolver(): Plugin {
     },
     load(id) {
       if (id.startsWith(virtualPrefix)) {
-        let { src, watches } = virtualContent(
-          cleanUrlQueryParams(id.slice(virtualPrefix.length)),
-          resolverLoader.resolver
-        );
+        let { pathname } = new URL(id, 'http://example.com');
+        let { src, watches } = virtualContent(pathname.slice(virtualPrefix.length + 1), resolverLoader.resolver);
         virtualDeps.set(id, watches);
         server?.watcher.add(watches);
         return src;


### PR DESCRIPTION
**Context**
PR #1805 highlighted how Vite sometimes adds internal query parameters to requests. For instance, if you include a CSS file _directly_ in `index.html` with a `link` tag pointing to a stylesheet, then Vite will internally add the query parameter `?direct` to the request so it knows it has to return the stylesheet as is without wrapping it in some hot-reload-related JS. This is just one example of the sort of things Vite can do for its own reason. 

The problem is that Embroider doesn't expect this kind of query params to exist, for instance when dealing with virtual files, and we can't let the core part of Embroider know about that: it is bundler-agnostic, it should behave the same way if you use Vite, or Webpack, or whatever.

**Problem to solve**
Everything that has to do with Vite query params should stay in `packages/vite/src` and from this point, we need to make sure that: 
- query-params added by Vite keep being propagated from request to request,
- but are always removed from the specifier when we call the `packages/core/src` functions that are bundler-agnostic.

**How to test**
- [x] No regression when testing the vite-app
- [x] If the changes are used in PR #1805, then we should be able to get rid of the last commit that handles `isDirect` in Vite resolver, and the `vendor.css` should still be generated correctly.