### PR TITLE
New `index.html` format - `test-support.css`, `vendor.css`

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -212,7 +212,6 @@ export class CompatAppBuilder {
             javascript: this.compatApp.findAppScript(scripts, entrypoint),
             styles: this.compatApp.findAppStyles(styles, entrypoint),
             implicitScripts: this.compatApp.findVendorScript(scripts, entrypoint),
-            implicitStyles: this.compatApp.findVendorStyles(styles, entrypoint),
             testJavascript: this.compatApp.findTestScript(scripts),
           };
         },
@@ -462,9 +461,6 @@ export class CompatAppBuilder {
         html.insertScriptTag(html.implicitScripts, script, { tag: 'fastboot-script' });
       }
     }
-
-    // virtual vendor.css entrypoint
-    html.insertStyleLink(html.implicitStyles, '@embroider/core/vendor.css');
 
     if (!asset.fileAsset.includeTests) {
       return;

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -214,7 +214,6 @@ export class CompatAppBuilder {
             implicitScripts: this.compatApp.findVendorScript(scripts, entrypoint),
             implicitStyles: this.compatApp.findVendorStyles(styles, entrypoint),
             testJavascript: this.compatApp.findTestScript(scripts),
-            implicitTestStyles: this.compatApp.findTestSupportStyles(styles),
           };
         },
       };
@@ -475,8 +474,6 @@ export class CompatAppBuilder {
 
     let testJS = this.testJSEntrypoint(appFiles, prepared);
     html.insertScriptTag(html.testJavascript, testJS.relativePath, { type: 'module' });
-
-    html.insertStyleLink(html.implicitTestStyles, '@embroider/core/test-support.css');
   }
 
   // recurse to find all active addons that don't cross an engine boundary.

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -751,12 +751,6 @@ export default class CompatApp {
     );
   }
 
-  findTestSupportStyles(styles: HTMLLinkElement[]): HTMLLinkElement | undefined {
-    return styles.find(
-      style => this.withoutRootURL(style.href) === this.legacyEmberAppInstance.options.outputPaths.testSupport.css
-    );
-  }
-
   findTestScript(scripts: HTMLScriptElement[]): HTMLScriptElement | undefined {
     return scripts.find(
       script => this.withoutRootURL(script.src) === this.legacyEmberAppInstance.options.outputPaths.tests.js

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -738,19 +738,6 @@ export default class CompatApp {
     );
   }
 
-  findVendorStyles(styles: HTMLLinkElement[], entrypoint: string): HTMLLinkElement {
-    let vendorStyle = styles.find(
-      style => this.withoutRootURL(style.href) === this.legacyEmberAppInstance.options.outputPaths.vendor.css
-    );
-    return throwIfMissing(
-      vendorStyle,
-      this.legacyEmberAppInstance.options.outputPaths.vendor.css,
-      styles.map(s => s.href),
-      entrypoint,
-      'vendor css'
-    );
-  }
-
   findTestScript(scripts: HTMLScriptElement[]): HTMLScriptElement | undefined {
     return scripts.find(
       script => this.withoutRootURL(script.src) === this.legacyEmberAppInstance.options.outputPaths.tests.js

--- a/packages/core/src/ember-html.ts
+++ b/packages/core/src/ember-html.ts
@@ -22,7 +22,6 @@ export interface EmberHTML {
   // Do not confuse these with controlling whether or not we will insert tests.
   // That is separately controlled via `includeTests`.
   testJavascript?: Node;
-  implicitTestStyles?: Node;
 }
 
 class Placeholder {
@@ -83,7 +82,6 @@ export class PreparedEmberHTML {
   implicitScripts: Placeholder;
   implicitStyles: Placeholder;
   testJavascript: Placeholder;
-  implicitTestStyles: Placeholder;
 
   constructor(private asset: EmberAsset) {
     this.dom = new JSDOM(readFileSync(asset.sourcePath, 'utf8'));
@@ -95,20 +93,10 @@ export class PreparedEmberHTML {
     this.testJavascript = html.testJavascript
       ? Placeholder.replacing(html.testJavascript)
       : Placeholder.immediatelyAfter(this.javascript.end);
-    this.implicitTestStyles = html.implicitTestStyles
-      ? Placeholder.replacing(html.implicitTestStyles)
-      : Placeholder.immediatelyAfter(this.implicitStyles.end);
   }
 
   private placeholders(): Placeholder[] {
-    return [
-      this.javascript,
-      this.styles,
-      this.implicitScripts,
-      this.implicitStyles,
-      this.implicitTestStyles,
-      this.testJavascript,
-    ];
+    return [this.javascript, this.styles, this.implicitScripts, this.implicitStyles, this.testJavascript];
   }
 
   clear() {

--- a/packages/core/src/ember-html.ts
+++ b/packages/core/src/ember-html.ts
@@ -12,7 +12,6 @@ export interface EmberHTML {
   javascript: Node;
   styles: Node;
   implicitScripts: Node;
-  implicitStyles: Node;
 
   // these are optional because you *may* choose to stick your implicit test
   // things into specific locations (which we need for backward-compat). But you
@@ -80,7 +79,6 @@ export class PreparedEmberHTML {
   javascript: Placeholder;
   styles: Placeholder;
   implicitScripts: Placeholder;
-  implicitStyles: Placeholder;
   testJavascript: Placeholder;
 
   constructor(private asset: EmberAsset) {
@@ -89,14 +87,13 @@ export class PreparedEmberHTML {
     this.javascript = Placeholder.replacing(html.javascript);
     this.styles = Placeholder.replacing(html.styles);
     this.implicitScripts = Placeholder.find(html.implicitScripts);
-    this.implicitStyles = Placeholder.replacing(html.implicitStyles);
     this.testJavascript = html.testJavascript
       ? Placeholder.replacing(html.testJavascript)
       : Placeholder.immediatelyAfter(this.javascript.end);
   }
 
   private placeholders(): Placeholder[] {
-    return [this.javascript, this.styles, this.implicitScripts, this.implicitStyles, this.testJavascript];
+    return [this.javascript, this.styles, this.implicitScripts, this.testJavascript];
   }
 
   clear() {

--- a/packages/util/tests/dummy/app/index.html
+++ b/packages/util/tests/dummy/app/index.html
@@ -8,7 +8,7 @@
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="/@embroider/core/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}

--- a/test-packages/sample-transforms/tests/dummy/app/index.html
+++ b/test-packages/sample-transforms/tests/dummy/app/index.html
@@ -9,7 +9,7 @@
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="/@embroider/core/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}

--- a/test-packages/sample-transforms/tests/index.html
+++ b/test-packages/sample-transforms/tests/index.html
@@ -10,7 +10,7 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="/@embroider/core/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
     <link rel="stylesheet" href="/@embroider/core/test-support.css">
 

--- a/test-packages/sample-transforms/tests/index.html
+++ b/test-packages/sample-transforms/tests/index.html
@@ -12,7 +12,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="/@embroider/core/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}

--- a/tests/addon-template/tests/dummy/app/index.html
+++ b/tests/addon-template/tests/dummy/app/index.html
@@ -8,7 +8,7 @@
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="/@embroider/core/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}

--- a/tests/addon-template/tests/index.html
+++ b/tests/addon-template/tests/index.html
@@ -9,7 +9,7 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="/@embroider/core/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
     <link rel="stylesheet" href="/@embroider/core/test-support.css">
 

--- a/tests/addon-template/tests/index.html
+++ b/tests/addon-template/tests/index.html
@@ -11,7 +11,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="/@embroider/core/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}

--- a/tests/app-template/app/index.html
+++ b/tests/app-template/app/index.html
@@ -8,7 +8,7 @@
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="/@embroider/core/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/app-template.css">
 
     {{content-for "head-footer"}}

--- a/tests/app-template/tests/index.html
+++ b/tests/app-template/tests/index.html
@@ -10,7 +10,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
     <link rel="stylesheet" href="{{rootURL}}assets/app-template.css" />
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css" />
+    <link rel="stylesheet" href="/@embroider/core/test-support.css" />
 
     {{content-for "head-footer"}} {{content-for "test-head-footer"}}
   </head>

--- a/tests/app-template/tests/index.html
+++ b/tests/app-template/tests/index.html
@@ -8,7 +8,7 @@
 
     {{content-for "head"}} {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link rel="stylesheet" href="/@embroider/core/vendor.css" />
     <link rel="stylesheet" href="{{rootURL}}assets/app-template.css" />
     <link rel="stylesheet" href="/@embroider/core/test-support.css" />
 

--- a/tests/fixtures/macro-test/tests/index.html
+++ b/tests/fixtures/macro-test/tests/index.html
@@ -10,7 +10,7 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="/@embroider/core/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/app-template.css">
     <link rel="stylesheet" href="/@embroider/core/test-support.css">
 

--- a/tests/fixtures/macro-test/tests/index.html
+++ b/tests/fixtures/macro-test/tests/index.html
@@ -12,7 +12,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/app-template.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="/@embroider/core/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}

--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -72,7 +72,7 @@ appScenarios
           
               {{content-for "head"}}
           
-              <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+              <link integrity="" rel="stylesheet" href="/@embroider/core/vendor.css">
               <link integrity="" rel="stylesheet" href="{{rootURL}}assets/app-template.css">
           
               {{content-for "head-footer"}}

--- a/tests/ts-app-template/app/index.html
+++ b/tests/ts-app-template/app/index.html
@@ -8,7 +8,7 @@
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="/@embroider/core/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/ts-app-template.css">
 
     {{content-for "head-footer"}}

--- a/tests/ts-app-template/tests/index.html
+++ b/tests/ts-app-template/tests/index.html
@@ -11,7 +11,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/ts-app-template.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="/@embroider/core/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}

--- a/tests/ts-app-template/tests/index.html
+++ b/tests/ts-app-template/tests/index.html
@@ -9,7 +9,7 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="/@embroider/core/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/ts-app-template.css">
     <link rel="stylesheet" href="/@embroider/core/test-support.css">
 


### PR DESCRIPTION
## Context 

Lately, we have been working on the inversion of control for the Vite build, we replaced script assets like `vendor.js` with virtual content Vite can request to Embroider. 

Until now, we have never changed the `index.html` file of the initial Ember app to handle virtualization: in stage 2, the compat-app-builder generates the `index.html` of the rewritten-app and inserts the virtual entry points. This rewritten file is the one consumed by Vite.

Now that we have virtualized all the entry points, we are ready for the next step that will get us closer to the new blueprint: we are going to write the virtual entry points directly in the `index.html` of the initial Ember app so Vite will be able to consume it directly, without intermediate change.

1st & 2nd commits handle `test-support.css`.
3rd & 4th commits handle `vendor.css`.