### PR TITLE
remove v* prefix GitHub Actions builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ on:
   push:
     branches:
       - stable
-      - 'v[0-9]+*' # prior release branches (e.g. `v0.30.x` branch)
-    tags:
-      - 'v*'
   pull_request:
     branches: [stable]
 


### PR DESCRIPTION
in a few of my previous branches related to the App v2 format I've started the branch name with `v2-` which has triggered Github to double up CI. This isn't usually so bad but when we have 200+ jobs of CI that run on every PR doubling that up can get a bit rediculous 🫠 