### PR TITLE
Command Watcher

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1368,8 +1368,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       ember-qunit:
-        specifier: ^6.1.1
-        version: 6.2.0(@ember/test-helpers@2.9.4)(ember-source@4.6.0)(qunit@2.20.1)(webpack@5.90.3)
+        specifier: ^7.0.0
+        version: 7.0.0(@ember/test-helpers@2.9.4)(ember-source@4.6.0)(qunit@2.20.1)(webpack@5.90.3)
       ember-resolver:
         specifier: ^10.1.0
         version: 10.1.1(@ember/string@3.1.1)(ember-source@4.6.0)
@@ -1793,6 +1793,9 @@ importers:
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0
+      strip-ansi:
+        specifier: ^6.0.0
+        version: 6.0.1
       tslib:
         specifier: ^2.6.0
         version: 2.6.2
@@ -15769,12 +15772,12 @@ packages:
       - webpack
     dev: true
 
-  /ember-qunit@6.2.0(@ember/test-helpers@2.9.4)(ember-source@4.6.0)(qunit@2.20.1)(webpack@5.90.3):
-    resolution: {integrity: sha512-mC+0bp8DwWzJLn8SW3GS8KDZIkl4yLsNYwMi5Dw6+aFllq7FM2crd/dfY4MuOIHK7GKdjtmWJTMGnjSpeSayaw==}
-    engines: {node: 14.* || 16.* || >= 18}
+  /ember-qunit@7.0.0(@ember/test-helpers@2.9.4)(ember-source@4.6.0)(qunit@2.20.1)(webpack@5.90.3):
+    resolution: {integrity: sha512-KhrndHYEXsHnXvmsGyJLJQ6VCudXaRs5dzPZBsdttZJIhsB6PmYAvq2Q+mh3GRDT/59T/sRDrB3FD3/lATS8aA==}
+    engines: {node: 16.* || >= 18}
     peerDependencies:
-      '@ember/test-helpers': ^2.9.3
-      ember-source: '>=3.28'
+      '@ember/test-helpers': '>=3.0.3'
+      ember-source: '>=4.0.0'
       qunit: ^2.13.0
     dependencies:
       '@ember/test-helpers': 2.9.4(@babel/core@7.23.9)(ember-source@4.6.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1706,6 +1706,9 @@ importers:
       '@types/lodash':
         specifier: ^4.14.170
         version: 4.14.202
+      '@types/node-fetch':
+        specifier: ^2.6.11
+        version: 2.6.11
       '@types/semver':
         specifier: ^7.3.6
         version: 7.5.8
@@ -1787,6 +1790,9 @@ importers:
       execa:
         specifier: ^5.1.1
         version: 5.1.1
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0
       tslib:
         specifier: ^2.6.0
         version: 2.6.2
@@ -9185,6 +9191,13 @@ packages:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: true
 
+  /@types/node-fetch@2.6.11:
+    resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
+    dependencies:
+      '@types/node': 15.14.9
+      form-data: 4.0.0
+    dev: true
+
   /@types/node@10.17.60:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
     dev: true
@@ -9768,6 +9781,9 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.12.0
 

--- a/tests/addon-template/package.json
+++ b/tests/addon-template/package.json
@@ -53,7 +53,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
-    "ember-qunit": "^6.1.1",
+    "ember-qunit": "^7.0.0",
     "ember-resolver": "^10.1.0",
     "ember-source": "~4.6.0",
     "ember-source-channel-url": "^3.0.0",

--- a/tests/addon-template/vite.config.mjs
+++ b/tests/addon-template/vite.config.mjs
@@ -6,6 +6,7 @@ import {
   templateTag,
   optimizeDeps,
   compatPrebuild,
+  assets,
 } from "@embroider/vite";
 import { resolve } from "path";
 import { babel } from "@rollup/plugin-babel";
@@ -24,6 +25,7 @@ export default defineConfig(({ mode }) => {
       scripts(),
       resolver(),
       compatPrebuild(),
+      assets(),
 
       babel({
         babelHelpers: "runtime",
@@ -42,6 +44,10 @@ export default defineConfig(({ mode }) => {
         ignored: ["!**/node_modules/.embroider/rewritten-app/**"],
       },
     },
+    // If the "app" is a classic addon dummy app, the public directory is tests/dummy/public,
+    // any public directory at the root would rather contain the assets provided by the addon,
+    // which are managed by the assets plugin.
+    publicDir: resolve(process.cwd(), "tests/dummy/public"),
     build: {
       outDir: resolve(process.cwd(), "dist"),
       rollupOptions: {

--- a/tests/scenarios/compat-dummy-app-test.ts
+++ b/tests/scenarios/compat-dummy-app-test.ts
@@ -88,7 +88,7 @@ dummyAppScenarios
       test('contains public assets from dummy app in dev mode', async function (assert) {
         const server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
         try {
-          const [, url] = await server.waitFor(/Local:\s+(http:\/\/127.0.0.1:\d+)\//);
+          const [, url] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
           let response = await fetch(`${url}/robots.txt`);
           let text = await response.text();
           assert.strictEqual(text, 'go away bots');

--- a/tests/scenarios/compat-dummy-app-test.ts
+++ b/tests/scenarios/compat-dummy-app-test.ts
@@ -21,6 +21,9 @@ dummyAppScenarios
           'example.hbs': `hello`,
         },
       },
+      public: {
+        'from-addon.txt': 'a public asset provided by the classic addon',
+      },
       tests: {
         dummy: {
           public: {
@@ -73,25 +76,31 @@ dummyAppScenarios
         app = await scenario.prepare();
       });
 
-      test('contains public assets from dummy app after a build', async function (assert) {
+      test('contains public assets from both addon and dummy app after a build', async function (assert) {
         await app.execute(`pnpm vite build`);
         expectFile = expectRewrittenFilesAt(resolve(app.dir, 'tests/dummy'), {
           qunit: assert,
         });
+        expectFile('../../node_modules/.embroider/rewritten-app/addon-template/from-addon.txt').exists();
         expectFile('../../node_modules/.embroider/rewritten-app/robots.txt').exists();
-        expectFile('../../node_modules/.embroider/rewritten-app/package.json')
+        let assets = expectFile('../../node_modules/.embroider/rewritten-app/package.json')
           .json()
-          .get('ember-addon.assets')
-          .includes('robots.txt');
+          .get('ember-addon.assets');
+        assets.includes('robots.txt');
+        assets.includes('./addon-template/from-addon.txt');
       });
 
-      test('contains public assets from dummy app in dev mode', async function (assert) {
+      test('contains public assets from both addon and dummy app in dev mode', async function (assert) {
         const server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
         try {
           const [, url] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
           let response = await fetch(`${url}/robots.txt`);
           let text = await response.text();
           assert.strictEqual(text, 'go away bots');
+
+          response = await fetch(`${url}/addon-template/from-addon.txt`);
+          text = await response.text();
+          assert.strictEqual(text, 'a public asset provided by the classic addon');
         } finally {
           await server.shutdown();
         }

--- a/tests/scenarios/helpers/command-watcher.ts
+++ b/tests/scenarios/helpers/command-watcher.ts
@@ -1,0 +1,131 @@
+import execa, { type Options, type ExecaChildProcess } from 'execa';
+import path from 'path';
+
+export const DEFAULT_TIMEOUT = process.env.CI ? 90000 : 30000;
+
+export default class CommandWatcher {
+  static launch(command: string, args: readonly string[], options: Options<string> = {}): CommandWatcher {
+    return new CommandWatcher(
+      execa(path.join(options.cwd as string, 'node_modules/.bin', command), [...args], {
+        ...options,
+        all: true,
+      })
+    );
+  }
+
+  private lines: string[] = [];
+  private nextWaitedLine = 0;
+  private exitCode: number | null = null;
+  private currentWaiter: (() => void) | undefined;
+
+  constructor(private process: ExecaChildProcess) {
+    process.all!.on('data', data => {
+      const lines = data.toString().split(/\r?\n/);
+      this.lines.push(...lines);
+      this.currentWaiter?.();
+    });
+
+    process.on('exit', code => {
+      // TODO why can code be null here?
+      this.exitCode = code ?? 0;
+      this.currentWaiter?.();
+    });
+  }
+
+  private async internalWait(timedOut?: Promise<void>): Promise<void> {
+    if (this.currentWaiter) {
+      throw new Error(`bug: only one wait at a time`);
+    }
+    try {
+      await Promise.race(
+        [
+          timedOut,
+          new Promise<void>(resolve => {
+            this.currentWaiter = resolve;
+          }),
+        ].filter(Boolean)
+      );
+    } finally {
+      this.currentWaiter = undefined;
+    }
+  }
+
+  private searchLines(output: string | RegExp): boolean | RegExpExecArray {
+    while (this.nextWaitedLine < this.lines.length) {
+      let line = this.lines[this.nextWaitedLine++];
+      if (typeof output === 'string') {
+        if (output === line) {
+          return true;
+        }
+      } else {
+        let result = output.exec(line);
+        if (result) {
+          return result;
+        }
+      }
+    }
+    return false;
+  }
+
+  async waitFor(output: string | RegExp, timeout = DEFAULT_TIMEOUT): Promise<any> {
+    let timedOut = new Promise<void>((_resolve, reject) => {
+      setTimeout(() => {
+        let err = new Error(
+          'Timed out after ' +
+            timeout +
+            'ms before output "' +
+            output +
+            '" was found. ' +
+            'Output:\n\n' +
+            this.lines.join('\n')
+        );
+        reject(err);
+      }, timeout);
+    });
+    while (true) {
+      if (this.exitCode != null) {
+        throw new Error(
+          'Process exited with code ' +
+            this.exitCode +
+            ' before output "' +
+            output +
+            '" was found. ' +
+            'Output:\n\n' +
+            this.lines.join('\n')
+        );
+      }
+      let result = this.searchLines(output);
+      if (result) {
+        return result;
+      }
+      await this.internalWait(timedOut);
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.exitCode != null) {
+      return;
+    }
+
+    this.process.kill();
+
+    // on windows the subprocess won't close if you don't end all the sockets
+    // we don't just end stdout because when you register a listener for stdout it auto registers stdin and stderr... for some reason :(
+    this.process.stdio.forEach((socket: any) => {
+      if (socket) {
+        socket.end();
+      }
+    });
+
+    await this.waitForExit();
+  }
+
+  async waitForExit(): Promise<number> {
+    while (true) {
+      if (this.exitCode != null) {
+        return this.exitCode;
+      }
+      await this.internalWait();
+    }
+  }
+}

--- a/tests/scenarios/helpers/command-watcher.ts
+++ b/tests/scenarios/helpers/command-watcher.ts
@@ -1,5 +1,6 @@
 import execa, { type Options, type ExecaChildProcess } from 'execa';
 import path from 'path';
+import stripAnsi from 'strip-ansi';
 
 export const DEFAULT_TIMEOUT = process.env.CI ? 90000 : 30000;
 
@@ -52,7 +53,7 @@ export default class CommandWatcher {
 
   private searchLines(output: string | RegExp): boolean | RegExpExecArray {
     while (this.nextWaitedLine < this.lines.length) {
-      let line = this.lines[this.nextWaitedLine++];
+      let line = stripAnsi(this.lines[this.nextWaitedLine++]);
       if (typeof output === 'string') {
         if (output === line) {
           return true;

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -54,6 +54,7 @@
     "@types/fs-extra": "^9.0.12",
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.170",
+    "@types/node-fetch": "^2.6.11",
     "@types/semver": "^7.3.6",
     "babel-plugin-ember-template-compilation": "^2.1.1",
     "bootstrap": "^4.3.1",
@@ -81,6 +82,7 @@
     "ember-source-latest": "npm:ember-source@latest",
     "ember-truth-helpers": "^3.0.0",
     "execa": "^5.1.1",
+    "node-fetch": "2.7.0",
     "tslib": "^2.6.0",
     "typescript": "^5.1.6",
     "webpack": "^5.90.3"

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -83,6 +83,7 @@
     "ember-truth-helpers": "^3.0.0",
     "execa": "^5.1.1",
     "node-fetch": "2.7.0",
+    "strip-ansi": "^6.0.0",
     "tslib": "^2.6.0",
     "typescript": "^5.1.6",
     "webpack": "^5.90.3"


### PR DESCRIPTION
**Context**

When working with vite, running the dev server and generating the production build with Rollup are two different actions that both have a specific execution. For instance, when dealing with public assets provided by the app and addons: 
- when running the vite dev server, the `assets` plugin uses a middleware to catch the assets-related request, find the actual location of the asset, and serve it.
- when building the app (like for a production build), the `assets` plugin will emit the public assets in the `dist/` output, where they are supposed to be. 

This case highlights why we need to test some behaviors for both dev mode and build mode now the test suite is using vite.

**Testing dev mode easily**

This PR implements a `CommandWatcher` utility to ease running a vite dev server in tests. It relies on the former `EmberCLI` class that was used to run `ember serve`, but it makes it more generic (you can now choose the name of the command like `ember` or `vite`) and it makes it an importable helper so we can test the dev mode in multiple test files.

**Compat dummy app test**

The first use case for the new `CommandWatcher` is the `compat-dummy-app-test`. This PR prepares the field so the tests that check public assets presence now use vite and check both the dev mode and the build.

This preparation work is required to complete #1859, which will remove the part of the code that is now managed by the `assets` plugin: in #1859, `compat-dummy-app-test` will have to stop testing public assets are present in the rewritten app and instead test they are present in the `dist` (in build mode) or served correctly (in dev mode). 

Here, aside of the assertions, we do the following things: 
- We update the addon template used for the dummy app test scenarios. vite is now configured to run the `assets` plugin and we also update `ember-qunit` to fix an issue in the development build.
- The test waits for the dev server to be ready, and it knows when it's ready using a regexp matching the text that is supposed to be output on the server when it's started. This regexp is now slightly more flexible, and in `CommandWatcher` implementation, we strip the Ansi characters before analyzing the server output, because vite server colorize the text, which can mess-up the regex.

