### PR TITLE
Splitting reusable module visitor out of Audit

### DIFF
--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -264,6 +264,11 @@ export class Audit {
 
   private inspectImports(filename: string, module: CompleteModule, modules: Record<string, Module>) {
     for (let imp of module.imports) {
+      // our Audit should always ignore any imports of @embroider/macros because we already ignored them
+      // in resolveId above
+      if (imp.source === '@embroider/macros') {
+        continue;
+      }
       let resolved = module.resolutions[imp.source];
       if (!resolved) {
         this.findings.push({

--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -1,18 +1,15 @@
 import { readFileSync, readJSONSync } from 'fs-extra';
-import { dirname, join, resolve as resolvePath } from 'path';
+import { join, resolve as resolvePath } from 'path';
 import type { AppMeta, ResolverOptions } from '@embroider/core';
 import { explicitRelative, hbsToJS, locateEmbroiderWorkingDir, Resolver, RewrittenPackageCache } from '@embroider/core';
 import { Memoize } from 'typescript-memoize';
 import chalk from 'chalk';
-import jsdom from 'jsdom';
 import groupBy from 'lodash/groupBy';
-import fromPairs from 'lodash/fromPairs';
-import type { ExportAll, InternalImport, NamespaceMarker } from './audit/babel-visitor';
-import { auditJS, CodeFrameStorage, isNamespaceMarker } from './audit/babel-visitor';
+import type { NamespaceMarker } from './audit/babel-visitor';
+import { CodeFrameStorage, isNamespaceMarker } from './audit/babel-visitor';
 import { AuditBuildOptions, AuditOptions } from './audit/options';
 import { buildApp, BuildError, isBuildError } from './audit/build';
-
-const { JSDOM } = jsdom;
+import { type ContentType, type Module, visitModules, isLinked } from './module-visitor';
 
 export interface AuditMessage {
   message: string;
@@ -36,110 +33,13 @@ export interface Finding {
   codeFrame?: string;
 }
 
-export interface Module {
-  appRelativePath: string;
-  consumedFrom: (string | RootMarker)[];
-  imports: Import[];
-  exports: string[];
-  resolutions: { [source: string]: string | null };
-  content: string;
-}
-
-interface ResolutionFailure {
-  isResolutionFailure: true;
-}
-
-function isResolutionFailure(result: string | ResolutionFailure | undefined): result is ResolutionFailure {
-  return typeof result === 'object' && 'isResolutionFailure' in result;
-}
-
-interface InternalModule {
-  consumedFrom: (string | RootMarker)[];
-
-  parsed?: {
-    imports: InternalImport[];
-    exports: Set<string | ExportAll>;
-    isCJS: boolean;
-    isAMD: boolean;
-    dependencies: string[];
-    transpiledContent: string | Buffer;
-  };
-
-  resolved?: Map<string, string | ResolutionFailure>;
-
-  linked?: {
-    exports: Set<string>;
-  };
-}
-
-type ParsedInternalModule = Omit<InternalModule, 'parsed'> & {
-  parsed: NonNullable<InternalModule['parsed']>;
-};
-
-type ResolvedInternalModule = Omit<ParsedInternalModule, 'resolved'> & {
-  resolved: NonNullable<ParsedInternalModule['resolved']>;
-};
-
-function isResolved(module: InternalModule | undefined): module is ResolvedInternalModule {
-  return Boolean(module?.parsed && module.resolved);
-}
-
-type LinkedInternalModule = Omit<ResolvedInternalModule, 'linked'> & {
-  linked: NonNullable<ResolvedInternalModule['linked']>;
-};
-
-function isLinked(module: InternalModule | undefined): module is LinkedInternalModule {
-  return Boolean(module?.parsed && module.resolved && module.linked);
-}
-
-export interface Import {
-  source: string;
-  specifiers: {
-    name: string | NamespaceMarker;
-    local: string | null; // can be null when re-exporting, because in that case we import `name` from `source` but don't create any local binding for it
-  }[];
-}
-
 export class AuditResults {
   modules: { [file: string]: Module } = {};
   findings: Finding[] = [];
 
-  static create(baseDir: string, findings: Finding[], modules: Map<string, InternalModule>) {
+  static create(baseDir: string, findings: Finding[], modules: Record<string, Module>) {
     let results = new this();
-    for (let [filename, module] of modules) {
-      let publicModule: Module = {
-        appRelativePath: explicitRelative(baseDir, filename),
-        consumedFrom: module.consumedFrom.map(entry => {
-          if (isRootMarker(entry)) {
-            return entry;
-          } else {
-            return explicitRelative(baseDir, entry);
-          }
-        }),
-        resolutions: module.resolved
-          ? fromPairs(
-              [...module.resolved].map(([source, target]) => [
-                source,
-                isResolutionFailure(target) ? null : explicitRelative(baseDir, target),
-              ])
-            )
-          : {},
-        imports: module.parsed?.imports
-          ? module.parsed.imports.map(i => ({
-              source: i.source,
-              specifiers: i.specifiers.map(s => ({
-                name: s.name,
-                local: s.local,
-              })),
-            }))
-          : [],
-        exports: module.linked?.exports ? [...module.linked.exports] : [],
-        content: module.parsed?.transpiledContent
-          ? module.parsed?.transpiledContent.toString()
-          : 'module failed to transpile',
-      };
-      results.modules[explicitRelative(baseDir, filename)] = publicModule;
-    }
+    results.modules = modules;
     for (let finding of findings) {
       let relFinding = Object.assign({}, finding, { filename: explicitRelative(baseDir, finding.filename) });
       results.findings.push(relFinding);
@@ -200,9 +100,7 @@ export class AuditResults {
 }
 
 export class Audit {
-  private modules: Map<string, InternalModule> = new Map();
   private virtualModules: Map<string, string> = new Map();
-  private moduleQueue = new Set<string>();
   private findings = [] as Finding[];
 
   private frames = new CodeFrameStorage();
@@ -265,73 +163,68 @@ export class Audit {
     }
   }
 
-  private visitorFor(
-    filename: string
-  ): (
-    this: Audit,
-    filename: string,
-    content: Buffer | string
-  ) => Promise<NonNullable<InternalModule['parsed']> | Finding[]> {
-    if (filename.endsWith('.html')) {
-      return this.visitHTML;
-    } else if (filename.endsWith('.hbs')) {
-      return this.visitHBS;
-    } else if (filename.endsWith('.json')) {
-      return this.visitJSON;
-    } else {
-      return this.visitJS;
-    }
-  }
-
-  private async drainQueue() {
-    while (this.moduleQueue.size > 0) {
-      let filename = this.moduleQueue.values().next().value as string;
-      this.moduleQueue.delete(filename);
-      this.debug('visit', filename);
-      let visitor = this.visitorFor(filename);
-      let content: string | Buffer;
-      if (this.virtualModules.has(filename)) {
-        content = this.virtualModules.get(filename)!;
-      } else {
-        content = readFileSync(filename);
-      }
-      // cast is safe because the only way to get into the queue is to go
-      // through scheduleVisit, and scheduleVisit creates the entry in
-      // this.modules.
-      let module: InternalModule = this.modules.get(filename)!;
-      let visitResult = await visitor.call(this, filename, content);
-      if (Array.isArray(visitResult)) {
-        // the visitor was unable to figure out the ParseFields and returned
-        // some number of Findings to us to explain why.
-        for (let finding of visitResult) {
-          this.pushFinding(finding);
-        }
-      } else {
-        module.parsed = visitResult;
-        module.resolved = await this.resolveDeps(visitResult.dependencies, filename);
-      }
-    }
-  }
-
   async run(): Promise<AuditResults> {
     (globalThis as any).embroider_audit = this.handleResolverError.bind(this);
 
     try {
       this.debug(`meta`, this.meta);
-      for (let asset of this.meta.assets) {
-        if (asset.endsWith('.html')) {
-          this.scheduleVisit(resolvePath(this.movedAppRoot, asset), { isRoot: true });
-        }
-      }
-      await this.drainQueue();
-      this.linkModules();
-      this.inspectModules();
+      let entrypoints = this.meta.assets.filter(a => a.endsWith('html')).map(a => resolvePath(this.movedAppRoot, a));
 
-      return AuditResults.create(this.originAppRoot, this.findings, this.modules);
+      let modules = await visitModules({
+        base: this.originAppRoot,
+        entrypoints,
+        resolveId: this.resolveId,
+        load: this.load,
+        findings: this.findings,
+        frames: this.frames,
+        babelConfig: this.babelConfig,
+      });
+
+      this.inspectModules(modules);
+
+      return AuditResults.create(this.originAppRoot, this.findings, modules);
     } finally {
       delete (globalThis as any).embroider_audit;
     }
   }
+
+  private resolveId = async (specifier: string, fromFile: string): Promise<string | undefined> => {
+    if (['@embroider/macros'].includes(specifier)) {
+      // the audit process deliberately removes the @embroider/macros babel
+      // plugins, so the imports are still present and should be left alone.
+      return undefined;
+    }
+
+    let resolution = await this.resolver.nodeResolve(specifier, fromFile);
+    switch (resolution.type) {
+      case 'virtual':
+        this.virtualModules.set(resolution.filename, resolution.content);
+        return resolution.filename;
+      case 'not_found':
+        return undefined;
+      case 'real':
+        return resolution.filename;
+    }
+  };
+
+  private load = async (id: string): Promise<Finding[] | { content: string | Buffer; type: ContentType }> => {
+    let content: string | Buffer;
+    if (this.virtualModules.has(id)) {
+      content = this.virtualModules.get(id)!;
+    } else {
+      content = readFileSync(id);
+    }
+
+    if (id.endsWith('.html')) {
+      return { content, type: 'html' };
+    } else if (id.endsWith('.hbs')) {
+      return { content: hbsToJS(content.toString('utf8')), type: 'javascript' };
+    } else if (id.endsWith('.json')) {
+      return this.handleJSON(id, content);
+    } else {
+      return { content, type: 'javascript' };
+    }
+  };
 
   private handleResolverError(msg: AuditMessage) {
     this.pushFinding({
@@ -342,55 +235,18 @@ export class Audit {
     });
   }
 
-  private linkModules() {
-    for (let module of this.modules.values()) {
-      if (isResolved(module)) {
-        this.linkModule(module);
-      }
-    }
-  }
-
-  private linkModule(module: ResolvedInternalModule) {
-    let exports = new Set<string>();
-    for (let exp of module.parsed.exports) {
-      if (typeof exp === 'string') {
-        exports.add(exp);
-      } else {
-        let moduleName = module.resolved.get(exp.all)!;
-        if (!isResolutionFailure(moduleName)) {
-          let target = this.modules.get(moduleName)!;
-          if (!isLinked(target) && isResolved(target)) {
-            this.linkModule(target);
-          }
-          if (isLinked(target)) {
-            for (let innerExp of target.linked.exports) {
-              exports.add(innerExp);
-            }
-          } else {
-            // our module doesn't successfully enter linked state because it
-            // depends on stuff that also couldn't
-            return;
-          }
-        }
-      }
-    }
-    module.linked = {
-      exports,
-    };
-  }
-
-  private inspectModules() {
-    for (let [filename, module] of this.modules) {
+  private inspectModules(modules: Record<string, Module>) {
+    for (let [filename, module] of Object.entries(modules)) {
       if (isLinked(module)) {
-        this.inspectImports(filename, module);
+        this.inspectImports(filename, module, modules);
       }
     }
   }
 
-  private inspectImports(filename: string, module: LinkedInternalModule) {
-    for (let imp of module.parsed.imports) {
-      let resolved = module.resolved.get(imp.source);
-      if (isResolutionFailure(resolved)) {
+  private inspectImports(filename: string, module: Module, modules: Record<string, Module>) {
+    for (let imp of module.imports) {
+      let resolved = module.resolutions[imp.source];
+      if (!resolved) {
         this.findings.push({
           filename,
           message: 'unable to resolve dependency',
@@ -398,7 +254,7 @@ export class Audit {
           codeFrame: this.frames.render(imp.codeFrameIndex),
         });
       } else if (resolved) {
-        let target = this.modules.get(resolved)!;
+        let target = modules[resolved]!;
         for (let specifier of imp.specifiers) {
           if (isLinked(target) && !this.moduleProvidesName(target, specifier.name)) {
             if (specifier.name === 'default') {
@@ -430,78 +286,6 @@ export class Audit {
     return isNamespaceMarker(name) || target.parsed.isCJS || target.parsed.isAMD || target.linked.exports.has(name);
   }
 
-  private async visitHTML(filename: string, content: Buffer | string): Promise<ParsedInternalModule['parsed']> {
-    let dom = new JSDOM(content);
-    let scripts = dom.window.document.querySelectorAll('script[type="module"]') as NodeListOf<HTMLScriptElement>;
-    let dependencies = [] as string[];
-    for (let script of scripts) {
-      let src = script.src;
-      if (!src) {
-        continue;
-      }
-      if (new URL(src, 'http://example.com:4321').origin !== 'http://example.com:4321') {
-        // src was absolute, we don't handle it
-        continue;
-      }
-      if (src.startsWith(this.meta['root-url'])) {
-        // root-relative URLs are actually relative to the appDir
-        src = explicitRelative(
-          dirname(filename),
-          resolvePath(this.movedAppRoot, src.replace(this.meta['root-url'], ''))
-        );
-      }
-      dependencies.push(src);
-    }
-
-    return {
-      imports: [],
-      exports: new Set(),
-      isCJS: false,
-      isAMD: false,
-      dependencies,
-      transpiledContent: content,
-    };
-  }
-
-  private async visitJS(
-    filename: string,
-    content: Buffer | string
-  ): Promise<ParsedInternalModule['parsed'] | Finding[]> {
-    let rawSource = content.toString('utf8');
-    try {
-      let result = auditJS(rawSource, filename, this.babelConfig, this.frames);
-
-      for (let problem of result.problems) {
-        this.pushFinding({
-          filename,
-          message: problem.message,
-          detail: problem.detail,
-          codeFrame: this.frames.render(problem.codeFrameIndex),
-        });
-      }
-      return {
-        exports: result.exports,
-        imports: result.imports,
-        isCJS: result.isCJS,
-        isAMD: result.isAMD,
-        dependencies: result.imports.map(i => i.source),
-        transpiledContent: result.transpiledContent,
-      };
-    } catch (err) {
-      if (['BABEL_PARSE_ERROR', 'BABEL_TRANSFORM_ERROR'].includes(err.code)) {
-        return [
-          {
-            filename,
-            message: `failed to parse`,
-            detail: err.toString().replace(filename, explicitRelative(this.originAppRoot, filename)),
-          },
-        ];
-      } else {
-        throw err;
-      }
-    }
-  }
-
   private async visitHBS(
     filename: string,
     content: Buffer | string
@@ -511,10 +295,7 @@ export class Audit {
     return this.visitJS(filename, js);
   }
 
-  private async visitJSON(
-    filename: string,
-    content: Buffer | string
-  ): Promise<ParsedInternalModule['parsed'] | Finding[]> {
+  private handleJSON(filename: string, content: Buffer | string): { content: string; type: ContentType } | Finding[] {
     let js;
     try {
       let structure = JSON.parse(content.toString('utf8'));
@@ -528,7 +309,7 @@ export class Audit {
         },
       ];
     }
-    return this.visitJS(filename, js);
+    return { content: js, type: 'javascript' };
   }
 
   private async resolveDeps(deps: string[], fromFile: string): Promise<InternalModule['resolved']> {
@@ -593,12 +374,4 @@ function indent(str: string, level: number) {
     .split('\n')
     .map(line => spaces + line)
     .join('\n');
-}
-
-export interface RootMarker {
-  isRoot: true;
-}
-
-export function isRootMarker(value: string | RootMarker | undefined): value is RootMarker {
-  return Boolean(value && typeof value !== 'string' && value.isRoot);
 }

--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readJSONSync } from 'fs-extra';
-import { join, resolve as resolvePath } from 'path';
+import { join, resolve as resolvePath, dirname } from 'path';
 import type { AppMeta, ResolverOptions } from '@embroider/core';
 import { explicitRelative, hbsToJS, locateEmbroiderWorkingDir, Resolver, RewrittenPackageCache } from '@embroider/core';
 import { Memoize } from 'typescript-memoize';
@@ -193,6 +193,14 @@ export class Audit {
       // the audit process deliberately removes the @embroider/macros babel
       // plugins, so the imports are still present and should be left alone.
       return undefined;
+    }
+
+    if (fromFile.endsWith('.html') && specifier.startsWith(this.meta['root-url'])) {
+      // root-relative URLs in HTML are actually relative to the appDir
+      specifier = explicitRelative(
+        dirname(fromFile),
+        resolvePath(this.movedAppRoot, specifier.replace(this.meta['root-url'], ''))
+      );
     }
 
     let resolution = await this.resolver.nodeResolve(specifier, fromFile);

--- a/packages/compat/src/module-visitor.ts
+++ b/packages/compat/src/module-visitor.ts
@@ -1,0 +1,378 @@
+// TODO: split this so we have the import-analysis part as part of
+// module-visitor and Audit adds its problem-detectoin stuff in the (optional)
+// babel config
+import { explicitRelative } from '@embroider/core';
+import {
+  type CodeFrameStorage,
+  auditJS,
+  type ExportAll,
+  type InternalImport,
+  type NamespaceMarker,
+} from './audit/babel-visitor';
+import fromPairs from 'lodash/fromPairs';
+import assertNever from 'assert-never';
+import { JSDOM } from 'jsdom';
+
+// TODO: this is an audit concern
+import type { Finding } from './audit';
+import type { TransformOptions } from '@babel/core';
+
+export interface Module {
+  appRelativePath: string;
+  consumedFrom: (string | RootMarker)[];
+  imports: Import[];
+  exports: string[];
+  resolutions: { [source: string]: string | null };
+  content: string;
+}
+
+interface InternalModule {
+  consumedFrom: (string | RootMarker)[];
+
+  parsed?: {
+    imports: InternalImport[];
+    exports: Set<string | ExportAll>;
+    isCJS: boolean;
+    isAMD: boolean;
+    dependencies: string[];
+    transpiledContent: string | Buffer;
+  };
+
+  resolved?: Map<string, string | ResolutionFailure>;
+
+  linked?: {
+    exports: Set<string>;
+  };
+}
+
+type ParsedInternalModule = Omit<InternalModule, 'parsed'> & {
+  parsed: NonNullable<InternalModule['parsed']>;
+};
+
+type ResolvedInternalModule = Omit<ParsedInternalModule, 'resolved'> & {
+  resolved: NonNullable<ParsedInternalModule['resolved']>;
+};
+
+function isResolved(module: InternalModule | undefined): module is ResolvedInternalModule {
+  return Boolean(module?.parsed && module.resolved);
+}
+
+type LinkedInternalModule = Omit<ResolvedInternalModule, 'linked'> & {
+  linked: NonNullable<ResolvedInternalModule['linked']>;
+};
+
+export function isLinked(module: InternalModule | undefined): module is LinkedInternalModule {
+  return Boolean(module?.parsed && module.resolved && module.linked);
+}
+
+export interface Import {
+  source: string;
+  specifiers: {
+    name: string | NamespaceMarker;
+    local: string | null; // can be null when re-exporting, because in that case we import `name` from `source` but don't create any local binding for it
+    codeFrameIndex: number | undefined;
+  }[];
+  codeFrameIndex: number | undefined;
+}
+
+interface VisitorParams {
+  base: string;
+  resolveId: (specifier: string, fromFile: string) => Promise<string | undefined>;
+  // TODO: remove Finding[] from this type
+  load: (id: string) => Promise<Finding[] | { content: string | Buffer; type: ContentType }>;
+  entrypoints: string[];
+  debug?: boolean;
+
+  // TODO: remove below this point
+  findings: Finding[];
+  frames: CodeFrameStorage;
+  babelConfig: TransformOptions;
+}
+
+export async function visitModules(params: VisitorParams): Promise<Record<string, Module>> {
+  let visitor = new ModuleVisitor(params);
+  return await visitor.run();
+}
+
+export type ContentType = 'javascript' | 'html';
+
+class ModuleVisitor {
+  private modules: Map<string, InternalModule> = new Map();
+
+  private moduleQueue = new Set<string>();
+  private base: string;
+  private debugEnabled: boolean;
+  private resolveId: (specifier: string, fromFile: string) => Promise<string | undefined>;
+  // TODO: remove Finding[] from return type
+  private load: (id: string) => Promise<Finding[] | { content: string | Buffer; type: ContentType }>;
+  private entrypoints: string[];
+
+  constructor(private params: VisitorParams) {
+    this.base = params.base;
+    this.debugEnabled = Boolean(params.debug);
+    this.resolveId = params.resolveId;
+    this.load = params.load;
+    this.entrypoints = params.entrypoints;
+  }
+
+  async run(): Promise<Record<string, Module>> {
+    for (let entry of this.entrypoints) {
+      this.scheduleVisit(entry, { isRoot: true });
+    }
+    await this.drainQueue();
+    this.linkModules();
+    return this.buildResults();
+  }
+
+  private async drainQueue() {
+    while (this.moduleQueue.size > 0) {
+      let id = this.moduleQueue.values().next().value as string;
+      this.moduleQueue.delete(id);
+      this.debug('visit', id);
+      let loaded = await this.load(id);
+      if (Array.isArray(loaded)) {
+        for (let finding of loaded) {
+          this.params.findings.push(finding);
+        }
+        continue;
+      }
+      let { content, type } = loaded;
+
+      let visitor = this.visitorFor(type);
+
+      // cast is safe because the only way to get into the queue is to go
+      // through scheduleVisit, and scheduleVisit creates the entry in
+      // this.modules.
+      let module: InternalModule = this.modules.get(id)!;
+      let visitResult = await visitor.call(this, id, content);
+      if (Array.isArray(visitResult)) {
+        // the visitor was unable to figure out the ParseFields and returned
+        // some number of Findings to us to explain why.
+        for (let finding of visitResult) {
+          this.params.findings.push(finding);
+        }
+      } else {
+        module.parsed = visitResult;
+        module.resolved = await this.resolveDeps(visitResult.dependencies, id);
+      }
+    }
+  }
+
+  private linkModules() {
+    for (let module of this.modules.values()) {
+      if (isResolved(module)) {
+        this.linkModule(module);
+      }
+    }
+  }
+
+  private linkModule(module: ResolvedInternalModule) {
+    let exports = new Set<string>();
+    for (let exp of module.parsed.exports) {
+      if (typeof exp === 'string') {
+        exports.add(exp);
+      } else {
+        let moduleName = module.resolved.get(exp.all)!;
+        if (!isResolutionFailure(moduleName)) {
+          let target = this.modules.get(moduleName)!;
+          if (!isLinked(target) && isResolved(target)) {
+            this.linkModule(target);
+          }
+          if (isLinked(target)) {
+            for (let innerExp of target.linked.exports) {
+              exports.add(innerExp);
+            }
+          } else {
+            // our module doesn't successfully enter linked state because it
+            // depends on stuff that also couldn't
+            return;
+          }
+        }
+      }
+    }
+    module.linked = {
+      exports,
+    };
+  }
+
+  private async resolveDeps(deps: string[], fromFile: string): Promise<InternalModule['resolved']> {
+    let resolved = new Map() as NonNullable<InternalModule['resolved']>;
+    for (let dep of deps) {
+      if (['@embroider/macros'].includes(dep)) {
+        // the audit process deliberately removes the @embroider/macros babel
+        // plugins, so the imports are still present and should be left alone.
+        continue;
+      }
+
+      let resolution = await this.resolveId(dep, fromFile);
+      if (resolution) {
+        resolved.set(dep, resolution);
+        this.scheduleVisit(resolution, fromFile);
+        break;
+      } else {
+        resolved.set(dep, { isResolutionFailure: true as true });
+        break;
+      }
+    }
+    return resolved;
+  }
+
+  private scheduleVisit(id: string, parent: string | RootMarker) {
+    let record = this.modules.get(id);
+    if (!record) {
+      this.debug(`discovered`, id);
+      record = {
+        consumedFrom: [parent],
+      };
+      this.modules.set(id, record);
+      this.moduleQueue.add(id);
+    } else {
+      record.consumedFrom.push(parent);
+    }
+  }
+
+  private visitorFor(
+    type: ContentType
+  ): (
+    this: ModuleVisitor,
+    filename: string,
+    content: Buffer | string
+  ) => Promise<NonNullable<InternalModule['parsed'] | Finding[]>> {
+    switch (type) {
+      case 'html':
+        return this.visitHTML;
+      case 'javascript':
+        return this.visitJS;
+      default:
+        throw assertNever(type);
+    }
+  }
+
+  private async visitHTML(_filename: string, content: Buffer | string): Promise<ParsedInternalModule['parsed']> {
+    let dom = new JSDOM(content);
+    let scripts = dom.window.document.querySelectorAll('script[type="module"]') as NodeListOf<HTMLScriptElement>;
+    let dependencies = [] as string[];
+    for (let script of scripts) {
+      let src = script.src;
+      if (!src) {
+        continue;
+      }
+      if (new URL(src, 'http://example.com:4321').origin !== 'http://example.com:4321') {
+        // src was absolute, we don't handle it
+        continue;
+      }
+      dependencies.push(src);
+    }
+
+    return {
+      imports: [],
+      exports: new Set(),
+      isCJS: false,
+      isAMD: false,
+      dependencies,
+      transpiledContent: content,
+    };
+  }
+
+  private async visitJS(
+    filename: string,
+    content: Buffer | string
+  ): Promise<ParsedInternalModule['parsed'] | Finding[]> {
+    let rawSource = content.toString('utf8');
+    try {
+      let result = auditJS(rawSource, filename, this.params.babelConfig, this.params.frames);
+
+      for (let problem of result.problems) {
+        this.params.findings.push({
+          filename,
+          message: problem.message,
+          detail: problem.detail,
+          codeFrame: this.params.frames.render(problem.codeFrameIndex),
+        });
+      }
+      return {
+        exports: result.exports,
+        imports: result.imports,
+        isCJS: result.isCJS,
+        isAMD: result.isAMD,
+        dependencies: result.imports.map(i => i.source),
+        transpiledContent: result.transpiledContent,
+      };
+    } catch (err) {
+      if (['BABEL_PARSE_ERROR', 'BABEL_TRANSFORM_ERROR'].includes(err.code)) {
+        return [
+          {
+            filename,
+            message: `failed to parse`,
+            detail: err.toString().replace(filename, explicitRelative(this.base, filename)),
+          },
+        ];
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  private debug(message: string, ...args: any[]) {
+    if (this.debugEnabled) {
+      console.log(message, ...args);
+    }
+  }
+
+  private buildResults() {
+    let publicModules: Record<string, Module> = {};
+    for (let [filename, module] of this.modules) {
+      let publicModule: Module = {
+        appRelativePath: explicitRelative(this.base, filename),
+        consumedFrom: module.consumedFrom.map(entry => {
+          if (isRootMarker(entry)) {
+            return entry;
+          } else {
+            return explicitRelative(this.base, entry);
+          }
+        }),
+        resolutions: module.resolved
+          ? fromPairs(
+              [...module.resolved].map(([source, target]) => [
+                source,
+                isResolutionFailure(target) ? null : explicitRelative(this.base, target),
+              ])
+            )
+          : {},
+        imports: module.parsed?.imports
+          ? module.parsed.imports.map(i => ({
+              source: i.source,
+              specifiers: i.specifiers.map(s => ({
+                name: s.name,
+                local: s.local,
+                codeFrameIndex: s.codeFrameIndex,
+              })),
+              codeFrameIndex: i.codeFrameIndex,
+            }))
+          : [],
+        exports: module.linked?.exports ? [...module.linked.exports] : [],
+        content: module.parsed?.transpiledContent
+          ? module.parsed?.transpiledContent.toString()
+          : 'module failed to transpile',
+      };
+      publicModules[explicitRelative(this.base, filename)] = publicModule;
+    }
+    return publicModules;
+  }
+}
+
+export interface RootMarker {
+  isRoot: true;
+}
+
+export function isRootMarker(value: string | RootMarker | undefined): value is RootMarker {
+  return Boolean(value && typeof value !== 'string' && value.isRoot);
+}
+
+interface ResolutionFailure {
+  isResolutionFailure: true;
+}
+
+function isResolutionFailure(result: string | ResolutionFailure | undefined): result is ResolutionFailure {
+  return typeof result === 'object' && 'isResolutionFailure' in result;
+}

--- a/packages/compat/src/module-visitor.ts
+++ b/packages/compat/src/module-visitor.ts
@@ -210,10 +210,10 @@ class ModuleVisitor {
       if (resolution) {
         resolved.set(dep, resolution);
         this.scheduleVisit(resolution, fromFile);
-        break;
+        continue;
       } else {
         resolved.set(dep, { isResolutionFailure: true as true });
-        break;
+        continue;
       }
     }
     return resolved;

--- a/packages/compat/src/module-visitor.ts
+++ b/packages/compat/src/module-visitor.ts
@@ -24,6 +24,8 @@ export interface Module {
   exports: string[];
   resolutions: { [source: string]: string | null };
   content: string;
+  isCJS: boolean;
+  isAMD: boolean;
 }
 
 interface InternalModule {
@@ -354,6 +356,8 @@ class ModuleVisitor {
         content: module.parsed?.transpiledContent
           ? module.parsed?.transpiledContent.toString()
           : 'module failed to transpile',
+        isAMD: Boolean(module.parsed?.isAMD),
+        isCJS: Boolean(module.parsed?.isCJS),
       };
       publicModules[explicitRelative(this.base, filename)] = publicModule;
     }

--- a/packages/compat/src/module-visitor.ts
+++ b/packages/compat/src/module-visitor.ts
@@ -1,6 +1,3 @@
-// TODO: split this so we have the import-analysis part as part of
-// module-visitor and Audit adds its problem-detectoin stuff in the (optional)
-// babel config
 import { explicitRelative } from '@embroider/core';
 import {
   type CodeFrameStorage,
@@ -13,7 +10,6 @@ import fromPairs from 'lodash/fromPairs';
 import assertNever from 'assert-never';
 import { JSDOM } from 'jsdom';
 
-// TODO: this is an audit concern
 import type { Finding } from './audit';
 import type { TransformOptions } from '@babel/core';
 
@@ -91,12 +87,10 @@ export interface Import {
 interface VisitorParams {
   base: string;
   resolveId: (specifier: string, fromFile: string) => Promise<string | undefined>;
-  // TODO: remove Finding[] from this type
-  load: (id: string) => Promise<Finding[] | { content: string | Buffer; type: ContentType }>;
+  load: (id: string) => Promise<{ content: string | Buffer; type: ContentType } | undefined>;
   entrypoints: string[];
   debug?: boolean;
 
-  // TODO: remove below this point
   findings: Finding[];
   frames: CodeFrameStorage;
   babelConfig: TransformOptions;
@@ -116,8 +110,7 @@ class ModuleVisitor {
   private base: string;
   private debugEnabled: boolean;
   private resolveId: (specifier: string, fromFile: string) => Promise<string | undefined>;
-  // TODO: remove Finding[] from return type
-  private load: (id: string) => Promise<Finding[] | { content: string | Buffer; type: ContentType }>;
+  private load: (id: string) => Promise<{ content: string | Buffer; type: ContentType } | undefined>;
   private entrypoints: string[];
 
   constructor(private params: VisitorParams) {
@@ -147,6 +140,10 @@ class ModuleVisitor {
         for (let finding of loaded) {
           this.params.findings.push(finding);
         }
+        continue;
+      }
+      // if the load hook returned undefined we need to just skip it
+      if (loaded === undefined) {
         continue;
       }
       let { content, type } = loaded;

--- a/packages/compat/tests/audit.test.ts
+++ b/packages/compat/tests/audit.test.ts
@@ -222,7 +222,11 @@ describe('audit', function () {
     });
     let result = await audit();
     expect(result.findings).toEqual([]);
-    let exports = result.modules['./app.js'].exports;
+    let appModule = result.modules['./app.js'];
+    if (appModule.type !== 'complete') {
+      throw new Error('./app.js module did not parse or resolve correctly');
+    }
+    let exports = appModule.exports;
     expect(exports).toContain('a');
     expect(exports).toContain('b');
     expect(exports).toContain('c');
@@ -269,7 +273,11 @@ describe('audit', function () {
 
     let result = await audit();
     expect(result.findings).toEqual([]);
-    let exports = result.modules['./app.js'].exports;
+    let appModule = result.modules['./app.js'];
+    if (appModule.type !== 'complete') {
+      throw new Error('./app.js module did not parse or resolve correctly');
+    }
+    let exports = appModule.exports;
     expect(exports).toContain('a');
     expect(exports).toContain('b');
     expect(exports).not.toContain('thing');
@@ -277,8 +285,8 @@ describe('audit', function () {
     expect(exports).toContain('alpha');
     expect(exports).toContain('beta');
     expect(exports).toContain('libC');
-    expect(result.modules['./app.js'].imports.length).toBe(3);
-    let imports = fromPairs(result.modules['./app.js'].imports.map(imp => [imp.source, imp.specifiers]));
+    expect(appModule.imports.length).toBe(3);
+    let imports = fromPairs(appModule.imports.map(imp => [imp.source, imp.specifiers]));
     expect(withoutCodeFrames(imports)).toEqual({
       './lib-a': [
         { name: 'default', local: null },

--- a/test-packages/support/audit-assertions.ts
+++ b/test-packages/support/audit-assertions.ts
@@ -114,6 +114,10 @@ export class ExpectModule {
       this.emitMissingModule();
       return;
     }
+    if (this.module.type === 'unparseable') {
+      this.emitUnparsableModule(message);
+      return;
+    }
     const result = fn(this.module.content);
     this.expectAudit.assert.pushResult({
       result,
@@ -123,9 +127,22 @@ export class ExpectModule {
     });
   }
 
+  private emitUnparsableModule(message?: string) {
+    this.expectAudit.assert.pushResult({
+      result: false,
+      actual: `${this.inputName} failed to parse`,
+      expected: true,
+      message: `${this.inputName} failed to parse${message ? `: (${message})` : ''}`,
+    });
+  }
+
   codeEquals(expectedSource: string) {
     if (!this.module) {
       this.emitMissingModule();
+      return;
+    }
+    if (this.module.type === 'unparseable') {
+      this.emitUnparsableModule();
       return;
     }
     this.expectAudit.assert.codeEqual(this.module.content, expectedSource);
@@ -136,6 +153,10 @@ export class ExpectModule {
       this.emitMissingModule();
       return;
     }
+    if (this.module.type === 'unparseable') {
+      this.emitUnparsableModule();
+      return;
+    }
     this.expectAudit.assert.codeContains(this.module.content, expectedSource);
   }
 
@@ -144,6 +165,12 @@ export class ExpectModule {
       this.emitMissingModule();
       return new EmptyExpectResolution();
     }
+
+    if (this.module.type === 'unparseable') {
+      this.emitUnparsableModule();
+      return new EmptyExpectResolution();
+    }
+
     if (!(specifier in this.module.resolutions)) {
       this.expectAudit.assert.pushResult({
         result: false,

--- a/tests/scenarios/compat-exclude-dot-files-test.ts
+++ b/tests/scenarios/compat-exclude-dot-files-test.ts
@@ -75,7 +75,7 @@ appScenarios
         // but not be picked up in the entrypoint
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/app-template.js')
+          .resolves('/assets/app-template.js')
           .toModule()
           .withContents(content => {
             assert.notOk(/app-template\/\.foobar/.test(content), '.foobar is not in the entrypoint');

--- a/tests/scenarios/compat-renaming-test.ts
+++ b/tests/scenarios/compat-renaming-test.ts
@@ -256,7 +256,7 @@ appScenarios
       test('renamed modules keep their classic runtime name when used as implicit-modules', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/app-template.js')
+          .resolves('/assets/app-template.js')
           .toModule()
           .resolves('./-embroider-implicit-modules.js')
           .toModule()

--- a/tests/scenarios/compat-stage2-test.ts
+++ b/tests/scenarios/compat-stage2-test.ts
@@ -132,7 +132,7 @@ stage2Scenarios
         // check that the app trees with in repo addon are combined correctly
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           //TODO investigate removing this @embroider-dep
           .resolves('my-app/service/in-repo.js')
@@ -143,7 +143,7 @@ stage2Scenarios
         // secondary in-repo-addon was correctly detected and activated
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           //TODO investigate removing this @embroider-dep
           .resolves('my-app/services/secondary.js')
@@ -210,7 +210,7 @@ stage2Scenarios
       test('verifies that the correct lexigraphically sorted addons win', function () {
         let expectModule = expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule();
         expectModule.resolves('my-app/service/in-repo.js').to('./lib/in-repo-b/_app_/service/in-repo.js');
         expectModule.resolves('my-app/service/addon.js').to('./node_modules/dep-b/_app_/service/addon.js');
@@ -220,7 +220,7 @@ stage2Scenarios
       test('addons declared as dependencies should win over devDependencies', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           .resolves('my-app/service/dep-wins-over-dev.js')
           .to('./node_modules/dep-b/_app_/service/dep-wins-over-dev.js');
@@ -229,7 +229,7 @@ stage2Scenarios
       test('in repo addons declared win over dependencies', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           .resolves('my-app/service/in-repo-over-deps.js')
           .to('./lib/in-repo-a/_app_/service/in-repo-over-deps.js');
@@ -238,7 +238,7 @@ stage2Scenarios
       test('ordering with before specified', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           .resolves('my-app/service/test-before.js')
           .to('./node_modules/dev-d/_app_/service/test-before.js');
@@ -247,7 +247,7 @@ stage2Scenarios
       test('ordering with after specified', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           .resolves('my-app/service/test-after.js')
           .to('./node_modules/dev-b/_app_/service/test-after.js');
@@ -709,7 +709,7 @@ stage2Scenarios
       test('non-static other paths are included in the entrypoint', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule().codeContains(`d("my-app/non-static-dir/another-library", function () {
             return i("my-app/non-static-dir/another-library.js");
           });`);
@@ -718,7 +718,7 @@ stage2Scenarios
       test('static other paths are not included in the entrypoint', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           .withContents(content => {
             return !/my-app\/static-dir\/my-library\.js"/.test(content);
@@ -728,7 +728,7 @@ stage2Scenarios
       test('top-level static other paths are not included in the entrypoint', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           .withContents(content => {
             return !content.includes('my-app/top-level-static.js');
@@ -738,7 +738,7 @@ stage2Scenarios
       test('staticAppPaths do not match partial path segments', function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule()
           .withContents(content => {
             return content.includes('my-app/static-dir-not-really/something.js');

--- a/tests/scenarios/compat-template-colocation-test.ts
+++ b/tests/scenarios/compat-template-colocation-test.ts
@@ -133,7 +133,7 @@ scenarios
       test(`app's colocated components are implicitly included correctly`, function () {
         expectAudit
           .module('./node_modules/.embroider/rewritten-app/index.html')
-          .resolves('./assets/my-app.js')
+          .resolves('/assets/my-app.js')
           .toModule().codeContains(`d("my-app/components/has-colocated-template", function () {
             return i("my-app/components/has-colocated-template.js");
           });`);


### PR DESCRIPTION
So we can use it to also traverse apps over HTTP when talking to vite, because we need to replace a bunch of stage2-style tests.