### PR TITLE
Remove template-only components compilation from Stage 2

### DIFF
--- a/packages/compat/src/audit/babel-visitor.ts
+++ b/packages/compat/src/audit/babel-visitor.ts
@@ -73,6 +73,8 @@ export function auditJS(rawSource: string, filename: string, babelConfig: Transf
             codeFrameIndex: saveCodeFrame(arg),
             specifiers: [],
           });
+        } else if (arg.type === 'BinaryExpression') {
+          // ignore binary expressions. Vite uses these (somehow) in the `@vite/client` import
         } else {
           problems.push({
             message: `audit tool is unable to understand this usage of ${

--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -22,7 +22,6 @@ import { isEmbroiderMacrosPlugin, MacrosConfig } from '@embroider/macros/src/nod
 import resolvePackagePath from 'resolve-package-path';
 import Concat from 'broccoli-concat';
 import mapKeys from 'lodash/mapKeys';
-import SynthesizeTemplateOnlyComponents from './synthesize-template-only-components';
 import { isEmberAutoImportDynamic, isInlinePrecompilePlugin } from './detect-babel-plugins';
 import loadAstPlugins from './prepare-htmlbars-ast-plugins';
 import { readFileSync } from 'fs';
@@ -693,9 +692,6 @@ export default class CompatApp {
 
     let trees: BroccoliNode[] = [];
     trees.push(appTree);
-    trees.push(
-      new SynthesizeTemplateOnlyComponents(appTree, { allowedPaths: ['components'], templateExtensions: ['.hbs'] })
-    );
 
     if (testsTree) {
       trees.push(testsTree);

--- a/packages/core/src/app-files.ts
+++ b/packages/core/src/app-files.ts
@@ -83,12 +83,23 @@ export class AppFiles {
       }
 
       if (relativePath.startsWith('components/')) {
-        // hbs files are resolvable, but not when they're used via co-location.
+        // hbs files are not resolvable when they're used via co-location with
+        // an associated js file because it's the js that is resolvable.
         // An hbs file is used via colocation when it's inside the components
         // directory, and also not named "template.hbs" (because that is an
         // older pattern used with pods-like layouts).
-        if (!relativePath.endsWith('.hbs') || relativePath.endsWith('/template.hbs')) {
+        let isHbs = relativePath.endsWith('.hbs');
+        if (!isHbs || relativePath.endsWith('/template.hbs')) {
           components.push(relativePath);
+        } else if (isHbs) {
+          // template-only components will be compiled as js files during the
+          // build process, so we push a virtual path to js in the list of files
+          // because the resolver will be able to recognize a template-only and
+          // give a correct answer in the end.
+          let jsPath = relativePath.replace(/\.hbs$/, '.js');
+          if (!combinedFiles.has(jsPath)) {
+            components.push(jsPath);
+          }
         }
         continue;
       }

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -3,7 +3,7 @@
 import { createFilter } from '@rollup/pluginutils';
 import type { PluginContext, ResolvedId } from 'rollup';
 import type { Plugin } from 'vite';
-import { hbsToJS, ResolverLoader } from '@embroider/core';
+import { hbsToJS, ResolverLoader, cleanUrl } from '@embroider/core';
 import assertNever from 'assert-never';
 import { readFileSync } from 'fs-extra';
 import { parse as pathParse } from 'path';
@@ -39,7 +39,7 @@ export function hbs(): Plugin {
 
       switch (meta.type) {
         case 'template':
-          let code = hbsToJS(`${readFileSync(id)}`);
+          let code = hbsToJS(`${readFileSync(cleanUrl(id))}`);
           return {
             code,
           };

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -5,6 +5,7 @@ import type { PluginContext, ResolvedId } from 'rollup';
 import type { Plugin } from 'vite';
 import { hbsToJS, ResolverLoader } from '@embroider/core';
 import assertNever from 'assert-never';
+import { readFileSync } from 'fs-extra';
 import { parse as pathParse } from 'path';
 import makeDebug from 'debug';
 
@@ -30,7 +31,7 @@ export function hbs(): Plugin {
       }
     },
 
-    transform(source: string, id: string) {
+    load(id: string) {
       const meta = getMeta(this, id);
       if (!meta) {
         return;
@@ -38,7 +39,7 @@ export function hbs(): Plugin {
 
       switch (meta.type) {
         case 'template':
-          let code = hbsToJS(source);
+          let code = hbsToJS(`${readFileSync(id)}`);
           return {
             code,
           };

--- a/test-packages/support/audit-assertions.ts
+++ b/test-packages/support/audit-assertions.ts
@@ -2,12 +2,13 @@ import type { AuditBuildOptions, Finding, Module } from '../../packages/compat/s
 import { httpAudit, type HTTPAuditOptions } from '../../packages/compat/src/http-audit';
 import type { Import } from '../../packages/compat/src/module-visitor';
 import { Audit } from '../../packages/compat/src/audit';
-import { explicitRelative } from '../../packages/shared-internals';
+import { cleanUrl, explicitRelative } from '../../packages/shared-internals';
 import { install as installCodeEqualityAssertions } from 'code-equality-assertions/qunit';
 import { posix } from 'path';
 import { distance } from 'fastest-levenshtein';
 import { sortBy } from 'lodash';
 import { getRewrittenLocation } from './rewritten-path';
+import { Memoize } from 'typescript-memoize';
 
 export { Import };
 
@@ -113,8 +114,14 @@ export class ExpectAuditResults {
 export class ExpectModule {
   constructor(private expectAudit: ExpectAuditResults, private inputName: string) {}
 
+  @Memoize()
   private get module() {
     let outputName = this.expectAudit.toRewrittenPath(this.inputName);
+    for (let [key, value] of Object.entries(this.expectAudit.result.modules)) {
+      if (cleanUrl(key) === outputName) {
+        return value;
+      }
+    }
     return this.expectAudit.result.modules[outputName];
   }
 

--- a/test-packages/support/audit-assertions.ts
+++ b/test-packages/support/audit-assertions.ts
@@ -271,7 +271,15 @@ export class ExpectModule {
       this.emitMissingModule();
       return;
     }
-    this.expectAudit.assert.deepEqual(this.module.consumedFrom, paths.map(this.expectAudit.toRewrittenPath));
+
+    let consumedFrom = this.module.consumedFrom.map(m => {
+      if (typeof m === 'string') {
+        return cleanUrl(m);
+      }
+      return m;
+    });
+
+    this.expectAudit.assert.deepEqual(consumedFrom, paths.map(this.expectAudit.toRewrittenPath));
   }
 }
 

--- a/tests/scenarios/compat-template-colocation-test.ts
+++ b/tests/scenarios/compat-template-colocation-test.ts
@@ -125,8 +125,7 @@ scenarios
           });
       });
 
-      // TODO make sure that app files picks up the template-only-component
-      QUnit.skip(`app's template-only component JS is synthesized`, function (assert) {
+      test(`app's template-only component JS is synthesized`, function (assert) {
         expectAudit
           .module('./index.html')
           .resolves('/@embroider/core/entrypoint')
@@ -139,10 +138,10 @@ scenarios
               'imported template'
             );
             assert.ok(/import \{ setComponentTemplate \}/.test(contents), 'found setComponentTemplate');
-            assert.ok(/import templateOnlyComponent/.test(contents), 'found templateOnlyComponent');
+            assert.ok(/import templateOnly/.test(contents), 'found templateOnly');
 
             assert.ok(
-              /export default setComponentTemplate\(TEMPLATE, templateOnlyComponent\(\)\)/.test(contents),
+              /export default setComponentTemplate\(TEMPLATE, templateOnly\(\)\)/.test(contents),
               'default export is wrapped'
             );
             return true;


### PR DESCRIPTION
Fixes: #1958

During the build, the `hbs` Vite plugin and Babel work together so template-only components of the app are compiled as `.js` files. When the app requests the `.js` through an import, the `hbs` Vite plugin detects it's a template-only component and returns a consistent answer.

This is in theory. In practice, Stage 2 already compiles template-only components using the Broccoli plugin `SynthesizeTemplateOnlyComponents` and puts the resulting `.js` in the rewritten-app files. From start, the `.js` already exists in the rewritten-app consumed by Vite and the part of the `hbs` Vite plugin that is supposed to deal with template-only components has nothing to do.

As explained in #1958, this is a problem because it creates a difference between the initial Ember app and the rewritten-app, which prevents us from removing the rewrittent-app. This PR first removes this template-compilation step happening in Stage 2, then deals with all the side-effect this change raises. 

The main changes are the following: 
- When the `hbs` Vite plugin returns js code for a given request, it's a `load` operation rather than a `transform`
- When the virtual entry point lists all the app files, it used to add only `.js` components to the list (which was not a problem before because thanks to Stage 2 compilation step, every component had an associated `.js`). There's now a special handling for template-only components that need to be listed as well.
- A bunch of tests had stage-2-specific checks. These tests were reworked using the `CommandWatcher` so the new version focuses on what's in the Vite build output.

