### PR TITLE
Add more tests virtual files

### DIFF
--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -135,35 +135,39 @@ appScenarios
 appScenarios
   .map('compat-addon-classic-features-virtual-scripts', () => {})
   .forEachScenario(scenario => {
-    let app: PreparedApp;
-
-    Qmodule(`${scenario.name} - build mode`, function (hooks) {
-      hooks.before(async assert => {
-        app = await scenario.prepare();
-        let result = await app.execute('pnpm build');
-        assert.equal(result.exitCode, 0, result.output);
-      });
-
-      test('vendor.js script is emitted in the build', async function (assert) {
-        assert.true(lstatSync(`${app.dir}/dist/@embroider/core/vendor.js`).isFile());
-      });
-    });
-
-    Qmodule(`${scenario.name} - dev mode`, function (hooks) {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
       hooks.before(async () => {
         app = await scenario.prepare();
       });
 
-      test('vendor.js script is served', async function (assert) {
+      test('virtual scripts are emitted in the build', async function (assert) {
+        let result = await app.execute('pnpm build');
+        assert.equal(result.exitCode, 0, result.output);
+
+        assert.true(lstatSync(`${app.dir}/dist/@embroider/core/vendor.js`).isFile());
+        assert.true(lstatSync(`${app.dir}/dist/@embroider/core/test-support.js`).isFile());
+      });
+
+      test('virtual scripts contents are served in dev mode', async function (assert) {
         const server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
         try {
           const [, url] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+
           let response = await fetch(`${url}/@embroider/core/vendor.js`);
           assert.strictEqual(response.status, 200);
           // checking the response status 200 is not enough to assert vendor.js is served,
           // because when the URL is not recognized, the response contains the index.html
           // and has a 200 status (for index.html being returned correctly)
           let text = await response.text();
+          assert.true(!text.includes('<!DOCTYPE html>'));
+
+          response = await fetch(`${url}/@embroider/core/test-support.js`);
+          assert.strictEqual(response.status, 200);
+          // checking the response status 200 is not enough to assert test-support.js is served,
+          // because when the URL is not recognized, the response contains the index.html
+          // and has a 200 status (for index.html being returned correctly)
+          text = await response.text();
           assert.true(!text.includes('<!DOCTYPE html>'));
         } finally {
           await server.shutdown();

--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -4,6 +4,8 @@ import { merge } from 'lodash';
 import QUnit from 'qunit';
 import type { PreparedApp } from 'scenario-tester';
 import fetch from 'node-fetch';
+import globby from 'globby';
+import { join } from 'path';
 
 import { appScenarios, baseAddon } from './scenarios';
 import CommandWatcher from './helpers/command-watcher';
@@ -169,6 +171,69 @@ appScenarios
           // and has a 200 status (for index.html being returned correctly)
           text = await response.text();
           assert.true(!text.includes('<!DOCTYPE html>'));
+        } finally {
+          await server.shutdown();
+        }
+      });
+    });
+  });
+
+appScenarios
+  .map('compat-addon-classic-features-virtual-styles', project => {
+    let myAddon = baseAddon();
+    myAddon.pkg.name = 'my-addon';
+    merge(myAddon.files, {
+      addon: {
+        styles: {
+          'addon.css': `
+            .my-addon-p { color: blue; }
+          `,
+        },
+      },
+    });
+    project.addDependency(myAddon);
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test('virtual styles are included in the CSS of the production build', async function (assert) {
+        let result = await app.execute('pnpm build');
+        assert.equal(result.exitCode, 0, result.output);
+
+        let [mainStyles] = await globby('dist/assets/main-*.css', { cwd: app.dir });
+        let content = readFileSync(join(app.dir, mainStyles)).toString();
+        assert.true(content.includes('.my-addon-p{color:#00f}'));
+      });
+
+      test('virtual styles are included in the CSS of the test build', async function (assert) {
+        let result = await app.execute('pnpm test');
+        assert.equal(result.exitCode, 0, result.output);
+
+        let [mainStyles] = await globby('dist/assets/app-template-*.css', { cwd: app.dir });
+        let content = readFileSync(join(app.dir, mainStyles)).toString();
+        assert.true(content.includes('.my-addon-p{color:#00f}'));
+
+        let [testStyles] = await globby('dist/assets/tests-*.css', { cwd: app.dir });
+        content = readFileSync(join(app.dir, testStyles)).toString();
+        assert.true(content.includes('#qunit-tests'));
+      });
+
+      test('virtual styles are served in dev mode', async function (assert) {
+        const server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+        try {
+          const [, url] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+
+          let response = await fetch(`${url}/@embroider/core/vendor.css?direct`);
+          let text = await response.text();
+          assert.true(text.includes('.my-addon-p { color: blue; }'));
+
+          response = await fetch(`${url}/@embroider/core/test-support.css?direct`);
+          text = await response.text();
+          assert.true(text.includes('#qunit-tests'));
         } finally {
           await server.shutdown();
         }


### PR DESCRIPTION
**Context**
Recently, several PRs have been merged that virtualize `vendor.css` (#1805), `test-support.js` (#1807), and `test-support.css` (#1811) files. These changes have been tested manually, but back then, we didn't add any new tests to assert the virtual contents are correctly served or present in the build output.

This PR adds the missing tests. 

**About searching code in CSS files**
The CSS-related tests should have ideally relied on the `Audit` system to look for the pieces of styles that are expected to be present. But for now, this system presumes too many things about the location of the files we want to audit, it's not made to just take any given `dist/`. That's why `globby` is used to retrieve all the CSS files in the build output and we read their content to find the expected styles.