### PR TITLE
vite: do not optimize dynamic addons 

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -561,7 +561,7 @@ export default class V1Addon {
         version: 2,
         'auto-upgraded': true,
         type: 'addon',
-        'is-dynamic': this.hasCustomizedTree()
+        'is-dynamic': this.hasCustomizedTree(),
       },
       built.staticMeta,
       ...built.dynamicMeta.map(d => d())

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -384,8 +384,12 @@ export default class V1Addon {
     );
   }
 
+  hasCustomizedTree(): boolean {
+    return this.customizes(...dynamicTreeHooks);
+  }
+
   hasAnyTrees(): boolean {
-    return Boolean(stockTreeNames.find(name => this.hasStockTree(name))) || this.customizes(...dynamicTreeHooks);
+    return Boolean(stockTreeNames.find(name => this.hasStockTree(name))) || this.hasCustomizedTree();
   }
 
   // we keep all these here to ensure that we always apply the same options to
@@ -557,6 +561,7 @@ export default class V1Addon {
         version: 2,
         'auto-upgraded': true,
         type: 'addon',
+        'is-dynamic': this.hasCustomizedTree()
       },
       built.staticMeta,
       ...built.dynamicMeta.map(d => d())

--- a/packages/shared-internals/src/metadata.ts
+++ b/packages/shared-internals/src/metadata.ts
@@ -26,6 +26,7 @@ export interface AddonMeta {
   main?: string;
   'order-index'?: number;
   'lazy-engine'?: boolean;
+  'is-dynamic'?: boolean;
 
   'auto-upgraded'?: true;
   'app-js'?: { [appName: string]: Filename };

--- a/packages/vite/src/optimize-deps.ts
+++ b/packages/vite/src/optimize-deps.ts
@@ -28,7 +28,7 @@ export function optimizeDeps(): OptimizeDeps {
         }
       }
       return ['@embroider/macros', ...addons];
-    }
+    },
   });
   
   return res;

--- a/packages/vite/src/optimize-deps.ts
+++ b/packages/vite/src/optimize-deps.ts
@@ -18,11 +18,18 @@ export function optimizeDeps(): OptimizeDeps {
     }
   }
 
-  return {
-    exclude: ['@embroider/macros', ...addons],
+  const res = {
     extensions: ['.hbs', '.gjs', '.gts'],
     esbuildOptions: {
       plugins: [esBuildResolver()],
     },
   };
+
+  Object.defineProperty(res, 'exclude', {
+    get() {
+      return ['@embroider/macros', ...addons];
+    }
+  });
+  
+  return res;
 }

--- a/packages/vite/src/optimize-deps.ts
+++ b/packages/vite/src/optimize-deps.ts
@@ -30,6 +30,6 @@ export function optimizeDeps(): OptimizeDeps {
       return ['@embroider/macros', ...addons];
     },
   });
-  
+
   return res;
 }

--- a/packages/vite/src/optimize-deps.ts
+++ b/packages/vite/src/optimize-deps.ts
@@ -8,15 +8,6 @@ export interface OptimizeDeps {
 
 export function optimizeDeps(): OptimizeDeps {
   let resolverLoader = new ResolverLoader(process.cwd());
-  const addons: string[] = [];
-  for (const engine of resolverLoader.resolver.options.engines) {
-    for (const activeAddon of engine.activeAddons) {
-      const pkg = resolverLoader.resolver.packageCache.get(activeAddon.root);
-      if (pkg.isV2Addon() && pkg.meta['is-dynamic']) {
-        addons.push(pkg.name);
-      }
-    }
-  }
 
   const res = {
     extensions: ['.hbs', '.gjs', '.gts'],
@@ -27,6 +18,15 @@ export function optimizeDeps(): OptimizeDeps {
 
   Object.defineProperty(res, 'exclude', {
     get() {
+      const addons: string[] = [];
+      for (const engine of resolverLoader.resolver.options.engines) {
+        for (const activeAddon of engine.activeAddons) {
+          const pkg = resolverLoader.resolver.packageCache.get(activeAddon.root);
+          if (pkg.isV2Addon() && pkg.meta['is-dynamic']) {
+            addons.push(pkg.name);
+          }
+        }
+      }
       return ['@embroider/macros', ...addons];
     }
   });

--- a/packages/vite/tests/optimize-deps.test.ts
+++ b/packages/vite/tests/optimize-deps.test.ts
@@ -17,9 +17,6 @@ describe('optimizeDeps', function () {
             Any<Object>,
           ],
         },
-        "exclude": [
-          "@embroider/macros",
-        ],
         "extensions": [
           ".hbs",
           ".gjs",


### PR DESCRIPTION
with dynamic addons I mean addons which override the treeFor methods.
they can potentially depend on app tree and rebuild whenever an app file changes. e.g ember-svg-jar, ember-cli-addon-docs.

With dep optimization that will not be updated. they need to be excluded