### PR TITLE
New config module, warning message

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -605,20 +605,25 @@ export class CompatAppBuilder {
 
       // This is the default script provided by https://github.com/ember-cli/ember-cli/blob/master/lib/utilities/ember-app-utils.js#L84
       // When storeConfigInMeta is true, this content is always present in the config-module key of content-for.json
-      const defaultConfigModule = `var prefix = '${modulePrefix}';\ntry {\n  var metaName = prefix + '/config/environment';\n  var rawConfig = document.querySelector('meta[name=\"' + metaName + '\"]').getAttribute('content');\n  var config = JSON.parse(decodeURIComponent(rawConfig));\n\n  var exports = { 'default': config };\n\n  Object.defineProperty(exports, '__esModule', { value: true });\n\n  return exports;\n}\ncatch(err) {\n  throw new Error('Could not read config from meta tag with name \"' + metaName + '\".');\n}\n`;
+      const defaultConfigModule =
+        `var prefix = '${modulePrefix}';\ntry {\n  var metaName = prefix + '/config/environment';\n  var rawConfig = document.querySelector('meta[name=\"' + metaName + '\"]').getAttribute('content');\n  var config = JSON.parse(decodeURIComponent(rawConfig));\n\n  var exports = { 'default': config };\n\n  Object.defineProperty(exports, '__esModule', { value: true });\n\n  return exports;\n}\ncatch(err) {\n  throw new Error('Could not read config from meta tag with name \"' + metaName + '\".');\n}\n`.replace(
+          /\s/g,
+          ''
+        );
 
-      const diff = contentForConfig['/index.html']['config-module'].replace(defaultConfigModule, '');
+      const configModule = contentForConfig['/index.html']['config-module'];
+      const diff = configModule.replace(/\s/g, '').replace(defaultConfigModule, '');
 
       if (diff.length) {
-        console.warn(`
+        throw new Error(`
           Your app uses at least one classic addon that provides content-for 'config-module'. This is no longer supported.
-          In classic builds, the following code was included in the config via content-for 'config-module':
-
-          ${diff}
-
           With Embroider, you have full control over the config module, so classic addons no longer need to modify it under the hood.
-          If the code above is still required, you should add it to your ${this.compatApp.name}/app/environment.js.
-          Once the required code is moved, you can remove the present warning by setting "useAddonConfigModule" to false in the build options.
+          The following code is included via content-for 'config-module':
+
+          ${configModule}
+          
+          1. If you want to keep the same behavior, add it to the app/environment.js.
+          2. Once app/environment.js has the content you need, remove the present error by setting "useAddonConfigModule" to false in the build options.
         `);
       }
     }

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -599,22 +599,28 @@ export class CompatAppBuilder {
 
     // In addition to outputting content-for.json, we also want to check if content-for 'config-module' has a custom content.
     // If so, it means some classic addons used to provide this custom content, which is no longer supported.
-    let modulePrefix = this.configTree.readConfig().modulePrefix;
-    // This is the default script provided by https://github.com/ember-cli/ember-cli/blob/master/lib/utilities/ember-app-utils.js#L84
-    // When storeConfigInMeta is true, this content is always present in the config-module key of content-for.json
-    const defaultConfigModule = `var prefix = '${modulePrefix}';\ntry {\n  var metaName = prefix + '/config/environment';\n  var rawConfig = document.querySelector('meta[name=\"' + metaName + '\"]').getAttribute('content');\n  var config = JSON.parse(decodeURIComponent(rawConfig));\n\n  var exports = { 'default': config };\n\n  Object.defineProperty(exports, '__esModule', { value: true });\n\n  return exports;\n}\ncatch(err) {\n  throw new Error('Could not read config from meta tag with name \"' + metaName + '\".');\n}\n`;
-    const diff = contentForConfig['/index.html']['config-module'].replace(defaultConfigModule, '');
-    if (diff.length) {
-      console.warn(`
-        Your app uses at least one classic addon that provides content-for 'config-module'. This is no longer supported.
-        In classic builds, the following code was included in the config via content-for 'config-module':
+    // Developers can deactivate this check (and the subsequent warning) with useAddonConfigModule
+    if (this.compatApp.options.useAddonConfigModule) {
+      let modulePrefix = this.configTree.readConfig().modulePrefix;
 
-        ${diff}
+      // This is the default script provided by https://github.com/ember-cli/ember-cli/blob/master/lib/utilities/ember-app-utils.js#L84
+      // When storeConfigInMeta is true, this content is always present in the config-module key of content-for.json
+      const defaultConfigModule = `var prefix = '${modulePrefix}';\ntry {\n  var metaName = prefix + '/config/environment';\n  var rawConfig = document.querySelector('meta[name=\"' + metaName + '\"]').getAttribute('content');\n  var config = JSON.parse(decodeURIComponent(rawConfig));\n\n  var exports = { 'default': config };\n\n  Object.defineProperty(exports, '__esModule', { value: true });\n\n  return exports;\n}\ncatch(err) {\n  throw new Error('Could not read config from meta tag with name \"' + metaName + '\".');\n}\n`;
 
-        With Embroider, you have full control over the config module, so classic addons no longer need to modify it under the hood.
-        If the code above is still required, you should add it to your ${this.compatApp.name}/app/environment.js.
-        Once the required code is moved, you can remove the present warning by setting "useAddonConfigModule" to false in the build options.
-      `);
+      const diff = contentForConfig['/index.html']['config-module'].replace(defaultConfigModule, '');
+
+      if (diff.length) {
+        console.warn(`
+          Your app uses at least one classic addon that provides content-for 'config-module'. This is no longer supported.
+          In classic builds, the following code was included in the config via content-for 'config-module':
+
+          ${diff}
+
+          With Embroider, you have full control over the config module, so classic addons no longer need to modify it under the hood.
+          If the code above is still required, you should add it to your ${this.compatApp.name}/app/environment.js.
+          Once the required code is moved, you can remove the present warning by setting "useAddonConfigModule" to false in the build options.
+        `);
+      }
     }
   }
 

--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -108,6 +108,11 @@ export default interface Options extends CoreOptions {
   // switching to Embroider, but is no longer necessary once content-for
   // 'app-boot' code has been properly moved to the app-side.
   useAddonAppBoot?: boolean;
+
+  // content-for 'config-module'. This warning brings awareness for developers
+  // switching to Embroider, but is no longer necessary once content-for
+  // 'config-module' code has been properly moved to the app-side.
+  useAddonConfigModule?: boolean;
 }
 
 const defaults = Object.assign(coreWithDefaults(), {
@@ -121,6 +126,7 @@ const defaults = Object.assign(coreWithDefaults(), {
   allowUnsafeDynamicComponents: false,
   availableContentForTypes: [],
   useAddonAppBoot: true,
+  useAddonConfigModule: true,
 });
 
 export function optionsWithDefaults(options?: Options): Required<Options> {

--- a/tests/fixtures/macro-sample-addon/ember-cli-build.js
+++ b/tests/fixtures/macro-sample-addon/ember-cli-build.js
@@ -17,6 +17,7 @@ module.exports = function(defaults) {
 
   return maybeEmbroider(app, {
     useAddonAppBoot: false,
+    useAddonConfigModule: false,
     skipBabel: [
       {
         package: 'qunit',

--- a/tests/fixtures/macro-test/ember-cli-build.js
+++ b/tests/fixtures/macro-test/ember-cli-build.js
@@ -44,5 +44,6 @@ module.exports = function (defaults) {
 
   return maybeEmbroider(app, {
     useAddonAppBoot: false,
+    useAddonConfigModule: false,
   });
 };

--- a/tests/scenarios/macro-test.ts
+++ b/tests/scenarios/macro-test.ts
@@ -297,6 +297,7 @@ dummyAppScenarios
         module.exports = function(defaults) {
           let app = new EmberAddon(defaults, {});
           return maybeEmbroider(app, {
+            useAddonConfigModule: false,
             useAddonAppBoot: true,
           });
         };
@@ -317,6 +318,43 @@ dummyAppScenarios
         assert.true(
           result.output.includes(`Your app uses at least one classic addon that provides content-for 'app-boot'.`),
           'the output contains the error message about migrating custom app-boot code'
+        );
+      });
+    });
+  });
+
+dummyAppScenarios
+  .map('macro-sample-addon-useAddonConfigModule', project => {
+    dummyAppScenarioSetup(project);
+    project.mergeFiles({
+      'ember-cli-build.js': `
+        'use strict';
+        const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+        const { maybeEmbroider } = require('@embroider/test-setup');
+        module.exports = function(defaults) {
+          let app = new EmberAddon(defaults, {});
+          return maybeEmbroider(app, {
+            useAddonConfigModule: true,
+            useAddonAppBoot: false,
+          });
+        };
+      `,
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let addon: PreparedApp;
+
+      hooks.before(async () => {
+        addon = await scenario.prepare();
+      });
+
+      test(`pnpm test`, async function (assert) {
+        let result = await addon.execute('pnpm test');
+        assert.equal(result.exitCode, 1, 'tests exit with errors');
+        assert.true(
+          result.output.includes(`Your app uses at least one classic addon that provides content-for 'config-module'.`),
+          'the output contains the error message about migrating custom config-module code'
         );
       });
     });


### PR DESCRIPTION
Content for "app-boot" and content for "config-module" follow more or less the same pattern. Classic addons could provide custom behaviors for it using the `contentFor` hook.

When we implemented the new app-boot (#1957), we decided to trigger [a build error](https://github.com/embroider-build/embroider/pull/1957/commits/98457db97bc6735ae95a25a4668c32fc0abb8127) when classic addons provide content for "app-boot". This way, developers are notified what app-boot code no longer executes and can update their app the way they want before deactivating the error.

But when we first implemented the new config module, we didn't introduce such an informative message. This PR is a proposal to do the same. 