### PR TITLE
Address these issues in new apps (5.9):

### DIFF
--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -88,9 +88,13 @@ export function makeFirstTransform(opts: FirstTransformParams) {
           if (node.path.type !== 'PathExpression') {
             return;
           }
-          if (inScope(scopeStack, node.path.parts[0])) {
+
+          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
+
+          if (inScope(scopeStack, head)) {
             return;
           }
+
           if (node.path.original === 'macroGetOwnConfig') {
             return literal(
               getConfig(node, opts.configs, opts.packageRoot, moduleName, true, packageCache),
@@ -120,7 +124,10 @@ export function makeFirstTransform(opts: FirstTransformParams) {
           if (node.path.type !== 'PathExpression') {
             return;
           }
-          if (inScope(scopeStack, node.path.parts[0])) {
+
+          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
+
+          if (inScope(scopeStack, head)) {
             return;
           }
           if (node.path.original === 'macroGetOwnConfig') {
@@ -166,7 +173,7 @@ export function makeSecondTransform() {
       name: '@embroider/macros/second',
 
       visitor: {
-        Program: {
+        Block: {
           enter(node: any) {
             if (node.blockParams.length > 0) {
               scopeStack.push(node.blockParams);
@@ -182,7 +189,10 @@ export function makeSecondTransform() {
           if (node.path.type !== 'PathExpression') {
             return;
           }
-          if (inScope(scopeStack, node.path.parts[0])) {
+
+          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
+
+          if (inScope(scopeStack, head)) {
             return;
           }
           if (node.path.original === 'if') {
@@ -196,7 +206,10 @@ export function makeSecondTransform() {
           if (node.path.type !== 'PathExpression') {
             return;
           }
-          if (inScope(scopeStack, node.path.parts[0])) {
+
+          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
+
+          if (inScope(scopeStack, head)) {
             return;
           }
           if (node.path.original === 'if') {
@@ -234,7 +247,10 @@ export function makeSecondTransform() {
             if (modifier.path.type !== 'PathExpression') {
               return true;
             }
-            if (inScope(scopeStack, modifier.path.parts[0])) {
+
+            let head = 'head' in node.path ? node.path.head : node.path.parts[0];
+
+            if (inScope(scopeStack, head)) {
               return true;
             }
             if (modifier.path.original === 'macroMaybeAttrs') {
@@ -248,7 +264,10 @@ export function makeSecondTransform() {
           if (node.path.type !== 'PathExpression') {
             return;
           }
-          if (inScope(scopeStack, node.path.parts[0])) {
+
+          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
+
+          if (inScope(scopeStack, head)) {
             return;
           }
           if (node.path.original === 'if') {

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -72,7 +72,7 @@ export function makeFirstTransform(opts: FirstTransformParams) {
       name: '@embroider/macros/first',
 
       visitor: {
-        Block: {
+        Template: {
           enter(node: any) {
             if (node.blockParams.length > 0) {
               scopeStack.push(node.blockParams);
@@ -89,9 +89,7 @@ export function makeFirstTransform(opts: FirstTransformParams) {
             return;
           }
 
-          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
-
-          if (inScope(scopeStack, head)) {
+          if (inScope(scopeStack, headOf(node.path))) {
             return;
           }
 
@@ -125,9 +123,7 @@ export function makeFirstTransform(opts: FirstTransformParams) {
             return;
           }
 
-          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
-
-          if (inScope(scopeStack, head)) {
+          if (inScope(scopeStack, headOf(node.path))) {
             return;
           }
           if (node.path.original === 'macroGetOwnConfig') {
@@ -173,7 +169,7 @@ export function makeSecondTransform() {
       name: '@embroider/macros/second',
 
       visitor: {
-        Block: {
+        Template: {
           enter(node: any) {
             if (node.blockParams.length > 0) {
               scopeStack.push(node.blockParams);
@@ -190,9 +186,7 @@ export function makeSecondTransform() {
             return;
           }
 
-          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
-
-          if (inScope(scopeStack, head)) {
+          if (inScope(scopeStack, headOf(node.path))) {
             return;
           }
           if (node.path.original === 'if') {
@@ -207,9 +201,7 @@ export function makeSecondTransform() {
             return;
           }
 
-          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
-
-          if (inScope(scopeStack, head)) {
+          if (inScope(scopeStack, headOf(node.path))) {
             return;
           }
           if (node.path.original === 'if') {
@@ -248,9 +240,7 @@ export function makeSecondTransform() {
               return true;
             }
 
-            let head = 'head' in node.path ? node.path.head : node.path.parts[0];
-
-            if (inScope(scopeStack, head)) {
+            if (inScope(scopeStack, headOf(node.path))) {
               return true;
             }
             if (modifier.path.original === 'macroMaybeAttrs') {
@@ -265,9 +255,7 @@ export function makeSecondTransform() {
             return;
           }
 
-          let head = 'head' in node.path ? node.path.head : node.path.parts[0];
-
-          if (inScope(scopeStack, head)) {
+          if (inScope(scopeStack, headOf(node.path))) {
             return;
           }
           if (node.path.original === 'if') {
@@ -299,4 +287,10 @@ function inScope(scopeStack: string[][], name: string) {
     }
   }
   return false;
+}
+
+function headOf(path: any) {
+  if (!path) return;
+
+  return 'head' in path ? path.head : path.parts[0];
 }

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -72,7 +72,7 @@ export function makeFirstTransform(opts: FirstTransformParams) {
       name: '@embroider/macros/first',
 
       visitor: {
-        Template: {
+        [rootVisitorKey(env)]: {
           enter(node: any) {
             if (node.blockParams.length > 0) {
               scopeStack.push(node.blockParams);
@@ -169,7 +169,7 @@ export function makeSecondTransform() {
       name: '@embroider/macros/second',
 
       visitor: {
-        Template: {
+        [rootVisitorKey(env)]: {
           enter(node: any) {
             if (node.blockParams.length > 0) {
               scopeStack.push(node.blockParams);
@@ -293,4 +293,15 @@ function headOf(path: any) {
   if (!path) return;
 
   return 'head' in path ? path.head : path.parts[0];
+}
+
+/**
+ * Template is available in ember-source 3.17+
+ * Program is deprecated in ember-source 5.9+
+ */
+function rootVisitorKey(env: any) {
+  let hasTemplate = 'template' in env.syntax.builders;
+  let rootKey = hasTemplate ? 'Template' : 'Program';
+
+  return rootKey;
 }

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -72,7 +72,7 @@ export function makeFirstTransform(opts: FirstTransformParams) {
       name: '@embroider/macros/first',
 
       visitor: {
-        Program: {
+        Block: {
           enter(node: any) {
             if (node.blockParams.length > 0) {
               scopeStack.push(node.blockParams);


### PR DESCRIPTION
In a new 5.9 app, these deprecations occur

```
DEPRECATION: The parts property on path nodes is deprecated, use head and tail instead
DEPRECATION: The 'Program' visitor node is deprecated. Use 'Template' or 'Block' instead (node was 'Template')
DEPRECATION: The parts property on path nodes is deprecated, use head and tail instead
DEPRECATION: The 'Program' visitor node is deprecated. Use 'Template' or 'Block' instead (node was 'Template')
DEPRECATION: The 'Program' visitor node is deprecated. Use 'Template' or 'Block' instead (node was 'Template')
DEPRECATION: The 'Program' visitor node is deprecated. Use 'Template' or 'Block' instead (node was 'Template')
DEPRECATION: The 'Program' visitor node is deprecated. Use 'Template' or 'Block' instead (node was 'Template')
```

The goal of this PR is to get the deprecations down to 0.


The suggested fix is to change the `Program` visitor to either `Template` or `Block`.
and both of those have been around since glimmer-vm 0.39.0, which was: **2019, Jan 18**.
_after_ ember-source 3.7 :: **2019, Jan 7**
_before_ Octane Preview: ember-source 3.13 :: **2019, Sept 25**.
_but_, 0.39.0's changes weren't pulled in to ember-source until ember-source 3.17............ and using glimmer-vm 0.47.9 
- 3.17 using 0.47.9 @ **2020, Mar 4** https://github.com/emberjs/ember.js/blob/v3.17.0/package.json#L84
- 3.16 using 0.38.5-alpha.3 @ **2020, Jan 20** https://github.com/emberjs/ember.js/blob/v3.16.0/package.json#L82


`Program` is more closely analogous to `Template` which
- is introduced here: https://github.com/glimmerjs/glimmer-vm/blob/v0.39.0/packages/%40glimmer/syntax/lib/types/nodes.ts#L243
- doesn't exist in the version used by ember-source at the time: https://github.com/glimmerjs/glimmer-vm/blob/v0.38.5-alpha.3/packages/%40glimmer/syntax/lib/types/nodes.ts#L198

------------------------------------------

The node.path.parts vs node.path.head support is easy, because we have something that we can ask if its the new API or not.