### PR TITLE
with namespace in publicAssets don't include path

### DIFF
--- a/packages/addon-dev/README.md
+++ b/packages/addon-dev/README.md
@@ -20,7 +20,7 @@ For a guide on porting a V1 addon to V2, see https://github.com/embroider-build/
 
 ### addon.publicAssets(path <required>, options)
 
-A rollup plugin to expose a folder of assets. `path` is a required to define which folder to expose. `options.include` is a glob pattern passed to `walkSync.include` to pick files. `options.exlude` is a glob pattern passed to `walkSync.ignore` to exclude files. `options.namespace` is the namespace to expose files, defaults to the package name
+A rollup plugin to expose a folder of assets. `path` is a required to define which folder to expose. `options.include` is a glob pattern passed to `walkSync.include` to pick files. `options.exlude` is a glob pattern passed to `walkSync.ignore` to exclude files. `options.namespace` is the namespace to expose files, defaults to the package name + the path that you provided e.g. if you call `addon.publicAssets('public')` in a v2 addon named `super-addon` then your namespace will default to `super-addon/public`.
 
 ## addon-dev command
 

--- a/packages/addon-dev/src/rollup-public-assets.ts
+++ b/packages/addon-dev/src/rollup-public-assets.ts
@@ -51,9 +51,9 @@ export default function publicAssets(
       });
       const publicAssets: Record<string, string> = filenames.reduce(
         (acc: Record<string, string>, v): Record<string, string> => {
-          acc[`./${path}/${v}`] = resolve(
-            '/' + join(opts?.namespace ?? pkg.name, path, v)
-          );
+          const namespace = opts?.namespace ?? join(pkg.name, path);
+
+          acc[`./${path}/${v}`] = resolve('/' + join(namespace, v));
           return acc;
         },
         {}

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -396,7 +396,7 @@ export { SingleFileComponent as default };
             './public/thing.txt': '/v2-addon/public/thing.txt',
           });
           expectNoNamespaceFile('package.json').json('ember-addon.public-assets').deepEquals({
-            './public/other.txt': '/public/other.txt',
+            './public/other.txt': '/other.txt',
           });
         });
       });


### PR DESCRIPTION
When you provide a namespace to the options of `addon.publicAssets()` don't include the folder path in the file names. It was likely included as a bug originally but we need to only out out of it when namespace is used to prevent the need for a major release

This essentially shows that https://github.com/embroider-build/embroider/pull/1867 didn't quite go far enough 🙈 