### PR TITLE
vite fix hbs loader for v1 addons

### DIFF
--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -132,7 +132,7 @@ async function maybeSynthesizeComponentJS(context: PluginContext, source: string
   };
 }
 
-const hbsFilter = createFilter('**/*.hbs?(\\?)*');
+const hbsFilter = createFilter('**/*.hbs?([?]*)');
 
 function maybeRewriteHBS(resolution: ResolvedId) {
   if (!hbsFilter(resolution.id)) {

--- a/tests/scenarios/vite-app-test.ts
+++ b/tests/scenarios/vite-app-test.ts
@@ -4,7 +4,6 @@ import QUnit from 'qunit';
 import { exec } from 'child_process';
 import { readdirSync } from 'fs-extra';
 import { join } from 'path';
-import { merge } from 'lodash';
 
 const { module: Qmodule, test } = QUnit;
 
@@ -28,7 +27,7 @@ viteAppScenarios
     let addon = baseAddon();
     addon.pkg.name = 'my-addon';
     // setup addon that triggers packages/compat/src/hbs-to-js-broccoli-plugin.ts
-    merge(addon.files, {
+    addon.mergeFiles({
       'index.js': `
         module.exports = {
           name: 'my-addon',
@@ -85,7 +84,7 @@ viteAppScenarios
 
     let addon2 = baseAddon();
     addon2.pkg.name = 'my-addon2';
-    merge(addon2.files, {
+    addon2.mergeFiles({
       app: {
         components: {
           'component-two.js': `export { default } from 'my-addon2/components/component-two';`,

--- a/tests/scenarios/vite-app-test.ts
+++ b/tests/scenarios/vite-app-test.ts
@@ -82,6 +82,23 @@ viteAppScenarios
     });
 
     project.addDevDependency(addon);
+
+    let addon2 = baseAddon();
+    addon2.pkg.name = 'my-addon2';
+    merge(addon2.files, {
+      app: {
+        components: {
+          'component-two.js': `export { default } from 'my-addon2/components/component-two';`,
+        },
+      },
+      addon: {
+        components: {
+          'component-two.hbs': `component two template: "{{this}}"`,
+        },
+      },
+    });
+
+    project.addDevDependency(addon2);
     project.mergeFiles({
       tests: {
         integration: {
@@ -97,9 +114,11 @@ viteAppScenarios
               test('should have component one template from addon', async function (assert) {
                 await render(hbs\`
                 <ComponentOne></ComponentOne>
+                <ComponentTwo />
                 \`);
                 await rerender();
                 assert.dom().includesText('component one template');
+                assert.dom().includesText('component two template: ""');
                 assert.dom().doesNotIncludeText('export default precompileTemplate');
               });
             });

--- a/tests/vite-app/tests/integration/example-test.js
+++ b/tests/vite-app/tests/integration/example-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, rerender, settled } from '@ember/test-helpers';
+import { render, rerender } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Example', (hooks) => {


### PR DESCRIPTION

?(pattern) | Match zero or one consecutive occurrences of pattern
-- | --


the pattern we want to match is `.hbs?v=343` or `.hbs`
so `*.hbs?([?]*)` should be correct one
pattern after hbs = `[?]*` or do not match if not exists (only .hbs)

