### PR TITLE
Fix getRoute override

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -68,8 +68,11 @@ if (macroCondition(getGlobalConfig<GlobalConfig>()['@embroider/core']?.active ??
     setupRouter(...args: unknown[]) {
       // @ts-expect-error extending private method
       let isSetup = super.setupRouter(...args);
-      let microLib = (this as unknown as { _routerMicrolib: { getRoute: (name: string) => unknown } })._routerMicrolib;
-      microLib.getRoute = this._handlerResolver(microLib.getRoute.bind(microLib));
+      if (isSetup) {
+        let microLib = (this as unknown as { _routerMicrolib: { getRoute: (name: string) => unknown } })
+          ._routerMicrolib;
+        microLib.getRoute = this._handlerResolver(microLib.getRoute.bind(microLib));
+      }
       return isSetup;
     }
 


### PR DESCRIPTION
This PR aims at resolving #1455 - `too much recursion` error.

The error is caused by `getRoute` being overridden multiple times: every time `setupRouter` is called, we create a new layer of recursion. This happens e.g. when we render a link, which calls `urlFor`, which calls `setupRouter`. So while the user clicks around the app, `getRoute` is overridden again and again, which can lead to `too much recursion` error at some point.

The proposed resolution is to leverage `isSetup` to make sure the `getRoute` is extended only once.