### PR TITLE
use pnpm to publish unstable

### DIFF
--- a/test-packages/unstable-release/publish.js
+++ b/test-packages/unstable-release/publish.js
@@ -10,7 +10,9 @@ async function publish() {
   for (let workspace of publicWorkspaces) {
     console.info(`Publishing ${workspace}`);
     try {
-      await execaCommand('npm publish --tag=unstable --verbose --access=public', { cwd: dirname(workspace) });
+      await execaCommand('pnpm publish --no-git-checks --tag=unstable --verbose --access=public', {
+        cwd: dirname(workspace),
+      });
     } catch (err) {
       console.info(`Publishing ${workspace} has failed. A full list of errors will be printed at the end of this run`);
       errors.push(err);

--- a/test-packages/unstable-release/version.js
+++ b/test-packages/unstable-release/version.js
@@ -17,12 +17,6 @@ async function updateVersions() {
     console.info(`Setting version of ${workspace}`);
     await setVersion(sha, workspace);
   }
-
-  // Update each dependency to use the new versions
-  for (let workspace of publicWorkspaces) {
-    console.info(`Updating dependencies of ${workspace}`);
-    await updateDependencies(workspace);
-  }
 }
 
 updateVersions();
@@ -41,26 +35,6 @@ async function setVersion(sha, filePath) {
   json.version = `${major}.${minor}.${parseInt(patch) + 1}-unstable.${sha}`;
 
   NEW_VERSIONS[json.name] = json.version;
-
-  await fse.writeJSON(filePath, json, { spaces: 2 });
-}
-
-async function updateDependencies(filePath) {
-  let json = await fse.readJSON(filePath);
-
-  for (let [dep, version] of Object.entries(NEW_VERSIONS)) {
-    if ((json.dependencies || {})[dep]) {
-      json.dependencies[dep] = version;
-    }
-
-    if ((json.devDependencies || {})[dep]) {
-      json.devDependencies[dep] = version;
-    }
-
-    if ((json.peerDependencies || {})[dep]) {
-      json.peerDependencies[dep] = version;
-    }
-  }
 
   await fse.writeJSON(filePath, json, { spaces: 2 });
 }


### PR DESCRIPTION
It looks like we're getting stung with https://github.com/npm/cli/issues/5007 when we're using npm to publish from this monorepo, so I'm going to swap it to pnpm for unstable 👍 

Edit: I tested this locally and I'm happy it's working as expected now 🎉 