### PR TITLE
Fix pre support in portable babel launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "overrides": {
       "browserslist": "^4.14.0",
       "graceful-fs": "^4.0.0",
-      "@types/eslint": "^8.37.0"
+      "@types/eslint": "^8.37.0",
+      "babel-plugin-module-resolver@5.0.1": "5.0.0"
     }
   },
   "devDependencies": {

--- a/packages/core/src/portable-babel-launcher.ts
+++ b/packages/core/src/portable-babel-launcher.ts
@@ -34,15 +34,15 @@ export default function babelLauncher(
 
   function wrap1(original: any) {
     if (typeof original === 'function') {
-      return function (this: any, state: any) {
-        return original.call(this, convertState(state));
+      return function (this: any, file: any) {
+        return original.call(convertState(this), file);
       };
     }
   }
 
   function wrap2(original: Function) {
     return function (this: any, path: any, state: any) {
-      return original.call(this, path, convertState(state));
+      return original.call(convertState(this), path, convertState(state));
     };
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   browserslist: ^4.14.0
   graceful-fs: ^4.0.0
   '@types/eslint': ^8.37.0
+  babel-plugin-module-resolver@5.0.1: 5.0.0
 
 importers:
 
@@ -8009,9 +8010,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.12.0
 
@@ -22890,7 +22888,7 @@ packages:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ^4.14.0
     dependencies:
       browserslist: 4.23.0
       escalade: 3.1.2

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -1406,7 +1406,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs.js': `
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("{{#each things as |capitalize|}} {{(capitalize)}} {{/each}}", {
-            scope: () => ({ thing }),
+            scope: () => ({ things }),
           });
         `,
         });
@@ -1416,7 +1416,7 @@ Scenarios.fromProject(() => new Project())
         expectTranspiled('templates/application.hbs.js').equalsCode(`
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("{{#each things as |capitalize|}} {{(capitalize)}} {{/each}}", {
-            scope: () => ({ thing }),
+            scope: () => ({ things }),
           });
         `);
       });
@@ -1426,7 +1426,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs.js': `
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("{{#each things as |capitalize|}} <capitalize /> {{/each}}", {
-            scope: () => ({ thing }),
+            scope: () => ({ things }),
           });
         `,
         });
@@ -1436,7 +1436,7 @@ Scenarios.fromProject(() => new Project())
         expectTranspiled('templates/application.hbs.js').equalsCode(`
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("{{#each things as |capitalize|}} <capitalize /> {{/each}}", {
-            scope: () => ({ thing }),
+            scope: () => ({ things }),
           });
         `);
       });
@@ -1446,7 +1446,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs.js': `
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("{{#each things as |capitalize|}} <div {{capitalize}} /> {{/each}}", {
-            scope: () => ({ thing }),
+            scope: () => ({ things }),
           });
         `,
         });
@@ -1456,7 +1456,7 @@ Scenarios.fromProject(() => new Project())
         expectTranspiled('templates/application.hbs.js').equalsCode(`
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("{{#each things as |capitalize|}} <div {{capitalize}} /> {{/each}}", {
-            scope: () => ({ thing }),
+            scope: () => ({ things }),
           });
         `);
       });
@@ -1466,7 +1466,7 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs.js': `
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("{{#each things as |capitalize|}} {{capitalize 1}} {{/each}}", {
-            scope: () => ({ thing }),
+            scope: () => ({ things }),
           });
         `,
         });
@@ -1476,7 +1476,7 @@ Scenarios.fromProject(() => new Project())
         expectTranspiled('templates/application.hbs.js').equalsCode(`
           import { precompileTemplate } from '@ember/template-compilation';
           export default precompileTemplate("{{#each things as |capitalize|}} {{capitalize 1}} {{/each}}", {
-            scope: () => ({ thing }),
+            scope: () => ({ things }),
           });
         `);
       });

--- a/tests/scenarios/stage1-test.ts
+++ b/tests/scenarios/stage1-test.ts
@@ -112,7 +112,7 @@ appScenarios
         );
 
         fileContents.matches(
-          /hbs\(["']<div class={{embroider-sample-transforms-result}}>Extra<\/div>["']\)/,
+          /precompileTemplate\(["']<div class={{embroider-sample-transforms-result}}>Extra<\/div>["']\)/,
           'called template is still hbs and custom transforms have run'
         );
 
@@ -188,7 +188,7 @@ appScenarios
         );
 
         file.matches(
-          /hbs\(["']<div class={{embroider-sample-transforms-result}}>Extra<\/div>["']\)/,
+          /precompileTemplate\(["']<div class={{embroider-sample-transforms-result}}>Extra<\/div>["']\)/,
           'called template is still hbs and custom transforms have run'
         );
 


### PR DESCRIPTION
The portable-babel-launcher that we use to deal with plugin serializability didn't correctly handle options in pre hooks. babel-plugin-ember-template-compilation just released with a change that needs to handle options in the pre hook.