### PR TITLE
Stop using "#with" in macro tests

### DIFF
--- a/packages/macros/tests/glimmer/get-config.test.ts
+++ b/packages/macros/tests/glimmer/get-config.test.ts
@@ -29,12 +29,12 @@ describe(`macroGetConfig`, function () {
     });
 
     test('macroGetOwnConfig in subexpression position', function () {
-      let code = transform(`{{#with (macroGetOwnConfig "mode") as |m|}}{{m}}{{/with}}`);
+      let code = transform(`{{#let (macroGetOwnConfig "mode") as |m|}}{{m}}{{/let}}`);
       expect(code).toMatch(/\{\{#with ["']amazing["'] as |m|\}\}/);
     });
 
     test('macroGetConfig in subexpression position', function () {
-      let code = transform(`{{#with (macroGetConfig "scenario-tester" "color") as |m|}}{{m}}{{/with}}`);
+      let code = transform(`{{#let (macroGetConfig "scenario-tester" "color") as |m|}}{{m}}{{/let}}`);
       expect(code).toMatch(/\{\{#with ["']orange["'] as |m|\}\}/);
     });
 

--- a/tests/fixtures/macro-test/tests/integration/components/common-test.js
+++ b/tests/fixtures/macro-test/tests/integration/components/common-test.js
@@ -7,7 +7,7 @@ module('Integration | Macro | common', function(hooks) {
   setupRenderingTest(hooks);
 
   test('our macros do not shadow local variables', async function(assert) {
-    await render(hbs`{{#with "hello" as |macroDependencySatisfies|}} {{macroDependencySatisfies}} {{/with}}`);
+    await render(hbs`{{#let "hello" as |macroDependencySatisfies|}} {{macroDependencySatisfies}} {{/let}}`);
     assert.equal(this.element.textContent.trim(), 'hello');
   });
 

--- a/tests/fixtures/macro-test/tests/integration/components/get-config-test.js
+++ b/tests/fixtures/macro-test/tests/integration/components/get-config-test.js
@@ -18,12 +18,12 @@ module('Integration | Macro | getConfig', function(hooks) {
   });
 
   test('macroGetOwnConfig in subexpression position', async function(assert) {
-    await render(hbs`{{#with (macroGetOwnConfig "mode") as |m|}}{{m}}{{/with}}`);
+    await render(hbs`{{#let (macroGetOwnConfig "mode") as |m|}}{{m}}{{/let}}`);
     assert.equal(this.element.textContent.trim(), 'amazing');
   });
 
   test('macroGetConfig in subexpression position', async function(assert) {
-    await render(hbs`{{#with (macroGetConfig "ember-source" "color") as |m|}}{{m}}{{/with}}`);
+    await render(hbs`{{#let (macroGetConfig "ember-source" "color") as |m|}}{{m}}{{/let}}`);
     assert.equal(this.element.textContent.trim(), 'orange');
   });
 

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -1158,8 +1158,8 @@ Scenarios.fromProject(() => new Project())
           'templates/application.hbs': `
         {{outlet}}
         {{yield bar}}
-        {{#with (hash submit=(action doit)) as |thing| }}
-        {{/with}}
+        {{#let (hash submit=(action doit)) as |thing| }}
+        {{/let}}
         <LinkTo @route="index"/>
         <form {{on "submit" doit}}></form>
       `,
@@ -1168,7 +1168,7 @@ Scenarios.fromProject(() => new Project())
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
         import { on } from "@ember/modifier";
-        export default precompileTemplate("\\n        {{outlet}}\\n        {{yield bar}}\\n        {{#with (hash submit=(action doit)) as |thing|}}\\n        {{/with}}\\n        <LinkTo @route=\\"index\\" />\\n        <form {{on \\"submit\\" doit}}></form>\\n      ", {
+        export default precompileTemplate("\\n        {{outlet}}\\n        {{yield bar}}\\n        {{#let (hash submit=(action doit)) as |thing|}}\\n        {{/let}}\\n        <LinkTo @route=\\"index\\" />\\n        <form {{on \\"submit\\" doit}}></form>\\n      ", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
             on,


### PR DESCRIPTION
This was dropped at ember 4.0 but [accidentally worked](https://github.com/emberjs/ember.js/issues/20694) until 5.9.