### PR TITLE
Webpack: close the compiler

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -564,7 +564,16 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
               })
             );
           }
-          resolve(stats);
+          webpack.close(err => {
+            if (err) {
+              if (stats) {
+                this.consoleWrite(stats.toString());
+              }
+              throw err;
+            }
+
+            resolve(stats);
+          });
         } catch (e) {
           reject(e);
         }


### PR DESCRIPTION
We wanted to try webpack cache for our embroider-powered apps but it didn't work. After some investigation I realized that embroider does not close the compiler. Here's excerpt from the [doc about compiler usage](https://webpack.js.org/api/node/#run):

> Don't forget to close the compiler, so that low-priority work (like persistent caching) have the opportunity to complete.
