### PR TITLE
output macros-config.json and _babel_config_ in the .embroider folder

### DIFF
--- a/packages/compat/src/audit.ts
+++ b/packages/compat/src/audit.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readJSONSync } from 'fs-extra';
+import { existsSync, readFileSync, readJSONSync } from 'fs-extra';
 import { join, resolve as resolvePath, dirname } from 'path';
 import type { AppMeta, ResolverOptions } from '@embroider/core';
 import { explicitRelative, hbsToJS, locateEmbroiderWorkingDir, Resolver, RewrittenPackageCache } from '@embroider/core';
@@ -153,8 +153,14 @@ export class Audit {
 
   @Memoize()
   private get babelConfig() {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    let config = require(join(this.movedAppRoot, this.meta.babel.filename));
+    // Depending on how the app builds, the babel config is not at the same location
+    let embroiderLocation = join(locateEmbroiderWorkingDir(this.originAppRoot), '_babel_config_.js');
+    let config = existsSync(embroiderLocation)
+      ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require(embroiderLocation)
+      : // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require(join(this.movedAppRoot, this.meta.babel.filename));
+
     config = Object.assign({}, config);
     config.plugins = config.plugins.filter((p: any) => !isMacrosPlugin(p));
 

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -488,10 +488,7 @@ export class CompatAppBuilder {
     this.addAppBoot(this.compatApp.appBoot.readAppBoot());
     let babelConfig = await this.babelConfig(resolverConfig);
     this.addBabelConfig(babelConfig);
-    writeFileSync(
-      join(this.root, 'macros-config.json'),
-      JSON.stringify(this.compatApp.macrosConfig.babelPluginConfig()[0], null, 2)
-    );
+    this.addMacrosConfig(this.compatApp.macrosConfig.babelPluginConfig()[0]);
   }
 
   private combinePackageJSON(meta: AppMeta): object {
@@ -591,6 +588,12 @@ export class CompatAppBuilder {
 
   private addEmberEnvConfig(emberEnvConfig: any) {
     outputJSONSync(join(locateEmbroiderWorkingDir(this.compatApp.root), 'ember-env.json'), emberEnvConfig, {
+      spaces: 2,
+    });
+  }
+
+  private addMacrosConfig(macrosConfig: any) {
+    outputJSONSync(join(locateEmbroiderWorkingDir(this.compatApp.root), 'macros-config.json'), macrosConfig, {
       spaces: 2,
     });
   }

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -565,7 +565,7 @@ export class CompatAppBuilder {
       warn('Your build is slower because some babel plugins are non-serializable');
     }
     writeFileSync(
-      join(this.root, '_babel_config_.js'),
+      join(locateEmbroiderWorkingDir(this.compatApp.root), '_babel_config_.js'),
       `module.exports = ${JSON.stringify(pconfig.config, null, 2)}`,
       'utf8'
     );

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -349,7 +349,7 @@ function shouldSplitRoute(routeName: string, splitAtRoutes: (RegExp | string)[] 
 
 export function getAppFiles(appRoot: string): Set<string> {
   const files: string[] = walkSync(appRoot, {
-    ignore: ['_babel_config_.js', '_babel_filter_.js', 'app.js', 'assets', 'testem.js', 'node_modules'],
+    ignore: ['_babel_filter_.js', 'app.js', 'assets', 'testem.js', 'node_modules'],
   });
   return new Set(files);
 }

--- a/packages/vite/src/esbuild-resolver.ts
+++ b/packages/vite/src/esbuild-resolver.ts
@@ -75,9 +75,7 @@ export function esBuildResolver(root = process.cwd()): EsBuildPlugin {
         }
         let { src } = virtualContent(path, resolverLoader.resolver);
         if (!macrosConfig) {
-          macrosConfig = readJSONSync(
-            resolve(locateEmbroiderWorkingDir(root), 'rewritten-app', 'macros-config.json')
-          ) as PluginItem;
+          macrosConfig = readJSONSync(resolve(locateEmbroiderWorkingDir(root), 'macros-config.json')) as PluginItem;
         }
         return { contents: runMacros(src, path, macrosConfig) };
       });
@@ -120,9 +118,7 @@ export function esBuildResolver(root = process.cwd()): EsBuildPlugin {
           src = readFileSync(path, 'utf8');
         }
         if (!macrosConfig) {
-          macrosConfig = readJSONSync(
-            resolve(locateEmbroiderWorkingDir(root), 'rewritten-app', 'macros-config.json')
-          ) as PluginItem;
+          macrosConfig = readJSONSync(resolve(locateEmbroiderWorkingDir(root), 'macros-config.json')) as PluginItem;
         }
         return { contents: runMacros(src, path, macrosConfig) };
       });

--- a/test-packages/support/transpiler.ts
+++ b/test-packages/support/transpiler.ts
@@ -1,10 +1,10 @@
-import { readJSONSync } from 'fs-extra';
+import { readJSONSync, existsSync } from 'fs-extra';
 import { join } from 'path';
 import type { TransformOptions } from '@babel/core';
 import { transform } from '@babel/core';
 import type { BoundExpectFile } from './file-assertions';
 import type { AppMeta } from '../../packages/core/src/index';
-import { hbsToJS, RewrittenPackageCache } from '../../packages/core/src/index';
+import { hbsToJS, locateEmbroiderWorkingDir, RewrittenPackageCache } from '../../packages/core/src/index';
 import { Memoize } from 'typescript-memoize';
 import { getRewrittenLocation } from './rewritten-path';
 
@@ -53,6 +53,10 @@ export class Transpiler {
       throw new Error(`@embroider/test-support only suports babel 7`);
     }
 
-    return require(join(this.appOutputPath, this.emberMeta['babel'].filename)) as TransformOptions;
+    // Depending on how the app builds, the babel config is not at the same location
+    let embroiderLocation = join(locateEmbroiderWorkingDir(this.appDir), '_babel_config_.js');
+    return existsSync(embroiderLocation)
+      ? (require(embroiderLocation) as TransformOptions)
+      : (require(join(this.appDir, this.emberMeta['babel'].filename)) as TransformOptions);
   }
 }

--- a/tests/addon-template/babel.config.cjs
+++ b/tests/addon-template/babel.config.cjs
@@ -13,7 +13,7 @@ if (
 ) {
   config = {};
 } else {
-  config = require("./node_modules/.embroider/rewritten-app/_babel_config_");
+  config = require("./node_modules/.embroider/_babel_config_");
 }
 
 module.exports = config;

--- a/tests/app-template/babel.config.cjs
+++ b/tests/app-template/babel.config.cjs
@@ -13,7 +13,7 @@ if (
 ) {
   config = {};
 } else {
-  config = require("./node_modules/.embroider/rewritten-app/_babel_config_");
+  config = require("./node_modules/.embroider/_babel_config_");
 }
 
 module.exports = config;

--- a/tests/ts-app-template-classic/babel.config.cjs
+++ b/tests/ts-app-template-classic/babel.config.cjs
@@ -10,7 +10,7 @@ let config;
 if (process.env.EMBROIDER_PREBUILD || process.env.EMBROIDER_TEST_SETUP_FORCE === 'classic') {
   config = {};
 } else {
-  config = require('./node_modules/.embroider/rewritten-app/_babel_config_');
+  config = require('./node_modules/.embroider/_babel_config_');
 }
 
 module.exports = config;

--- a/tests/ts-app-template/babel.config.cjs
+++ b/tests/ts-app-template/babel.config.cjs
@@ -10,7 +10,7 @@ let config;
 if (process.env.EMBROIDER_PREBUILD || process.env.EMBROIDER_TEST_SETUP_FORCE === 'classic') {
   config = {};
 } else {
-  config = require('./node_modules/.embroider/rewritten-app/_babel_config_');
+  config = require('./node_modules/.embroider/_babel_config_');
 }
 
 module.exports = config;


### PR DESCRIPTION
## Context

We are still working on removing the rewritten app completely. To achieve this goal, we need to remove all the remaining differences between the initial Ember app and the rewritten app generated at stage 2.

One of these differences is the presence of `macros-config.json` and `_babel_config_.js` in the root folder of the rewritten-app.

## Solution

Instead of outputting `macros-config.json` and `_babel_config_.js` in the rewritten app, we now output them directly in the `.embroider` folder, which contains all the config files we need.