### PR TITLE
New config module

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -11,7 +11,7 @@ import mergeTrees from 'broccoli-merge-trees';
 import { WatchedDir } from 'broccoli-source';
 import resolve from 'resolve';
 import ContentForConfig from './content-for-config';
-import { V1Config, WriteV1Config } from './v1-config';
+import { V1Config } from './v1-config';
 import { WriteV1AppBoot, ReadV1AppBoot } from './v1-appboot';
 import type { AddonMeta, EmberAppInstance, OutputFileToInputFileMap, PackageInfo } from '@embroider/core';
 import { writeJSONSync, ensureDirSync, copySync, pathExistsSync, existsSync, writeFileSync } from 'fs-extra';
@@ -690,13 +690,6 @@ export default class CompatApp {
     let appTree = this.appTree;
     let testsTree = this.testsTree;
     let lintTree = this.lintTree;
-    let config = new WriteV1Config(this.config, this.storeConfigInMeta, this.testConfig);
-    let patterns = this.configReplacePatterns;
-    let configReplaced = new this.configReplace(config, this.configTree, {
-      configPath: join('environments', `${this.legacyEmberAppInstance.env}.json`),
-      files: ['config/environment.js'],
-      patterns,
-    });
 
     let trees: BroccoliNode[] = [];
     trees.push(appTree);
@@ -704,7 +697,6 @@ export default class CompatApp {
       new SynthesizeTemplateOnlyComponents(appTree, { allowedPaths: ['components'], templateExtensions: ['.hbs'] })
     );
 
-    trees.push(configReplaced);
     if (testsTree) {
       trees.push(testsTree);
     }

--- a/packages/compat/src/v1-config.ts
+++ b/packages/compat/src/v1-config.ts
@@ -1,7 +1,7 @@
 import Plugin from 'broccoli-plugin';
 import type { Node } from 'broccoli-node-api';
 import { join } from 'path';
-import { readFileSync, outputFileSync } from 'fs-extra';
+import { readFileSync } from 'fs-extra';
 
 export interface ConfigContents {
   modulePrefix: string;
@@ -25,51 +25,4 @@ export class V1Config extends Plugin {
     }
     return this.lastConfig;
   }
-}
-
-export class WriteV1Config extends Plugin {
-  private lastContents: string | undefined;
-  constructor(private inputTree: V1Config, private storeConfigInMeta: boolean, private testInputTree?: V1Config) {
-    super([inputTree, testInputTree as V1Config].filter(Boolean), {
-      persistentOutput: true,
-      needsCache: false,
-    });
-  }
-  build() {
-    let filename = join(this.outputPath, 'config/environment.js');
-    let contents;
-    if (this.storeConfigInMeta) {
-      contents = metaLoader();
-    } else {
-      if (this.testInputTree) {
-        contents = `
-        import { isTesting } from '@embroider/macros';
-        let env;
-        if (isTesting()) {
-          env = ${JSON.stringify(this.testInputTree.readConfig())};
-        } else {
-          env = ${JSON.stringify(this.inputTree.readConfig())};
-        }
-        export default env;
-        `;
-      } else {
-        contents = `export default ${JSON.stringify(this.inputTree.readConfig())};`;
-      }
-    }
-    if (!this.lastContents || this.lastContents !== contents) {
-      outputFileSync(filename, contents);
-    }
-    this.lastContents = contents;
-  }
-}
-
-function metaLoader() {
-  // Supporting config content as JS Module.
-  // Wrapping the content with immediate invoked function as
-  // replaced content for config-module was meant to support AMD module.
-  return `
-    export default (function() {
-      {{content-for 'config-module'}}
-    })().default;
-  `;
 }

--- a/tests/addon-template/tests/dummy/app/config/environment.js
+++ b/tests/addon-template/tests/dummy/app/config/environment.js
@@ -1,0 +1,33 @@
+import { macroCondition, isTesting } from '@embroider/macros';
+
+const ENV = {
+  modulePrefix: 'dummy',
+  rootURL: '/',
+  locationType: 'history',
+  EmberENV: {
+    EXTEND_PROTOTYPES: false,
+    FEATURES: {
+      // Here you can enable experimental features on an ember canary build
+      // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
+    },
+  },
+
+  APP: {
+    // Here you can pass flags/options to your application instance
+    // when it is created
+  },
+};
+
+if (macroCondition(isTesting())) {
+  // Testem prefers this...
+  ENV.locationType = 'none';
+
+  // keep test console output quieter
+  ENV.APP.LOG_ACTIVE_GENERATION = false;
+  ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+  ENV.APP.rootElement = '#ember-testing';
+  ENV.APP.autoboot = false;
+}
+
+export default ENV;

--- a/tests/app-template/app/config/environment.js
+++ b/tests/app-template/app/config/environment.js
@@ -1,0 +1,33 @@
+import { macroCondition, isTesting } from '@embroider/macros';
+
+const ENV = {
+  modulePrefix: 'app-template',
+  rootURL: '/',
+  locationType: 'history',
+  EmberENV: {
+    EXTEND_PROTOTYPES: false,
+    FEATURES: {
+      // Here you can enable experimental features on an ember canary build
+      // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
+    },
+  },
+
+  APP: {
+    // Here you can pass flags/options to your application instance
+    // when it is created
+  },
+};
+
+if (macroCondition(isTesting())) {
+  // Testem prefers this...
+  ENV.locationType = 'none';
+
+  // keep test console output quieter
+  ENV.APP.LOG_ACTIVE_GENERATION = false;
+  ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+  ENV.APP.rootElement = '#ember-testing';
+  ENV.APP.autoboot = false;
+}
+
+export default ENV;

--- a/tests/fixtures/macro-test/app/config/environment.js
+++ b/tests/fixtures/macro-test/app/config/environment.js
@@ -1,0 +1,33 @@
+import { macroCondition, isTesting } from '@embroider/macros';
+
+const ENV = {
+  modulePrefix: 'app-template',
+  rootURL: '/',
+  locationType: 'history',
+  EmberENV: {
+    EXTEND_PROTOTYPES: false,
+    FEATURES: {
+      // Here you can enable experimental features on an ember canary build
+      // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
+    },
+  },
+
+  APP: {
+    // Here you can pass flags/options to your application instance
+    // when it is created
+  },
+};
+
+if (macroCondition(isTesting())) {
+  // Testem prefers this...
+  ENV.locationType = 'none';
+
+  // keep test console output quieter
+  ENV.APP.LOG_ACTIVE_GENERATION = false;
+  ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+  ENV.APP.rootElement = '#ember-testing';
+  ENV.APP.autoboot = false;
+}
+
+export default ENV;

--- a/tests/fixtures/macro-test/ember-cli-build.js
+++ b/tests/fixtures/macro-test/ember-cli-build.js
@@ -13,6 +13,7 @@ module.exports = function (defaults) {
           items: [{ name: 'Arthur', awesome: true }],
           description: null,
         },
+        EXPECTED_VERSION: process.env.EXPECTED_VERSION || 'four',
       },
       setConfig: {
         'ember-source': {

--- a/tests/fixtures/macro-test/tests/acceptance/basic-test.js
+++ b/tests/fixtures/macro-test/tests/acceptance/basic-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import ENV from 'app-template/config/environment';
+import { getOwnConfig } from '@embroider/macros';
 
 module('Acceptance | smoke tests', function (hooks) {
   setupApplicationTest(hooks);
@@ -62,6 +62,6 @@ module('Acceptance | smoke tests', function (hooks) {
   test('dependency satisfies works correctly', async function (assert) {
     await visit('/');
     assert.equal(currentURL(), '/');
-    assert.equal(this.element.querySelector('[data-test-version]').textContent.trim(), ENV.EXPECTED_VERSION);
+    assert.equal(this.element.querySelector('[data-test-version]').textContent.trim(), getOwnConfig().EXPECTED_VERSION);
   });
 });

--- a/tests/fixtures/macro-test/tests/integration/components/get-config-test.js
+++ b/tests/fixtures/macro-test/tests/integration/components/get-config-test.js
@@ -70,7 +70,13 @@ module('Integration | Macro | getConfig', function(hooks) {
   test('macroGetOwnConfig emits complex pojo', async function(assert) {
     assert.expect(1);
     function myAssertion(value) {
-      assert.deepEqual(value, {
+      assert.deepEqual({
+        ...value, 
+        // this isn't what this test is actually checking for, we need to reuse this fixture between
+        // different tests that this value will be different so it's easier to just remove from the
+        // pojo
+        EXPECTED_VERSION: null 
+      }, {
         mode: 'amazing',
         count: 42,
         inner: {
@@ -78,7 +84,8 @@ module('Integration | Macro | getConfig', function(hooks) {
             { name: 'Arthur', awesome: true }
           ],
           description: null
-        }
+        },
+        EXPECTED_VERSION: null,
       });
     }
     await render(precompileTemplate(`{{myAssertion (macroGetOwnConfig) }}`, {

--- a/tests/scenarios/app-config-environment-test.ts
+++ b/tests/scenarios/app-config-environment-test.ts
@@ -1,5 +1,7 @@
 import merge from 'lodash/merge';
+import CommandWatcher from './helpers/command-watcher';
 import { appScenarios } from './scenarios';
+import fetch from 'node-fetch';
 import type { PreparedApp } from 'scenario-tester';
 import QUnit from 'qunit';
 
@@ -17,50 +19,126 @@ appScenarios
 
         module.exports = function (defaults) {
           let app = new EmberApp(defaults, {
-            tests: true,
-            storeConfigInMeta: false,
+            ...(process.env.FORCE_BUILD_TESTS ? {
+              tests: true,
+            } : undefined),
           });
           return maybeEmbroider(app, {});
         };
       `,
       config: {
-        'environment.js': `module.exports = function(environment) {
-          // DEFAULT config/environment.js
-          let ENV = {
+        'environment.js': `
+          module.exports = function(environment) {
+            // DEFAULT config/environment.js
+            let ENV = {
+              modulePrefix: 'app-template',
+              environment,
+              rootURL: '/',
+              locationType: 'history',
+              EmberENV: {
+                EXTEND_PROTOTYPES: false,
+                FEATURES: {},
+              },
+              APP: {},
+              'legacy-config-format': 'production',
+            };
+
+            if (environment === 'development') {
+              ENV['legacy-config-format'] = 'development';
+            };
+
+            if (environment === 'test') {
+              ENV.locationType = 'none';
+              ENV.APP.LOG_ACTIVE_GENERATION = false;
+              ENV.APP.LOG_VIEW_LOOKUPS = false;
+              ENV.APP.rootElement = '#ember-testing';
+              ENV.APP.autoboot = false;
+
+              ENV['legacy-config-format'] = 'test';
+            };
+
+            return ENV;
+          };
+        `,
+      },
+      app: {
+        config: {
+          'environment.js': `
+          import { macroCondition, isDevelopingApp, isTesting } from '@embroider/macros';
+
+          const ENV = {
             modulePrefix: 'app-template',
-            environment,
             rootURL: '/',
             locationType: 'history',
             EmberENV: {
               EXTEND_PROTOTYPES: false,
-              FEATURES: {},
+              FEATURES: {
+                // Here you can enable experimental features on an ember canary build
+                // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
+              },
             },
-            APP: {},
+
+            APP: {
+              // Here you can pass flags/options to your application instance
+              // when it is created
+            },
+
+            // CUSTOM
+            'new-config-format': 'production',
           };
 
-          if (environment === 'test') {
+          if (macroCondition(isDevelopingApp())) {
+            // CUSTOM
+            ENV['new-config-format'] = 'development';
+          }
+
+          if (macroCondition(isTesting())) {
+            // Testem prefers this...
             ENV.locationType = 'none';
+
+            // keep test console output quieter
             ENV.APP.LOG_ACTIVE_GENERATION = false;
             ENV.APP.LOG_VIEW_LOOKUPS = false;
+
             ENV.APP.rootElement = '#ember-testing';
             ENV.APP.autoboot = false;
 
             // CUSTOM
-            ENV.someCustomField = true;
-          };
+            ENV['new-config-format'] = 'test';
+          }
 
-          return ENV;
-        };`,
+          export default ENV;`,
+        },
+        controllers: {
+          'application.js': `
+          import Controller from '@ember/controller';
+          import config from '../config/environment';
+
+          export default class ApplicationController extends Controller {
+            config = config;
+
+            get configValue() {
+              console.log(this.config);
+              return this.config['new-config-format'];
+            }
+          }
+          `,
+        },
+        templates: {
+          'application.hbs': `
+            <p>new-config-format: {{this.configValue}}</p>
+          `,
+        },
       },
       tests: {
         unit: {
-          'store-config-in-meta-test.js': `
+          'config-test.js': `
             import { module, test } from 'qunit';
             import ENV from 'app-template/config/environment';
 
-            module('Unit | storeConfigInMeta set to false', function (hooks) {
+            module('Unit | it loads the config', function (hooks) {
               test('it has loaded the correct config values', async function (assert) {
-                assert.equal(ENV.someCustomField, true);
+                assert.equal(ENV['new-config-format'], 'test');
               });
             });`,
         },
@@ -74,7 +152,7 @@ appScenarios
         app = await scenario.prepare();
       });
 
-      test(`ember test ran against dev build with custom unit test`, async function (assert) {
+      test(`environement config v2 is imported and correct: test mode`, async function (assert) {
         // here we build the app with environment set to dev so that we can use
         // the build output directory as the input path to an `ember test` run
         // later. This difference in environment is important because it's the
@@ -84,6 +162,18 @@ appScenarios
         assert.equal(devBuildResult.exitCode, 0, devBuildResult.output);
         let testRunResult = await app.execute(`pnpm test:ember --path dist`);
         assert.equal(testRunResult.exitCode, 0, testRunResult.output);
+      });
+
+      test('environement config v2 is imported and correct: dev mode', async function (assert) {
+        const server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+        try {
+          const [, url] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+          let response = await fetch(`${url}/`);
+          let text = await response.text();
+          assert.true(text.includes('development'));
+        } finally {
+          await server.shutdown();
+        }
       });
     });
   });

--- a/tests/ts-app-template/app/config/environment.js
+++ b/tests/ts-app-template/app/config/environment.js
@@ -1,0 +1,33 @@
+import { macroCondition, isTesting } from '@embroider/macros';
+
+const ENV = {
+  modulePrefix: 'ts-app-template',
+  rootURL: '/',
+  locationType: 'history',
+  EmberENV: {
+    EXTEND_PROTOTYPES: false,
+    FEATURES: {
+      // Here you can enable experimental features on an ember canary build
+      // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
+    },
+  },
+
+  APP: {
+    // Here you can pass flags/options to your application instance
+    // when it is created
+  },
+};
+
+if (macroCondition(isTesting())) {
+  // Testem prefers this...
+  ENV.locationType = 'none';
+
+  // keep test console output quieter
+  ENV.APP.LOG_ACTIVE_GENERATION = false;
+  ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+  ENV.APP.rootElement = '#ember-testing';
+  ENV.APP.autoboot = false;
+}
+
+export default ENV;


### PR DESCRIPTION
This PR introduces a change in the Ember app hierarchy. We want the `config/environment.js` to be a module located in the `app/` folder, so it's more standard and follows the same behavior as the other app files.

## Before this PR
During the Vite build, all the source app files are moved to the root of the rewritten-app, so imports like...
```
// ember-app/app/app.js
import config from './config/environment'
```
...become "magically" correct. 

The file `rewritten-app/config/environment.js` is not a copy of the `ember-app/config/environment.js`, it's entirely rewritten, and its value depends mainly on the boolean `storeConfigInMeta`. If this boolean is `true`, then the generated code will find the `<meta>` in the DOM, which will be added to the `index.html` during the build process.

## With this PR
We stop rewriting a brand new `rewritten-app/config/environment.js` during the build process. 

We have a `ember-app/app/config/environment.js` on the source side, and it is simply moved to the root of the rewritten-app, like every other app file. Note the content is quite close to what was generated with `storeConfigInMeta` set to `false`.

⚠️ We are aware of the following:
- This PR breaks `storeConfigInMeta`, the config is no longer written in a `<meta>` in the `index.html`. We will re-implement this behavior differently using macros at a later time.
- We now have 2 configs in the source Ember app, because the old one is still read by some parts of the code, so the PR doesn't remove it. We will teach the concerned code to rely on the new format instead, at a later time. 



