### PR TITLE
Vite dep tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -68,3 +68,6 @@ package.json.ember-try
 #types added
 /types/**
 
+# scenario tester output
+/tests/scenarios/output/
+

--- a/packages/compat/src/audit/options.ts
+++ b/packages/compat/src/audit/options.ts
@@ -1,8 +1,15 @@
-export interface AuditOptions {
-  debug?: boolean;
-}
+export type AuditOptions = FileAuditOptions | HTTPAuditOptions;
 
-export interface AuditBuildOptions extends AuditOptions {
+export interface FileAuditOptions {
+  mode: 'file';
+  debug?: boolean;
   'reuse-build'?: boolean;
   app: string;
+}
+
+export interface HTTPAuditOptions {
+  mode: 'http';
+  debug?: boolean;
+  app: string;
+  startingFrom: string[];
 }

--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -66,7 +66,35 @@ class BuildWithVite extends Plugin {
         stdio: 'inherit',
         env: { ...process.env },
       });
-      child.on('exit', code => (code === 0 ? resolve() : reject(new Error('vite build failed'))));
+
+      process.on('exit', function () {
+        console.log('killing vite process on exit');
+        child.kill();
+      });
+
+      process.on('SIGINT', function () {
+        console.log('killing vite process on sigint');
+        child.kill();
+      });
+
+      // catches "kill pid" (for example: nodemon restart)
+      process.on('SIGUSR1', function () {
+        console.log('killing vite process on sigusr1');
+        child.kill();
+      });
+      process.on('SIGUSR2', function () {
+        console.log('killing vite process on sigusr2');
+        child.kill();
+      });
+
+      child.on('exit', code => {
+        console.log('child has exited', code);
+        if (code === 0) {
+          return resolve();
+        } else {
+          reject(new Error('vite build failed'));
+        }
+      });
     });
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1232,6 +1232,9 @@ importers:
       lodash:
         specifier: ^4.17.10
         version: 4.17.21
+      node-fetch:
+        specifier: ^2.0.0
+        version: 2.7.0
       qunit:
         specifier: ^2.16.0
         version: 2.20.1
@@ -1260,6 +1263,9 @@ importers:
       '@types/node':
         specifier: ^10.5.2
         version: 10.17.60
+      '@types/node-fetch':
+        specifier: 2.x
+        version: 2.6.11
 
   test-packages/unstable-release:
     dependencies:
@@ -1722,8 +1728,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       ember-bootstrap:
-        specifier: ^5.0.0
-        version: 5.1.1(@babel/core@7.23.9)(ember-source@3.28.12)(webpack@5.90.3)
+        specifier: ^6.0.0
+        version: 6.2.0(@babel/core@7.23.9)(ember-source@3.28.12)(webpack@5.90.3)
       ember-cli:
         specifier: ~3.28.0
         version: 3.28.6(lodash@4.17.21)
@@ -4334,35 +4340,6 @@ packages:
       - '@babel/core'
       - '@glint/template'
       - ember-source
-      - supports-color
-    dev: true
-
-  /@ember-decorators/component@6.1.1:
-    resolution: {integrity: sha512-Cj8tY/c0MC/rsipqsiWLh3YVN72DK92edPYamD/HzvftwzC6oDwawWk8RmStiBnG9PG/vntAt41l3S7HSSA+1Q==}
-    engines: {node: '>= 8.*'}
-    dependencies:
-      '@ember-decorators/utils': 6.1.1
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@ember-decorators/object@6.1.1:
-    resolution: {integrity: sha512-cb4CNR9sRoA31J3FCOFLDuR9ztM4wO9w1WlS4JeNRS7Z69SlB/XSXB/vplA3i9OOaXEy/zKWbu5ndZrHz0gvLw==}
-    engines: {node: '>= 8.*'}
-    dependencies:
-      '@ember-decorators/utils': 6.1.1
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@ember-decorators/utils@6.1.1:
-    resolution: {integrity: sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==}
-    engines: {node: '>= 8.*'}
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
       - supports-color
     dev: true
 
@@ -8005,6 +7982,13 @@ packages:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: true
 
+  /@types/node-fetch@2.6.11:
+    resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
+    dependencies:
+      '@types/node': 15.14.9
+      form-data: 4.0.0
+    dev: true
+
   /@types/node@10.17.60:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
     dev: true
@@ -8588,9 +8572,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.12.0
 
@@ -12222,32 +12203,29 @@ packages:
       - supports-color
       - webpack
 
-  /ember-bootstrap@5.1.1(@babel/core@7.23.9)(ember-source@3.28.12)(webpack@5.90.3):
-    resolution: {integrity: sha512-ETb+DBYvVC+cAeABcfWUCHMHdO7S8gR8yZSvGmhHcgQo7jbKOVDDCARA7C12lmn3RojMwlfJMJu0LV3CXRwCHg==}
-    engines: {node: 12.* || 14.* || >= 16}
+  /ember-bootstrap@6.2.0(@babel/core@7.23.9)(ember-source@3.28.12)(webpack@5.90.3):
+    resolution: {integrity: sha512-4Hl9daEIp7DoCAKzyjOpK0mKKSGiqz+B5554o09i+lSyI6ajXxPKIIvj4wOMjpc7PlwX1I6qRFo19Wx1/d/QMw==}
+    engines: {node: 18.* || >= 20}
     peerDependencies:
-      ember-source: '>=3.24'
+      '@glimmer/component': ^1.0.4
+      '@glimmer/tracking': ^1.0.4
+      ember-source: '>=4.8.0'
     dependencies:
       '@ember/render-modifiers': 2.1.0(@babel/core@7.23.9)(ember-source@3.28.12)
       '@embroider/macros': 1.13.5(@glint/template@1.3.0)
       '@embroider/util': 1.12.1(ember-source@3.28.12)
-      '@glimmer/component': 1.1.2(@babel/core@7.23.9)
-      '@glimmer/tracking': 1.1.2
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
       ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
-      ember-cli-babel: 7.26.11
+      ember-cli-babel: 8.2.0(@babel/core@7.23.9)
       ember-cli-build-config-editor: 0.5.1
       ember-cli-htmlbars: 6.3.0
       ember-cli-version-checker: 5.1.2
       ember-concurrency: 2.3.7(@babel/core@7.23.9)
-      ember-decorators: 6.1.1
       ember-element-helper: 0.6.1(ember-source@3.28.12)
       ember-focus-trap: 1.1.0(ember-source@3.28.12)
-      ember-in-element-polyfill: 1.0.1
-      ember-named-blocks-polyfill: 0.2.5
       ember-on-helper: 0.1.0
       ember-popper-modifier: 2.0.1(@babel/core@7.23.9)(webpack@5.90.3)
       ember-ref-bucket: 4.1.0(@babel/core@7.23.9)
@@ -12255,9 +12233,7 @@ packages:
       ember-source: 3.28.12(@babel/core@7.23.9)
       ember-style-modifier: 0.8.0(@babel/core@7.23.9)
       findup-sync: 5.0.0
-      fs-extra: 10.1.0
       resolve: 1.22.8
-      rsvp: 4.8.5
       silent-error: 1.1.1
       tracked-toolbox: 1.3.0(@babel/core@7.23.9)
     transitivePeerDependencies:
@@ -14049,17 +14025,6 @@ packages:
       - webpack-cli
     dev: true
 
-  /ember-decorators@6.1.1:
-    resolution: {integrity: sha512-63vZPntPn1aqMyeNRLoYjJD+8A8obd+c2iZkJflswpDRNVIsp2m7aQdSCtPt4G0U/TEq2251g+N10maHX3rnJQ==}
-    engines: {node: '>= 8.*'}
-    dependencies:
-      '@ember-decorators/component': 6.1.1
-      '@ember-decorators/object': 6.1.1
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /ember-destroyable-polyfill@2.0.3(@babel/core@7.23.9):
     resolution: {integrity: sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==}
     engines: {node: 10.* || >= 12}
@@ -14169,18 +14134,6 @@ packages:
       '@embroider/addon-shim': 1.8.7
       ember-source: 3.28.12(@babel/core@7.23.9)
       focus-trap: 6.9.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /ember-in-element-polyfill@1.0.1:
-    resolution: {integrity: sha512-eHs+7D7PuQr8a1DPqsJTsEyo3FZ1XuH6WEZaEBPDa9s0xLlwByCNKl8hi1EbXOgvgEZNHHi9Rh0vjxyfakrlgg==}
-    engines: {node: 10.* || >= 12}
-    dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 5.7.2
-      ember-cli-version-checker: 5.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14322,16 +14275,6 @@ packages:
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-source: 5.7.0-beta.1(@babel/core@7.23.9)(@glimmer/component@1.1.2)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /ember-named-blocks-polyfill@0.2.5:
-    resolution: {integrity: sha512-OVMxzkfqJrEvmiky7gFzmuTaImCGm7DOudHWTdMBPO7E+dQSunrcRsJMgO9ZZ56suqBIz/yXbEURrmGS+avHxA==}
-    engines: {node: 10.* || >= 12}
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/test-packages/support/file-assertions/qunit.ts
+++ b/test-packages/support/file-assertions/qunit.ts
@@ -1,6 +1,6 @@
 import { install } from 'code-equality-assertions/qunit';
 import type { AssertionAdapter } from '../file-assertions';
-import { BoundExpectFile, ExpectFile } from '../file-assertions';
+import { BoundExpectFile, ExpectFile, RemoteExpectFile } from '../file-assertions';
 import { getRewrittenLocation } from '../rewritten-path';
 
 class QUnitAdapter implements AssertionAdapter {
@@ -32,6 +32,18 @@ class QUnitAdapter implements AssertionAdapter {
 export function expectFilesAt(basePath: string, params: { qunit: Assert }): ExpectFile {
   let func: any = (relativePath: string) => {
     return new BoundExpectFile(basePath, relativePath, new QUnitAdapter(params.qunit));
+  };
+  Object.defineProperty(func, 'basePath', {
+    get() {
+      return basePath;
+    },
+  });
+  return func;
+}
+
+export function expectRemoteFile(basePath: string, params: { qunit: Assert }): ExpectFile {
+  let func: any = (relativePath: string) => {
+    return new RemoteExpectFile(basePath, relativePath, new QUnitAdapter(params.qunit));
   };
   Object.defineProperty(func, 'basePath', {
     get() {

--- a/test-packages/support/package.json
+++ b/test-packages/support/package.json
@@ -23,6 +23,7 @@
     "fs-extra": "^7.0.0",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.10",
+    "node-fetch": "^2.0.0",
     "qunit": "^2.16.0",
     "typescript-memoize": "^1.0.1",
     "webpack": "^5"
@@ -33,6 +34,7 @@
     "@types/babel__traverse": "^7.18.5",
     "@types/fs-extra": "^9.0.12",
     "@types/lodash": "^4.14.170",
-    "@types/node": "^10.5.2"
+    "@types/node": "^10.5.2",
+    "@types/node-fetch": "2.x"
   }
 }

--- a/tests/fixtures/macro-sample-addon/addon/components/reflect-hbs-config.js
+++ b/tests/fixtures/macro-sample-addon/addon/components/reflect-hbs-config.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
-import layout from '../templates/components/reflect-hbs-config';
+// TODO remove this
+import layout from '../templates/components/reflect-hbs-config.hbs';
 
 export default Component.extend({
   layout

--- a/tests/scenarios/compat-addon-styles-test.ts
+++ b/tests/scenarios/compat-addon-styles-test.ts
@@ -119,10 +119,10 @@ appScenarios
         ).matches('.success { color: green }');
       });
 
-      test(`all addon CSS gets convert to implicit-styles`, function () {
-        let implicitStyles = expectRewrittenFile('./node_modules/my-addon3/package.json')
-          .json()
-          .get('ember-addon.implicit-styles');
+      test(`all addon CSS gets convert to implicit-styles`, async function () {
+        let implicitStyles = (await expectRewrittenFile('./node_modules/my-addon3/package.json').json()).get(
+          'ember-addon.implicit-styles'
+        );
         implicitStyles.includes('./my-addon3.css');
         implicitStyles.includes('./outer.css');
         implicitStyles.includes('./nested/inner.css');

--- a/tests/scenarios/compat-app-dot-import-test.ts
+++ b/tests/scenarios/compat-app-dot-import-test.ts
@@ -50,9 +50,12 @@ appScenarios
           qunit: assert,
         });
       });
-      test('destDir puts vendor files into public assets', function () {
-        expectFile('./node_modules/.embroider/rewritten-packages/@embroider/synthesized-vendor/package.json')
-          .json()
+      test('destDir puts vendor files into public assets', async function () {
+        (
+          await expectFile(
+            './node_modules/.embroider/rewritten-packages/@embroider/synthesized-vendor/package.json'
+          ).json()
+        )
           .get(['ember-addon', 'public-assets', './vendor/some-font.ttf'])
           .equals('fonts/some-font.ttf');
         expectFile(
@@ -60,9 +63,12 @@ appScenarios
         ).exists();
       });
 
-      test('handle non-transformed node_module with explicit outputFile', function () {
-        expectFile('./node_modules/.embroider/rewritten-packages/@embroider/synthesized-vendor/package.json')
-          .json()
+      test('handle non-transformed node_module with explicit outputFile', async function () {
+        (
+          await expectFile(
+            './node_modules/.embroider/rewritten-packages/@embroider/synthesized-vendor/package.json'
+          ).json()
+        )
           .get([
             'ember-addon',
             'public-assets',

--- a/tests/scenarios/compat-dummy-app-test.ts
+++ b/tests/scenarios/compat-dummy-app-test.ts
@@ -67,8 +67,7 @@ dummyAppScenarios
         // containing addon. By writing out the rewritten paths ourselves we
         // sidestep that problem≥
         expectFile('../../node_modules/.embroider/rewritten-app/robots.txt').exists();
-        expectFile('../../node_modules/.embroider/rewritten-app/package.json')
-          .json()
+        (await expectFile('../../node_modules/.embroider/rewritten-app/package.json').json())
           .get('ember-addon.assets')
           .includes('robots.txt');
       });

--- a/tests/scenarios/compat-exclude-dot-files-test.ts
+++ b/tests/scenarios/compat-exclude-dot-files-test.ts
@@ -87,12 +87,12 @@ appScenarios
           });
       });
 
-      test('dot files are not included as addon implicit-modules', function () {
+      test('dot files are not included as addon implicit-modules', async function () {
         // Dot files should exist on disk
         expectFile('./node_modules/my-addon/.fooaddon.js').exists();
         expectFile('./node_modules/my-addon/baraddon.js').exists();
 
-        let myAddonPackage = expectFile('./node_modules/my-addon/package.json').json();
+        let myAddonPackage = await expectFile('./node_modules/my-addon/package.json').json();
 
         // dot files are not included as implicit-modules
         myAddonPackage.get(['ember-addon', 'implicit-modules']).deepEquals(['./baraddon']);

--- a/tests/scenarios/compat-plugin-hints-test.ts
+++ b/tests/scenarios/compat-plugin-hints-test.ts
@@ -64,8 +64,8 @@ appScenarios
         expectFile = expectFilesAt(readFileSync(join(app.dir, 'dist/.stage2-output'), 'utf8'), { qunit: assert });
       });
 
-      test('is parallel safe', function () {
-        expectFile('./package.json').json().get('ember-addon.babel.isParallelSafe').equals(true);
+      test('is parallel safe', async function () {
+        (await expectFile('./package.json').json()).get('ember-addon.babel.isParallelSafe').equals(true);
       });
     });
   });

--- a/tests/scenarios/compat-stage2-test.ts
+++ b/tests/scenarios/compat-stage2-test.ts
@@ -112,11 +112,11 @@ stage2Scenarios
 
       let expectAudit = setupAuditTest(hooks, () => ({ app: app.dir, 'reuse-build': true }));
 
-      test('in repo addons are symlinked correctly', function () {
+      test('in repo addons are symlinked correctly', async function () {
         // check that package json contains in repo dep
-        expectFile('./node_modules/dep-a/package.json').json().get('dependencies.in-repo-a').equals('0.0.0');
-        expectFile('./node_modules/dep-b/package.json').json().get('dependencies.in-repo-c').equals('0.0.0');
-        expectFile('./node_modules/dep-b/package.json').json().get('dependencies.in-repo-b').equals('0.0.0');
+        (await expectFile('./node_modules/dep-a/package.json').json()).get('dependencies.in-repo-a').equals('0.0.0');
+        (await expectFile('./node_modules/dep-b/package.json').json()).get('dependencies.in-repo-c').equals('0.0.0');
+        (await expectFile('./node_modules/dep-b/package.json').json()).get('dependencies.in-repo-b').equals('0.0.0');
 
         // check that in-repo addons are resolvable
         expectAudit
@@ -125,9 +125,15 @@ stage2Scenarios
           .to('./node_modules/dep-a/lib/in-repo-a/check-resolution-target.js');
 
         // check that the in repo addons are correctly upgraded
-        expectFile('./node_modules/dep-a/lib/in-repo-a/package.json').json().get('ember-addon.version').equals(2);
-        expectFile('./node_modules/dep-b/lib/in-repo-b/package.json').json().get('ember-addon.version').equals(2);
-        expectFile('./node_modules/dep-b/lib/in-repo-c/package.json').json().get('ember-addon.version').equals(2);
+        (await expectFile('./node_modules/dep-a/lib/in-repo-a/package.json').json())
+          .get('ember-addon.version')
+          .equals(2);
+        (await expectFile('./node_modules/dep-b/lib/in-repo-b/package.json').json())
+          .get('ember-addon.version')
+          .equals(2);
+        (await expectFile('./node_modules/dep-b/lib/in-repo-c/package.json').json())
+          .get('ember-addon.version')
+          .equals(2);
 
         // check that the app trees with in repo addon are combined correctly
         expectAudit
@@ -668,7 +674,7 @@ stage2Scenarios
 
       test(`public assets are included`, async function () {
         expectFile('public-file-1.txt').matches(/initial state/);
-        expectFile('package.json').json().get('ember-addon.assets').includes('public-file-1.txt');
+        (await expectFile('package.json').json()).get('ember-addon.assets').includes('public-file-1.txt');
       });
 
       test(`updated public asset`, async function () {
@@ -682,14 +688,14 @@ stage2Scenarios
         writeFileSync(join(app.dir, 'public/public-file-2.txt'), `added`);
         await builder.build({ changedDirs: [join(app.dir, 'app')] });
         expectFile('public-file-2.txt').matches(/added/);
-        expectFile('package.json').json().get('ember-addon.assets').includes('public-file-2.txt');
+        (await expectFile('package.json').json()).get('ember-addon.assets').includes('public-file-2.txt');
       });
 
       test(`removed public asset`, async function () {
         unlinkSync(join(app.dir, 'public/public-file-1.txt'));
         await builder.build({ changedDirs: [join(app.dir, 'app')] });
         expectFile('public-file-1.txt').doesNotExist();
-        expectFile('package.json').json().get('ember-addon.assets').doesNotInclude('public-file-1.txt');
+        (await expectFile('package.json').json()).get('ember-addon.assets').doesNotInclude('public-file-1.txt');
       });
 
       test('dynamic import is preserved', function () {

--- a/tests/scenarios/compat-template-colocation-test.ts
+++ b/tests/scenarios/compat-template-colocation-test.ts
@@ -160,8 +160,8 @@ scenarios
         );
       });
 
-      test(`addon's colocated components are correct in implicit-modules`, function () {
-        let assertFile = expectFile('./node_modules/my-addon/package.json').json();
+      test(`addon's colocated components are correct in implicit-modules`, async function () {
+        let assertFile = await expectFile('./node_modules/my-addon/package.json').json();
         assertFile.get(['ember-addon', 'implicit-modules']).includes('./components/component-one');
         assertFile.get(['ember-addon', 'implicit-modules']).includes('./components/component-two');
         assertFile.get(['ember-addon', 'implicit-modules']).doesNotInclude('./components/component-one.hbs');
@@ -199,8 +199,8 @@ scenarios
         );
       });
 
-      test(`addon's colocated components are not in implicit-modules`, function () {
-        let assertFile = expectFile('./node_modules/my-addon/package.json').json();
+      test(`addon's colocated components are not in implicit-modules`, async function () {
+        let assertFile = await expectFile('./node_modules/my-addon/package.json').json();
         assertFile.get(['ember-addon', 'implicit-modules']).equals(undefined);
       });
     });

--- a/tests/scenarios/glimmer-tracking-test.ts
+++ b/tests/scenarios/glimmer-tracking-test.ts
@@ -55,7 +55,8 @@ appScenarios
       });
 
       test(`pnpm test`, async function (assert) {
-        let result = await app.execute('pnpm test');
+        await app.execute('pnpm build');
+        let result = await app.execute('pnpm test --dir dist');
         assert.equal(result.exitCode, 0, result.output);
       });
     });

--- a/tests/scenarios/helpers/command-watcher.ts
+++ b/tests/scenarios/helpers/command-watcher.ts
@@ -1,0 +1,141 @@
+import execa, { type Options, type ExecaChildProcess } from 'execa';
+import path from 'path';
+
+export const DEFAULT_TIMEOUT = process.env.CI ? 90000 : 30000;
+
+export default class CommandWatcher {
+  static launch(command: string, args: readonly string[], options: Options<string> = {}): CommandWatcher {
+    return new CommandWatcher(
+      execa(path.join(options.cwd as string, 'node_modules/.bin', command), [...args], {
+        ...options,
+        all: true,
+      })
+    );
+  }
+
+  private lines: string[] = [];
+  private nextWaitedLine = 0;
+  private exitCode: number | null = null;
+  private currentWaiter: (() => void) | undefined;
+
+  constructor(private process: ExecaChildProcess) {
+    process.all!.on('data', data => {
+      const lines = data.toString().split(/\r?\n/);
+      // console.log(lines);
+      this.lines.push(...lines);
+      this.currentWaiter?.();
+    });
+
+    process.on('exit', code => {
+      console.log('subprocess exited', code);
+      // TODO why can code be null here?
+      this.exitCode = code ?? 0;
+      this.currentWaiter?.();
+    });
+  }
+
+  private async internalWait(timedOut?: Promise<void>): Promise<void> {
+    if (this.currentWaiter) {
+      throw new Error(`bug: only one wait at a time`);
+    }
+    try {
+      await Promise.race(
+        [
+          timedOut,
+          new Promise<void>(resolve => {
+            this.currentWaiter = resolve;
+          }),
+        ].filter(Boolean)
+      );
+    } finally {
+      console.log('hit the internalWait finally');
+      this.currentWaiter = undefined;
+    }
+  }
+
+  private searchLines(output: string | RegExp): boolean | RegExpExecArray {
+    while (this.nextWaitedLine < this.lines.length) {
+      let line = this.lines[this.nextWaitedLine++];
+      console.log(line);
+      if (typeof output === 'string') {
+        if (output === line) {
+          return true;
+        }
+      } else {
+        let result = output.exec(line);
+        if (result) {
+          return result;
+        }
+      }
+    }
+    return false;
+  }
+
+  async waitFor(output: string | RegExp, timeout = DEFAULT_TIMEOUT): Promise<any> {
+    let timedOut = new Promise<void>((_resolve, reject) => {
+      setTimeout(() => {
+        let err = new Error(
+          'Timed out after ' +
+            timeout +
+            'ms before output "' +
+            output +
+            '" was found. ' +
+            'Output:\n\n' +
+            this.lines.join('\n')
+        );
+        reject(err);
+      }, timeout);
+    });
+    while (true) {
+      if (this.exitCode != null) {
+        throw new Error(
+          'Process exited with code ' +
+            this.exitCode +
+            ' before output "' +
+            output +
+            '" was found. ' +
+            'Output:\n\n' +
+            this.lines.join('\n')
+        );
+      }
+      let result = this.searchLines(output);
+      if (result) {
+        return result;
+      }
+      await this.internalWait(timedOut);
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.exitCode != null) {
+      console.log('exitCode is not null');
+      return;
+    }
+
+    this.process.kill();
+
+    // on windows the subprocess won't close if you don't end all the sockets
+    // we don't just end stdout because when you register a listener for stdout it auto registers stdin and stderr... for some reason :(
+    this.process.stdio.forEach((socket: any) => {
+      if (socket) {
+        socket.end();
+      }
+    });
+
+    console.log('waiting for exit');
+    await this.waitForExit();
+  }
+
+  async waitForExit(): Promise<number> {
+    while (true) {
+      console.log('waiting for exit in waitForExit()', this.exitCode);
+      if (this.exitCode != null) {
+        console.log('exitCode is not null in waitForExit()');
+        return this.exitCode;
+      }
+      console.log('about to wait for internal wait');
+      await this.internalWait();
+      console.log('finished waiting for internal wait');
+    }
+  }
+}

--- a/tests/scenarios/macro-test.ts
+++ b/tests/scenarios/macro-test.ts
@@ -226,6 +226,9 @@ dummyAppScenarios
         assert.equal(result.exitCode, 0, result.output);
       });
 
+      // TODO make the vite-app template still work with a classic build
+      // alternatively instead of polluting the vite app on disk you have scenario-tester change things
+      // we could consider this as a script that moves things around
       test(`pnpm test EMBROIDER_TEST_SETUP_FORCE=classic`, async function (assert) {
         let result = await addon.execute('cross-env EMBROIDER_TEST_SETUP_FORCE=classic pnpm ember test');
         assert.equal(result.exitCode, 0, result.output);

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -61,7 +61,7 @@
     "broccoli-merge-trees": "^3.0.2",
     "broccoli-persistent-filter": "^3.1.2",
     "broccoli-stew": "^3.0.0",
-    "ember-bootstrap": "^5.0.0",
+    "ember-bootstrap": "^6.0.0",
     "ember-cli": "~3.28.0",
     "ember-cli-4.4": "npm:ember-cli@~4.4.0",
     "ember-cli-beta": "npm:ember-cli@beta",

--- a/tests/scenarios/stage1-test.ts
+++ b/tests/scenarios/stage1-test.ts
@@ -77,8 +77,8 @@ appScenarios
         expectFile('node_modules/my-addon/_app_/components/hello-world.js').exists();
       });
 
-      test('addon metadata', function () {
-        let myAddonPkg = expectFile('node_modules/my-addon/package.json').json();
+      test('addon metadata', async function () {
+        let myAddonPkg = await expectFile('node_modules/my-addon/package.json').json();
         myAddonPkg
           .get('ember-addon.app-js')
           .deepEquals({ './components/hello-world.js': './_app_/components/hello-world.js' });
@@ -466,8 +466,10 @@ appScenarios
         expectFile('node_modules/has-custom-base/file.js').matches(/weird-addon-path\/file\.js/);
       });
 
-      test('no fastboot-js is emitted', function () {
-        expectFile('node_modules/undefined-fastboot/package.json').json().get('ember-addon.fastboot-js').equals(null);
+      test('no fastboot-js is emitted', async function () {
+        (await expectFile('node_modules/undefined-fastboot/package.json').json())
+          .get('ember-addon.fastboot-js')
+          .equals(null);
       });
 
       test('custom tree hooks are detected when they have been patched into the addon instance', function () {

--- a/tests/scenarios/static-app-test.ts
+++ b/tests/scenarios/static-app-test.ts
@@ -1,15 +1,13 @@
 import { appScenarios, baseAddon } from './scenarios';
 import type { PreparedApp } from 'scenario-tester';
-import { Project } from 'scenario-tester';
 import QUnit from 'qunit';
 import merge from 'lodash/merge';
-import { dirname } from 'path';
 const { module: Qmodule, test } = QUnit;
 
 appScenarios
   .map('static-app', project => {
     project.linkDevDependency('bootstrap', { baseDir: __dirname });
-    project.addDevDependency(emberBootstrap());
+    project.linkDevDependency('ember-bootstrap', { baseDir: __dirname });
     project.linkDevDependency('@embroider/macros', { baseDir: __dirname });
     project.linkDevDependency('ember-modifier', { baseDir: __dirname });
 
@@ -429,12 +427,3 @@ appScenarios
       });
     });
   });
-
-function emberBootstrap() {
-  // https://github.com/kaliber5/ember-bootstrap/pull/1750
-  let modifiers = Project.fromDir(dirname(require.resolve('@ember/render-modifiers')), { linkDeps: true });
-  modifiers.removeDependency('ember-source');
-  let eb = Project.fromDir(dirname(require.resolve('ember-bootstrap')), { linkDeps: true });
-  eb.addDependency(modifiers);
-  return eb;
-}

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -239,7 +239,7 @@ appScenarios
         });
 
         test('package.json is modified appropriately', async function () {
-          expectFile('package.json').json('ember-addon.app-js').deepEquals({
+          (await expectFile('package.json').json('ember-addon.app-js')).deepEquals({
             './components/another.js': './dist/_app_/components/another.js',
             './components/demo/button.js': './dist/_app_/components/demo/button.js',
             './components/single-file-component.js': './dist/_app_/components/single-file-component.js',

--- a/tests/scenarios/vite-test.ts
+++ b/tests/scenarios/vite-test.ts
@@ -14,6 +14,7 @@ let app = appScenarios.map('vite-specific', () => {
 });
 
 import CommandWatcher from './helpers/command-watcher';
+import { setupAuditTest } from '@embroider/test-support/audit-assertions';
 
 app.forEachScenario(scenario => {
   Qmodule(scenario.name, function (hooks) {
@@ -21,37 +22,33 @@ app.forEachScenario(scenario => {
     let server: CommandWatcher;
     let serverPort: string;
 
-    async function waitFor(...args: Parameters<CommandWatcher['waitFor']>): Promise<any> {
-      return server.waitFor(...args);
-    }
-
-    hooks.beforeEach(async () => {
+    hooks.before(async () => {
       app = await scenario.prepare();
       server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
-      const [, port] = await waitFor(/Local:\s+http:\/\/127.0.0.1:(\d+)\//);
+      const [, port] = await server.waitFor(/Local:\s+http:\/\/127.0.0.1:(\d+)\//);
 
       serverPort = port;
     });
 
-    hooks.afterEach(async () => {
+    let expectAudit = setupAuditTest(hooks, () => ({
+      appURL: `http://localhost:${serverPort}/`,
+      startingFrom: ['index.html'],
+    }));
+
+    hooks.after(async () => {
       console.log('shutting down');
       await server.shutdown();
       console.log('done shutting down');
     });
 
-    function getRemoteFile(assert: Assert, path: string) {
-      return expectRemoteFile(`http://localhost:${serverPort}`, { qunit: assert })(path);
-    }
-
-    test(`vite`, async function (assert) {
-      await getRemoteFile(assert, '/assets/app-template.js').doesNotMatch(
-        /import \* as .* from.*rewritten_packages.*ember-page-title/
-      );
-
-      // TODO write the correct one
-      await getRemoteFile(assert, '/assets/app-template.js').matches(
-        /import \* as .* from.*.vite\/deps\/app-template_services_page-title/
-      );
+    test(`vite`, async function () {
+      expectAudit
+        .module('index.html')
+        .resolves(/app-template\.js/)
+        .toModule()
+        .withContents((_src, imports) => {
+          return imports.filter(imp => /page-title/.test(imp.source)).every(imp => /\.vite\/deps/.test(imp.source));
+        });
     });
   });
 });

--- a/tests/scenarios/vite-test.ts
+++ b/tests/scenarios/vite-test.ts
@@ -1,0 +1,57 @@
+import { appScenarios } from './scenarios';
+import type { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+
+import { expectRemoteFile } from '@embroider/test-support/file-assertions/qunit';
+
+const { module: Qmodule, test } = QUnit;
+
+let app = appScenarios.map('vite-specific', () => {
+  /**
+   * We will create files as a part of the watch-mode tests,
+   * because creating files should cause appropriate watch/update behavior
+   */
+});
+
+import CommandWatcher from './helpers/command-watcher';
+
+app.forEachScenario(scenario => {
+  Qmodule(scenario.name, function (hooks) {
+    let app: PreparedApp;
+    let server: CommandWatcher;
+    let serverPort: string;
+
+    async function waitFor(...args: Parameters<CommandWatcher['waitFor']>): Promise<any> {
+      return server.waitFor(...args);
+    }
+
+    hooks.beforeEach(async () => {
+      app = await scenario.prepare();
+      server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+      const [, port] = await waitFor(/Local:\s+http:\/\/127.0.0.1:(\d+)\//);
+
+      serverPort = port;
+    });
+
+    hooks.afterEach(async () => {
+      console.log('shutting down');
+      await server.shutdown();
+      console.log('done shutting down');
+    });
+
+    function getRemoteFile(assert: Assert, path: string) {
+      return expectRemoteFile(`http://localhost:${serverPort}`, { qunit: assert })(path);
+    }
+
+    test(`vite`, async function (assert) {
+      await getRemoteFile(assert, '/assets/app-template.js').doesNotMatch(
+        /import \* as .* from.*rewritten_packages.*ember-page-title/
+      );
+
+      // TODO write the correct one
+      await getRemoteFile(assert, '/assets/app-template.js').matches(
+        /import \* as .* from.*.vite\/deps\/app-template_services_page-title/
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR is to demonstrate how we want to do vite dependency optimisation tests in the future. We don't want any/much vite-specific infrastructure in our tests and we want to rely on the audit system to make sure that the correct dependencies being built in vite dev mode

## TODO

- [ ] update the audit system to be able to load html (and references) across HTTP
- [ ] remove the "async file" implementation from this PR and make sure it uses the new audit system 