### PR TITLE
Move rewritten app to ./tmp

### DIFF
--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -35,7 +35,7 @@ export default class CompatAddons implements Stage {
 
   async ready(): Promise<{ outputPath: string }> {
     return {
-      outputPath: resolve(locateEmbroiderWorkingDir(this.compatApp.root), 'rewritten-app'),
+      outputPath: resolve(this.compatApp.root, 'tmp', 'rewritten-app'),
     };
   }
 

--- a/packages/compat/src/compat-addons.ts
+++ b/packages/compat/src/compat-addons.ts
@@ -35,7 +35,7 @@ export default class CompatAddons implements Stage {
 
   async ready(): Promise<{ outputPath: string }> {
     return {
-      outputPath: resolve(this.compatApp.root, 'tmp', 'rewritten-app'),
+      outputPath: resolve(locateEmbroiderWorkingDir(this.compatApp.root), '..', '..', 'tmp', 'rewritten-app'),
     };
   }
 

--- a/packages/compat/src/standalone-addon-build.ts
+++ b/packages/compat/src/standalone-addon-build.ts
@@ -92,14 +92,14 @@ function buildAddonIndex(compatApp: CompatApp, appPackage: Package, packages: Se
   // yet. This directory lives outside our rewritten-pacakges directory because
   // it's produced by a separate build stage, and it's easier to have them
   // writing into separate directories.
-  content.packages[compatApp.root] = join('..', 'rewritten-app');
+  content.packages[compatApp.root] = join('..', '..', '..', 'tmp', 'rewritten-app');
 
   let nonResolvableDeps = appPackage.nonResolvableDeps;
   if (nonResolvableDeps) {
     let extraRoots = [...nonResolvableDeps.values()].map(v => v.root);
 
     // the app gets extraResolutions support just like every addon does
-    content.extraResolutions[join('..', 'rewritten-app')] = extraRoots;
+    content.extraResolutions[join('..', '..', '..', 'tmp', 'rewritten-app')] = extraRoots;
 
     // but it also gets extraResolutions registered against its *original*
     // location, because the app is unique because stage2 needs a Package

--- a/tests/addon-template/vite.config.mjs
+++ b/tests/addon-template/vite.config.mjs
@@ -12,7 +12,7 @@ import {
 import { resolve } from "path";
 import { babel } from "@rollup/plugin-babel";
 
-const root = "node_modules/.embroider/rewritten-app";
+const root = "tmp/rewritten-app";
 
 export default defineConfig(({ mode }) => {
   return {
@@ -43,7 +43,7 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 4200,
       watch: {
-        ignored: ["!**/node_modules/.embroider/rewritten-app/**"],
+        ignored: ["!**/tmp/rewritten-app/**"],
       },
     },
     // If the "app" is a classic addon dummy app, the public directory is tests/dummy/public,

--- a/tests/app-template/vite.config.mjs
+++ b/tests/app-template/vite.config.mjs
@@ -12,7 +12,7 @@ import {
 import { resolve } from "path";
 import { babel } from "@rollup/plugin-babel";
 
-const root = "node_modules/.embroider/rewritten-app";
+const root = "tmp/rewritten-app";
 
 export default defineConfig(({ mode }) => {
   return {
@@ -44,7 +44,7 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 4200,
       watch: {
-        ignored: ["!**/node_modules/.embroider/rewritten-app/**"],
+        ignored: ["!**/tmp/**"],
       },
     },
     build: {

--- a/tests/scenarios/compat-app-html-attributes-test.ts
+++ b/tests/scenarios/compat-app-html-attributes-test.ts
@@ -51,7 +51,7 @@ appScenarios
         let app = await scenario.prepare();
         let result = await app.execute('ember build', { env: { EMBROIDER_PREBUILD: 'true' } });
         assert.equal(result.exitCode, 0, result.output);
-        expectFile = expectFilesAt(join(app.dir, 'node_modules', '.embroider', 'rewritten-app'), { qunit: assert });
+        expectFile = expectFilesAt(join(app.dir, 'tmp', 'rewritten-app'), { qunit: assert });
       });
 
       test('custom HTML attributes are passed through', () => {

--- a/tests/scenarios/compat-exclude-dot-files-test.ts
+++ b/tests/scenarios/compat-exclude-dot-files-test.ts
@@ -74,7 +74,7 @@ appScenarios
 
         // but not be picked up in the entrypoint
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .withContents(content => {

--- a/tests/scenarios/compat-renaming-test.ts
+++ b/tests/scenarios/compat-renaming-test.ts
@@ -255,7 +255,7 @@ appScenarios
       });
       test('renamed modules keep their classic runtime name when used as implicit-modules', function () {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .resolves('./-embroider-implicit-modules.js')

--- a/tests/scenarios/compat-stage2-test.ts
+++ b/tests/scenarios/compat-stage2-test.ts
@@ -130,7 +130,7 @@ stage2Scenarios
 
         // check that the app trees with in repo addon are combined correctly
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .resolves('./service/in-repo.js')
@@ -140,7 +140,7 @@ stage2Scenarios
       test('incorporates in-repo-addons of in-repo-addons correctly', function () {
         // secondary in-repo-addon was correctly detected and activated
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .resolves('./services/secondary.js')
@@ -206,7 +206,7 @@ stage2Scenarios
 
       test('verifies that the correct lexigraphically sorted addons win', function () {
         let expectModule = expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule();
         expectModule.resolves('./service/in-repo.js').to('./lib/in-repo-b/_app_/service/in-repo.js');
@@ -216,7 +216,7 @@ stage2Scenarios
 
       test('addons declared as dependencies should win over devDependencies', function () {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .resolves('./service/dep-wins-over-dev.js')
@@ -225,7 +225,7 @@ stage2Scenarios
 
       test('in repo addons declared win over dependencies', function () {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .resolves('./service/in-repo-over-deps.js')
@@ -234,7 +234,7 @@ stage2Scenarios
 
       test('ordering with before specified', function () {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .resolves('./service/test-before.js')
@@ -243,7 +243,7 @@ stage2Scenarios
 
       test('ordering with after specified', function () {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .resolves('./service/test-after.js')
@@ -672,7 +672,7 @@ stage2Scenarios
 
       test('non-static other paths are included in the entrypoint', function (assert) {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .withContents(contents => {
@@ -696,7 +696,7 @@ stage2Scenarios
 
       test('static other paths are not included in the entrypoint', function () {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .withContents(content => {
@@ -706,7 +706,7 @@ stage2Scenarios
 
       test('top-level static other paths are not included in the entrypoint', function () {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .withContents(content => {
@@ -716,7 +716,7 @@ stage2Scenarios
 
       test('staticAppPaths do not match partial path segments', function () {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .withContents(content => {
@@ -788,9 +788,9 @@ dummyAppScenarios
       });
 
       test('dummy app sees that its being developed', function () {
-        let assertFile = expectFile(
-          '../../node_modules/.embroider/rewritten-app/components/inside-dummy-app.js'
-        ).transform(build.transpile);
+        let assertFile = expectFile('../../tmp/rewritten-app/components/inside-dummy-app.js').transform(
+          build.transpile
+        );
         assertFile.matches(/console\.log\(true\)/);
       });
 

--- a/tests/scenarios/compat-template-colocation-test.ts
+++ b/tests/scenarios/compat-template-colocation-test.ts
@@ -261,7 +261,7 @@ scenarios
 
       test(`app's colocated components are not implicitly included`, function (assert) {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .withContents(content => {
@@ -354,7 +354,7 @@ appScenarios
 
       test(`app's pod components and templates are implicitly included correctly`, function (assert) {
         expectAudit
-          .module('./node_modules/.embroider/rewritten-app/index.html')
+          .module('./tmp/rewritten-app/index.html')
           .resolves('/@embroider/core/entrypoint')
           .toModule()
           .withContents(content => {

--- a/tests/scenarios/watch-mode-test.ts
+++ b/tests/scenarios/watch-mode-test.ts
@@ -222,7 +222,7 @@ app.forEachScenario(scenario => {
 
       hooks.beforeEach(assert => {
         assertRewrittenFile = (rewrittenPath: string) => {
-          let fullPath = path.join(app.dir, 'node_modules', '.embroider', 'rewritten-app', ...rewrittenPath.split('/'));
+          let fullPath = path.join(app.dir, 'tmp', 'rewritten-app', ...rewrittenPath.split('/'));
           let file = new File(rewrittenPath, fullPath);
           return new AssertFile(assert, file);
         };

--- a/tests/ts-app-template-classic/vite.config.mjs
+++ b/tests/ts-app-template-classic/vite.config.mjs
@@ -3,7 +3,7 @@ import { resolver, hbs, scripts, templateTag, optimizeDeps, compatPrebuild, cont
 import { resolve } from 'path';
 import { babel } from '@rollup/plugin-babel';
 
-const root = 'node_modules/.embroider/rewritten-app';
+const root = 'tmp/rewritten-app';
 
 export default defineConfig({
   root,
@@ -32,7 +32,7 @@ export default defineConfig({
   server: {
     port: 4200,
     watch: {
-      ignored: ['!**/node_modules/.embroider/rewritten-app/**'],
+      ignored: ['!**/tmp/rewritten-app/**'],
     },
   },
   build: {

--- a/tests/ts-app-template/vite.config.mjs
+++ b/tests/ts-app-template/vite.config.mjs
@@ -3,7 +3,7 @@ import { resolver, hbs, scripts, templateTag, optimizeDeps, compatPrebuild, cont
 import { resolve } from 'path';
 import { babel } from '@rollup/plugin-babel';
 
-const root = 'node_modules/.embroider/rewritten-app';
+const root = 'tmp/rewritten-app';
 
 export default defineConfig({
   root,
@@ -32,7 +32,7 @@ export default defineConfig({
   server: {
     port: 4200,
     watch: {
-      ignored: ['!**/node_modules/.embroider/rewritten-app/**'],
+      ignored: ['!**/tmp/rewritten-app/**'],
     },
   },
   build: {


### PR DESCRIPTION
We're very close to eliminating the rewritten app, but vite's extremely loose `inNodeModules` behavior is breaking features that we need to use to actually get there. So we're moving the rewritten-app from `./node_modules/.embroider` to `./tmp`, since this path stops confusing vite.

The immediate motivation here was to get inline script tags working in index.html. If your index.html has the string `node_modules` anywhere in its path that vite feature breaks.