### PR TITLE
Revert "Webpack: close the compiler"

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -564,16 +564,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
               })
             );
           }
-          webpack.close(err => {
-            if (err) {
-              if (stats) {
-                this.consoleWrite(stats.toString());
-              }
-              throw err;
-            }
-
-            resolve(stats);
-          });
+          resolve(stats);
         } catch (e) {
           reject(e);
         }


### PR DESCRIPTION
Revert of #1971 #1978 

Sorry for causing trouble with this, but that change broke rebuild. Since embroider reuses the compiler for rebuilds we can't close it because otherwise rebuilds won't work.

Maybe it would be possible to close it when process is about to exit, to save the cache if we're running the regular build, but I don't want to complicate this.