### PR TITLE
Support corepack's packageManager field 

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,11 +16,8 @@ runs:
       run: echo "auto-install-peers=false" > .npmrc
       if: inputs.use_pinned_node == 'false'
       shell: bash
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@v4
       name: Install pnpm
-      with:
-        version: 8
-        run_install: false
     - uses: actions/setup-node@v4
       with:
         node-version: 16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  VOLTA_FEATURE_PNPM: 1
-
 on:
   workflow_dispatch:
   schedule:

--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
       "unlabeled": ":question: Unlabeled"
     },
     "wildcardLabel": "unlabeled"
-  }
+  },
+  "packageManager": "pnpm@8.15.8+sha256.691fe176eea9a8a80df20e4976f3dfb44a04841ceb885638fe2a26174f81e65e"
 }


### PR DESCRIPTION
For users that have [corepack](https://nodejs.org/api/corepack.html) enabled, this will auto-install the version of pnpm that we expect. The Github action will respect this field as well, so we have a single source of truth.