### PR TITLE
Output `_babel_filter_.js` in the `.embroider` folder

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -570,7 +570,7 @@ export class CompatAppBuilder {
       'utf8'
     );
     writeFileSync(
-      join(this.root, '_babel_filter_.js'),
+      join(locateEmbroiderWorkingDir(this.compatApp.root), '_babel_filter_.js'),
       babelFilterTemplate({ skipBabel: this.options.skipBabel, appRoot: this.origAppPackage.root }),
       'utf8'
     );

--- a/test-packages/support/transpiler.ts
+++ b/test-packages/support/transpiler.ts
@@ -34,7 +34,11 @@ export class Transpiler {
   }
 
   shouldTranspile(relativePath: string) {
-    let shouldTranspile = require(join(this.appOutputPath, '_babel_filter_'));
+    // Depending on how the app builds, the babel filter is not at the same location
+    let embroiderLocation = join(locateEmbroiderWorkingDir(this.appDir), '_babel_filter_.js');
+    let shouldTranspile = existsSync(embroiderLocation)
+      ? require(embroiderLocation)
+      : require(join(this.appOutputPath, '_babel_filter_'));
     return shouldTranspile(join(this.appDir, getRewrittenLocation(this.appDir, relativePath))) as boolean;
   }
 


### PR DESCRIPTION
Follows #1935 

## Context

We are still working on removing the rewritten app completely. To achieve this goal, we need to remove all the remaining differences between the initial Ember app and the rewritten app generated at stage 2.

One of these differences is the presence of `_babel_filter_.js` in the root folder of the rewritten-app.

`_babel_filter_.js` is related to the `skipBabel` option and how `ember-cli-babel` works. It's something **we don't want to keep** in the new Embroider + Vite world because we don't want `ember-cli-babel` to be a requirement and the Babel config should be standard and defined in the user's Ember app. So the ultimate goal is to remove `_babel_filter_.js`.

## This PR

This PR should be seen as an intermediate step.

Even though we want to remove the `skipBabel` option and `_babel_filter_.js`, here, we simply move the file out of the rewritten app, and we now output it directly in the `.embroider` folder, which contains all the config files we need.

The point of this intermediate step is to unblock the removal of the rewritten app and manage the deletion of `skipBabel` as a separated topic, independent from the deactivation of the rewritten app.
