### PR TITLE
New `index.html`- format test-entrypoint

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -177,7 +177,6 @@ export class CompatAppBuilder {
           return {
             javascript: this.compatApp.findAppScript(scripts, entrypoint),
             implicitScripts: this.compatApp.findVendorScript(scripts, entrypoint),
-            testJavascript: this.compatApp.findTestScript(scripts),
           };
         },
       };
@@ -367,13 +366,6 @@ export class CompatAppBuilder {
         html.insertScriptTag(html.implicitScripts, script, { tag: 'fastboot-script' });
       }
     }
-
-    if (!asset.fileAsset.includeTests) {
-      return;
-    }
-
-    // Test-related assets happen below this point
-    html.insertScriptTag(html.javascript, '@embroider/core/test-entrypoint', { type: 'module' });
   }
 
   // recurse to find all active addons that don't cross an engine boundary.

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -750,12 +750,6 @@ export default class CompatApp {
     );
   }
 
-  findTestScript(scripts: HTMLScriptElement[]): HTMLScriptElement | undefined {
-    return scripts.find(
-      script => this.withoutRootURL(script.src) === this.legacyEmberAppInstance.options.outputPaths.tests.js
-    );
-  }
-
   readonly macrosConfig: MacrosConfig;
 
   constructor(readonly legacyEmberAppInstance: EmberAppInstance, _options?: Options) {

--- a/packages/core/src/ember-html.ts
+++ b/packages/core/src/ember-html.ts
@@ -77,20 +77,16 @@ export class PreparedEmberHTML {
   dom: JSDOM;
   javascript: Placeholder;
   implicitScripts: Placeholder;
-  testJavascript: Placeholder;
 
   constructor(private asset: EmberAsset) {
     this.dom = new JSDOM(readFileSync(asset.sourcePath, 'utf8'));
     let html = asset.prepare(this.dom);
     this.javascript = Placeholder.find(html.javascript);
     this.implicitScripts = Placeholder.find(html.implicitScripts);
-    this.testJavascript = html.testJavascript
-      ? Placeholder.replacing(html.testJavascript)
-      : Placeholder.immediatelyAfter(this.javascript.end);
   }
 
   private placeholders(): Placeholder[] {
-    return [this.javascript, this.implicitScripts, this.testJavascript];
+    return [this.javascript, this.implicitScripts];
   }
 
   clear() {

--- a/test-packages/sample-transforms/tests/index.html
+++ b/test-packages/sample-transforms/tests/index.html
@@ -32,7 +32,7 @@
     <script src="/@embroider/core/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
     <script src="/@embroider/core/entrypoint" type="module"></script>
-    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="/@embroider/core/test-entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}

--- a/tests/addon-template/tests/index.html
+++ b/tests/addon-template/tests/index.html
@@ -31,7 +31,7 @@
     <script src="/@embroider/core/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
     <script src="/@embroider/core/entrypoint" type="module"></script>
-    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="/@embroider/core/test-entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}

--- a/tests/app-template/tests/index.html
+++ b/tests/app-template/tests/index.html
@@ -28,7 +28,7 @@
     <script src="/@embroider/core/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
     <script src="/@embroider/core/entrypoint" type="module"></script>
-    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="/@embroider/core/test-entrypoint" type="module"></script>
 
     {{content-for "body-footer"}} {{content-for "test-body-footer"}}
   </body>

--- a/tests/fixtures/macro-test/tests/index.html
+++ b/tests/fixtures/macro-test/tests/index.html
@@ -37,7 +37,7 @@
     <script src="{{rootURL}}ordered.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
     <script src="/@embroider/core/entrypoint" type="module"></script>
-    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="/@embroider/core/test-entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}

--- a/tests/ts-app-template/tests/index.html
+++ b/tests/ts-app-template/tests/index.html
@@ -31,7 +31,7 @@
     <script src="/@embroider/core/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
     <script src="/@embroider/core/entrypoint" type="module"></script>
-    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="/@embroider/core/test-entrypoint" type="module"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
## Context 

Lately, we have been working on the inversion of control for the Vite build, we replaced script assets like `vendor.js` with virtual content Vite can request to Embroider. 

Until now, we have never changed the `index.html` file of the initial Ember app to handle virtualization: in stage 2, the compat-app-builder generates the `index.html` of the rewritten-app and inserts the virtual entry points. This rewritten file is the one consumed by Vite.

Now that we have virtualized all the entry points, we are ready for the next step that will get us closer to the new blueprint: we are going to write the virtual entry points directly in the `index.html` of the initial Ember app so Vite will be able to consume it directly, without intermediate change.

This PR handles the `test-entrypoint`.
