### PR TITLE
New `index.html` format - entrypoint

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -381,12 +381,6 @@ export class CompatAppBuilder {
       });
     }
 
-    // our tests entrypoint already includes a correct module dependency on the
-    // app, so we only insert the app when we're not inserting tests
-    if (!asset.fileAsset.includeTests) {
-      html.insertScriptTag(html.javascript, '@embroider/core/entrypoint', { type: 'module' });
-    }
-
     if (this.fastbootConfig) {
       // any extra fastboot app files get inserted into our html.javascript
       // section, after the app has been inserted.

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -701,12 +701,11 @@ export default class CompatApp {
   }
 
   findAppScript(scripts: HTMLScriptElement[], entrypoint: string): HTMLScriptElement {
-    let appJS = scripts.find(
-      script => this.withoutRootURL(script.src) === this.legacyEmberAppInstance.options.outputPaths.app.js
-    );
+    let moduleName = '/@embroider/core/entrypoint';
+    let appJS = scripts.find(script => this.withoutRootURL(script.src) === moduleName);
     return throwIfMissing(
       appJS,
-      this.legacyEmberAppInstance.options.outputPaths.app.js,
+      moduleName,
       scripts.map(s => s.src),
       entrypoint,
       'app javascript'

--- a/packages/core/src/ember-html.ts
+++ b/packages/core/src/ember-html.ts
@@ -84,7 +84,7 @@ export class PreparedEmberHTML {
   constructor(private asset: EmberAsset) {
     this.dom = new JSDOM(readFileSync(asset.sourcePath, 'utf8'));
     let html = asset.prepare(this.dom);
-    this.javascript = Placeholder.replacing(html.javascript);
+    this.javascript = Placeholder.find(html.javascript);
     this.styles = Placeholder.replacing(html.styles);
     this.implicitScripts = Placeholder.find(html.implicitScripts);
     this.testJavascript = html.testJavascript

--- a/packages/util/tests/dummy/app/index.html
+++ b/packages/util/tests/dummy/app/index.html
@@ -17,7 +17,7 @@
     {{content-for "body"}}
 
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/test-packages/sample-transforms/tests/dummy/app/index.html
+++ b/test-packages/sample-transforms/tests/dummy/app/index.html
@@ -18,7 +18,7 @@
     {{content-for "body"}}
 
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/test-packages/sample-transforms/tests/index.html
+++ b/test-packages/sample-transforms/tests/index.html
@@ -31,7 +31,7 @@
     <script src="/testem.js" integrity=""></script>
     <script src="/@embroider/core/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
-    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}

--- a/tests/addon-template/tests/dummy/app/index.html
+++ b/tests/addon-template/tests/dummy/app/index.html
@@ -17,7 +17,7 @@
     {{content-for "body"}}
 
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/addon-template/tests/index.html
+++ b/tests/addon-template/tests/index.html
@@ -30,7 +30,7 @@
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="/@embroider/core/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
-    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}

--- a/tests/app-template/app/index.html
+++ b/tests/app-template/app/index.html
@@ -17,7 +17,7 @@
     {{content-for "body"}}
 
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/app-template.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/app-template/tests/index.html
+++ b/tests/app-template/tests/index.html
@@ -27,7 +27,7 @@
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="/@embroider/core/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
-    <script src="{{rootURL}}assets/app-template.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}} {{content-for "test-body-footer"}}

--- a/tests/fixtures/macro-test/tests/index.html
+++ b/tests/fixtures/macro-test/tests/index.html
@@ -36,7 +36,7 @@
     <script src="{{rootURL}}apple.js"></script>
     <script src="{{rootURL}}ordered.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
-    <script src="{{rootURL}}assets/app-template.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}

--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -82,7 +82,7 @@ appScenarios
               {{content-for "custom"}}
           
               <script src="/@embroider/core/vendor.js"></script>
-              <script src="{{rootURL}}assets/app-template.js"></script>
+              <script src="/@embroider/core/entrypoint" type="module"></script>
           
               {{content-for "body-footer"}}
             </body>

--- a/tests/scenarios/compat-app-html-attributes-test.ts
+++ b/tests/scenarios/compat-app-html-attributes-test.ts
@@ -32,7 +32,7 @@ appScenarios
 
     // <script ... src=".../vendor.js"> => <script ... src=".../vendor.js" data-original-filename="vendor.js">
     indexHtml = indexHtml.replace('vendor.js">', 'vendor.js" data-original-filename="vendor.js">');
-    indexHtml = indexHtml.replace('app-template.js">', 'app-template.js" data-original-filename="app-template.js">');
+    indexHtml = indexHtml.replace('entrypoint" ', 'entrypoint" data-original-filename="entrypoint" ');
 
     // <script ... => <script defer ...
     indexHtml = indexHtml.replace(/<script /g, '<script defer ');
@@ -72,8 +72,8 @@ appScenarios
           'has data-original-filename vendor.js'
         );
         expectFile('./index.html').matches(
-          '" data-original-filename="app-template.js" type="module">',
-          'has data-original-filename app-template.js'
+          '" data-original-filename="entrypoint" type="module">',
+          'has data-original-filename entrypoint'
         );
       });
     });

--- a/tests/ts-app-template/app/index.html
+++ b/tests/ts-app-template/app/index.html
@@ -17,7 +17,7 @@
     {{content-for "body"}}
 
     <script src="/@embroider/core/vendor.js"></script>
-    <script src="{{rootURL}}assets/ts-app-template.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/ts-app-template/tests/index.html
+++ b/tests/ts-app-template/tests/index.html
@@ -30,7 +30,7 @@
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="/@embroider/core/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
-    <script src="{{rootURL}}assets/ts-app-template.js"></script>
+    <script src="/@embroider/core/entrypoint" type="module"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}


### PR DESCRIPTION
## Context 

Lately, we have been working on the inversion of control for the Vite build, we replaced script assets like `vendor.js` with virtual content Vite can request to Embroider. 

Until now, we have never changed the `index.html` file of the initial Ember app to handle virtualization: in stage 2, the compat-app-builder generates the `index.html` of the rewritten-app and inserts the virtual entry points. This rewritten file is the one consumed by Vite.

Now that we have virtualized all the entry points, we are ready for the next step that will get us closer to the new blueprint: we are going to write the virtual entry points directly in the `index.html` of the initial Ember app so Vite will be able to consume it directly, without intermediate change.

This PR handles `entrypoint`.
