### PR TITLE
only register v2 addons with parent addons

### DIFF
--- a/packages/addon-shim/src/index.ts
+++ b/packages/addon-shim/src/index.ts
@@ -163,9 +163,12 @@ export function addonV1Shim(directory: string, options: ShimOptions = {}) {
         }
         autoImport.instance.registerV2Addon(name, root);
       } else {
-        // if we're being used by a v2 addon, it also has this shim and will
-        // forward our registration onward to ember-auto-import
-        (this.parent as EAI2Instance).registerV2Addon(name, root);
+        // This should only be done if we're being consumed by an addon
+        if (this.parent.pkg['ember-addon'].type === 'addon') {
+          // if we're being used by a v2 addon, it also has this shim and will
+          // forward our registration onward to ember-auto-import
+          (this.parent as EAI2Instance).registerV2Addon(name, root);
+        }
       }
     },
   };


### PR DESCRIPTION
This is something that is needed for https://github.com/embroider-build/embroider/pull/1936

Up until this point, if the parent of an addon has `version: 2` in it's `ember-addon` package.json it was always going to be an addon. With recent changes in the authoring format of a v2 app we now need to check that the parent is indeed an addon, so we just ignore it if it has `type: app`

This PR is marked as a bug which technically isn't true because this is new design work, but it's safe enough (and important) that this goes out in a patch release 👍 