### PR TITLE
fix vite watch mode dep optimizer

### DIFF
--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -148,7 +148,7 @@ export function renderEntrypoint(
 
   return {
     src: entryTemplate(params),
-    watches: [],
+    watches: [fromDir],
   };
 }
 

--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -42,6 +42,10 @@ export function emberBuild(command: string, mode: string, resolvableExtensions: 
   });
 }
 
+// we need a bare specifier for rewritten packages that is resolvable from root
+// we cannot use a bare specifier that starts with .embroider, that is not a bare import
+// according to vite
+// which is why we make this symlink
 function createSymlinkToRewrittenPackages(appRoot: string = process.cwd()) {
   const resolvableRewrittenPackages = resolve(
     locateEmbroiderWorkingDir(appRoot),

--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -1,5 +1,10 @@
 import { fork } from 'child_process';
 import type { Plugin } from 'vite';
+import { resolve } from 'path';
+import fs from 'fs-extra';
+const { ensureSymlinkSync, existsSync, writeFileSync } = fs;
+import { locateEmbroiderWorkingDir } from '@embroider/core';
+import * as process from 'process';
 
 export function emberBuild(command: string, mode: string, resolvableExtensions: string[] | undefined): Promise<void> {
   let env: Record<string, string> = {
@@ -37,6 +42,30 @@ export function emberBuild(command: string, mode: string, resolvableExtensions: 
   });
 }
 
+function createSymlinkToRewrittenPackages(appRoot: string = process.cwd()) {
+  const resolvableRewrittenPackages = resolve(
+    locateEmbroiderWorkingDir(appRoot),
+    '..',
+    '@embroider',
+    'rewritten-packages'
+  );
+  const embroiderDir = resolve(locateEmbroiderWorkingDir(appRoot), 'rewritten-packages');
+  if (existsSync(embroiderDir)) {
+    ensureSymlinkSync(embroiderDir, resolvableRewrittenPackages, 'dir');
+    writeFileSync(
+      resolve(resolvableRewrittenPackages, 'package.json'),
+      JSON.stringify(
+        {
+          name: '@embroider/rewritten-packages',
+          main: 'moved-package-target.js',
+        },
+        null,
+        2
+      )
+    );
+  }
+}
+
 export function compatPrebuild(): Plugin {
   let viteCommand: string | undefined;
   let viteMode: string | undefined;
@@ -58,6 +87,7 @@ export function compatPrebuild(): Plugin {
         throw new Error(`bug: embroider compatPrebuild did not detect Vite's mode`);
       }
       await emberBuild(viteCommand, viteMode, resolvableExtensions);
+      createSymlinkToRewrittenPackages();
     },
   };
 }

--- a/packages/vite/src/request.ts
+++ b/packages/vite/src/request.ts
@@ -1,12 +1,17 @@
-import type { ModuleRequest, Resolution } from '@embroider/core';
+import type { ModuleRequest, Resolution, Package, PackageCache as _PackageCache } from '@embroider/core';
 import core from '@embroider/core';
-const { cleanUrl, getUrlQueryParams } = core;
+const { cleanUrl, getUrlQueryParams, locateEmbroiderWorkingDir, packageName } = core;
 import type { PluginContext, ResolveIdResult } from 'rollup';
+import { resolve } from 'path';
+
+type PublicAPI<T> = { [K in keyof T]: T[K] };
+type PackageCache = PublicAPI<_PackageCache>;
 
 export const virtualPrefix = 'embroider_virtual:';
 
 export class RollupModuleRequest implements ModuleRequest {
   static from(
+    packageCache: PackageCache,
     context: PluginContext,
     source: string,
     importer: string | undefined,
@@ -34,6 +39,7 @@ export class RollupModuleRequest implements ModuleRequest {
       let queryParams = getUrlQueryParams(source);
 
       return new RollupModuleRequest(
+        packageCache,
         context,
         cleanSource,
         fromFile,
@@ -47,6 +53,7 @@ export class RollupModuleRequest implements ModuleRequest {
   }
 
   private constructor(
+    public packageCache: PackageCache,
     private context: PluginContext,
     readonly specifier: string,
     readonly fromFile: string,
@@ -75,6 +82,7 @@ export class RollupModuleRequest implements ModuleRequest {
 
   alias(newSpecifier: string) {
     return new RollupModuleRequest(
+      this.packageCache,
       this.context,
       newSpecifier,
       this.fromFile,
@@ -90,6 +98,7 @@ export class RollupModuleRequest implements ModuleRequest {
       return this;
     } else {
       return new RollupModuleRequest(
+        this.packageCache,
         this.context,
         this.specifier,
         newFromFile,
@@ -103,6 +112,7 @@ export class RollupModuleRequest implements ModuleRequest {
   }
   virtualize(filename: string) {
     return new RollupModuleRequest(
+      this.packageCache,
       this.context,
       virtualPrefix + filename,
       this.fromFile,
@@ -115,6 +125,7 @@ export class RollupModuleRequest implements ModuleRequest {
   }
   withMeta(meta: Record<string, any> | undefined): this {
     return new RollupModuleRequest(
+      this.packageCache,
       this.context,
       this.specifier,
       this.fromFile,
@@ -127,6 +138,7 @@ export class RollupModuleRequest implements ModuleRequest {
   }
   notFound(): this {
     return new RollupModuleRequest(
+      this.packageCache,
       this.context,
       this.specifier,
       this.fromFile,
@@ -137,6 +149,7 @@ export class RollupModuleRequest implements ModuleRequest {
       this.importerQueryParams
     ) as this;
   }
+
   async defaultResolve(): Promise<Resolution<ResolveIdResult>> {
     if (this.isVirtual) {
       return {
@@ -153,7 +166,9 @@ export class RollupModuleRequest implements ModuleRequest {
       (err as any).code = 'MODULE_NOT_FOUND';
       return { type: 'not_found', err };
     }
-    let result = await this.context.resolve(this.specifierWithQueryParams, this.fromFileWithQueryParams, {
+    let resolvable = makeResolvable(this.packageCache, this.fromFile, this.specifier);
+    let r = this.alias(resolvable.specifier).rehome(resolvable.fromFile);
+    let result = await this.context.resolve(r.specifierWithQueryParams, r.fromFileWithQueryParams, {
       skipSelf: true,
       custom: {
         embroider: {
@@ -172,6 +187,7 @@ export class RollupModuleRequest implements ModuleRequest {
 
   resolveTo(resolution: Resolution<ResolveIdResult>): this {
     return new RollupModuleRequest(
+      this.packageCache,
       this.context,
       this.specifier,
       this.fromFile,
@@ -182,4 +198,59 @@ export class RollupModuleRequest implements ModuleRequest {
       this.importerQueryParams
     ) as this;
   }
+}
+
+/**
+ * For Vite to correctly detect and optimize dependencies the request must have the following conditions
+ * 1. specifier must be a bare import
+ * 2. specifier must be node resolvable without any plugins
+ * 3. importer must not be in node_modules
+ *
+ * this functions changes the request for rewritten addons such that they are resolvable from app root
+ */
+export function makeResolvable(
+  packageCache: PackageCache,
+  fromFile: string,
+  specifier: string
+): { fromFile: string; specifier: string } {
+  if (fromFile.startsWith('@embroider/rewritten-packages')) {
+    let workingDir = locateEmbroiderWorkingDir(process.cwd());
+    const rewrittenRoot = resolve(workingDir, 'rewritten-packages');
+    fromFile = fromFile.replace('@embroider/rewritten-packages', rewrittenRoot);
+  }
+  if (fromFile && !fromFile.startsWith('./')) {
+    let fromPkg: Package;
+    try {
+      fromPkg = packageCache.ownerOfFile(fromFile) || packageCache.ownerOfFile(process.cwd())!;
+    } catch (e) {
+      fromPkg = packageCache.ownerOfFile(process.cwd())!;
+    }
+
+    if (!fromPkg.isV2App()) {
+      return { fromFile, specifier };
+    }
+
+    let pkgName = packageName(specifier);
+    try {
+      let pkg = pkgName ? packageCache.resolve(pkgName, fromPkg!) : fromPkg;
+      if (!pkg.isV2Addon() || !pkg.meta['auto-upgraded'] || !pkg.root.includes('rewritten-packages')) {
+        // some tests make addons be auto-upgraded, but are not actually in rewritten-packages
+        return { fromFile, specifier };
+      }
+      let levels = ['..'];
+      if (pkg.name.startsWith('@')) {
+        levels.push('..');
+      }
+      let resolvedRoot = resolve(pkg.root, ...levels, ...levels, '..');
+      if (specifier.startsWith(pkg.name)) {
+        specifier = resolve(pkg.root, ...levels, specifier);
+      }
+      specifier = specifier.replace(resolvedRoot, '@embroider/rewritten-packages').replace(/\\/g, '/');
+      return {
+        specifier,
+        fromFile: resolve(process.cwd(), 'package.json'),
+      };
+    } catch (e) {}
+  }
+  return { fromFile, specifier };
 }

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -42,7 +42,13 @@ export function resolver(): Plugin {
         return await observeDepScan(this, source, importer, options);
       }
 
-      let request = RollupModuleRequest.from(this, source, importer, options.custom);
+      let request = RollupModuleRequest.from(
+        resolverLoader.resolver.packageCache,
+        this,
+        source,
+        importer,
+        options.custom
+      );
       if (!request) {
         // fallthrough to other rollup plugins
         return null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
         version: 29.5.12
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.5
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.6.2)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/parser':
         specifier: ^5.59.5
-        version: 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+        version: 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       concurrently:
         specifier: ^7.2.1
         version: 7.6.0
@@ -45,7 +45,7 @@ importers:
         version: 8.10.0(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.27.5
-        version: 2.30.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
@@ -60,7 +60,7 @@ importers:
         version: 0.9.2
       typescript:
         specifier: ^5.5.2
-        version: 5.6.2
+        version: 5.5.4
 
   packages/addon-dev:
     dependencies:
@@ -112,7 +112,7 @@ importers:
         version: 0.1.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
 
   packages/addon-shim:
     dependencies:
@@ -140,7 +140,7 @@ importers:
         version: 1.7.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
       webpack:
         specifier: ^5
         version: 5.94.0
@@ -255,7 +255,7 @@ importers:
         version: 4.1.2
       debug:
         specifier: ^4.3.2
-        version: 4.3.7(supports-color@8.1.1)
+        version: 4.3.6(supports-color@8.1.1)
       fast-sourcemap-concat:
         specifier: ^2.1.1
         version: 2.1.1
@@ -370,13 +370,13 @@ importers:
         version: 3.1.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
 
   packages/config-meta-loader:
     devDependencies:
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
 
   packages/core:
     dependencies:
@@ -418,7 +418,7 @@ importers:
         version: 3.0.1
       debug:
         specifier: ^4.3.2
-        version: 4.3.7(supports-color@8.1.1)
+        version: 4.3.6(supports-color@8.1.1)
       escape-string-regexp:
         specifier: ^4.0.0
         version: 4.0.0
@@ -509,7 +509,7 @@ importers:
         version: 0.1.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
 
   packages/hbs-loader:
     devDependencies:
@@ -521,7 +521,7 @@ importers:
         version: 15.14.9
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
       webpack:
         specifier: ^5
         version: 5.94.0
@@ -606,7 +606,7 @@ importers:
         version: 3.1.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
 
   packages/reverse-exports:
     dependencies:
@@ -640,16 +640,16 @@ importers:
         version: 5.3.1(@babel/core@7.25.2)(rollup@3.29.4)
       '@rollup/plugin-typescript':
         specifier: ^11.1.2
-        version: 11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.6.2)
+        version: 11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.5.4)
       '@tsconfig/ember':
         specifier: ^1.0.0
         version: 1.0.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.5
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.6.2)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.5.4)
       '@typescript-eslint/parser':
         specifier: ^5.59.5
-        version: 5.62.0(eslint@7.32.0)(typescript@5.6.2)
+        version: 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       concurrently:
         specifier: ^7.2.1
         version: 7.6.0
@@ -685,7 +685,7 @@ importers:
         version: 2.7.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
 
   packages/shared-internals:
     dependencies:
@@ -694,7 +694,7 @@ importers:
         version: 2.1.1
       debug:
         specifier: ^4.3.2
-        version: 4.3.7(supports-color@8.1.1)
+        version: 4.3.6(supports-color@8.1.1)
       ember-rfc176-data:
         specifier: ^0.3.17
         version: 0.3.18
@@ -764,7 +764,7 @@ importers:
         version: 0.1.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
 
   packages/test-setup:
     dependencies:
@@ -847,10 +847,10 @@ importers:
         version: 1.4.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.5
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.6.2)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.5.4)
       '@typescript-eslint/parser':
         specifier: ^5.59.5
-        version: 5.62.0(eslint@7.32.0)(typescript@5.6.2)
+        version: 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       babel-eslint:
         specifier: ^10.1.0
         version: 10.1.0(eslint@7.32.0)
@@ -940,7 +940,7 @@ importers:
         version: 2.0.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
       webpack:
         specifier: ^5.74.0
         version: 5.94.0
@@ -967,7 +967,7 @@ importers:
         version: 2.0.2
       debug:
         specifier: ^4.3.2
-        version: 4.3.7(supports-color@8.1.1)
+        version: 4.3.6(supports-color@8.1.1)
       esbuild:
         specifier: ^0.17.19
         version: 0.17.19
@@ -988,7 +988,7 @@ importers:
         version: 0.4.1
       terser:
         specifier: ^5.7.0
-        version: 5.32.0
+        version: 5.31.6
     devDependencies:
       '@embroider/core':
         specifier: workspace:^
@@ -1013,7 +1013,7 @@ importers:
         version: 4.21.2
       vite:
         specifier: ^5.3.3
-        version: 5.4.3(terser@5.32.0)
+        version: 5.4.2(terser@5.31.6)
 
   packages/webpack:
     dependencies:
@@ -1049,7 +1049,7 @@ importers:
         version: 4.2.0
       debug:
         specifier: ^4.3.2
-        version: 4.3.7(supports-color@8.1.1)
+        version: 4.3.6(supports-color@8.1.1)
       escape-string-regexp:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1079,7 +1079,7 @@ importers:
         version: 8.1.1
       terser:
         specifier: ^5.7.0
-        version: 5.32.0
+        version: 5.31.6
       thread-loader:
         specifier: ^3.0.4
         version: 3.0.4(webpack@5.94.0)
@@ -1110,7 +1110,7 @@ importers:
         version: 7.5.8
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
       webpack:
         specifier: ^5.38.1
         version: 5.94.0
@@ -1462,7 +1462,7 @@ importers:
         version: 2.0.0
       vite:
         specifier: ^5.2.8
-        version: 5.4.3(terser@5.32.0)
+        version: 5.4.2(terser@5.31.6)
       webpack:
         specifier: ^5.74.0
         version: 5.94.0
@@ -1609,7 +1609,7 @@ importers:
         version: 2.0.0
       stylelint:
         specifier: ^15.7.0
-        version: 15.11.0(typescript@5.6.2)
+        version: 15.11.0(typescript@5.5.4)
       stylelint-config-standard:
         specifier: ^33.0.0
         version: 33.0.0(stylelint@15.11.0)
@@ -1621,7 +1621,7 @@ importers:
         version: 3.3.0
       vite:
         specifier: ^5.0.9
-        version: 5.4.3(terser@5.32.0)
+        version: 5.4.2(terser@5.31.6)
 
   tests/fixtures: {}
 
@@ -1689,7 +1689,7 @@ importers:
         version: 7.6.3
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(typescript@5.6.2)
+        version: 10.9.2(typescript@5.5.4)
     devDependencies:
       '@babel/core':
         specifier: ^7.17.5
@@ -1747,7 +1747,7 @@ importers:
         version: 5.3.1(@babel/core@7.25.2)(rollup@3.29.4)
       '@rollup/plugin-typescript':
         specifier: ^11.1.2
-        version: 11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.6.2)
+        version: 11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.5.4)
       '@tsconfig/ember':
         specifier: 1.0.1
         version: 1.0.1
@@ -1912,7 +1912,7 @@ importers:
         version: 2.7.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
       webpack:
         specifier: ^5.90.3
         version: 5.94.0
@@ -2059,7 +2059,7 @@ importers:
         version: 2.0.0
       stylelint:
         specifier: ^15.10.3
-        version: 15.11.0(typescript@5.6.2)
+        version: 15.11.0(typescript@5.5.4)
       stylelint-config-standard:
         specifier: ^34.0.0
         version: 34.0.0(stylelint@15.11.0)
@@ -2071,10 +2071,10 @@ importers:
         version: 3.3.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
       vite:
         specifier: ^5.1.5
-        version: 5.4.3(terser@5.32.0)
+        version: 5.4.2(terser@5.31.6)
       webpack:
         specifier: ^5.88.2
         version: 5.94.0
@@ -2221,7 +2221,7 @@ importers:
         version: 2.0.0
       stylelint:
         specifier: ^15.10.3
-        version: 15.11.0(typescript@5.6.2)
+        version: 15.11.0(typescript@5.5.4)
       stylelint-config-standard:
         specifier: ^34.0.0
         version: 34.0.0(stylelint@15.11.0)
@@ -2233,10 +2233,10 @@ importers:
         version: 3.3.0
       typescript:
         specifier: ^5.4.5
-        version: 5.6.2
+        version: 5.5.4
       vite:
         specifier: ^5.1.5
-        version: 5.4.3(terser@5.32.0)
+        version: 5.4.2(terser@5.31.6)
       webpack:
         specifier: ^5.88.2
         version: 5.94.0
@@ -2295,7 +2295,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.1.0
+      picocolors: 1.0.1
 
   /@babel/compat-data@7.25.4:
     resolution: {integrity: sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==}
@@ -2316,7 +2316,7 @@ packages:
       '@babel/traverse': 7.25.6(supports-color@8.1.1)
       '@babel/types': 7.25.6
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2338,7 +2338,7 @@ packages:
       '@babel/traverse': 7.25.6(supports-color@8.1.1)
       '@babel/types': 7.25.6
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2460,7 +2460,7 @@ packages:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -2474,7 +2474,7 @@ packages:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -2645,7 +2645,7 @@ packages:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.1.0
+      picocolors: 1.0.1
 
   /@babel/parser@7.25.6:
     resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
@@ -4057,7 +4057,7 @@ packages:
       '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
       '@babel/types': 7.25.6
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4157,7 +4157,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.3(ember-source@3.28.12)
@@ -4197,7 +4197,7 @@ packages:
       '@ember-data/store': 4.8.8(@babel/core@7.25.2)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(ember-source@3.28.12)(webpack@5.94.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
@@ -4219,7 +4219,7 @@ packages:
       '@ember-data/private-build-infra': 5.3.0
       '@ember-data/store': 5.3.0(@babel/core@7.25.2)(@ember-data/tracking@5.3.0)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.3(ember-source@3.28.12)
@@ -4242,7 +4242,7 @@ packages:
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-path-utils: 1.0.0
@@ -4277,7 +4277,7 @@ packages:
     resolution: {integrity: sha512-pmHrbPPqwMINDhfW+Hd0KR39X3baSwQf0Fk19YCzxxGYQ2wrcanOdlKhL4U/T6UUN8AXpRtqe6+YcDg5eVJkZg==}
     engines: {node: ^14.8.0 || 16.* || >= 18.*}
     dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -4310,7 +4310,7 @@ packages:
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -4346,7 +4346,7 @@ packages:
       '@ember-data/private-build-infra': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -4367,7 +4367,7 @@ packages:
       '@ember-data/store': 5.3.0(@babel/core@7.25.2)(@ember-data/tracking@5.3.0)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       webpack: 5.94.0
@@ -4393,7 +4393,7 @@ packages:
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -4410,7 +4410,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -4426,7 +4426,7 @@ packages:
       '@ember-data/private-build-infra': 5.3.0
       '@ember-data/store': 5.3.0(@babel/core@7.25.2)(@ember-data/tracking@5.3.0)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4442,7 +4442,7 @@ packages:
       '@warp-drive/core-types': 0.0.0-beta.11
     dependencies:
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -4461,7 +4461,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -4482,7 +4482,7 @@ packages:
       '@ember-data/request-utils': 5.3.0(@babel/core@7.25.2)
       '@ember-data/store': 5.3.0(@babel/core@7.25.2)(@ember-data/tracking@5.3.0)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-inflector: 4.0.3(ember-source@3.28.12)
     transitivePeerDependencies:
@@ -4503,7 +4503,7 @@ packages:
       '@ember-data/graph': 5.4.0-beta.11(@ember-data/store@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -4528,7 +4528,7 @@ packages:
       '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)
       '@ember-data/private-build-infra': 4.12.8
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -4552,7 +4552,7 @@ packages:
       '@ember-data/json-api': 5.3.0(@babel/core@7.25.2)(@ember-data/graph@5.3.0)(@ember-data/request-utils@5.3.0)(@ember-data/store@5.3.0)(ember-inflector@4.0.3)
       '@ember-data/private-build-infra': 5.3.0
       '@ember-data/request': 5.3.0(@babel/core@7.25.2)
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4583,7 +4583,7 @@ packages:
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -4641,7 +4641,7 @@ packages:
       '@ember-data/tracking': 4.12.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
@@ -4699,7 +4699,7 @@ packages:
       '@ember-data/tracking': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 7.26.11
@@ -4745,7 +4745,7 @@ packages:
       '@ember-data/tracking': 5.3.0(@babel/core@7.25.2)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-cli-string-utils: 1.1.0
@@ -4783,7 +4783,7 @@ packages:
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/tracking': 5.4.0-beta.11(@warp-drive/core-types@0.0.0-beta.11)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-string-utils: 1.1.0
@@ -4837,7 +4837,7 @@ packages:
       '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.25.2)
       '@babel/runtime': 7.25.6
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       babel-import-util: 1.4.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.25.2)
       babel-plugin-filter-imports: 4.0.0
@@ -4907,7 +4907,7 @@ packages:
       '@babel/runtime': 7.25.6
       '@ember-data/canary-features': 4.8.8
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       babel-import-util: 1.4.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.25.2)
       babel-plugin-filter-imports: 4.0.0
@@ -4943,7 +4943,7 @@ packages:
       '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.25.2)
       '@babel/runtime': 7.25.6
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       babel-import-util: 1.4.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.25.2)
       babel-plugin-filter-imports: 4.0.0
@@ -5011,7 +5011,7 @@ packages:
       '@ember-data/private-build-infra': 4.8.8
       '@ember-data/store': 4.8.8(@babel/core@7.25.2)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(ember-source@3.28.12)(webpack@5.94.0)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -5044,7 +5044,7 @@ packages:
         optional: true
     dependencies:
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -5058,7 +5058,7 @@ packages:
     dependencies:
       '@ember-data/private-build-infra': 4.12.8
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -5071,7 +5071,7 @@ packages:
     dependencies:
       '@ember-data/private-build-infra': 5.3.0
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -5086,7 +5086,7 @@ packages:
       '@warp-drive/core-types': 0.0.0-beta.11
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -5122,7 +5122,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.3(ember-source@3.28.12)
@@ -5159,7 +5159,7 @@ packages:
       '@ember-data/private-build-infra': 4.8.8
       '@ember-data/store': 4.8.8(@babel/core@7.25.2)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(ember-source@3.28.12)(webpack@5.94.0)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
@@ -5179,7 +5179,7 @@ packages:
     dependencies:
       '@ember-data/private-build-infra': 5.3.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.3(ember-source@3.28.12)
@@ -5202,7 +5202,7 @@ packages:
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-path-utils: 1.0.0
@@ -5258,7 +5258,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/tracking': 4.12.8
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -5309,7 +5309,7 @@ packages:
       '@ember-data/record-data': 4.8.8(@ember-data/store@4.8.8)(webpack@5.94.0)
       '@ember-data/tracking': 4.8.8
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 7.26.11
@@ -5332,7 +5332,7 @@ packages:
       '@ember-data/private-build-infra': 5.3.0
       '@ember-data/tracking': 5.3.0(@babel/core@7.25.2)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
@@ -5354,7 +5354,7 @@ packages:
       '@ember-data/request': 5.4.0-beta.11(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/tracking': 5.4.0-beta.11(@warp-drive/core-types@0.0.0-beta.11)(ember-source@3.28.12)
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -5367,7 +5367,7 @@ packages:
     engines: {node: 16.* || >= 18}
     dependencies:
       '@ember-data/private-build-infra': 4.12.8
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -5389,7 +5389,7 @@ packages:
     engines: {node: 16.* || >= 18}
     dependencies:
       '@ember-data/private-build-infra': 5.3.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -5404,7 +5404,7 @@ packages:
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-source: '>= 3.28.12'
     dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-source: 3.28.12(@babel/core@7.25.2)
@@ -5474,7 +5474,7 @@ packages:
     peerDependencies:
       ember-source: '*'
     dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-typescript: 4.2.1
@@ -5524,7 +5524,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.25.2)
       ember-source: 3.28.12(@babel/core@7.25.2)
@@ -5548,7 +5548,7 @@ packages:
       ember-source: '>=3.8.0'
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@embroider/util': 1.13.2(ember-source@3.28.12)
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5570,7 +5570,7 @@ packages:
       ember-source: ^4.0.0 || ^5.0.0
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5593,7 +5593,7 @@ packages:
       ember-source: ^4.0.0 || ^5.0.0
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5616,7 +5616,7 @@ packages:
       ember-source: ^4.0.0 || ^5.0.0
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5639,7 +5639,7 @@ packages:
       ember-source: ^4.0.0 || ^5.0.0
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5670,7 +5670,7 @@ packages:
     resolution: {integrity: sha512-qyN64T1jMHZ99ihlk7VFHCWHYZHLE1DOdHi0J7lmn5waV1DoW7gD8JLi1i7FregzXtKhbDc7shyEmTmWPTs8MQ==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@embroider/shared-internals': 2.6.3
+      '@embroider/shared-internals': 2.6.2
       broccoli-funnel: 3.0.8
       common-ancestor-path: 1.0.1
       semver: 7.6.3
@@ -5678,8 +5678,8 @@ packages:
       - supports-color
     dev: true
 
-  /@embroider/macros@1.16.6(@glint/template@1.4.0):
-    resolution: {integrity: sha512-aSdRetg0vY3c70G/3K85fOSlGtDzSV4ozwF9qD8ToQB+4RLZusxwItnctWEa+MKkhAYB6rbFiQ+bhFwEnaEazg==}
+  /@embroider/macros@1.16.5(@glint/template@1.4.0):
+    resolution: {integrity: sha512-Oz8bUZvZzOV1Gk3qSgIzZJJzs6acclSTcEFyB+KdKbKqjTC3uebn53aU2gAlLU7/YdTRZrg2gNbQuwAp+tGkGg==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
       '@glint/template': ^1.0.0
@@ -5687,7 +5687,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/shared-internals': 2.6.3
+      '@embroider/shared-internals': 2.6.2
       '@glint/template': 1.4.0
       assert-never: 1.3.0
       babel-import-util: 2.1.1
@@ -5699,12 +5699,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@embroider/shared-internals@2.6.3:
-    resolution: {integrity: sha512-wyFQNSqN+RZWg5ckqsk0Qfun433aEd70L6sc16sY4FFf/AzDnolmc0t3eR7lkdyxltYSrO5eqkFN7hW7l/glaw==}
+  /@embroider/shared-internals@2.6.2:
+    resolution: {integrity: sha512-jL3Bjn8C73AUBlTex+VixP7YmqvPNN/BZFB85odTstzLFOuR8y2mmGiuWbq17qNuFyoxc6xtndMnAeqwCXBNkA==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
       babel-import-util: 2.1.1
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       ember-rfc176-data: 0.3.18
       fs-extra: 9.1.0
       js-string-escape: 1.0.1
@@ -5729,7 +5729,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-source: 3.28.12(@babel/core@7.25.2)
@@ -6172,7 +6172,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -6189,7 +6189,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -7061,7 +7061,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7073,7 +7073,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8071,7 +8071,7 @@ packages:
       - supports-color
     dev: true
 
-  /@rollup/plugin-typescript@11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.6.2):
+  /@rollup/plugin-typescript@11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.5.4):
     resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -8088,7 +8088,7 @@ packages:
       resolve: 1.22.8
       rollup: 3.29.4
       tslib: 2.7.0
-      typescript: 5.6.2
+      typescript: 5.5.4
     dev: true
 
   /@rollup/pluginutils@3.1.0(rollup@3.29.4):
@@ -8244,10 +8244,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rtsao/scc@1.1.0:
-    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
-    dev: true
-
   /@simple-dom/document@1.4.0:
     resolution: {integrity: sha512-/RUeVH4kuD3rzo5/91+h4Z1meLSLP66eXqpVAw/4aZmYozkeqUkMprq0znL4psX/adEed5cBgiNJcfMz/eKZLg==}
     dependencies:
@@ -8379,7 +8375,7 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 10.17.60
+      '@types/node': 15.14.9
 
   /@types/broccoli-plugin@3.0.0:
     resolution: {integrity: sha512-f+TcsARR2PovfFRKFdCX0kfH/QoM3ZVD2h1rl2mNvrKO0fq2uBNCBsTU3JanfU4COCt5cXpTfARyUsERlC8vIw==}
@@ -8405,7 +8401,7 @@ packages:
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 10.17.60
+      '@types/node': 15.14.9
 
   /@types/cookie@0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
@@ -8448,7 +8444,7 @@ packages:
   /@types/express-serve-static-core@4.19.5:
     resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
     dependencies:
-      '@types/node': 10.17.60
+      '@types/node': 15.14.9
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -8504,7 +8500,7 @@ packages:
   /@types/http-proxy@1.17.15:
     resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
     dependencies:
-      '@types/node': 10.17.60
+      '@types/node': 15.14.9
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.6:
@@ -8598,6 +8594,7 @@ packages:
 
   /@types/node@10.17.60:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
+    dev: true
 
   /@types/node@15.14.9:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
@@ -8663,7 +8660,7 @@ packages:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 10.17.60
+      '@types/node': 15.14.9
       '@types/send': 0.17.4
 
   /@types/ssri@7.1.5:
@@ -8702,7 +8699,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.6.2):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@7.32.0)(typescript@5.5.4):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8714,23 +8711,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@5.6.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.6.2)
-      debug: 4.3.7(supports-color@8.1.1)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.6.3
-      tsutils: 3.21.0(typescript@5.6.2)
-      typescript: 5.6.2
+      tsutils: 3.21.0(typescript@5.5.4)
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.6.2):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.5.4):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8742,23 +8739,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
-      debug: 4.3.7(supports-color@8.1.1)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.6.3
-      tsutils: 3.21.0(typescript@5.6.2)
-      typescript: 5.6.2
+      tsutils: 3.21.0(typescript@5.5.4)
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.2):
+  /@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.5.4):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8770,15 +8767,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
-      debug: 4.3.7(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 7.32.0
-      typescript: 5.6.2
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.2):
+  /@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8790,10 +8787,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
-      debug: 4.3.7(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 8.57.0
-      typescript: 5.6.2
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8806,7 +8803,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.6.2):
+  /@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.5.4):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8816,17 +8813,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.6.2)
-      debug: 4.3.7(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 7.32.0
-      tsutils: 3.21.0(typescript@5.6.2)
-      typescript: 5.6.2
+      tsutils: 3.21.0(typescript@5.5.4)
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.57.0)(typescript@5.6.2):
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.57.0)(typescript@5.5.4):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8836,12 +8833,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
-      debug: 4.3.7(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 8.57.0
-      tsutils: 3.21.0(typescript@5.6.2)
-      typescript: 5.6.2
+      tsutils: 3.21.0(typescript@5.5.4)
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8851,7 +8848,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.2):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.5.4):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8862,17 +8859,17 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
-      tsutils: 3.21.0(typescript@5.6.2)
-      typescript: 5.6.2
+      tsutils: 3.21.0(typescript@5.5.4)
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.6.2):
+  /@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.5.4):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8883,7 +8880,7 @@ packages:
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.6.3
@@ -8892,7 +8889,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.6.2):
+  /@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.5.4):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8903,7 +8900,7 @@ packages:
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       eslint: 8.57.0
       eslint-scope: 5.1.1
       semver: 7.6.3
@@ -8929,7 +8926,7 @@ packages:
     engines: {node: '>= 18.20.3'}
     dependencies:
       '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       babel-import-util: 2.1.1
       broccoli-funnel: 3.0.8
       semver: 7.6.3
@@ -8942,7 +8939,7 @@ packages:
     resolution: {integrity: sha512-GHQE+woaGdRDGj6VG3Qt0uGBNog1zq5XO2Ccce35cYPpM3FOCOdmqB4Wt0miD1bBdbAuWQZmmQOIYAMSMCOdZQ==}
     engines: {node: '>= 18.20.3'}
     dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
     transitivePeerDependencies:
       - '@glint/template'
@@ -9105,8 +9102,8 @@ packages:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
 
-  /acorn-walk@8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+  /acorn-walk@8.3.3:
+    resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
     engines: {node: '>=0.4.0'}
     dependencies:
       acorn: 8.12.1
@@ -9132,7 +9129,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9153,6 +9150,9 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.17.1
 
@@ -9260,8 +9260,8 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  /ansi-regex@6.1.0:
-    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+  /ansi-regex@6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
     dev: true
 
@@ -9518,7 +9518,7 @@ packages:
     resolution: {integrity: sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       heimdalljs: 0.2.6
       istextorbinary: 2.6.0
       mkdirp: 0.5.6
@@ -9941,7 +9941,7 @@ packages:
     resolution: {integrity: sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==}
     engines: {node: '>= 16'}
     dependencies:
-      find-babel-config: 2.1.2
+      find-babel-config: 2.1.1
       glob: 8.1.0
       pkg-up: 3.1.0
       reselect: 4.1.8
@@ -10516,7 +10516,7 @@ packages:
       wordwrap: 0.0.3
 
   /bower-endpoint-parser@0.2.2:
-    resolution: {integrity: sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=}
+    resolution: {integrity: sha512-YWZHhWkPdXtIfH3VRu3QIV95sa75O9vrQWBOHjexWCLBCTy5qJvRr36LXTqFwTchSXVlzy5piYJOjzHr7qhsNg==}
     engines: {node: '>=0.8.0'}
 
   /boxen@5.1.2:
@@ -10823,7 +10823,7 @@ packages:
     dependencies:
       array-equal: 1.0.2
       broccoli-plugin: 4.0.7
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       fs-tree-diff: 2.0.1
       heimdalljs: 0.2.6
       minimatch: 3.1.2
@@ -11079,7 +11079,7 @@ packages:
       broccoli-persistent-filter: 2.3.1
       broccoli-plugin: 2.1.0
       chalk: 2.4.2
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       ensure-posix-path: 1.1.1
       fs-extra: 8.1.0
       minimatch: 3.1.2
@@ -11097,11 +11097,11 @@ packages:
       async-promise-queue: 1.0.5
       broccoli-plugin: 4.0.7
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       lodash.defaultsdeep: 4.6.1
       matcher-collection: 2.0.1
       symlink-or-copy: 1.3.1
-      terser: 5.32.0
+      terser: 5.31.6
       walk-sync: 2.2.0
       workerpool: 6.5.1
     transitivePeerDependencies:
@@ -11206,8 +11206,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001659
-      electron-to-chromium: 1.5.18
+      caniuse-lite: 1.0.30001655
+      electron-to-chromium: 1.5.13
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
 
@@ -11375,8 +11375,8 @@ packages:
       path-temp: 2.1.0
     dev: false
 
-  /caniuse-lite@1.0.30001659:
-    resolution: {integrity: sha512-Qxxyfv3RdHAfJcXelgf0hU4DFUVXBGTjqrBUZLUh8AtlGnsDo+CnncYtTd95+ZKfnANUOzxyIQCuU/UeBZBYoA==}
+  /caniuse-lite@1.0.30001655:
+    resolution: {integrity: sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==}
 
   /capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -11452,8 +11452,8 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
-  /cjs-module-lexer@1.4.1:
-    resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
+  /cjs-module-lexer@1.4.0:
+    resolution: {integrity: sha512-N1NGmowPlGBLsOZLPvm48StN04V4YvQRL0i6b7ctrVY3epjP/ct7hFLOItz6pDIvRjwpfPxi52a2UWV2ziir8g==}
     dev: true
 
   /class-utils@0.3.6:
@@ -11776,7 +11776,7 @@ packages:
       - supports-color
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /concurrently@7.6.0:
     resolution: {integrity: sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==}
@@ -12049,7 +12049,7 @@ packages:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   /cookie-signature@1.0.6:
-    resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   /cookie@0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
@@ -12093,7 +12093,7 @@ packages:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  /cosmiconfig@8.3.6(typescript@5.6.2):
+  /cosmiconfig@8.3.6(typescript@5.5.4):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -12106,7 +12106,7 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      typescript: 5.6.2
+      typescript: 5.5.4
     dev: true
 
   /create-jest@29.7.0:
@@ -12173,13 +12173,13 @@ packages:
     peerDependencies:
       webpack: ^4.27.0 || ^5.0.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.45)
+      icss-utils: 5.1.0(postcss@8.4.41)
       loader-utils: 2.0.4
-      postcss: 8.4.45
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.45)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.45)
-      postcss-modules-scope: 3.2.0(postcss@8.4.45)
-      postcss-modules-values: 4.0.0(postcss@8.4.45)
+      postcss: 8.4.41
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.41)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.41)
+      postcss-modules-scope: 3.2.0(postcss@8.4.41)
+      postcss-modules-values: 4.0.0(postcss@8.4.41)
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.6.3
@@ -12227,7 +12227,7 @@ packages:
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
     dependencies:
       mdn-data: 2.0.30
-      source-map-js: 1.2.1
+      source-map-js: 1.2.0
     dev: true
 
   /css-url-regex@1.1.0:
@@ -12348,8 +12348,8 @@ packages:
     dependencies:
       ms: 2.1.3
 
-  /debug@4.3.7(supports-color@8.1.1):
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+  /debug@4.3.6(supports-color@8.1.1):
+    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -12357,7 +12357,7 @@ packages:
       supports-color:
         optional: true
     dependencies:
-      ms: 2.1.3
+      ms: 2.1.2
       supports-color: 8.1.1
 
   /decamelize-keys@1.1.1:
@@ -12626,10 +12626,10 @@ packages:
       semver: 6.3.1
 
   /ee-first@1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  /electron-to-chromium@1.5.18:
-    resolution: {integrity: sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ==}
+  /electron-to-chromium@1.5.13:
+    resolution: {integrity: sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==}
 
   /ember-asset-loader@0.6.1:
     resolution: {integrity: sha512-e2zafQJBMLhzl69caTG/+mQMH20uMHYrm7KcmdbmnX0oY2dZ48bhm0Wh1SPLXS/6G2T9NsNMWX6J2pVSnI+xyA==}
@@ -12656,8 +12656,8 @@ packages:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.25.2)
       '@babel/preset-env': 7.25.4(@babel/core@7.25.2)
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
-      '@embroider/shared-internals': 2.6.3
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/shared-internals': 2.6.2
       babel-loader: 8.3.0(@babel/core@7.25.2)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.3.0
@@ -12669,7 +12669,7 @@ packages:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       css-loader: 5.2.7(webpack@5.94.0)
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       fs-extra: 10.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.8
@@ -12700,8 +12700,8 @@ packages:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.25.2)
       '@babel/preset-env': 7.25.4(@babel/core@7.25.2)
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
-      '@embroider/shared-internals': 2.6.3
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/shared-internals': 2.6.2
       babel-loader: 8.3.0(@babel/core@7.25.2)(webpack@5.94.0)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.3.0
@@ -12713,7 +12713,7 @@ packages:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       css-loader: 5.2.7(webpack@5.94.0)
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       fs-extra: 10.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.8
@@ -12740,7 +12740,7 @@ packages:
       ember-source: '>=3.24'
     dependencies:
       '@ember/render-modifiers': 2.1.0(@babel/core@7.25.2)(ember-source@3.28.12)
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@embroider/util': 1.13.2(ember-source@3.28.12)
       '@glimmer/component': 1.1.2(@babel/core@7.25.2)
       '@glimmer/tracking': 1.1.2
@@ -12811,7 +12811,7 @@ packages:
     peerDependencies:
       ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
     dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@glimmer/tracking': 1.1.2
       babel-import-util: 1.4.1
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.25.2)
@@ -13171,7 +13171,7 @@ packages:
     engines: {node: 16.* || >= 18}
     dependencies:
       broccoli-funnel: 3.0.8
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13228,7 +13228,7 @@ packages:
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-transform-typescript': 7.4.5(@babel/core@7.25.2)
       ansi-to-html: 0.6.15
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       ember-cli-babel-plugin-helpers: 1.1.1
       execa: 1.0.0
       fs-extra: 7.0.1
@@ -13248,7 +13248,7 @@ packages:
     dependencies:
       '@babel/plugin-transform-typescript': 7.5.5(@babel/core@7.25.2)
       ansi-to-html: 0.6.15
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       ember-cli-babel-plugin-helpers: 1.1.1
       execa: 2.1.0
       fs-extra: 8.1.0
@@ -13267,7 +13267,7 @@ packages:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.8
@@ -13285,7 +13285,7 @@ packages:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.8
@@ -13543,7 +13543,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.6
+      filesize: 10.1.4
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14160,7 +14160,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.6
+      filesize: 10.1.4
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14310,7 +14310,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.6
+      filesize: 10.1.4
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14457,7 +14457,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.6
+      filesize: 10.1.4
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14604,7 +14604,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.6
+      filesize: 10.1.4
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14752,7 +14752,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.6
+      filesize: 10.1.4
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14899,7 +14899,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.6
+      filesize: 10.1.4
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -15079,7 +15079,7 @@ packages:
       '@ember-data/tracking': 4.12.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@glimmer/env': 0.1.7
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
@@ -15135,7 +15135,7 @@ packages:
       '@ember-data/tracking': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@glimmer/env': 0.1.7
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
@@ -15170,7 +15170,7 @@ packages:
       '@ember-data/tracking': 5.3.0(@babel/core@7.25.2)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
@@ -15217,7 +15217,7 @@ packages:
       '@ember/edition-utils': 1.2.0
       '@ember/test-helpers': 2.9.4(@babel/core@7.25.2)(ember-source@3.28.12)
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       qunit: 2.22.0
@@ -15281,7 +15281,7 @@ packages:
       ember-source: ^3.12 || 4
     dependencies:
       '@ember/legacy-built-in-components': 0.4.2(ember-source@3.28.12)
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       amd-name-resolver: 1.3.1
       babel-plugin-compact-reexports: 1.1.0
       broccoli-babel-transpiler: 7.8.1
@@ -15312,7 +15312,7 @@ packages:
       '@ember/legacy-built-in-components': '*'
       ember-source: ^3.12 || 4
     dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       amd-name-resolver: 1.3.1
       babel-plugin-compact-reexports: 1.1.0
       broccoli-babel-transpiler: 7.8.1
@@ -15347,7 +15347,7 @@ packages:
     dependencies:
       '@babel/eslint-parser': 7.23.10(eslint@8.57.0)
       '@glimmer/syntax': 0.92.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       content-tag: 1.2.2
       eslint-scope: 7.2.2
       html-tags: 3.3.1
@@ -15377,7 +15377,7 @@ packages:
     resolution: {integrity: sha512-eHs+7D7PuQr8a1DPqsJTsEyo3FZ1XuH6WEZaEBPDa9s0xLlwByCNKl8hi1EbXOgvgEZNHHi9Rh0vjxyfakrlgg==}
     engines: {node: 10.* || >= 12}
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-version-checker: 5.1.2
@@ -15728,7 +15728,7 @@ packages:
     dependencies:
       '@ember/test-helpers': 3.3.1(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@5.3.0)(webpack@5.94.0)
       '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-test-loader: 3.1.0
       ember-source: 5.3.0(@babel/core@7.25.2)(@glimmer/component@1.1.2)(@glint/template@1.4.0)(webpack@5.94.0)
       qunit: 2.22.0
@@ -16663,7 +16663,7 @@ packages:
       chalk: 4.1.2
       cli-table3: 0.6.5
       core-object: 3.1.5
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       ember-try-config: 4.0.0
       execa: 4.1.0
       fs-extra: 9.1.0
@@ -16732,7 +16732,7 @@ packages:
       base64id: 2.0.0
       cookie: 0.4.2
       cors: 2.8.5
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.17.1
     transitivePeerDependencies:
@@ -17019,8 +17019,8 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.11.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
-    resolution: {integrity: sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==}
+  /eslint-module-utils@2.8.2(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    resolution: {integrity: sha512-3XnC5fDyc8M4J2E8pt8pmSVRX2M+5yWMCfI/kDZwauQeFgzQOuhcRBFKjTeJagqgk4sFKxe1mvNVnaWwImx/Tg==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -17040,7 +17040,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -17124,7 +17124,7 @@ packages:
         optional: true
     dependencies:
       '@ember-data/rfc395-data': 0.0.4
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       css-tree: 2.3.1
       ember-eslint-parser: 0.4.3(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)
       ember-rfc176-data: 0.3.18
@@ -17173,8 +17173,8 @@ packages:
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-import@2.30.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0):
-    resolution: {integrity: sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==}
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0)(eslint@8.57.0):
+    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -17183,8 +17183,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -17193,7 +17192,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.8.2(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -17381,7 +17380,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -17435,7 +17434,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -17819,7 +17818,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       cookie: 0.4.2
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       jsdom: 19.0.0
       resolve: 1.22.8
       simple-dom: 1.4.0
@@ -17837,7 +17836,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       cookie: 0.4.2
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       jsdom: 19.0.0
       resolve: 1.22.8
       simple-dom: 1.4.0
@@ -17895,8 +17894,8 @@ packages:
       flat-cache: 3.2.0
     dev: true
 
-  /filesize@10.1.6:
-    resolution: {integrity: sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==}
+  /filesize@10.1.4:
+    resolution: {integrity: sha512-ryBwPIIeErmxgPnm6cbESAzXjuEFubs+yKYLBZvg3CaiNcmkJChoOGcBSrZ6IwkMwPABwPpVXE6IlNdGJJrvEg==}
     engines: {node: '>= 10.4.0'}
     dev: true
 
@@ -17964,10 +17963,11 @@ packages:
       json5: 1.0.2
       path-exists: 3.0.0
 
-  /find-babel-config@2.1.2:
-    resolution: {integrity: sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==}
+  /find-babel-config@2.1.1:
+    resolution: {integrity: sha512-5Ji+EAysHGe1OipH7GN4qDjok5Z1uw5KAwDCbicU/4wyTZY7CqOCzcWbG7J5ad9mazq67k89fXlbc1MuIfl9uA==}
     dependencies:
       json5: 2.2.3
+      path-exists: 4.0.0
     dev: true
 
   /find-cache-dir@3.3.2:
@@ -18099,7 +18099,7 @@ packages:
       fixturify: 3.0.0
       resolve-package-path: 4.0.3
       tmp: 0.0.33
-      type-fest: 4.26.1
+      type-fest: 4.26.0
       walk-sync: 3.0.0
     dev: true
 
@@ -18107,7 +18107,7 @@ packages:
     resolution: {integrity: sha512-Dyns5nXY9LEvqnUBzfejnb7w1JfabduNvXmYXfnbqmro4QxkF0vgs3eBu2X8kVR3geL+LmPZwXb4aKy6k5gtvQ==}
     engines: {node: '>= 14.*'}
     dependencies:
-      '@embroider/shared-internals': 2.6.3
+      '@embroider/shared-internals': 2.6.2
       '@pnpm/find-workspace-dir': 7.0.1
       '@pnpm/fs.packlist': 2.0.0
       '@pnpm/logger': 5.2.0
@@ -18118,7 +18118,7 @@ packages:
       fs-extra: 10.1.0
       resolve-package-path: 4.0.3
       tmp: 0.0.33
-      type-fest: 4.26.1
+      type-fest: 4.26.0
       walk-sync: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -18182,8 +18182,8 @@ packages:
       tabbable: 5.3.3
     dev: true
 
-  /follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  /follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -19022,7 +19022,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19032,7 +19032,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19041,7 +19041,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.6
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -19051,7 +19051,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19089,13 +19089,13 @@ packages:
     dependencies:
       safer-buffer: 2.1.2
 
-  /icss-utils@5.1.0(postcss@8.4.45):
+  /icss-utils@5.1.0(postcss@8.4.41):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.45
+      postcss: 8.4.41
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -19602,7 +19602,7 @@ packages:
       has-symbols: 1.0.3
 
   /is-type@0.0.1:
-    resolution: {integrity: sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=}
+    resolution: {integrity: sha512-YwJh/zBVrcJ90aAnPBM0CbHvm7lG9ao7lIFeqTZ1UQj4iFLpM5CikdaU+dGGesrMJwxLqPGmjjrUrQ6Kn3Zh+w==}
     dependencies:
       core-util-is: 1.0.3
 
@@ -19714,7 +19714,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -20053,7 +20053,7 @@ packages:
       '@jest/types': 29.6.3
       '@types/node': 15.14.9
       chalk: 4.1.2
-      cjs-module-lexer: 1.4.1
+      cjs-module-lexer: 1.4.0
       collect-v8-coverage: 1.0.2
       glob: 7.2.3
       graceful-fs: 4.2.11
@@ -20314,7 +20314,7 @@ packages:
     hasBin: true
 
   /json-buffer@3.0.0:
-    resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
+    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
     dev: true
 
   /json-buffer@3.0.1:
@@ -20446,8 +20446,8 @@ packages:
     resolution: {integrity: sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ==}
     dev: true
 
-  /ky@1.7.2:
-    resolution: {integrity: sha512-OzIvbHKKDpi60TnF9t7UUVAF1B4mcqc02z5PIvrm08Wyb+yOcz63GRvEuVxNT18a9E1SrNouhB4W2NNLeD7Ykg==}
+  /ky@1.7.1:
+    resolution: {integrity: sha512-KJ/IXXkFhTDqxcN8wKqMXk1/UoOpc0UnOB6H7QcqlPInh/M2B5Mlj+i9exez1w4RSwJhNFmHiUDPriAYFwb5VA==}
     engines: {node: '>=18'}
     dev: true
 
@@ -20477,7 +20477,7 @@ packages:
     dev: true
 
   /leek@0.0.24:
-    resolution: {integrity: sha1-5ADlfw5g2O8r1NBo3EKKVDRdvNo=}
+    resolution: {integrity: sha512-6PVFIYXxlYF0o6hrAsHtGpTmi06otkwNrMcmQ0K96SeSRHPREPa9J3nJZ1frliVH7XT0XFswoJFQoXsDukzGNQ==}
     dependencies:
       debug: 2.6.9
       lodash.assign: 3.2.0
@@ -20946,7 +20946,7 @@ packages:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
   /media-typer@0.3.0:
-    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
   /mem@5.1.1:
@@ -20995,7 +20995,7 @@ packages:
     dev: true
 
   /merge-descriptors@1.0.1:
-    resolution: {integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=}
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -21299,6 +21299,9 @@ packages:
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  /ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -21956,7 +21959,7 @@ packages:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
     dependencies:
-      ky: 1.7.2
+      ky: 1.7.1
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
       semver: 7.6.3
@@ -22116,8 +22119,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  /picocolors@1.1.0:
-    resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
+  /picocolors@1.0.1:
+    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -22197,54 +22200,54 @@ packages:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
 
-  /postcss-modules-extract-imports@3.1.0(postcss@8.4.45):
+  /postcss-modules-extract-imports@3.1.0(postcss@8.4.41):
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.45
+      postcss: 8.4.41
 
-  /postcss-modules-local-by-default@4.0.5(postcss@8.4.45):
+  /postcss-modules-local-by-default@4.0.5(postcss@8.4.41):
     resolution: {integrity: sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.45)
-      postcss: 8.4.45
+      icss-utils: 5.1.0(postcss@8.4.41)
+      postcss: 8.4.41
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
-  /postcss-modules-scope@3.2.0(postcss@8.4.45):
+  /postcss-modules-scope@3.2.0(postcss@8.4.41):
     resolution: {integrity: sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.45
+      postcss: 8.4.41
       postcss-selector-parser: 6.1.2
 
-  /postcss-modules-values@4.0.0(postcss@8.4.45):
+  /postcss-modules-values@4.0.0(postcss@8.4.41):
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.45)
-      postcss: 8.4.45
+      icss-utils: 5.1.0(postcss@8.4.41)
+      postcss: 8.4.41
 
   /postcss-resolve-nested-selector@0.1.6:
     resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
     dev: true
 
-  /postcss-safe-parser@6.0.0(postcss@8.4.45):
+  /postcss-safe-parser@6.0.0(postcss@8.4.41):
     resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
-      postcss: 8.4.45
+      postcss: 8.4.41
     dev: true
 
   /postcss-selector-parser@6.1.2:
@@ -22257,13 +22260,13 @@ packages:
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  /postcss@8.4.45:
-    resolution: {integrity: sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==}
+  /postcss@8.4.41:
+    resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.1.0
-      source-map-js: 1.2.1
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -22443,6 +22446,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
     dev: true
 
@@ -23507,7 +23511,7 @@ packages:
   /socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -23519,7 +23523,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23530,7 +23534,7 @@ packages:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       engine.io: 6.5.5
       socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.4
@@ -23544,7 +23548,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -23586,8 +23590,8 @@ packages:
       is-plain-obj: 2.1.0
       sort-object-keys: 1.1.3
 
-  /source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+  /source-map-js@1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
 
   /source-map-resolve@0.5.3:
@@ -23726,7 +23730,7 @@ packages:
     resolution: {integrity: sha512-GqXBq2SPWv9hTXDFKS8WrKK1aISB0aKGHZzH+uD4ShAgs+Fz20ZfoerLOm8U+f62iRWLrw6nimOY/uYuTcVhvg==}
     engines: {node: 6.* || 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23877,7 +23881,7 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
     dependencies:
-      ansi-regex: 6.1.0
+      ansi-regex: 6.0.1
     dev: true
 
   /strip-bom@3.0.0:
@@ -23938,14 +23942,14 @@ packages:
     dev: true
 
   /styled_string@0.0.1:
-    resolution: {integrity: sha1-0ieCvYEpVFm8Tx3xjEutjpTdEko=}
+    resolution: {integrity: sha512-DU2KZiB6VbPkO2tGSqQ9n96ZstUPjW7X4sGO6V2m1myIQluX0p1Ol8BrA/l6/EesqhMqXOIXs3cJNOy1UuU2BA==}
 
   /stylelint-config-recommended@12.0.0(stylelint@15.11.0):
     resolution: {integrity: sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==}
     peerDependencies:
       stylelint: ^15.5.0
     dependencies:
-      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint: 15.11.0(typescript@5.5.4)
     dev: true
 
   /stylelint-config-recommended@13.0.0(stylelint@15.11.0):
@@ -23954,7 +23958,7 @@ packages:
     peerDependencies:
       stylelint: ^15.10.0
     dependencies:
-      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint: 15.11.0(typescript@5.5.4)
     dev: true
 
   /stylelint-config-standard@33.0.0(stylelint@15.11.0):
@@ -23962,7 +23966,7 @@ packages:
     peerDependencies:
       stylelint: ^15.5.0
     dependencies:
-      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint: 15.11.0(typescript@5.5.4)
       stylelint-config-recommended: 12.0.0(stylelint@15.11.0)
     dev: true
 
@@ -23972,7 +23976,7 @@ packages:
     peerDependencies:
       stylelint: ^15.10.0
     dependencies:
-      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint: 15.11.0(typescript@5.5.4)
       stylelint-config-recommended: 13.0.0(stylelint@15.11.0)
     dev: true
 
@@ -23985,7 +23989,7 @@ packages:
     dependencies:
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
-      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint: 15.11.0(typescript@5.5.4)
     dev: true
 
   /stylelint-prettier@4.1.0(prettier@3.3.3)(stylelint@15.11.0):
@@ -23997,10 +24001,10 @@ packages:
     dependencies:
       prettier: 3.3.3
       prettier-linter-helpers: 1.0.0
-      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint: 15.11.0(typescript@5.5.4)
     dev: true
 
-  /stylelint@15.11.0(typescript@5.6.2):
+  /stylelint@15.11.0(typescript@5.5.4):
     resolution: {integrity: sha512-78O4c6IswZ9TzpcIiQJIN49K3qNoXTM8zEJzhaTE/xRTCZswaovSEVIa/uwbOltZrk16X4jAxjaOhzz/hTm1Kw==}
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
@@ -24011,10 +24015,10 @@ packages:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.2)
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 8.3.6(typescript@5.6.2)
+      cosmiconfig: 8.3.6(typescript@5.5.4)
       css-functions-list: 3.2.2
       css-tree: 2.3.1
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 7.0.2
@@ -24031,10 +24035,10 @@ packages:
       meow: 10.1.5
       micromatch: 4.0.8
       normalize-path: 3.0.0
-      picocolors: 1.1.0
-      postcss: 8.4.45
+      picocolors: 1.0.1
+      postcss: 8.4.41
       postcss-resolve-nested-selector: 0.1.6
-      postcss-safe-parser: 6.0.0(postcss@8.4.45)
+      postcss-safe-parser: 6.0.0(postcss@8.4.41)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
@@ -24136,7 +24140,7 @@ packages:
     resolution: {integrity: sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       heimdalljs: 0.2.6
       mkdirp: 0.5.6
       rimraf: 3.0.2
@@ -24210,7 +24214,7 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      terser: 5.32.0
+      terser: 5.31.6
       webpack: 5.94.0
 
   /terser@3.17.0:
@@ -24224,8 +24228,8 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
-  /terser@5.32.0:
-    resolution: {integrity: sha512-v3Gtw3IzpBJ0ugkxEX8U0W6+TnPKRRCWGh1jC/iM/e3Ki5+qvO1L1EAZ56bZasc64aXHwRHNIQEzm6//i5cemQ==}
+  /terser@5.31.6:
+    resolution: {integrity: sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -24538,7 +24542,7 @@ packages:
     resolution: {integrity: sha512-OLWW+Nd99NOM53aZ8ilT/YpEiOo6mXD3F4/wLbARqybSZ3Jb8IxHK5UGVbZaae0wtXAyQshVV+SeqVBik+Fbmw==}
     engines: {node: '>=8'}
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       fs-tree-diff: 2.0.1
       mkdirp: 0.5.6
       quick-temp: 0.1.8
@@ -24556,7 +24560,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /ts-node@10.9.2(typescript@5.6.2):
+  /ts-node@10.9.2(typescript@5.5.4):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -24576,12 +24580,12 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       acorn: 8.12.1
-      acorn-walk: 8.3.4
+      acorn-walk: 8.3.3
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.6.2
+      typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: false
@@ -24601,14 +24605,14 @@ packages:
   /tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
-  /tsutils@3.21.0(typescript@5.6.2):
+  /tsutils@3.21.0(typescript@5.5.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.6.2
+      typescript: 5.5.4
     dev: true
 
   /type-check@0.4.0:
@@ -24646,8 +24650,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest@4.26.1:
-    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
+  /type-fest@4.26.0:
+    resolution: {integrity: sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==}
     engines: {node: '>=16'}
 
   /type-is@1.6.18:
@@ -24705,8 +24709,8 @@ packages:
   /typescript-memoize@1.1.1:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
-  /typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+  /typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -24833,7 +24837,7 @@ packages:
     dependencies:
       browserslist: 4.23.3
       escalade: 3.2.0
-      picocolors: 1.1.0
+      picocolors: 1.0.1
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -24894,7 +24898,7 @@ packages:
     dev: true
 
   /utils-merge@1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
   /uuid@8.3.2:
@@ -24973,8 +24977,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /vite@5.4.3(terser@5.32.0):
-    resolution: {integrity: sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==}
+  /vite@5.4.2(terser@5.31.6):
+    resolution: {integrity: sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -25005,9 +25009,9 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.45
+      postcss: 8.4.41
       rollup: 4.21.2
-      terser: 5.32.0
+      terser: 5.31.6
     optionalDependencies:
       fsevents: 2.3.3
     dev: true

--- a/test-packages/support/audit-assertions.ts
+++ b/test-packages/support/audit-assertions.ts
@@ -31,6 +31,24 @@ export function setupAuditTest(hooks: NestedHooks, opts: () => AuditBuildOptions
     }
   }
 
+  async function visitWithRetries() {
+    for (let i = 0; i < 30; i++) {
+      try {
+        await visit();
+        return;
+      } catch (e) {
+        if (e.message.includes('oops status code 504 - Outdated Optimize Dep for')) {
+          continue;
+        }
+        if (e.message.includes('oops status code 404') && e.message.includes('.vite/deps')) {
+          continue;
+        }
+        throw e;
+      }
+    }
+    throw new Error('failed to rerun');
+  }
+
   function prepareResult(assert: Assert) {
     let o = opts();
     let pathRewriter: (p: string) => string;
@@ -43,7 +61,7 @@ export function setupAuditTest(hooks: NestedHooks, opts: () => AuditBuildOptions
   }
 
   hooks.before(async () => {
-    await visit();
+    await visitWithRetries();
   });
 
   hooks.beforeEach(assert => {
@@ -53,7 +71,7 @@ export function setupAuditTest(hooks: NestedHooks, opts: () => AuditBuildOptions
 
   return {
     async rerun() {
-      await visit();
+      await visitWithRetries();
       prepareResult(expectAudit.assert);
     },
     module(name: string | RegExp) {
@@ -162,14 +180,14 @@ export class ExpectModule {
     });
   }
 
-  withContents(fn: (src: string, imports: Import[]) => boolean, message?: string) {
+  withContents(fn: (src: string, imports: Import[]) => boolean, message?: string): PublicAPI<this> {
     if (!this.module) {
       this.emitMissingModule();
-      return;
+      return this;
     }
     if (this.module.type === 'unparseable') {
       this.emitUnparsableModule(message);
-      return;
+      return this;
     }
     const result = fn(this.module.content, this.module.imports);
     this.expectAudit.assert.pushResult({
@@ -178,6 +196,7 @@ export class ExpectModule {
       expected: true,
       message: message ?? `Expected passed function to return true for the contents of ${this.inputName}`,
     });
+    return this;
   }
 
   private emitUnparsableModule(message?: string) {
@@ -326,7 +345,9 @@ class EmptyExpectModule implements PublicAPI<ExpectModule> {
   doesNotExist() {}
   codeEquals() {}
   codeContains() {}
-  withContents() {}
+  withContents() {
+    return this;
+  }
 
   resolves(): PublicAPI<ExpectResolution> {
     return new EmptyExpectResolution() as PublicAPI<ExpectResolution>;

--- a/tests/scenarios/helpers/command-watcher.ts
+++ b/tests/scenarios/helpers/command-watcher.ts
@@ -109,7 +109,7 @@ export default class CommandWatcher {
       return;
     }
 
-    console.log('kill')
+    console.log('kill');
     this.process.kill('SIGTERM');
 
     // on windows the subprocess won't close if you don't end all the sockets

--- a/tests/scenarios/helpers/command-watcher.ts
+++ b/tests/scenarios/helpers/command-watcher.ts
@@ -125,6 +125,7 @@ export default class CommandWatcher {
 
   private emitLogs() {
     console.log(`CommandWatcher dumping logs:`);
+    console.log(`exited with`, this.exitCode);
     console.log(this.lines.join('\n'));
   }
 

--- a/tests/scenarios/helpers/command-watcher.ts
+++ b/tests/scenarios/helpers/command-watcher.ts
@@ -109,7 +109,8 @@ export default class CommandWatcher {
       return;
     }
 
-    this.process.kill('SIGINT');
+    console.log('kill')
+    this.process.kill('SIGTERM');
 
     // on windows the subprocess won't close if you don't end all the sockets
     // we don't just end stdout because when you register a listener for stdout it auto registers stdin and stderr... for some reason :(

--- a/tests/scenarios/v2-addon-test.ts
+++ b/tests/scenarios/v2-addon-test.ts
@@ -32,9 +32,9 @@ appScenarios
         'example-component.css': '/* not empty */ h1 { color: red }',
       },
       'import-from-npm.js': `
-        export default async function() { 
+        export default async function() {
           let { message } = await import('third-party');
-          return message() 
+          return message()
         }
         `,
     });

--- a/tests/scenarios/vite-dep-optimizer-test.ts
+++ b/tests/scenarios/vite-dep-optimizer-test.ts
@@ -1,0 +1,345 @@
+import { appScenarios, baseAddon } from './scenarios';
+import type { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+import CommandWatcher from './helpers/command-watcher';
+import { setupAuditTest, type Import } from '@embroider/test-support/audit-assertions';
+import fetch from 'node-fetch';
+import { writeFileSync, readdirSync, rmSync, existsSync } from 'fs-extra';
+import { join } from 'path';
+import execa from 'execa';
+
+const { module: Qmodule, test } = QUnit;
+
+let app = appScenarios.map('vite-dep-optimizer', project => {
+  let myServicesAddon = baseAddon();
+  myServicesAddon.pkg.name = 'my-services-addon';
+  myServicesAddon.mergeFiles({
+    app: {
+      services: {
+        'service.js': `export { default } from 'my-services-addon/services/service'`,
+      },
+    },
+    addon: {
+      services: {
+        'service.js': `
+            import app from 'app-template/app.js';
+
+            console.log(app);
+            const foo=1;
+            export default foo;
+          `,
+      },
+    },
+  });
+  project.addDevDependency(myServicesAddon);
+});
+
+async function rerunUntilReady(expectAudit: ReturnType<typeof setupAuditTest>) {
+  for (let i = 0; i < 30; i++) {
+    try {
+      await expectAudit.rerun();
+      return;
+    } catch (e) {
+      if (!e.message.includes('oops status code 504 - Outdated Optimize Dep for')) {
+        throw e;
+      }
+    }
+  }
+  throw new Error('failed to rerun');
+}
+
+app.forEachScenario(scenario => {
+  Qmodule(scenario.name, function (hooks) {
+    let app: PreparedApp;
+    let appURL: string;
+    let optimizedFiles = [];
+
+    hooks.before(async () => {
+      app = await scenario.prepare();
+    });
+
+    function isOptimizedImport(imp: Import) {
+      return /\.vite\/deps/.test(imp.source);
+    }
+
+    function allDepFilesAreUsed(
+      expectAudit: ReturnType<typeof setupAuditTest>,
+      assert: Assert,
+      optimizedFiles: string[]
+    ) {
+      const used: string[] = [];
+      Object.keys(expectAudit.modules).forEach(m => {
+        if (m.includes('.vite/deps')) {
+          const part = m.split('.vite/deps/')[1];
+          const f = optimizedFiles.find(f => part.startsWith(f));
+          if (f) {
+            used.push(f);
+          }
+        }
+        return false;
+      });
+
+      function difference(a: string[], b: string[]) {
+        const bSet = new Set(b);
+        return a.filter(item => !bSet.has(item));
+      }
+
+      assert.ok(
+        used.length === optimizedFiles.length,
+        `all optimized files should be used, unused: ${difference(optimizedFiles, used)}`
+      );
+    }
+
+    Qmodule('vite esbuild dep scan', function (hooks) {
+      let server: CommandWatcher;
+      hooks.before(async () => {
+        server = CommandWatcher.launch('vite', ['--force', '--clearScreen', 'false'], { cwd: app.dir });
+        [, appURL] = await server.waitFor(/Local:\s*(.*)/);
+      });
+      hooks.after(async () => {
+        await server.shutdown();
+      });
+      test('initial dep scan', async function (assert) {
+        // wait until deps are generated without accessing any API
+        await execa('pnpm', ['vite', 'optimize', '--force'], {
+          cwd: app.dir,
+        });
+        assert.ok(existsSync(join(app.dir, 'node_modules', '.vite')));
+        const deps = readdirSync(join(app.dir, 'node_modules', '.vite'))[0];
+        let currentOptimizedFiles = readdirSync(join(app.dir, 'node_modules', '.vite', deps)).filter(f =>
+          f.endsWith('.js')
+        );
+        optimizedFiles.push(...currentOptimizedFiles);
+      });
+    });
+
+    Qmodule(`vite dep tests`, function (hooks) {
+      let server: CommandWatcher;
+      hooks.before(async () => {
+        server = CommandWatcher.launch('vite', ['--force', '--clearScreen', 'false'], { cwd: app.dir });
+        [, appURL] = await server.waitFor(/Local:\s*(.*)/);
+      });
+      let expectAudit = setupAuditTest(hooks, () => ({
+        appURL,
+        startingFrom: ['tests/index.html', 'index.html'],
+        fetch: fetch as unknown as typeof globalThis.fetch,
+      }));
+      hooks.after(async () => {
+        await server.shutdown();
+      });
+      let optimizedFiles: string[] = [];
+      test('created initial optimized deps', async function (assert) {
+        optimizedFiles = readdirSync(join(app.dir, 'node_modules', '.vite', 'deps')).filter(f => f.endsWith('.js'));
+        // must be the same as initial scan, otherwise it means we are missing some in the esbuild scan
+        assert.ok(
+          optimizedFiles.length === optimizedFiles.length,
+          `should have created optimized deps: ${optimizedFiles.length}`
+        );
+      });
+
+      test('should use all optimized deps', function (assert) {
+        allDepFilesAreUsed(expectAudit, assert, optimizedFiles);
+      });
+
+      test('all deps are optimized', function (assert) {
+        const allow = ['vite/dist/client/env.mjs', '@babel+runtime', '.css', '@embroider/macros'];
+        const notOptimized = Object.keys(expectAudit.modules).filter(m => {
+          const isOptimized = m.includes('.vite/deps');
+          if (!isOptimized) {
+            if (m.startsWith('.')) return false;
+            if (allow.some(a => m.includes(a))) return false;
+            return true;
+          }
+          return false;
+        });
+        assert.ok(notOptimized.length === 0, `not all are optimized: ${notOptimized}`);
+      });
+
+      test('should use optimized files for deps', function (assert) {
+        expectAudit.module(/.*\/-embroider-entrypoint.js/).withContents((_src, imports) => {
+          let pageTitleImports = imports.filter(imp => /page-title/.test(imp.source));
+          assert.strictEqual(pageTitleImports.length, 2, 'found two uses of page-title addon');
+          assert.ok(
+            pageTitleImports.every(x => isOptimizedImport(x)),
+            `every page-title module is optimized but we saw ${pageTitleImports.map(i => i.source).join(', ')}`
+          );
+          return true;
+        });
+      });
+    });
+
+    Qmodule('should optimize newly added deps', function (hooks) {
+      let server: CommandWatcher;
+      hooks.before(async () => {
+        writeFileSync(join(app.dir, 'app/dep-tests.js'), ``);
+        server = CommandWatcher.launch('vite', ['--clearScreen', 'false', '--force'], { cwd: app.dir });
+        [, appURL] = await server.waitFor(/Local:\s*(.*)/);
+      });
+      let expectAudit = setupAuditTest(hooks, () => ({
+        appURL,
+        startingFrom: ['tests/index.html', 'index.html'],
+        fetch: fetch as unknown as typeof globalThis.fetch,
+      }));
+      hooks.beforeEach(async () => {
+        await server.shutdown();
+        server = CommandWatcher.launch('vite', ['--clearScreen', 'false', '--force'], { cwd: app.dir });
+        [, appURL] = await server.waitFor(/Local:\s*(.*)/);
+      });
+      hooks.afterEach(async () => {
+        await server.shutdown();
+        rmSync(join(app.dir, 'app/dep-tests.js'), { force: true });
+      });
+
+      test(`should optimize newly added deps`, async function (assert) {
+        await expectAudit.rerun();
+        writeFileSync(
+          join(app.dir, 'app/dep-tests.js'),
+          `
+        import 'ember-page-title/helpers/page-title';
+      `
+        );
+        await server.waitFor(/page reload/, 90000);
+        await rerunUntilReady(expectAudit);
+
+        expectAudit.module(/dep-tests\.js/).withContents((_src, imports) => {
+          let pageTitleImports = imports.filter(imp => /page-title/.test(imp.source));
+          assert.strictEqual(pageTitleImports.length, 1, `found one uses of page-title addon: ${imports}`);
+          assert.ok(
+            pageTitleImports.every(isOptimizedImport),
+            `every page-title module is optimized but we saw ${pageTitleImports.map(i => i.source).join(', ')}`
+          );
+          return true;
+        });
+      });
+
+      test('all optimized deps are used', async function (assert) {
+        await expectAudit.rerun();
+        const optimizedFiles = readdirSync(join(app.dir, 'node_modules', '.vite', 'deps')).filter(f =>
+          f.endsWith('.js')
+        );
+        allDepFilesAreUsed(expectAudit, assert, optimizedFiles);
+      });
+
+      test(`should optimize newly added deps via appjs match`, async function (assert) {
+        await expectAudit.rerun();
+        writeFileSync(
+          join(app.dir, 'app/dep-tests.js'),
+          `
+        import 'app-template/helpers/page-title';
+      `
+        );
+        await server.waitFor(/page reload/, 90000);
+        await rerunUntilReady(expectAudit);
+
+        expectAudit.module(/dep-tests\.js/).withContents((_src, imports) => {
+          let pageTitleImports = imports.filter(imp => /page-title/.test(imp.source));
+          assert.strictEqual(pageTitleImports.length, 1, `found one use of page-title addon: ${imports}`);
+          assert.ok(
+            pageTitleImports.every(isOptimizedImport),
+            `every page-title module is optimized but we saw ${pageTitleImports.map(i => i.source).join(', ')}`
+          );
+          return true;
+        });
+      });
+      test(`should optimize newly added deps via relative appjs match`, async function (assert) {
+        await expectAudit.rerun();
+        writeFileSync(
+          join(app.dir, 'app/dep-tests.js'),
+          `
+        import './helpers/page-title';
+      `
+        );
+        await server.waitFor(/page reload/, 90000);
+        await rerunUntilReady(expectAudit);
+
+        expectAudit.module(/dep-tests\.js/).withContents((_src, imports) => {
+          let pageTitleImports = imports.filter(imp => /page-title/.test(imp.source));
+          assert.strictEqual(pageTitleImports.length, 1, 'found two uses of page-title addon');
+          assert.ok(
+            pageTitleImports.every(isOptimizedImport),
+            `every page-title module is optimized but we saw ${pageTitleImports.map(i => i.source).join(', ')}`
+          );
+          return true;
+        });
+      });
+
+      test(`should give same optimized id`, async function (assert) {
+        await expectAudit.rerun();
+        writeFileSync(
+          join(app.dir, 'app/dep-tests.js'),
+          `
+        import './helpers/page-title';
+        import 'app-template/helpers/page-title';
+        import '@embroider/virtual/helpers/page-title';
+        import 'ember-page-title/_app_/helpers/page-title.js';
+        // todo: import 'ember-page-title/_app_/helpers/page-title';
+      `
+        );
+        await server.waitFor(/page reload/, 90000);
+        await rerunUntilReady(expectAudit);
+
+        expectAudit.module(/dep-tests\.js/).withContents((_src, imports) => {
+          let pageTitleImports = imports.filter(imp => /page-title/.test(imp.source));
+          assert.strictEqual(pageTitleImports.length, 4, 'found three uses of page-title addon');
+          assert.ok(
+            pageTitleImports.every(isOptimizedImport),
+            `every page-title module is optimized but we saw ${pageTitleImports.map(i => i.source).join(', ')}`
+          );
+          const first = pageTitleImports[0];
+          assert.ok(
+            pageTitleImports.every(imp => imp.source === first.source),
+            `every page-title module uses same id but we saw ${pageTitleImports.map(i => i.source).join(', ')}`
+          );
+          return true;
+        });
+      });
+    });
+
+    Qmodule('optimized v1 addons can use v1 resolving rules', function (hooks) {
+      let server: CommandWatcher;
+      hooks.before(async () => {
+        server = CommandWatcher.launch('vite', ['--clearScreen', 'false', '--force'], { cwd: app.dir });
+        [, appURL] = await server.waitFor(/Local:\s*(.*)/);
+      });
+      let expectAudit = setupAuditTest(hooks, () => ({
+        appURL,
+        startingFrom: ['tests/index.html', 'index.html'],
+        fetch: fetch as unknown as typeof globalThis.fetch,
+      }));
+      hooks.beforeEach(async () => {
+        await server.shutdown();
+        server = CommandWatcher.launch('vite', ['--clearScreen', 'false', '--force'], { cwd: app.dir });
+        [, appURL] = await server.waitFor(/Local:\s*(.*)/);
+      });
+      hooks.afterEach(async () => {
+        await server.shutdown();
+        rmSync(join(app.dir, 'app/dep-tests.js'), { force: true });
+      });
+
+      test(`addon should be able to import app files and not include it in the chunks`, async function (assert) {
+        await expectAudit.rerun();
+        writeFileSync(
+          join(app.dir, 'app/dep-tests.js'),
+          `
+        import * as service from 'my-services-addon/services/service';
+        console.log(service);
+        `
+        );
+        await server.waitFor(/page reload/, 90000);
+        await rerunUntilReady(expectAudit);
+
+        expectAudit
+          .module(/dep-tests\.js/)
+          .resolves(/my-services-addon/)
+          .toModule()
+          .resolves(/chunk-.*\.js/)
+          .toModule()
+          .withContents((_src, imports) => {
+            const appImport = imports.find(i => i.source.match(/\/app\.js/));
+            assert.ok(appImport, 'should import app: ' + imports.map(i => i.source));
+            return true;
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION

- [x] all deps are optimized
- [x] initial dep scan creates all deps
- [x] all optimized chunks are used
- [x] new deps are optimized
- [x] different specifiers use same optimized id
- [ ] addon rebuilds are newly optimized

dep optimizer has multiple phases 
* Scanning, which uses the vite plugins and configured rollup plugins .
* pre bundle, does not use configured rollup plugins.

This is the order 
* inital scan 
* initial scan must provide correct import specifier to vite import analysis plugin, this is probably because we cannot use vite own alias handling 
* pre bundling 
* vite starts and gets requests
* vite checks if some need optimization 
* rules:
1. Specifier must be bare import 
2. Importer cannot be in node modules
3. Needs to be node_resolveable, so follow node resolution without additional plugin resolution 
* if a new dep is detected, vite schedules a new scan

Currently this is broken because of 2 things. app is in rewritten-app. It's actually easy to fix by changing to importer to the original app. Only needed when resolving bare imports.

The more difficult one is rewritten-packages. They must be node resolvable from original app. They are not currently.
I suggest to create a link from `@embroider/rewritten-packages` to the one inside . embroider and rewrite specifiers accordingly.


It currently looks like it's working, because the initial scan detects the deps. But any new dep added later will not be optimized.


fixes:
* rewrite rewritten-app to original app location 
* link rewritten-package to be node resolvable
* esbuild scan needs to pass renamed modules and appjsmatch to vite import analysis 
* 