### PR TITLE
reset version of config-meta-loader to 0.0.0

### DIFF
--- a/packages/config-meta-loader/package.json
+++ b/packages/config-meta-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embroider/config-meta-loader",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": false,
   "type": "module",
   "description": "Read the config meta in the document. Inspired by ember-cli/lib/broccoli/app-config-from-meta.js",


### PR DESCRIPTION
this means that when release-plan creates the new version it will be a 1.0.0