### PR TITLE
New `index.html` format - `test-support.js`

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -214,7 +214,6 @@ export class CompatAppBuilder {
             implicitScripts: this.compatApp.findVendorScript(scripts, entrypoint),
             implicitStyles: this.compatApp.findVendorStyles(styles, entrypoint),
             testJavascript: this.compatApp.findTestScript(scripts),
-            implicitTestScripts: this.compatApp.findTestSupportScript(scripts),
             implicitTestStyles: this.compatApp.findTestSupportStyles(styles),
           };
         },
@@ -476,9 +475,6 @@ export class CompatAppBuilder {
 
     let testJS = this.testJSEntrypoint(appFiles, prepared);
     html.insertScriptTag(html.testJavascript, testJS.relativePath, { type: 'module' });
-
-    // virtual test-support.js
-    html.insertScriptTag(html.implicitTestScripts, '@embroider/core/test-support.js');
 
     html.insertStyleLink(html.implicitTestStyles, '@embroider/core/test-support.css');
   }

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -757,13 +757,6 @@ export default class CompatApp {
     );
   }
 
-  findTestSupportScript(scripts: HTMLScriptElement[]): HTMLScriptElement | undefined {
-    return scripts.find(
-      script =>
-        this.withoutRootURL(script.src) === this.legacyEmberAppInstance.options.outputPaths.testSupport.js.testSupport
-    );
-  }
-
   findTestScript(scripts: HTMLScriptElement[]): HTMLScriptElement | undefined {
     return scripts.find(
       script => this.withoutRootURL(script.src) === this.legacyEmberAppInstance.options.outputPaths.tests.js

--- a/packages/core/src/ember-html.ts
+++ b/packages/core/src/ember-html.ts
@@ -22,7 +22,6 @@ export interface EmberHTML {
   // Do not confuse these with controlling whether or not we will insert tests.
   // That is separately controlled via `includeTests`.
   testJavascript?: Node;
-  implicitTestScripts?: Node;
   implicitTestStyles?: Node;
 }
 
@@ -84,7 +83,6 @@ export class PreparedEmberHTML {
   implicitScripts: Placeholder;
   implicitStyles: Placeholder;
   testJavascript: Placeholder;
-  implicitTestScripts: Placeholder;
   implicitTestStyles: Placeholder;
 
   constructor(private asset: EmberAsset) {
@@ -97,9 +95,6 @@ export class PreparedEmberHTML {
     this.testJavascript = html.testJavascript
       ? Placeholder.replacing(html.testJavascript)
       : Placeholder.immediatelyAfter(this.javascript.end);
-    this.implicitTestScripts = html.implicitTestScripts
-      ? Placeholder.replacing(html.implicitTestScripts)
-      : Placeholder.immediatelyAfter(this.implicitScripts.end);
     this.implicitTestStyles = html.implicitTestStyles
       ? Placeholder.replacing(html.implicitTestStyles)
       : Placeholder.immediatelyAfter(this.implicitStyles.end);
@@ -111,7 +106,6 @@ export class PreparedEmberHTML {
       this.styles,
       this.implicitScripts,
       this.implicitStyles,
-      this.implicitTestScripts,
       this.implicitTestStyles,
       this.testJavascript,
     ];

--- a/test-packages/sample-transforms/tests/index.html
+++ b/test-packages/sample-transforms/tests/index.html
@@ -30,7 +30,7 @@
 
     <script src="/testem.js" integrity=""></script>
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="/@embroider/core/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 

--- a/tests/addon-template/tests/index.html
+++ b/tests/addon-template/tests/index.html
@@ -29,7 +29,7 @@
 
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="/@embroider/core/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 

--- a/tests/app-template/tests/index.html
+++ b/tests/app-template/tests/index.html
@@ -26,7 +26,7 @@
 
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="/@embroider/core/test-support.js"></script>
     <script src="{{rootURL}}assets/app-template.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 

--- a/tests/fixtures/macro-test/tests/index.html
+++ b/tests/fixtures/macro-test/tests/index.html
@@ -35,7 +35,7 @@
     <script src="/@embroider/core/vendor.js"></script>
     <script src="{{rootURL}}apple.js"></script>
     <script src="{{rootURL}}ordered.js"></script>
-    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="/@embroider/core/test-support.js"></script>
     <script src="{{rootURL}}assets/app-template.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 

--- a/tests/ts-app-template/tests/index.html
+++ b/tests/ts-app-template/tests/index.html
@@ -29,7 +29,7 @@
 
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="/@embroider/core/test-support.js"></script>
     <script src="{{rootURL}}assets/ts-app-template.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 


### PR DESCRIPTION
## Context 

Lately, we have been working on the inversion of control for the Vite build, we replaced script assets like `vendor.js` with virtual content Vite can request to Embroider. 

Until now, we have never changed the `index.html` file of the initial Ember app to handle virtualization: in stage 2, the compat-app-builder generates the `index.html` of the rewritten-app and inserts the virtual entry points. This rewritten file is the one consumed by Vite.

Now that we have virtualized all the entry points, we are ready for the next step that will get us closer to the new blueprint: we are going to write the virtual entry points directly in the `index.html` of the initial Ember app so Vite will be able to consume it directly, without intermediate change.

This PR handles `test-support.js`.
