### PR TITLE
Compile Hbs route templates correctly

### DIFF
--- a/docs/v2-faq.md
+++ b/docs/v2-faq.md
@@ -17,6 +17,7 @@
   * [Why do v2 addons need a build step?](#why-do-v2-addons-need-a-build-step)
   * [How can I integrate with the app's build?](#how-can-i-integrate-with-the-apps-build)
   * [How can I define the public exports of my addon?](#how-can-i-define-the-public-exports-of-my-addon)
+  * [How can I provide route templates with my v2 addon?](#how-can-i-provide-route-templates-with-my-v2-addon)
 
 <!-- tocstop -->
 
@@ -195,3 +196,29 @@ Additionally, there is a feature supported in node.js and modern bundlers to def
 When using `package.json#exports` make sure that:
 - the `addon.publicEntrypoints(...)` plugin in `rollup.config.mjs` includes _at least_ whatever is defined in `package.json#exports`
 - the modules that `addon.appReexports(...)` exposes must have overlap with the `package.json#exports` so that the app-tree merging may import from the addon
+
+### How can I provide route templates with my v2 addon?
+
+During a v2 addon build step, standalone `.hbs` are considered template-only components by default.
+
+If you want your v2 addon to provide a route template, the best way to proceed is to make it a `.gjs` file using [ember-route-template](https://github.com/discourse/ember-route-template). Similarly, if you want to migrate to v2 a classic addon that used to provide `.hbs` route templates, you should refactor the `.hbs` to `.gjs` files to complete the migration.
+
+If for whatever reason the `.gjs` approach cannot be used, it's still possible to have your v2 addon providing the route templates as `.hbs`, but it requires extra configuration. During the build step, Rollup and Babel work together to transform all standalone `.hbs` into template-only components. Therefore, you need to tell both Rollup and Babel to _not_ compile a given list of `.hbs` files this way.
+
+Let's assume your addon has a `templates/` folder that contains all your route templates. The files in `templates/` should be compiled as simple templates (not template-only components).
+
+In the `rollup.config.mjs`, pass a list of glob patterns in the `excludeColocation` option of the function `addon.hbs`:
+
+```js 
+addon.hbs({ excludeColocation: ['templates/**/*'] }),
+```
+
+In the `babel.config.json`, pass the same list of glob patterns in the `exclude` option of the `template-colocation-plugin`:
+
+```
+"plugins": [
+  ["@embroider/addon-dev/template-colocation-plugin", {
+    exclude: ['templates/**/*']
+  }],
+],
+```

--- a/packages/addon-dev/src/rollup-hbs-plugin.ts
+++ b/packages/addon-dev/src/rollup-hbs-plugin.ts
@@ -2,9 +2,14 @@ import { createFilter } from '@rollup/pluginutils';
 import type { Plugin, PluginContext, CustomPluginOptions } from 'rollup';
 import { readFileSync } from 'fs';
 import { hbsToJS } from '@embroider/core';
+import minimatch from 'minimatch';
 import { parse as pathParse } from 'path';
 
-export default function rollupHbsPlugin(): Plugin {
+export default function rollupHbsPlugin({
+  templates,
+}: {
+  templates?: string[];
+}): Plugin {
   return {
     name: 'rollup-hbs-plugin',
     async resolveId(source: string, importer: string | undefined, options) {
@@ -16,19 +21,26 @@ export default function rollupHbsPlugin(): Plugin {
       if (resolution) {
         return resolution;
       } else {
-        return maybeSynthesizeComponentJS(this, source, importer, options);
+        return maybeSynthesizeComponentJS(
+          this,
+          source,
+          importer,
+          options,
+          templates
+        );
       }
     },
 
     load(id: string) {
       if (hbsFilter(id)) {
-        let input = readFileSync(id, 'utf8');
-        let code = hbsToJS(input);
-        return {
-          code,
-        };
+        return getHbsToJSCode(id);
       }
-      if (getMeta(this, id)) {
+      let meta = getMeta(this, id);
+      if (meta) {
+        if (meta?.type === 'template-js') {
+          const hbsFile = id.replace(/\.js$/, '.hbs');
+          return getHbsToJSCode(hbsFile);
+        }
         return {
           code: templateOnlyComponent,
         };
@@ -42,7 +54,7 @@ const templateOnlyComponent =
   `export default templateOnly();\n`;
 
 type Meta = {
-  type: 'template-only-component-js';
+  type: 'template-only-component-js' | 'template-js';
 };
 
 function getMeta(context: PluginContext, id: string): Meta | null {
@@ -54,6 +66,14 @@ function getMeta(context: PluginContext, id: string): Meta | null {
   }
 }
 
+function getHbsToJSCode(file: string): { code: string } {
+  let input = readFileSync(file, 'utf8');
+  let code = hbsToJS(input);
+  return {
+    code,
+  };
+}
+
 function correspondingTemplate(filename: string): string {
   let { ext } = pathParse(filename);
   return filename.slice(0, filename.length - ext.length) + '.hbs';
@@ -63,7 +83,8 @@ async function maybeSynthesizeComponentJS(
   context: PluginContext,
   source: string,
   importer: string | undefined,
-  options: { custom?: CustomPluginOptions; isEntry: boolean }
+  options: { custom?: CustomPluginOptions; isEntry: boolean },
+  templates: string[] | undefined
 ) {
   let templateResolution = await context.resolve(
     correspondingTemplate(source),
@@ -76,13 +97,17 @@ async function maybeSynthesizeComponentJS(
   if (!templateResolution) {
     return null;
   }
+  let type = templates?.some((glob) => minimatch(source, glob))
+    ? 'template-js'
+    : 'template-only-component-js';
   // we're trying to resolve a JS module but only the corresponding HBS
-  // file exists. Synthesize the template-only component JS.
+  // file exists. Synthesize the JS. The meta states if the hbs corresponds
+  // to a template-only component or a simple template like a route template.
   return {
     id: templateResolution.id.replace(/\.hbs$/, '.js'),
     meta: {
       'rollup-hbs-plugin': {
-        type: 'template-only-component-js',
+        type,
       },
     },
   };

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -53,8 +53,8 @@ export class Addon {
   // This wraps standalone .hbs files as Javascript files using inline
   // templates. This means special resolving rules for .hbs files aren't
   // required for javascript tooling to understand your package.
-  hbs() {
-    return hbs();
+  hbs(options = {}) {
+    return hbs(options);
   }
 
   gjs(options?: { inline_source_map: boolean }) {

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -36,6 +36,7 @@
     "typescript-memoize": "^1.0.1",
     "fs-extra": "^9.1.0",
     "lodash": "^4.17.21",
+    "minimatch": "^3.0.4",
     "semver": "^7.3.5"
   },
   "devDependencies": {
@@ -47,6 +48,7 @@
     "@types/fs-extra": "^9.0.12",
     "@types/lodash": "^4.14.170",
     "@types/js-string-escape": "^1.0.0",
+    "@types/minimatch": "^3.0.4",
     "@types/semver": "^7.3.6",
     "@types/tmp": "^0.1.0",
     "fixturify": "^2.1.1",

--- a/packages/shared-internals/src/index.ts
+++ b/packages/shared-internals/src/index.ts
@@ -1,5 +1,5 @@
 export { AppMeta, AddonMeta, PackageInfo } from './metadata';
-export { explicitRelative, extensionsPattern, unrelativize, cleanUrl } from './paths';
+export { explicitRelative, extensionsPattern, unrelativize, cleanUrl, correspondingTemplate } from './paths';
 export { getOrCreate } from './get-or-create';
 export { default as Package, V2AddonPackage as AddonPackage, V2AppPackage as AppPackage, V2Package } from './package';
 export { default as PackageCache } from './package-cache';

--- a/packages/shared-internals/src/paths.ts
+++ b/packages/shared-internals/src/paths.ts
@@ -1,4 +1,4 @@
-import { relative, isAbsolute, dirname, join, basename, resolve, sep } from 'path';
+import { relative, isAbsolute, dirname, join, basename, resolve, sep, parse as pathParse } from 'path';
 import type Package from './package';
 
 // by "explicit", I mean that we want "./local/thing" instead of "local/thing"
@@ -48,4 +48,11 @@ const postfixRE = /[?#].*$/s;
 // cache-busting query params from leaking where they shouldn't.
 export function cleanUrl(url: string): string {
   return url.replace(postfixRE, '');
+}
+
+// given a filename, returns it with the hbs extension
+// for instance, passing filename.js returns filename.hbs
+export function correspondingTemplate(filename: string): string {
+  let { ext } = pathParse(filename);
+  return filename.slice(0, filename.length - ext.length) + '.hbs';
 }

--- a/packages/shared-internals/src/template-colocation-plugin.ts
+++ b/packages/shared-internals/src/template-colocation-plugin.ts
@@ -7,7 +7,7 @@ import { explicitRelative, PackageCache } from '.';
 import { ImportUtil } from 'babel-import-util';
 import makeDebug from 'debug';
 import minimatch from 'minimatch';
-import { cleanUrl } from './paths';
+import { cleanUrl, correspondingTemplate } from './paths';
 
 const debug = makeDebug('embroider:template-colocation-plugin');
 
@@ -75,7 +75,7 @@ export default function main(babel: typeof Babel) {
             }
           }
 
-          if (state.opts.exclude?.some(glob => minimatch(filename, glob))) {
+          if (state.opts.exclude?.some(glob => minimatch(correspondingTemplate(filename), glob))) {
             debug('not handling colocation for %s', filename);
             return;
           }

--- a/packages/shared-internals/src/template-colocation-plugin.ts
+++ b/packages/shared-internals/src/template-colocation-plugin.ts
@@ -6,6 +6,7 @@ import { dirname } from 'path';
 import { explicitRelative, PackageCache } from '.';
 import { ImportUtil } from 'babel-import-util';
 import makeDebug from 'debug';
+import minimatch from 'minimatch';
 import { cleanUrl } from './paths';
 
 const debug = makeDebug('embroider:template-colocation-plugin');
@@ -36,6 +37,14 @@ export interface Options {
   // This option is used by Embroider itself to help with v1 addon
   // compatibility, other users should probably not use it.
   templateExtensions?: string[];
+
+  // Default to []
+  //
+  // Skip the plugin for files that match the specified globs.
+  //
+  // This option is used to prevent the plugin to transform the
+  // compiled output of hbs files that are not colocated components.
+  exclude?: string[];
 }
 
 interface State {
@@ -64,6 +73,11 @@ export default function main(babel: typeof Babel) {
               debug('not handling colocation for %s', filename);
               return;
             }
+          }
+
+          if (state.opts.exclude?.some(glob => minimatch(filename, glob))) {
+            debug('not handling colocation for %s', filename);
+            return;
           }
 
           debug('handling colocation for %s', filename);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,6 +665,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      minimatch:
+        specifier: ^3.0.4
+        version: 3.1.2
       resolve-package-path:
         specifier: ^4.0.1
         version: 4.0.3
@@ -696,6 +699,9 @@ importers:
       '@types/lodash':
         specifier: ^4.14.170
         version: 4.14.202
+      '@types/minimatch':
+        specifier: ^3.0.4
+        version: 3.0.5
       '@types/semver':
         specifier: ^7.3.6
         version: 7.5.8

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -29,7 +29,9 @@ appScenarios
       'babel.config.json': `
         {
           "plugins": [
-            "@embroider/addon-dev/template-colocation-plugin",
+            ["@embroider/addon-dev/template-colocation-plugin", {
+              exclude: ['**/just-a-template.js'],
+            }],
             "@babel/plugin-transform-class-static-block",
             ["babel-plugin-ember-template-compilation", {
               targetFormat: 'hbs',
@@ -286,9 +288,7 @@ appScenarios
           expectFile(
             'dist/components/demo/just-a-template.js'
           ).equalsCode(`import { precompileTemplate } from '@ember/template-compilation';
-import { setComponentTemplate } from '@ember/component';
-var TEMPLATE = precompileTemplate("<p>I am not a component but a template.</p>");
-var justATemplate = setComponentTemplate(TEMPLATE, precompileTemplate("<p>I am not a component but a template.</p>"));
+var justATemplate = precompileTemplate("<p>I am not a component but a template.</p>");
 export { justATemplate as default };
 //# sourceMappingURL=just-a-template.js.map`);
         });

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -71,7 +71,9 @@ appScenarios
               exclude: ['**/-excluded/**/*'],
             }),
 
-            addon.hbs(),
+            addon.hbs({
+              templates: ['**/just-a-template.js'],
+            }),
             addon.gjs(),
             addon.dependencies(),
 
@@ -125,12 +127,10 @@ appScenarios
                 import { tracked } from '@glimmer/tracking';
 
                 import FlipButton from './button';
-                import JustATemplate from './just-a-template';
                 import Out from './out';
 
                 export default class ExampleComponent extends Component {
                   Button = FlipButton;
-                  JustATemplate = JustATemplate;
                   Out = Out;
 
                   @tracked active = false;
@@ -139,8 +139,6 @@ appScenarios
                 }
               `,
             'index.hbs': `Hello there!
-
-              <this.JustATemplate />
 
               <this.Out>{{this.active}}</this.Out>
 
@@ -287,12 +285,11 @@ appScenarios
 
           expectFile(
             'dist/components/demo/just-a-template.js'
-          ).equalsCode(`import templateOnly from '@ember/component/template-only';
-import { precompileTemplate } from '@ember/template-compilation';
+          ).equalsCode(`import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@ember/component';
 var TEMPLATE = precompileTemplate("<p>I am not a component but a template.</p>");
-var JustATemplate = setComponentTemplate(TEMPLATE, templateOnly());
-export { JustATemplate as default };
+var justATemplate = setComponentTemplate(TEMPLATE, precompileTemplate("<p>I am not a component but a template.</p>"));
+export { justATemplate as default };
 //# sourceMappingURL=just-a-template.js.map`);
         });
 

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -113,6 +113,7 @@ appScenarios
                 flip
               </button>
             `,
+            'just-a-template.hbs': `<p>I am not a component but a template.</p>`,
             'out.hbs': `
               <out>{{yield}}</out>
             `,
@@ -124,10 +125,12 @@ appScenarios
                 import { tracked } from '@glimmer/tracking';
 
                 import FlipButton from './button';
+                import JustATemplate from './just-a-template';
                 import Out from './out';
 
                 export default class ExampleComponent extends Component {
                   Button = FlipButton;
+                  JustATemplate = JustATemplate;
                   Out = Out;
 
                   @tracked active = false;
@@ -136,6 +139,8 @@ appScenarios
                 }
               `,
             'index.hbs': `Hello there!
+
+              <this.JustATemplate />
 
               <this.Out>{{this.active}}</this.Out>
 
@@ -244,6 +249,7 @@ appScenarios
             './components/demo/button.js': './dist/_app_/components/demo/button.js',
             './components/single-file-component.js': './dist/_app_/components/single-file-component.js',
             './components/demo/index.js': './dist/_app_/components/demo/index.js',
+            './components/demo/just-a-template.js': './dist/_app_/components/demo/just-a-template.js',
             './components/demo/out.js': './dist/_app_/components/demo/out.js',
             './components/demo/namespace/namespace-me.js': './dist/_app_/components/demo/namespace/namespace-me.js',
           });
@@ -251,6 +257,7 @@ appScenarios
 
         test('the addon has expected public entrypoints', async function () {
           expectFile('dist/components/demo/index.js').exists();
+          expectFile('dist/components/demo/just-a-template.js').exists();
           expectFile('dist/components/demo/out.js').exists();
           expectFile('dist/components/demo/namespace-me.js').exists();
           expectFile('dist/components/-excluded/never-import-this.js').doesNotExist();
@@ -259,6 +266,9 @@ appScenarios
         test('the addon has expected app-reexports', async function () {
           expectFile('dist/_app_/components/demo/index.js').matches(
             'export { default } from "v2-addon/components/demo/index"'
+          );
+          expectFile('dist/_app_/components/demo/just-a-template.js').matches(
+            'export { default } from "v2-addon/components/demo/just-a-template"'
           );
           expectFile('dist/_app_/components/demo/out.js').matches(
             'export { default } from "v2-addon/components/demo/out"'
@@ -274,6 +284,16 @@ appScenarios
             /TEMPLATE = precompileTemplate\("Hello there/,
             'template is still in hbs format'
           );
+
+          expectFile(
+            'dist/components/demo/just-a-template.js'
+          ).equalsCode(`import templateOnly from '@ember/component/template-only';
+import { precompileTemplate } from '@ember/template-compilation';
+import { setComponentTemplate } from '@ember/component';
+var TEMPLATE = precompileTemplate("<p>I am not a component but a template.</p>");
+var JustATemplate = setComponentTemplate(TEMPLATE, templateOnly());
+export { JustATemplate as default };
+//# sourceMappingURL=just-a-template.js.map`);
         });
 
         test('gjs components compiled correctly', async function () {

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -30,7 +30,7 @@ appScenarios
         {
           "plugins": [
             ["@embroider/addon-dev/template-colocation-plugin", {
-              exclude: ['**/just-a-template.js'],
+              exclude: ['**/just-a-template.hbs'],
             }],
             "@babel/plugin-transform-class-static-block",
             ["babel-plugin-ember-template-compilation", {
@@ -74,7 +74,7 @@ appScenarios
             }),
 
             addon.hbs({
-              templates: ['**/just-a-template.js'],
+              excludeColocation: ['**/just-a-template.hbs'],
             }),
             addon.gjs(),
             addon.dependencies(),


### PR DESCRIPTION
Relates to #1776

**Problem**
In `main` branch, any hbs that is not colocated with its js is compiled as a template-only component. This behavior breaks the possibility for addons to provide hbs templates that are not components, like route templates.

**Solution**
This PR introduces the possibility of specifying in config the hbs files that should not be compiled as template-only components. 

Two different layers transform the standalone `.hbs` in the codebase into a template-only component `.js` in the addon build: the Rollup plugin `rollup-hbs-plugin` and the Babel plugin `template-colocation-plugin`. As Rollup config and Babel config are currently not shared, the glob patterns that prevent this compilation from happening will have to be specified for both tools.

In the `rollup.config.mjs` of the v2 addon:
```diff 
// Ensure that standalone .hbs files are properly integrated as Javascript.
- addon.hbs(),
+ addon.hbs({
+  excludeColocation: ['templates/**/*'] // all files in the templates folder are not colocated components
+ })
```

In the `babel.config.json` of the v2 addon:
```diff
"plugins": [
- "@embroider/addon-dev/template-colocation-plugin",
+ ["@embroider/addon-dev/template-colocation-plugin", {
+   exclude: ['templates/**/*'] 
+ }],
],
```

**Required refactorings**
Helpers that are not provided by the addon itself need to be explicitly imported.

For instance, let's assume your v1 addon used to have a dependency to [ember-root-url](https://github.com/ef4/ember-root-url) and the helper was called in a hbs route template:
```hbs
<img src={{root-url "images/hello.png"}} />
```
You'll be able to build the v2 addon, but when starting the app you'll run into `Attempted to resolve 'root-url', which was expected to be a component or helper, but nothing was found.`

To get rid of the error, one solution is to import the helper into the route controller so it's passed down to the template through the context:
```js
import Controller from '@ember/controller';
import rootUrl from 'ember-root-url/helpers/root-url';

export default class ApplicationController extends Controller {
  rootUrl = rootUrl;
}
```
```hbs
<img src={{this.root-url "images/hello.png"}} />
```
(This example doesn't apply to built-in helpers like the `{{component}}` helper, the hbs route template your v2 addon provides can use such a helper and it will continue to work with your classic Ember app.)






