### PR TITLE
fix release-plan unlabelled changes PR

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -58,17 +58,17 @@ jobs:
         run: |
           set +e
 
-          pnpm release-plan prepare 2> >(tee -a stderr.log >&2)
-
+          pnpm release-plan prepare 2> >(tee -a stderr.txt >&2)
 
           if [ $? -ne 0 ]; then
             echo 'text<<EOF' >> $GITHUB_OUTPUT
-            cat stderr.log >> $GITHUB_OUTPUT
+            cat stderr.txt >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
           else
             echo 'text<<EOF' >> $GITHUB_OUTPUT
             jq .description .release-plan.json -r >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
+            rm stderr.txt
           fi
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
release-plan is supposed to report unlabelled PRs in the Prepare Release pr but it hasn't been working correctly. I figured out that the issue is that the pull request action won't open a PR unless there are some file changes and `stderr.log` is covered by our .gitignore file.

This PR fixes that and it also makes sure that the stderr.txt doesn't make it into the PR when the release-plan job is successful.