### PR TITLE
narrow the audit exception for vite internals

### DIFF
--- a/packages/compat/src/audit/babel-visitor.ts
+++ b/packages/compat/src/audit/babel-visitor.ts
@@ -73,8 +73,8 @@ export function auditJS(rawSource: string, filename: string, babelConfig: Transf
             codeFrameIndex: saveCodeFrame(arg),
             specifiers: [],
           });
-        } else if (arg.type === 'BinaryExpression') {
-          // ignore binary expressions. Vite uses these (somehow) in the `@vite/client` import
+        } else if (arg.leadingComments?.find(c => /@vite-ignore/.test(c.value))) {
+          // this is vite internals that we should ignore too
         } else {
           problems.push({
             message: `audit tool is unable to understand this usage of ${


### PR DESCRIPTION
The binary expression vite's inserting is always marked by a special comment, so we can narrow this audit exception in order to not avoid other arbitrary binary expressions people might use.