### PR TITLE
move adjust virtual import into own resolve hook

### DIFF
--- a/packages/vite/src/esbuild-resolver.ts
+++ b/packages/vite/src/esbuild-resolver.ts
@@ -69,7 +69,7 @@ export function esBuildResolver(root = process.cwd()): EsBuildPlugin {
       });
 
       build.onResolve({ filter: /./ }, async args => {
-        let { path, importer, namespace, resolveDir, kind  } = args;
+        let { path, importer, namespace, resolveDir, kind } = args;
         let { specifier, fromFile } = adjustVirtualImport(path, importer);
         if (specifier === path) {
           return null;
@@ -84,7 +84,7 @@ export function esBuildResolver(root = process.cwd()): EsBuildPlugin {
             embroiderExtensionSearch: true,
             embroider: {
               enableCustomResolver: false,
-            }
+            },
           },
         });
 
@@ -92,7 +92,7 @@ export function esBuildResolver(root = process.cwd()): EsBuildPlugin {
           return result;
         }
         return null;
-      })
+      });
 
       build.onLoad({ namespace: 'embroider', filter: /./ }, ({ path }) => {
         // We don't want esbuild to try loading virtual CSS files


### PR DESCRIPTION
adjustVirtualImport is still not good.
now its making the target file as base to create new from dir, but that doesnt work if the target file does not exist (e.g appJsMatch). addons importing app config file like `./config/environment`
