### PR TITLE
[addon-shim]: Narrowed down broccoli trees for optimized file watching

### DIFF
--- a/packages/addon-shim/package.json
+++ b/packages/addon-shim/package.json
@@ -19,9 +19,11 @@
   "dependencies": {
     "@embroider/shared-internals": "workspace:^",
     "broccoli-funnel": "^3.0.8",
+    "common-ancestor-path": "^1.0.1",
     "semver": "^7.3.8"
   },
   "devDependencies": {
+    "@types/common-ancestor-path": "^1.0.2",
     "@types/semver": "^7.3.6",
     "broccoli-node-api": "^1.7.0",
     "typescript": "^5.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,10 +117,16 @@ importers:
       broccoli-funnel:
         specifier: ^3.0.8
         version: 3.0.8
+      common-ancestor-path:
+        specifier: ^1.0.1
+        version: 1.0.1
       semver:
         specifier: ^7.3.8
         version: 7.6.0
     devDependencies:
+      '@types/common-ancestor-path':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@types/semver':
         specifier: ^7.3.6
         version: 7.5.8
@@ -1664,13 +1670,13 @@ importers:
         version: /ember-cli@4.4.1(lodash@4.17.21)
       ember-cli-beta:
         specifier: npm:ember-cli@beta
-        version: /ember-cli@5.2.0-beta.0(lodash@4.17.21)
+        version: /ember-cli@5.8.0-beta.0(lodash@4.17.21)
       ember-cli-fastboot:
         specifier: ^4.1.1
         version: 4.1.2
       ember-cli-latest:
         specifier: npm:ember-cli@latest
-        version: /ember-cli@5.1.0(lodash@4.17.21)
+        version: /ember-cli@5.7.0(lodash@4.17.21)
       ember-composable-helpers:
         specifier: ^4.4.1
         version: 4.5.0
@@ -1703,10 +1709,10 @@ importers:
         version: /ember-source@4.4.5(@babel/core@7.23.9)
       ember-source-beta:
         specifier: npm:ember-source@beta
-        version: /ember-source@5.2.0-beta.4(@babel/core@7.23.9)
+        version: /ember-source@5.8.0-beta.1(@babel/core@7.23.9)
       ember-source-latest:
         specifier: npm:ember-source@latest
-        version: /ember-source@5.1.2(@babel/core@7.23.9)
+        version: /ember-source@5.7.0(@babel/core@7.23.9)
       ember-truth-helpers:
         specifier: ^3.0.0
         version: 3.1.1
@@ -1976,7 +1982,7 @@ importers:
         version: 10.1.1(@ember/string@3.1.1)(ember-source@5.1.2)
       ember-source:
         specifier: ~5.1.0
-        version: 5.1.2(@babel/core@7.24.0)
+        version: 5.1.2(@babel/core@7.24.0)(@glimmer/component@1.1.2)
       ember-template-lint:
         specifier: ^5.10.3
         version: 5.13.0
@@ -2176,7 +2182,7 @@ packages:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.22.15:
     resolution: {integrity: sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==}
@@ -2299,13 +2305,13 @@ packages:
     resolution: {integrity: sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
 
   /@babel/helper-module-imports@7.22.15:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
@@ -2337,7 +2343,7 @@ packages:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
 
   /@babel/helper-plugin-utils@7.22.5:
     resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
@@ -2391,13 +2397,13 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
@@ -4433,6 +4439,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/types@7.23.0:
+    resolution: {integrity: sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.23.4
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+    dev: true
+
   /@babel/types@7.23.9:
     resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
     engines: {node: '>=6.9.0'}
@@ -5589,7 +5604,7 @@ packages:
       ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-source: 5.1.2(@babel/core@7.24.0)
+      ember-source: 5.1.2(@babel/core@7.24.0)(@glimmer/component@1.1.2)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -6017,6 +6032,17 @@ packages:
       '@simple-dom/interface': 1.4.0
     dev: true
 
+  /@glimmer/compiler@0.87.1:
+    resolution: {integrity: sha512-7qXrOv55cH/YW+Vs4dFkNJsNXAW/jP+7kZLhKcH8wCduPfBCQxb9HNh1lBESuFej2rCks6h9I1qXeZHkc/oWxQ==}
+    engines: {node: '>= 16.0.0'}
+    dependencies:
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/syntax': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/vm': 0.87.1
+      '@glimmer/wire-format': 0.87.1
+    dev: true
+
   /@glimmer/component@1.1.2(@babel/core@7.23.9):
     resolution: {integrity: sha512-XyAsEEa4kWOPy+gIdMjJ8XlzA3qrGH55ZDv6nA16ibalCR17k74BI0CztxuRds+Rm6CtbUVgheCVlcCULuqD7A==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -6062,6 +6088,14 @@ packages:
       - supports-color
     dev: true
 
+  /@glimmer/debug@0.87.1:
+    resolution: {integrity: sha512-rja9/Hofv1NEjIqp8P2eQuHY3+orlS3BL4fbFyvrE+Pw4lRwQPLm6UdgCMHZGGe9yweZAGvNVH6CimDBq7biwA==}
+    dependencies:
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/vm': 0.87.1
+    dev: true
+
   /@glimmer/destroyable@0.84.2:
     resolution: {integrity: sha512-74L4+jlGUhzhUe87lTxjFdYEEfcDWcza+jqLXoyIb/p4cS0hWsTGlyF+OcuUbHO4yqJd4bXchGOVocoajmSp6w==}
     dependencies:
@@ -6069,6 +6103,15 @@ packages:
       '@glimmer/global-context': 0.84.2
       '@glimmer/interfaces': 0.84.2
       '@glimmer/util': 0.84.2
+    dev: true
+
+  /@glimmer/destroyable@0.87.1:
+    resolution: {integrity: sha512-v9kdMq/FCSMcXK4gIKxPCSEcYXjDAnapKVY2o9fCgqky+mbpd0XuGoxaXa35nFwDk69L/9/8B3vXQOpa6ThikA==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.87.1
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/util': 0.87.1
     dev: true
 
   /@glimmer/di@0.1.11:
@@ -6080,6 +6123,13 @@ packages:
       '@glimmer/env': 0.1.7
       '@glimmer/interfaces': 0.84.2
       '@glimmer/vm': 0.84.2
+    dev: true
+
+  /@glimmer/encoder@0.87.1:
+    resolution: {integrity: sha512-5oZEkdtYcAbkiWuXFQ8ofSEGH5uzqi86WK9/IXb7Qn4t6o7ixadWk8nhtORRpVS1u4FpAjhsAysnzRFoNqJwbQ==}
+    dependencies:
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/vm': 0.87.1
     dev: true
 
   /@glimmer/env@0.1.7:
@@ -6103,6 +6153,10 @@ packages:
       '@glimmer/env': 0.1.7
     dev: true
 
+  /@glimmer/global-context@0.87.1:
+    resolution: {integrity: sha512-Mitr7pBeVDTplFWlohyzxWLpFll7ffMZN+fnkBmUj8HiDLbD790Lb8lR9B2nL3t4RGnh6W9kDkCnZB+hvDm/eQ==}
+    dev: true
+
   /@glimmer/interfaces@0.65.4:
     resolution: {integrity: sha512-R0kby79tGNKZOojVJa/7y0JH9Eq4SV+L1s6GcZy30QUZ1g1AAGS5XwCIXc9Sc09coGcv//q+6NLeSw7nlx1y4A==}
     dependencies:
@@ -6120,6 +6174,18 @@ packages:
     dependencies:
       '@simple-dom/interface': 1.4.0
 
+  /@glimmer/interfaces@0.87.1:
+    resolution: {integrity: sha512-2lbwLY4Bt9i2SvwT4hhY0TgEYKhOMQBgYvRiraq2BYHwO8iLKh3lC8iO3d+rQ3VgDtQ9i/sP6HG848VNRyVHxA==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+    dev: true
+
+  /@glimmer/interfaces@0.88.1:
+    resolution: {integrity: sha512-BOcN8xFNX/eppGxwS9Rm1+PlQaFX+tK91cuQLHj2sRwB+qVbL/WeutIa3AUQYr0VVEzMm2S6bYCLvG6p0a8v9A==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+    dev: true
+
   /@glimmer/low-level@0.78.2:
     resolution: {integrity: sha512-0S6TWOOd0fzLLysw1pWZN0TgasaHmYs1Sjz9Til1mTByIXU1S+1rhdyr2veSQPO/aRjPuEQyKXZQHvx23Zax6w==}
     dev: true
@@ -6136,6 +6202,20 @@ packages:
       '@glimmer/validator': 0.84.2
     dev: true
 
+  /@glimmer/manager@0.87.1:
+    resolution: {integrity: sha512-jEUZZQWcuxKg+Ri/A1HGURm9pBrx13JDHx1djYCnPo96yjtQFYxEG0VcwLq2EtAEpFrekwfO1b6m3JZiFqmtGg==}
+    dependencies:
+      '@glimmer/debug': 0.87.1
+      '@glimmer/destroyable': 0.87.1
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.87.1
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/reference': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/validator': 0.87.1
+      '@glimmer/vm': 0.87.1
+    dev: true
+
   /@glimmer/node@0.84.2:
     resolution: {integrity: sha512-kefGxH+0N0xNyb6QovdPzmIBefZwu8TID45qsASgVbFx7mfFiXjQiyaxbRUyam4MAEb8Nzzx1Byxn1FQCYyLdA==}
     dependencies:
@@ -6144,6 +6224,15 @@ packages:
       '@glimmer/util': 0.84.2
       '@simple-dom/document': 1.4.0
       '@simple-dom/interface': 1.4.0
+    dev: true
+
+  /@glimmer/node@0.87.1:
+    resolution: {integrity: sha512-peESyArA08Va9f3gpBnhO+RNkK4Oe0Q8sMPQILCloAukNe2+DQOhTvDgVjRUKmVXMJCWoSgmJtxkiB3ZE193vw==}
+    dependencies:
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/runtime': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@simple-dom/document': 1.4.0
     dev: true
 
   /@glimmer/opcode-compiler@0.84.2:
@@ -6158,10 +6247,31 @@ packages:
       '@glimmer/wire-format': 0.84.2
     dev: true
 
+  /@glimmer/opcode-compiler@0.87.1:
+    resolution: {integrity: sha512-D9OFrH3CrGNXfGtgcVWvu3xofpQZPoYFkqj3RrcDwnsSIYPSqUYTIOO6dwpxTbPlzkASidq0B2htXK7WkCERVw==}
+    dependencies:
+      '@glimmer/debug': 0.87.1
+      '@glimmer/encoder': 0.87.1
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.87.1
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/manager': 0.87.1
+      '@glimmer/reference': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/vm': 0.87.1
+      '@glimmer/wire-format': 0.87.1
+    dev: true
+
   /@glimmer/owner@0.84.2:
     resolution: {integrity: sha512-maZn642eXRImp/hOSa4nQmzMLEIywXwgahS/ZMuzD4HTTsA2SlEdjXSrVbRQYarYF8LkiJ7fpcKHkyNCe8SHrQ==}
     dependencies:
       '@glimmer/util': 0.84.2
+    dev: true
+
+  /@glimmer/owner@0.87.1:
+    resolution: {integrity: sha512-ayYjznPMSGpgygNT7XlTXeel6Cl/fafm4WJeRRgdPxG1EZMjKPlfpfAyNzf9peEIlW3WMbPu3RAIYrf54aThWQ==}
+    dependencies:
+      '@glimmer/util': 0.87.1
     dev: true
 
   /@glimmer/program@0.84.2:
@@ -6173,6 +6283,19 @@ packages:
       '@glimmer/manager': 0.84.2
       '@glimmer/opcode-compiler': 0.84.2
       '@glimmer/util': 0.84.2
+    dev: true
+
+  /@glimmer/program@0.87.1:
+    resolution: {integrity: sha512-+r1Dz5Da0zyYwBhPmqoXiw3qmDamqqhVmSCtJLLcZ6exXXC2ZjGoNdynfos80A91dx+PFqYgHg+5lfa5STT9iQ==}
+    dependencies:
+      '@glimmer/encoder': 0.87.1
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/manager': 0.87.1
+      '@glimmer/opcode-compiler': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/vm': 0.87.1
+      '@glimmer/wire-format': 0.87.1
     dev: true
 
   /@glimmer/reference@0.65.4:
@@ -6205,6 +6328,16 @@ packages:
       '@glimmer/validator': 0.84.3
     dev: true
 
+  /@glimmer/reference@0.87.1:
+    resolution: {integrity: sha512-KJwKYDnds6amsmVB1YxmFhJGI/TNCNmsFBWKUH8K0odmiggUCjt3AwUoOKztkwh3xxy/jpq+5AahIuV+uBgW7A==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.87.1
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/validator': 0.87.1
+    dev: true
+
   /@glimmer/runtime@0.84.2:
     resolution: {integrity: sha512-mUefYwq8l4df61iWYsRKVYQUqAeCgeZ3fuYNRNbvKDudnT9bQXayJLqr6ZxwTVaDoeKjg+7lMjkDSDSvqoxfsA==}
     dependencies:
@@ -6221,6 +6354,23 @@ packages:
       '@glimmer/vm': 0.84.2
       '@glimmer/wire-format': 0.84.2
       '@simple-dom/interface': 1.4.0
+    dev: true
+
+  /@glimmer/runtime@0.87.1:
+    resolution: {integrity: sha512-7QBONxRFesnHzelCiUahZjRj3nhbUxPg0F+iD+3rALrXaWfB1pkhngMTK2DYEmsJ7kq04qVzwBnTSrqsmLzOTg==}
+    dependencies:
+      '@glimmer/destroyable': 0.87.1
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.87.1
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/manager': 0.87.1
+      '@glimmer/owner': 0.87.1
+      '@glimmer/program': 0.87.1
+      '@glimmer/reference': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/validator': 0.87.1
+      '@glimmer/vm': 0.87.1
+      '@glimmer/wire-format': 0.87.1
     dev: true
 
   /@glimmer/syntax@0.65.4:
@@ -6248,6 +6398,26 @@ packages:
       '@glimmer/util': 0.84.3
       '@handlebars/parser': 2.0.0
       simple-html-tokenizer: 0.5.11
+
+  /@glimmer/syntax@0.87.1:
+    resolution: {integrity: sha512-zYzZT6LgpSF0iv5iuxmMV5Pf52aE8dukNC2KfrHC6gXJfM4eLZMZcyk76NW5m+SEetZSOXX6AWv/KwLnoxiMfQ==}
+    dependencies:
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/wire-format': 0.87.1
+      '@handlebars/parser': 2.0.0
+      simple-html-tokenizer: 0.5.11
+    dev: true
+
+  /@glimmer/syntax@0.88.1:
+    resolution: {integrity: sha512-tucexG0j5SSbk3d4ayCOnvjg5FldvWyrZbzxukZOBhDgAYhGWUnGFAqdoXjpr3w6FkD4xIVliVD9GFrH4lI8DA==}
+    dependencies:
+      '@glimmer/interfaces': 0.88.1
+      '@glimmer/util': 0.88.1
+      '@glimmer/wire-format': 0.88.1
+      '@handlebars/parser': 2.0.0
+      simple-html-tokenizer: 0.5.11
+    dev: true
 
   /@glimmer/tracking@1.1.2:
     resolution: {integrity: sha512-cyV32zsHh+CnftuRX84ALZpd2rpbDrhLhJnTXn9W//QpqdRZ5rdMsxSY9fOsj0CKEc706tmEU299oNnDc0d7tA==}
@@ -6282,6 +6452,20 @@ packages:
       '@glimmer/interfaces': 0.84.3
       '@simple-dom/interface': 1.4.0
 
+  /@glimmer/util@0.87.1:
+    resolution: {integrity: sha512-Duxi2JutaIewfIWp8PJl7U5n12yasKWtZFHNLSrg+C8TKeMXdRyJtI7uqtqg0Z/6F9JwdJe/IPhTvdsTTfzAuA==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.87.1
+    dev: true
+
+  /@glimmer/util@0.88.1:
+    resolution: {integrity: sha512-PV/24+vBmsReR78UQXJlEHDblU6QBAeIJa8MwKhQoxSD6WgvQHP4KmX23rvlCz11GxApTwyPm/2qyp/SwVvX2A==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.88.1
+    dev: true
+
   /@glimmer/validator@0.44.0:
     resolution: {integrity: sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==}
     dev: true
@@ -6305,6 +6489,15 @@ packages:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.84.3
+    dev: true
+
+  /@glimmer/validator@0.87.1:
+    resolution: {integrity: sha512-GqzULgK9m2QPfPswhyV30tZmsUegowv9Tyfz2l15cLDFX9L5GcEORpzKXjR0TzCplffuqOC1g8rnMaPsP55apw==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.87.1
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/util': 0.87.1
     dev: true
 
   /@glimmer/vm-babel-plugins@0.77.5(@babel/core@7.23.9):
@@ -6354,6 +6547,15 @@ packages:
       - '@babel/core'
     dev: true
 
+  /@glimmer/vm-babel-plugins@0.87.1(@babel/core@7.23.9):
+    resolution: {integrity: sha512-VbhYHa+HfGFiTIOOkvFuYPwBTaDvWTAR1Q55RI25JI6Nno0duBLB3UVRTDgHM+iOfbgRN7OSR5XCe/C5X5C5LA==}
+    engines: {node: '>=16'}
+    dependencies:
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.23.9)
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: true
+
   /@glimmer/vm@0.84.2:
     resolution: {integrity: sha512-IuQeDlh+AUOOX8QXc+ehPv5uFnqstQVZGplqqvPQRcKvsEalog88RC34dAEwFdB756SKjgRSw+N+nT3ZDNVlvA==}
     dependencies:
@@ -6361,11 +6563,32 @@ packages:
       '@glimmer/util': 0.84.2
     dev: true
 
+  /@glimmer/vm@0.87.1:
+    resolution: {integrity: sha512-JSFr85ASZmuN4H72px7GHtnW79PPRHpqHw6O/6UUZd+ocwWHy+nG9JGbo8kntvqN5xP0SdCipjv/c0u7nkc8tg==}
+    dependencies:
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/util': 0.87.1
+    dev: true
+
   /@glimmer/wire-format@0.84.2:
     resolution: {integrity: sha512-/FmbXSPFJAoIZ6qu28xVXpAdy2Ln++Ewe6mRHFpnudV1lUrBN+Q09A4j/RN/hpAkyz/8ai5W+5rHKuaWxoi4Dg==}
     dependencies:
       '@glimmer/interfaces': 0.84.2
       '@glimmer/util': 0.84.2
+    dev: true
+
+  /@glimmer/wire-format@0.87.1:
+    resolution: {integrity: sha512-O3W1HDfRGX7wHZqvP8UzI/nWyZ2GIMFolU7l6WcLGU9HIdzqfxsc7ae2Icob/fq2kV9meHti4yDEdTMlBVK9AQ==}
+    dependencies:
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/util': 0.87.1
+    dev: true
+
+  /@glimmer/wire-format@0.88.1:
+    resolution: {integrity: sha512-DPM2UiYRNzcWdOUrSa8/IFbWKovH+c2JPnbvtk04DpfQapU7+hteBj34coEN/pW3FJiP3WMvx/EuPfWROkeDsg==}
+    dependencies:
+      '@glimmer/interfaces': 0.88.1
+      '@glimmer/util': 0.88.1
     dev: true
 
   /@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0):
@@ -7281,6 +7504,10 @@ packages:
   /@types/chai@4.3.12:
     resolution: {integrity: sha512-zNKDHG/1yxm8Il6uCCVsm+dRdEsJlFoDu73X17y09bId6UwoYww+vFBsAcRzl8knM1sab3Dp1VRikFQwDOtDDw==}
 
+  /@types/common-ancestor-path@1.0.2:
+    resolution: {integrity: sha512-8llyULydTb7nM9yfiW78n6id3cet+qnATPV3R44yIywxgBaa8QXFSM9QTMf4OH64QOB45BlgZ3/oL4mmFLztQw==}
+    dev: true
+
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
@@ -8010,6 +8237,9 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.12.0
 
@@ -8732,7 +8962,7 @@ packages:
     resolution: {integrity: sha512-jDLlxI8QnfKd7PtieH6pl4tZJzymzfCDCPGdTq/grgbiYAikwDPp/oL0IlFJn0HQjLpcLkyYhPKkUVneRESw5w==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
       lodash: 4.17.21
 
   /babel-plugin-htmlbars-inline-precompile@5.3.1:
@@ -8763,7 +8993,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.5
     dev: true
@@ -10671,6 +10901,10 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
+  /common-ancestor-path@1.0.1:
+    resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
+    dev: false
+
   /common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
     dev: false
@@ -10951,6 +11185,10 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       safe-buffer: 5.2.1
+
+  /content-tag@1.2.2:
+    resolution: {integrity: sha512-9guqKIx2H+78N17otBpl8yLZbQGL5q1vBO/jDb3gF2JjixtcVpC62jDUNxjVMNoaZ09oxRX84ZOD6VX02qkVvg==}
+    dev: true
 
   /content-tag@2.0.1:
     resolution: {integrity: sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==}
@@ -11746,7 +11984,7 @@ packages:
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.0)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 5.1.2(@babel/core@7.24.0)
+      ember-source: 5.1.2(@babel/core@7.24.0)(@glimmer/component@1.1.2)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -11770,7 +12008,7 @@ packages:
       ember-source: ^3.28.0 || >= 4.0.0
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 5.1.2(@babel/core@7.24.0)
+      ember-source: 5.1.2(@babel/core@7.24.0)(@glimmer/component@1.1.2)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -12990,308 +13228,6 @@ packages:
       - whiskers
     dev: true
 
-  /ember-cli@5.1.0(lodash@4.17.21):
-    resolution: {integrity: sha512-TlnfO+V5lZqRQ7eGXt+P8q24Cu90GSXXAS/2NasaCtC1WY7eVzhfMsoNZiOw3Pe1CaB7i5fPDR8jAMsTwx8Tpg==}
-    engines: {node: '>= 16'}
-    hasBin: true
-    dependencies:
-      '@babel/core': 7.24.0
-      '@pnpm/find-workspace-dir': 6.0.3
-      broccoli: 3.5.2
-      broccoli-builder: 0.18.14
-      broccoli-concat: 4.2.5
-      broccoli-config-loader: 1.0.1
-      broccoli-config-replace: 1.1.2
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      broccoli-funnel-reducer: 1.0.0
-      broccoli-merge-trees: 4.2.0
-      broccoli-middleware: 2.1.1
-      broccoli-slow-trees: 3.1.0
-      broccoli-source: 3.0.1
-      broccoli-stew: 3.0.0
-      calculate-cache-key-for-tree: 2.0.0
-      capture-exit: 2.0.0
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      clean-base-url: 1.0.0
-      compression: 1.7.4
-      configstore: 5.0.1
-      console-ui: 3.1.2
-      core-object: 3.1.5
-      dag-map: 2.0.2
-      diff: 5.2.0
-      ember-cli-is-package-missing: 1.0.0
-      ember-cli-lodash-subset: 2.0.1
-      ember-cli-normalize-entity-name: 1.0.0
-      ember-cli-preprocess-registry: 5.0.1
-      ember-cli-string-utils: 1.1.0
-      ensure-posix-path: 1.1.1
-      execa: 5.1.1
-      exit: 0.1.2
-      express: 4.18.2
-      filesize: 10.1.0
-      find-up: 5.0.0
-      find-yarn-workspace-root: 2.0.0
-      fixturify-project: 2.1.1
-      fs-extra: 11.2.0
-      fs-tree-diff: 2.0.1
-      get-caller-file: 2.0.5
-      git-repo-info: 2.1.1
-      glob: 8.1.0
-      heimdalljs: 0.2.6
-      heimdalljs-fs-monitor: 1.1.1
-      heimdalljs-graph: 1.0.0
-      heimdalljs-logger: 0.1.10
-      http-proxy: 1.18.1
-      inflection: 2.0.1
-      inquirer: 9.2.15
-      is-git-url: 1.0.0
-      is-language-code: 3.1.0
-      isbinaryfile: 5.0.2
-      js-yaml: 4.1.0
-      leek: 0.0.24
-      lodash.template: 4.5.0
-      markdown-it: 13.0.2
-      markdown-it-terminal: 0.4.0(markdown-it@13.0.2)
-      minimatch: 7.4.6
-      morgan: 1.10.0
-      nopt: 3.0.6
-      npm-package-arg: 10.1.0
-      os-locale: 5.0.0
-      p-defer: 3.0.0
-      portfinder: 1.0.32
-      promise-map-series: 0.3.0
-      promise.hash.helper: 1.0.8
-      quick-temp: 0.1.8
-      remove-types: 1.0.0
-      resolve: 1.22.8
-      resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
-      sane: 5.0.1
-      semver: 7.6.0
-      silent-error: 1.1.1
-      sort-package-json: 1.57.0
-      symlink-or-copy: 1.3.1
-      temp: 0.9.4
-      testem: 3.12.0(lodash@4.17.21)
-      tiny-lr: 2.0.0
-      tree-sync: 2.1.0
-      uuid: 9.0.1
-      walk-sync: 3.0.0
-      watch-detector: 1.0.2
-      workerpool: 6.5.1
-      yam: 1.0.0
-    transitivePeerDependencies:
-      - arc-templates
-      - atpl
-      - babel-core
-      - bracket-template
-      - bufferutil
-      - coffee-script
-      - debug
-      - dot
-      - dust
-      - dustjs-helpers
-      - dustjs-linkedin
-      - eco
-      - ect
-      - ejs
-      - haml-coffee
-      - hamlet
-      - hamljs
-      - handlebars
-      - hogan.js
-      - htmling
-      - jade
-      - jazz
-      - jqtpl
-      - just
-      - liquid-node
-      - liquor
-      - lodash
-      - marko
-      - mote
-      - nunjucks
-      - plates
-      - pug
-      - qejs
-      - ractive
-      - razor-tmpl
-      - react
-      - react-dom
-      - slm
-      - squirrelly
-      - supports-color
-      - swig
-      - swig-templates
-      - teacup
-      - templayed
-      - then-jade
-      - then-pug
-      - tinyliquid
-      - toffee
-      - twig
-      - twing
-      - underscore
-      - utf-8-validate
-      - vash
-      - velocityjs
-      - walrus
-      - whiskers
-    dev: true
-
-  /ember-cli@5.2.0-beta.0(lodash@4.17.21):
-    resolution: {integrity: sha512-4iiRyV6DJVsIcZMbUzBnNkUHjV5P4UYGJ1mecFP2IX8aFvsYLCzE370L4gsfUnans3l43JXiwPPu+tSIbTO9ZQ==}
-    engines: {node: '>= 16'}
-    hasBin: true
-    dependencies:
-      '@babel/core': 7.24.0
-      '@pnpm/find-workspace-dir': 6.0.3
-      broccoli: 3.5.2
-      broccoli-builder: 0.18.14
-      broccoli-concat: 4.2.5
-      broccoli-config-loader: 1.0.1
-      broccoli-config-replace: 1.1.2
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      broccoli-funnel-reducer: 1.0.0
-      broccoli-merge-trees: 4.2.0
-      broccoli-middleware: 2.1.1
-      broccoli-slow-trees: 3.1.0
-      broccoli-source: 3.0.1
-      broccoli-stew: 3.0.0
-      calculate-cache-key-for-tree: 2.0.0
-      capture-exit: 2.0.0
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      clean-base-url: 1.0.0
-      compression: 1.7.4
-      configstore: 5.0.1
-      console-ui: 3.1.2
-      core-object: 3.1.5
-      dag-map: 2.0.2
-      diff: 5.2.0
-      ember-cli-is-package-missing: 1.0.0
-      ember-cli-lodash-subset: 2.0.1
-      ember-cli-normalize-entity-name: 1.0.0
-      ember-cli-preprocess-registry: 5.0.1
-      ember-cli-string-utils: 1.1.0
-      ensure-posix-path: 1.1.1
-      execa: 5.1.1
-      exit: 0.1.2
-      express: 4.18.2
-      filesize: 10.1.0
-      find-up: 5.0.0
-      find-yarn-workspace-root: 2.0.0
-      fixturify-project: 2.1.1
-      fs-extra: 11.2.0
-      fs-tree-diff: 2.0.1
-      get-caller-file: 2.0.5
-      git-repo-info: 2.1.1
-      glob: 8.1.0
-      heimdalljs: 0.2.6
-      heimdalljs-fs-monitor: 1.1.1
-      heimdalljs-graph: 1.0.0
-      heimdalljs-logger: 0.1.10
-      http-proxy: 1.18.1
-      inflection: 2.0.1
-      inquirer: 9.2.15
-      is-git-url: 1.0.0
-      is-language-code: 3.1.0
-      isbinaryfile: 5.0.2
-      js-yaml: 4.1.0
-      leek: 0.0.24
-      lodash.template: 4.5.0
-      markdown-it: 13.0.2
-      markdown-it-terminal: 0.4.0(markdown-it@13.0.2)
-      minimatch: 7.4.6
-      morgan: 1.10.0
-      nopt: 3.0.6
-      npm-package-arg: 10.1.0
-      os-locale: 5.0.0
-      p-defer: 3.0.0
-      portfinder: 1.0.32
-      promise-map-series: 0.3.0
-      promise.hash.helper: 1.0.8
-      quick-temp: 0.1.8
-      remove-types: 1.0.0
-      resolve: 1.22.8
-      resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
-      sane: 5.0.1
-      semver: 7.6.0
-      silent-error: 1.1.1
-      sort-package-json: 1.57.0
-      symlink-or-copy: 1.3.1
-      temp: 0.9.4
-      testem: 3.12.0(lodash@4.17.21)
-      tiny-lr: 2.0.0
-      tree-sync: 2.1.0
-      uuid: 9.0.1
-      walk-sync: 3.0.0
-      watch-detector: 1.0.2
-      workerpool: 6.5.1
-      yam: 1.0.0
-    transitivePeerDependencies:
-      - arc-templates
-      - atpl
-      - babel-core
-      - bracket-template
-      - bufferutil
-      - coffee-script
-      - debug
-      - dot
-      - dust
-      - dustjs-helpers
-      - dustjs-linkedin
-      - eco
-      - ect
-      - ejs
-      - haml-coffee
-      - hamlet
-      - hamljs
-      - handlebars
-      - hogan.js
-      - htmling
-      - jade
-      - jazz
-      - jqtpl
-      - just
-      - liquid-node
-      - liquor
-      - lodash
-      - marko
-      - mote
-      - nunjucks
-      - plates
-      - pug
-      - qejs
-      - ractive
-      - razor-tmpl
-      - react
-      - react-dom
-      - slm
-      - squirrelly
-      - supports-color
-      - swig
-      - swig-templates
-      - teacup
-      - templayed
-      - then-jade
-      - then-pug
-      - tinyliquid
-      - toffee
-      - twig
-      - twing
-      - underscore
-      - utf-8-validate
-      - vash
-      - velocityjs
-      - walrus
-      - whiskers
-    dev: true
-
   /ember-cli@5.3.0:
     resolution: {integrity: sha512-Om19C49hAYFgVduidtfQPbZcR3bmdHhYJ4XxEEEvW+sP1WAXNOPWf5e3W6HGDarjIeg04bZxOMkMZy28bubOBA==}
     engines: {node: '>= 16'}
@@ -13379,6 +13315,302 @@ packages:
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
       uuid: 9.0.1
+      walk-sync: 3.0.0
+      watch-detector: 1.0.2
+      workerpool: 6.5.1
+      yam: 1.0.0
+    transitivePeerDependencies:
+      - arc-templates
+      - atpl
+      - babel-core
+      - bracket-template
+      - bufferutil
+      - coffee-script
+      - debug
+      - dot
+      - dust
+      - dustjs-helpers
+      - dustjs-linkedin
+      - eco
+      - ect
+      - ejs
+      - haml-coffee
+      - hamlet
+      - hamljs
+      - handlebars
+      - hogan.js
+      - htmling
+      - jade
+      - jazz
+      - jqtpl
+      - just
+      - liquid-node
+      - liquor
+      - lodash
+      - marko
+      - mote
+      - nunjucks
+      - plates
+      - pug
+      - qejs
+      - ractive
+      - razor-tmpl
+      - react
+      - react-dom
+      - slm
+      - squirrelly
+      - supports-color
+      - swig
+      - swig-templates
+      - teacup
+      - templayed
+      - then-jade
+      - then-pug
+      - tinyliquid
+      - toffee
+      - twig
+      - twing
+      - underscore
+      - utf-8-validate
+      - vash
+      - velocityjs
+      - walrus
+      - whiskers
+    dev: true
+
+  /ember-cli@5.7.0(lodash@4.17.21):
+    resolution: {integrity: sha512-MKHVcRpDk1ENUCCRGGqZ8yfkCsszvSUbwO09h14vqcfaqcJkOWI+p0oynmdZQMM8OkZp484oLe3+CZCsXO9LfA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    dependencies:
+      '@pnpm/find-workspace-dir': 6.0.3
+      broccoli: 3.5.2
+      broccoli-builder: 0.18.14
+      broccoli-concat: 4.2.5
+      broccoli-config-loader: 1.0.1
+      broccoli-config-replace: 1.1.2
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-funnel-reducer: 1.0.0
+      broccoli-merge-trees: 4.2.0
+      broccoli-middleware: 2.1.1
+      broccoli-slow-trees: 3.1.0
+      broccoli-source: 3.0.1
+      broccoli-stew: 3.0.0
+      calculate-cache-key-for-tree: 2.0.0
+      capture-exit: 2.0.0
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      clean-base-url: 1.0.0
+      compression: 1.7.4
+      configstore: 5.0.1
+      console-ui: 3.1.2
+      core-object: 3.1.5
+      dag-map: 2.0.2
+      diff: 5.2.0
+      ember-cli-is-package-missing: 1.0.0
+      ember-cli-lodash-subset: 2.0.1
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-preprocess-registry: 5.0.1
+      ember-cli-string-utils: 1.1.0
+      ember-template-tag: 2.3.16
+      ensure-posix-path: 1.1.1
+      execa: 5.1.1
+      exit: 0.1.2
+      express: 4.18.2
+      filesize: 10.1.0
+      find-up: 5.0.0
+      find-yarn-workspace-root: 2.0.0
+      fixturify-project: 2.1.1
+      fs-extra: 11.2.0
+      fs-tree-diff: 2.0.1
+      get-caller-file: 2.0.5
+      git-repo-info: 2.1.1
+      glob: 8.1.0
+      heimdalljs: 0.2.6
+      heimdalljs-fs-monitor: 1.1.1
+      heimdalljs-graph: 1.0.0
+      heimdalljs-logger: 0.1.10
+      http-proxy: 1.18.1
+      inflection: 2.0.1
+      inquirer: 9.2.15
+      is-git-url: 1.0.0
+      is-language-code: 3.1.0
+      isbinaryfile: 5.0.2
+      lodash.template: 4.5.0
+      markdown-it: 13.0.2
+      markdown-it-terminal: 0.4.0(markdown-it@13.0.2)
+      minimatch: 7.4.6
+      morgan: 1.10.0
+      nopt: 3.0.6
+      npm-package-arg: 10.1.0
+      os-locale: 5.0.0
+      p-defer: 3.0.0
+      portfinder: 1.0.32
+      promise-map-series: 0.3.0
+      promise.hash.helper: 1.0.8
+      quick-temp: 0.1.8
+      remove-types: 1.0.0
+      resolve: 1.22.8
+      resolve-package-path: 4.0.3
+      safe-stable-stringify: 2.4.3
+      sane: 5.0.1
+      semver: 7.6.0
+      silent-error: 1.1.1
+      sort-package-json: 1.57.0
+      symlink-or-copy: 1.3.1
+      temp: 0.9.4
+      testem: 3.12.0(lodash@4.17.21)
+      tiny-lr: 2.0.0
+      tree-sync: 2.1.0
+      walk-sync: 3.0.0
+      watch-detector: 1.0.2
+      workerpool: 6.5.1
+      yam: 1.0.0
+    transitivePeerDependencies:
+      - arc-templates
+      - atpl
+      - babel-core
+      - bracket-template
+      - bufferutil
+      - coffee-script
+      - debug
+      - dot
+      - dust
+      - dustjs-helpers
+      - dustjs-linkedin
+      - eco
+      - ect
+      - ejs
+      - haml-coffee
+      - hamlet
+      - hamljs
+      - handlebars
+      - hogan.js
+      - htmling
+      - jade
+      - jazz
+      - jqtpl
+      - just
+      - liquid-node
+      - liquor
+      - lodash
+      - marko
+      - mote
+      - nunjucks
+      - plates
+      - pug
+      - qejs
+      - ractive
+      - razor-tmpl
+      - react
+      - react-dom
+      - slm
+      - squirrelly
+      - supports-color
+      - swig
+      - swig-templates
+      - teacup
+      - templayed
+      - then-jade
+      - then-pug
+      - tinyliquid
+      - toffee
+      - twig
+      - twing
+      - underscore
+      - utf-8-validate
+      - vash
+      - velocityjs
+      - walrus
+      - whiskers
+    dev: true
+
+  /ember-cli@5.8.0-beta.0(lodash@4.17.21):
+    resolution: {integrity: sha512-kQghQlKqgAk55G7410YQLNx9j3EhWlCCWB62Yer92SN3lzzjQU4ewubAMRtKDkqIltIwtTN3ch3zPtfMoc48vQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    dependencies:
+      '@pnpm/find-workspace-dir': 6.0.3
+      broccoli: 3.5.2
+      broccoli-builder: 0.18.14
+      broccoli-concat: 4.2.5
+      broccoli-config-loader: 1.0.1
+      broccoli-config-replace: 1.1.2
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-funnel-reducer: 1.0.0
+      broccoli-merge-trees: 4.2.0
+      broccoli-middleware: 2.1.1
+      broccoli-slow-trees: 3.1.0
+      broccoli-source: 3.0.1
+      broccoli-stew: 3.0.0
+      calculate-cache-key-for-tree: 2.0.0
+      capture-exit: 2.0.0
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      clean-base-url: 1.0.0
+      compression: 1.7.4
+      configstore: 5.0.1
+      console-ui: 3.1.2
+      content-tag: 1.2.2
+      core-object: 3.1.5
+      dag-map: 2.0.2
+      diff: 5.2.0
+      ember-cli-is-package-missing: 1.0.0
+      ember-cli-lodash-subset: 2.0.1
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-preprocess-registry: 5.0.1
+      ember-cli-string-utils: 1.1.0
+      ensure-posix-path: 1.1.1
+      execa: 5.1.1
+      exit: 0.1.2
+      express: 4.18.2
+      filesize: 10.1.0
+      find-up: 5.0.0
+      find-yarn-workspace-root: 2.0.0
+      fixturify-project: 2.1.1
+      fs-extra: 11.2.0
+      fs-tree-diff: 2.0.1
+      get-caller-file: 2.0.5
+      git-repo-info: 2.1.1
+      glob: 8.1.0
+      heimdalljs: 0.2.6
+      heimdalljs-fs-monitor: 1.1.1
+      heimdalljs-graph: 1.0.0
+      heimdalljs-logger: 0.1.10
+      http-proxy: 1.18.1
+      inflection: 2.0.1
+      inquirer: 9.2.15
+      is-git-url: 1.0.0
+      is-language-code: 3.1.0
+      isbinaryfile: 5.0.2
+      lodash.template: 4.5.0
+      markdown-it: 13.0.2
+      markdown-it-terminal: 0.4.0(markdown-it@13.0.2)
+      minimatch: 7.4.6
+      morgan: 1.10.0
+      nopt: 3.0.6
+      npm-package-arg: 10.1.0
+      os-locale: 5.0.0
+      p-defer: 3.0.0
+      portfinder: 1.0.32
+      promise-map-series: 0.3.0
+      promise.hash.helper: 1.0.8
+      quick-temp: 0.1.8
+      remove-types: 1.0.0
+      resolve: 1.22.8
+      resolve-package-path: 4.0.3
+      safe-stable-stringify: 2.4.3
+      sane: 5.0.1
+      semver: 7.6.0
+      silent-error: 1.1.1
+      sort-package-json: 1.57.0
+      symlink-or-copy: 1.3.1
+      temp: 0.9.4
+      testem: 3.12.0(lodash@4.17.21)
+      tiny-lr: 2.0.0
+      tree-sync: 2.1.0
       walk-sync: 3.0.0
       watch-detector: 1.0.2
       workerpool: 6.5.1
@@ -13909,7 +14141,7 @@ packages:
       '@embroider/addon-shim': 1.8.7
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 5.1.2(@babel/core@7.24.0)
+      ember-source: 5.1.2(@babel/core@7.24.0)(@glimmer/component@1.1.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14106,7 +14338,7 @@ packages:
       ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.1.0
-      ember-source: 5.1.2(@babel/core@7.24.0)
+      ember-source: 5.1.2(@babel/core@7.24.0)(@glimmer/component@1.1.2)
       qunit: 2.20.1
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -14203,7 +14435,7 @@ packages:
     dependencies:
       '@ember/string': 3.1.1
       ember-cli-babel: 7.26.11
-      ember-source: 5.1.2(@babel/core@7.24.0)
+      ember-source: 5.1.2(@babel/core@7.24.0)(@glimmer/component@1.1.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14230,8 +14462,8 @@ packages:
     resolution: {integrity: sha512-89oVHVJwmLDvGvAUWgS87KpBoRhy3aZ6U0Ql6HOmU4TrPkyaa8pM0W81wj9cIwjYprcQtN9EwzZMHnq46+oUyw==}
     engines: {node: 8.* || 10.* || >= 12}
     dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/traverse': 7.23.9(supports-color@8.1.1)
+      '@babel/parser': 7.24.0
+      '@babel/traverse': 7.24.0
       recast: 0.18.10
     transitivePeerDependencies:
       - supports-color
@@ -14472,66 +14704,11 @@ packages:
       - webpack
     dev: true
 
-  /ember-source@5.1.2(@babel/core@7.23.9):
+  /ember-source@5.1.2(@babel/core@7.24.0)(@glimmer/component@1.1.2):
     resolution: {integrity: sha512-HTh8CANROxGuBIy/x3c42v4u4255IA55E40KXI3YABww/tV9N1vBRiXolkPcR8aSRDdl32UxL3wBV6/v8npxDQ==}
     engines: {node: '>= 16.*'}
-    dependencies:
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.9)
-      '@ember/edition-utils': 1.2.0
-      '@glimmer/compiler': 0.84.2
-      '@glimmer/component': 1.1.2(@babel/core@7.23.9)
-      '@glimmer/destroyable': 0.84.2
-      '@glimmer/env': 0.1.7
-      '@glimmer/global-context': 0.84.3
-      '@glimmer/interfaces': 0.84.2
-      '@glimmer/manager': 0.84.2
-      '@glimmer/node': 0.84.2
-      '@glimmer/opcode-compiler': 0.84.2
-      '@glimmer/owner': 0.84.2
-      '@glimmer/program': 0.84.2
-      '@glimmer/reference': 0.84.2
-      '@glimmer/runtime': 0.84.2
-      '@glimmer/syntax': 0.84.2
-      '@glimmer/validator': 0.84.2
-      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.23.9)
-      '@simple-dom/interface': 1.4.0
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.23.9)
-      babel-plugin-filter-imports: 4.0.0
-      backburner.js: 2.8.0
-      broccoli-concat: 4.2.5
-      broccoli-debug: 0.6.5
-      broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      chalk: 4.1.2
-      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
-      ember-cli-babel: 7.26.11
-      ember-cli-get-component-path-option: 1.0.0
-      ember-cli-is-package-missing: 1.0.0
-      ember-cli-normalize-entity-name: 1.0.0
-      ember-cli-path-utils: 1.0.0
-      ember-cli-string-utils: 1.1.0
-      ember-cli-typescript-blueprint-polyfill: 0.1.0
-      ember-cli-version-checker: 5.1.2
-      ember-router-generator: 2.0.0
-      inflection: 1.13.4
-      resolve: 1.22.8
-      route-recognizer: 0.3.4
-      router_js: 8.0.3(route-recognizer@0.3.4)
-      semver: 7.6.0
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - rsvp
-      - supports-color
-      - webpack
-    dev: true
-
-  /ember-source@5.1.2(@babel/core@7.24.0):
-    resolution: {integrity: sha512-HTh8CANROxGuBIy/x3c42v4u4255IA55E40KXI3YABww/tV9N1vBRiXolkPcR8aSRDdl32UxL3wBV6/v8npxDQ==}
-    engines: {node: '>= 16.*'}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
     dependencies:
       '@babel/helper-module-imports': 7.22.15
       '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.24.0)
@@ -14554,63 +14731,6 @@ packages:
       '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.24.0)
       '@simple-dom/interface': 1.4.0
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.0)
-      babel-plugin-filter-imports: 4.0.0
-      backburner.js: 2.8.0
-      broccoli-concat: 4.2.5
-      broccoli-debug: 0.6.5
-      broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      chalk: 4.1.2
-      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
-      ember-cli-babel: 7.26.11
-      ember-cli-get-component-path-option: 1.0.0
-      ember-cli-is-package-missing: 1.0.0
-      ember-cli-normalize-entity-name: 1.0.0
-      ember-cli-path-utils: 1.0.0
-      ember-cli-string-utils: 1.1.0
-      ember-cli-typescript-blueprint-polyfill: 0.1.0
-      ember-cli-version-checker: 5.1.2
-      ember-router-generator: 2.0.0
-      inflection: 1.13.4
-      resolve: 1.22.8
-      route-recognizer: 0.3.4
-      router_js: 8.0.3(route-recognizer@0.3.4)
-      semver: 7.6.0
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - rsvp
-      - supports-color
-      - webpack
-    dev: true
-
-  /ember-source@5.2.0-beta.4(@babel/core@7.23.9):
-    resolution: {integrity: sha512-b1Obm3gCkOk5KimtEoXTMbzxXemU8N+WT2mTTa4+9cMxv2qCO8ZVBpkyEmZvQl+W6BrF7tFVl+k6pUDQvuwWKA==}
-    engines: {node: '>= 16.*'}
-    dependencies:
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.9)
-      '@ember/edition-utils': 1.2.0
-      '@glimmer/compiler': 0.84.2
-      '@glimmer/component': 1.1.2(@babel/core@7.23.9)
-      '@glimmer/destroyable': 0.84.2
-      '@glimmer/env': 0.1.7
-      '@glimmer/global-context': 0.84.3
-      '@glimmer/interfaces': 0.84.2
-      '@glimmer/manager': 0.84.2
-      '@glimmer/node': 0.84.2
-      '@glimmer/opcode-compiler': 0.84.2
-      '@glimmer/owner': 0.84.2
-      '@glimmer/program': 0.84.2
-      '@glimmer/reference': 0.84.2
-      '@glimmer/runtime': 0.84.2
-      '@glimmer/syntax': 0.84.2
-      '@glimmer/validator': 0.84.2
-      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.23.9)
-      '@simple-dom/interface': 1.4.0
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.23.9)
       babel-plugin-filter-imports: 4.0.0
       backburner.js: 2.8.0
       broccoli-concat: 4.2.5
@@ -14694,6 +14814,124 @@ packages:
       router_js: 8.0.3(route-recognizer@0.3.4)
       semver: 7.6.0
       silent-error: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - rsvp
+      - supports-color
+      - webpack
+    dev: true
+
+  /ember-source@5.7.0(@babel/core@7.23.9):
+    resolution: {integrity: sha512-iOZVyxLBzGewEThDDsNRZ9y02SNH42PWSPC9U4O94pew7ktld3IpIODCDjLCtKWn2zAGM9DhWTMrXz27HI1UKw==}
+    engines: {node: '>= 16.*'}
+    dependencies:
+      '@babel/helper-module-imports': 7.22.15
+      '@ember/edition-utils': 1.2.0
+      '@glimmer/compiler': 0.87.1
+      '@glimmer/component': 1.1.2(@babel/core@7.23.9)
+      '@glimmer/destroyable': 0.87.1
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.87.1
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/manager': 0.87.1
+      '@glimmer/node': 0.87.1
+      '@glimmer/opcode-compiler': 0.87.1
+      '@glimmer/owner': 0.87.1
+      '@glimmer/program': 0.87.1
+      '@glimmer/reference': 0.87.1
+      '@glimmer/runtime': 0.87.1
+      '@glimmer/syntax': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/validator': 0.87.1
+      '@glimmer/vm': 0.87.1
+      '@glimmer/vm-babel-plugins': 0.87.1(@babel/core@7.23.9)
+      '@simple-dom/interface': 1.4.0
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.23.9)
+      babel-plugin-ember-template-compilation: 2.2.1
+      babel-plugin-filter-imports: 4.0.0
+      backburner.js: 2.8.0
+      broccoli-concat: 4.2.5
+      broccoli-debug: 0.6.5
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      chalk: 4.1.2
+      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-cli-babel: 7.26.11
+      ember-cli-get-component-path-option: 1.0.0
+      ember-cli-is-package-missing: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0
+      ember-cli-version-checker: 5.1.2
+      ember-router-generator: 2.0.0
+      inflection: 2.0.1
+      route-recognizer: 0.3.4
+      router_js: 8.0.3(route-recognizer@0.3.4)
+      semver: 7.6.0
+      silent-error: 1.1.1
+      simple-html-tokenizer: 0.5.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - rsvp
+      - supports-color
+      - webpack
+    dev: true
+
+  /ember-source@5.8.0-beta.1(@babel/core@7.23.9):
+    resolution: {integrity: sha512-UxvbEu7is7rl797D4SybwFOy+O6PeXNcN/IKSHcBAc4SGOoUQZ+UNFHZveWedX5SdYbnN/miziDD3lmo2rzCQg==}
+    engines: {node: '>= 16.*'}
+    dependencies:
+      '@babel/helper-module-imports': 7.22.15
+      '@ember/edition-utils': 1.2.0
+      '@glimmer/compiler': 0.87.1
+      '@glimmer/component': 1.1.2(@babel/core@7.23.9)
+      '@glimmer/destroyable': 0.87.1
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.87.1
+      '@glimmer/interfaces': 0.87.1
+      '@glimmer/manager': 0.87.1
+      '@glimmer/node': 0.87.1
+      '@glimmer/opcode-compiler': 0.87.1
+      '@glimmer/owner': 0.87.1
+      '@glimmer/program': 0.87.1
+      '@glimmer/reference': 0.87.1
+      '@glimmer/runtime': 0.87.1
+      '@glimmer/syntax': 0.87.1
+      '@glimmer/util': 0.87.1
+      '@glimmer/validator': 0.87.1
+      '@glimmer/vm': 0.87.1
+      '@glimmer/vm-babel-plugins': 0.87.1(@babel/core@7.23.9)
+      '@simple-dom/interface': 1.4.0
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.23.9)
+      babel-plugin-ember-template-compilation: 2.2.1
+      babel-plugin-filter-imports: 4.0.0
+      backburner.js: 2.8.0
+      broccoli-concat: 4.2.5
+      broccoli-debug: 0.6.5
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      chalk: 4.1.2
+      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-cli-babel: 7.26.11
+      ember-cli-get-component-path-option: 1.0.0
+      ember-cli-is-package-missing: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0
+      ember-cli-version-checker: 5.1.2
+      ember-router-generator: 2.0.0
+      inflection: 2.0.1
+      route-recognizer: 0.3.4
+      router_js: 8.0.3(route-recognizer@0.3.4)
+      semver: 7.6.0
+      silent-error: 1.1.1
+      simple-html-tokenizer: 0.5.11
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -14843,6 +15081,17 @@ packages:
       slash: 3.0.0
       tmp: 0.2.1
       workerpool: 6.5.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /ember-template-tag@2.3.16:
+    resolution: {integrity: sha512-G6bIBcT4VnLlBUogkXxEXIzVvdYXhmLe+Io2yJzRYYZeHrdxKa6u2ZHXF4qII298grgqnqGo6tNqqgtD4AAS5g==}
+    dependencies:
+      '@babel/generator': 7.23.6
+      '@babel/traverse': 7.23.9(supports-color@8.1.1)
+      '@babel/types': 7.23.0
+      '@glimmer/syntax': 0.88.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17839,7 +18088,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.24.0
-      '@babel/parser': 7.23.9
+      '@babel/parser': 7.24.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -17852,7 +18101,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/core': 7.24.0
-      '@babel/parser': 7.23.9
+      '@babel/parser': 7.24.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.6.0
@@ -18238,7 +18487,7 @@ packages:
       '@babel/generator': 7.23.6
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.24.0)
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.24.0)
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -22895,7 +23144,7 @@ packages:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
     peerDependencies:
-      browserslist: ^4.14.0
+      browserslist: '>= 4.21.0'
     dependencies:
       browserslist: 4.23.0
       escalade: 3.1.2


### PR DESCRIPTION
addon-shim is currently creating a broccoli tree based on the v2 addon's root folder, and funnelling that based on the entries in app-js/public-assets, and exposing these trees as treeForApp/treeForPublic for integration into a classic build.

The problem with this is that it will trigger a rebuild of the app when something changes outside of the folders where the actual files live in (like `dist/_app_` for the app tree), most notably the `./src` folder, causing the app watcher to fire multiple times in succession: once for the change in `./src`, and later (when the rollup build has finished) for the change in `./dist`.

The PR here optimizes this, by making the root folder that goes into the broccoli-funnel to be as close as possible to the actual files. So (assuming our opionionated v2 setup based on the blueprint), that would be `/path/to/addon/dist/_app_` instead of `/path/to/addon` for the app tree, and same for the public tree.

This is one part of addressing the "ignoring source files" approach discussed in https://github.com/embroider-build/addon-blueprint/issues/32, the other (for the addon tree that is not covered by addon-shim) is this PR: https://github.com/embroider-build/ember-auto-import/pull/623

I tested this in a local installation, and it did have the desired effect (when combined with the other PR): when changing only source files and not having the addon's build running in parallel, the app would not rebuild, as it would be expected.
