### PR TITLE
remove auto-upgraded from app package.json and add a basic exports block

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -508,6 +508,12 @@ export class CompatAppBuilder {
     }
     // but our own new v2 app metadata takes precedence over both
     pkgLayers.push({ 'ember-addon': meta });
+    // add a default package exports
+    pkgLayers.push({
+      exports: {
+        './*': './*.js',
+      },
+    });
     return combinePackageJSON(...pkgLayers);
   }
 

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -508,12 +508,6 @@ export class CompatAppBuilder {
     }
     // but our own new v2 app metadata takes precedence over both
     pkgLayers.push({ 'ember-addon': meta });
-    // add a default package exports
-    pkgLayers.push({
-      exports: {
-        './*': './*.js',
-      },
-    });
     return combinePackageJSON(...pkgLayers);
   }
 
@@ -624,7 +618,7 @@ export class CompatAppBuilder {
           The following code is included via content-for 'config-module':
 
           ${configModule}
-          
+
           1. If you want to keep the same behavior, add it to the app/environment.js.
           2. Once app/environment.js has the content you need, remove the present error by setting "useAddonConfigModule" to false in the build options.
         `);

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -494,23 +494,25 @@ export class CompatAppBuilder {
       pkgLayers.push(fastbootConfig.packageJSON);
     }
 
+    let meta: AppMeta = {
+      type: 'app',
+      version: 2,
+      assets: assetPaths,
+      babel: {
+        filename: '_babel_config_.js',
+        isParallelSafe: true, // TODO
+        majorVersion: this.compatApp.babelMajorVersion(),
+        fileFilter: '_babel_filter_.js',
+      },
+      'root-url': this.rootURL(),
+    };
+
     if ((this.origAppPackage.packageJSON['ember-addon']?.version ?? 0) < 2) {
-      // the app has no v2 metdata, so we must be auto-upgrading it
-      let meta: AppMeta = {
-        type: 'app',
-        version: 2,
-        assets: assetPaths,
-        babel: {
-          filename: '_babel_config_.js',
-          isParallelSafe: true, // TODO
-          majorVersion: this.compatApp.babelMajorVersion(),
-          fileFilter: '_babel_filter_.js',
-        },
-        'root-url': this.rootURL(),
-        'auto-upgraded': true,
-      };
-      pkgLayers.push({ 'ember-addon': meta });
+      meta['auto-upgraded'] = true;
     }
+
+    pkgLayers.push({ 'ember-addon': meta });
+
     return combinePackageJSON(...pkgLayers);
   }
 

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -483,9 +483,6 @@ export class CompatAppBuilder {
       'root-url': this.rootURL(),
     };
 
-    // all compat apps are auto-upgraded, there's no v2 app format here
-    meta['auto-upgraded'] = true;
-
     let pkg = this.combinePackageJSON(meta);
     writeFileSync(join(this.root, 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
 

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1030,6 +1030,19 @@ export class Resolver {
           );
         }
       } else {
+        // v2 apps can't rely on packageJSON exports because they will essentially enforce an extension
+        // we need to do an extensionless search so that things like template-only components can get their
+        // synthesized JS. This isn't an issue for addons because they are expected to have their template-only
+        // implementation backed in at deploy time
+        if (pkg.root === this.options.engines[0].root) {
+          let selfImportPath = request.specifier === pkg.name ? './' : request.specifier.replace(pkg.name, '.');
+          return logTransition(
+            `v2 app self-import`,
+            request,
+            request.alias(selfImportPath).rehome(resolve(pkg.root, 'package.json'))
+          );
+        }
+
         // v2 packages are supposed to use package.json `exports` to enable
         // self-imports, but not all build tools actually follow the spec. This
         // is a workaround for badly behaved packagers.

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1189,17 +1189,16 @@ export class Resolver {
     }
 
     // assertions on what native v2 addons can import
-    if (!pkg.meta['auto-upgraded']) {
-      if (
-        !pkg.meta['auto-upgraded'] &&
-        !appImportInAppTree(pkg, logicalPackage, packageName) &&
-        !reliablyResolvable(pkg, packageName)
-      ) {
-        throw new Error(
-          `${pkg.name} is trying to import from ${packageName} but that is not one of its explicit dependencies`
-        );
-      }
+    if (
+      !pkg.needsLooseResolving() &&
+      !appImportInAppTree(pkg, logicalPackage, packageName) &&
+      !reliablyResolvable(pkg, packageName)
+    ) {
+      throw new Error(
+        `${pkg.name} is trying to import from ${packageName} but that is not one of its explicit dependencies`
+      );
     }
+
     return request;
   }
 
@@ -1339,7 +1338,7 @@ export class Resolver {
     }
 
     // auto-upgraded packages can fall back to the set of known active addons
-    if (pkg.meta['auto-upgraded']) {
+    if (pkg.needsLooseResolving()) {
       let addon = this.locateActiveAddon(packageName);
       if (addon) {
         const rehomed = request.rehome(addon.canResolveFromFile);
@@ -1375,7 +1374,7 @@ export class Resolver {
       }
     }
 
-    if (pkg.meta['auto-upgraded'] && (request.meta?.runtimeFallback ?? true)) {
+    if (pkg.needsLooseResolving() && (request.meta?.runtimeFallback ?? true)) {
       // auto-upgraded packages can fall back to attempting to find dependencies at
       // runtime. Native v2 packages can only get this behavior in the
       // isExplicitlyExternal case above because they need to explicitly ask for

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1030,19 +1030,6 @@ export class Resolver {
           );
         }
       } else {
-        // v2 apps can't rely on packageJSON exports because they will essentially enforce an extension
-        // we need to do an extensionless search so that things like template-only components can get their
-        // synthesized JS. This isn't an issue for addons because they are expected to have their template-only
-        // implementation backed in at deploy time
-        if (pkg.root === this.options.engines[0].root) {
-          let selfImportPath = request.specifier === pkg.name ? './' : request.specifier.replace(pkg.name, '.');
-          return logTransition(
-            `v2 app self-import`,
-            request,
-            request.alias(selfImportPath).rehome(resolve(pkg.root, 'package.json'))
-          );
-        }
-
         // v2 packages are supposed to use package.json `exports` to enable
         // self-imports, but not all build tools actually follow the spec. This
         // is a workaround for badly behaved packagers.

--- a/packages/shared-internals/src/package.ts
+++ b/packages/shared-internals/src/package.ts
@@ -81,6 +81,10 @@ export default class Package {
     return this.isV2Ember() && this.packageJSON['ember-addon'].type === 'app';
   }
 
+  needsLooseResolving(): boolean {
+    return this.isV2App() || ((this.isV2Addon() && this.meta['auto-upgraded']) ?? false);
+  }
+
   isV2Addon(): this is V2AddonPackage {
     return this.isV2Ember() && this.packageJSON['ember-addon'].type === 'addon';
   }

--- a/packages/shared-internals/src/rewritten-package-cache.ts
+++ b/packages/shared-internals/src/rewritten-package-cache.ts
@@ -253,6 +253,10 @@ class WrappedPackage implements PackageTheGoodParts {
     return this.plainPkg.isV2Addon();
   }
 
+  needsLooseResolving(): boolean {
+    return this.plainPkg.needsLooseResolving();
+  }
+
   // it's important that we're calling this.dependencies here at this level, not
   // plainPkg.dependencies, which wouldn't be correct
   findDescendants(filter?: (pkg: Package) => boolean): Package[] {

--- a/packages/shared-internals/src/template-colocation-plugin.ts
+++ b/packages/shared-internals/src/template-colocation-plugin.ts
@@ -69,7 +69,7 @@ export default function main(babel: typeof Babel) {
 
           if (state.opts.packageGuard) {
             let owningPackage = PackageCache.shared('embroider', state.opts.appRoot).ownerOfFile(filename);
-            if (!owningPackage || !owningPackage.isV2Ember() || !owningPackage.meta['auto-upgraded']) {
+            if (!owningPackage || !owningPackage.needsLooseResolving()) {
               debug('not handling colocation for %s', filename);
               return;
             }

--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -10,6 +10,9 @@
     "doc": "doc",
     "test": "tests"
   },
+  "exports": {
+    "./*": "./*"
+  },
   "scripts": {
     "build": "vite build",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",

--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -80,5 +80,9 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "ember-addon": {
+    "type": "app",
+    "version": 2
   }
 }

--- a/tests/ts-app-template/package.json
+++ b/tests/ts-app-template/package.json
@@ -10,6 +10,9 @@
     "doc": "doc",
     "test": "tests"
   },
+  "exports": {
+    "./*": "./*"
+  },
   "scripts": {
     "build": "ember build --environment=production",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",

--- a/tests/ts-app-template/package.json
+++ b/tests/ts-app-template/package.json
@@ -84,5 +84,9 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "ember-addon": {
+    "type": "app",
+    "version": 2
   }
 }


### PR DESCRIPTION
This PR starts to add the v2 config to the package.json as part of the authoring format and not as something that compat-app-builder adds during the app rewriting.

~Blocked on https://github.com/embroider-build/embroider/pull/1937 being released~ merged and released 👍 