### PR TITLE
unskip engines tests

### DIFF
--- a/tests/scenarios/engines-test.ts
+++ b/tests/scenarios/engines-test.ts
@@ -81,10 +81,6 @@ let engineScenarios = appScenarios.map('engines', project => {
 });
 
 engineScenarios
-  .skip('lts_3_28-engines') // this skip should be removed before https://github.com/embroider-build/embroider/pull/1435 is merged
-  .skip('lts_4_4-engines') // this skip should be removed before https://github.com/embroider-build/embroider/pull/1435 is merged
-  .skip('release-engines') // this skip should be removed before https://github.com/embroider-build/embroider/pull/1435 is merged
-  .skip('canary-engines') // this shouldn't be run
   .map('without-fastboot', () => {})
   .forEachScenario(scenario => {
     Qmodule(scenario.name, function (hooks) {
@@ -138,10 +134,6 @@ engineScenarios
   });
 
 engineScenarios
-  .skip('lts_3_28-engines') // fails due to https://github.com/emberjs/ember.js/pull/20461
-  .skip('lts_4_4-engines') // fails due to https://github.com/emberjs/ember.js/pull/20461
-  .skip('release-engines') // fails due to https://github.com/emberjs/ember.js/pull/20461
-  .skip('canary-engines') // this shouldn't be run
   .map('with-fastboot', app => {
     app.linkDependency('ember-cli-fastboot', { baseDir: __dirname });
     app.linkDependency('fastboot', { baseDir: __dirname });


### PR DESCRIPTION
In #1915 I updated ember engines but there are no tests checking if that made a difference. I have unskipped tests on that PR but I need a baseline to compare so this PR just unskips the tests without updating engines 👍 

This will probably fail and will likely not get merged independently of the upgrade 🤷 