### PR TITLE
Virtual entrypoint export modules

### DIFF
--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -181,7 +181,6 @@ import environment from './config/environment';
 
 {{#each amdModules as |amdModule index| ~}}
   import * as amdModule{{index}} from "{{js-string-escape amdModule.buildtime}}"
-  d("{{js-string-escape amdModule.runtime}}", function(){ return amdModule{{index}}; });
 {{/each}}
 
 {{#if fastbootOnlyAmdModules}}
@@ -226,6 +225,12 @@ w._embroiderEngineBundles_ = [
   {{/each}}
 ]
 {{/if}}
+
+export default {
+  {{#each amdModules as |amdModule index| ~}}
+    "{{js-string-escape amdModule.runtime}}": amdModule{{index}},
+  {{/each}}
+};
 `) as (params: {
   amdModules: { runtime: string; buildtime: string }[];
   fastbootOnlyAmdModules?: { runtime: string; buildtime: string }[];

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -168,12 +168,7 @@ import environment from './config/environment';
 
 {{#if defineModulesFrom ~}}
   import implicitModules from "{{js-string-escape defineModulesFrom}}";
-
-  for(const [name, module] of Object.entries(implicitModules)) {
-    d(name, function() { return module });
-  }
 {{/if}}
-
 
 {{#each eagerModules as |eagerModule| ~}}
   import "{{js-string-escape eagerModule}}";
@@ -226,11 +221,15 @@ w._embroiderEngineBundles_ = [
 ]
 {{/if}}
 
-export default {
-  {{#each amdModules as |amdModule index| ~}}
-    "{{js-string-escape amdModule.runtime}}": amdModule{{index}},
-  {{/each}}
-};
+export default Object.assign(
+  {},
+  {
+    {{#each amdModules as |amdModule index| ~}}
+      "{{js-string-escape amdModule.runtime}}": amdModule{{index}},
+    {{/each}}
+  },
+  implicitModules
+);
 `) as (params: {
   amdModules: { runtime: string; buildtime: string }[];
   fastbootOnlyAmdModules?: { runtime: string; buildtime: string }[];

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -152,8 +152,7 @@ export function renderEntrypoint(
 }
 
 const entryTemplate = compile(`
-import { importSync as i, macroCondition, getGlobalConfig } from '@embroider/macros';
-let w = window;
+import { macroCondition, getGlobalConfig } from '@embroider/macros';
 
 import environment from './config/environment';
 
@@ -197,7 +196,7 @@ let exportFastbootModules = {};
 
 
 {{#if lazyRoutes}}
-w._embroiderRouteBundles_ = [
+window._embroiderRouteBundles_ = [
   {{#each lazyRoutes as |route|}}
   {
     names: {{json-stringify route.names}},
@@ -210,7 +209,7 @@ w._embroiderRouteBundles_ = [
 {{/if}}
 
 {{#if lazyEngines}}
-w._embroiderEngineBundles_ = [
+window._embroiderEngineBundles_ = [
   {{#each lazyEngines as |engine|}}
   {
     names: {{json-stringify engine.names}},

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -154,7 +154,6 @@ export function renderEntrypoint(
 const entryTemplate = compile(`
 import { importSync as i, macroCondition, getGlobalConfig } from '@embroider/macros';
 let w = window;
-let d = w.define;
 
 import environment from './config/environment';
 
@@ -178,6 +177,8 @@ import environment from './config/environment';
   import * as amdModule{{index}} from "{{js-string-escape amdModule.buildtime}}"
 {{/each}}
 
+let exportFastbootModules = {};
+
 {{#if fastbootOnlyAmdModules}}
   if (macroCondition(getGlobalConfig().fastboot?.isRunning)) {
     let fastbootModules = {};
@@ -189,7 +190,7 @@ import environment from './config/environment';
     const resolvedValues = await Promise.all(Object.values(fastbootModules));
 
     Object.keys(fastbootModules).forEach((k, i) => {
-      d(k, function(){ return resolvedValues[i];});
+      exportFasbootModules[k] = resolvedValues[i];
     })
   }
 {{/if}}
@@ -223,12 +224,13 @@ w._embroiderEngineBundles_ = [
 
 export default Object.assign(
   {},
+  implicitModules,
   {
     {{#each amdModules as |amdModule index| ~}}
       "{{js-string-escape amdModule.runtime}}": amdModule{{index}},
     {{/each}}
   },
-  implicitModules
+  exportFastbootModules
 );
 `) as (params: {
   amdModules: { runtime: string; buildtime: string }[];

--- a/tests/addon-template/tests/dummy/app/app.js
+++ b/tests/addon-template/tests/dummy/app/app.js
@@ -1,9 +1,17 @@
 import Application from '@ember/application';
+import '@embroider/core/entrypoint';
+import coreModules from '@embroider/core/entrypoint';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'dummy/config/environment';
 
-import '@embroider/core/entrypoint';
+let d = window.define;
+
+for (const [name, module] of Object.entries(coreModules)) {
+  d(name, function () {
+    return module;
+  });
+}
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/tests/addon-template/tests/dummy/app/app.js
+++ b/tests/addon-template/tests/dummy/app/app.js
@@ -1,13 +1,12 @@
 import Application from '@ember/application';
-import '@embroider/core/entrypoint';
-import coreModules from '@embroider/core/entrypoint';
+import compatModules from '@embroider/core/entrypoint';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'dummy/config/environment';
 
 let d = window.define;
 
-for (const [name, module] of Object.entries(coreModules)) {
+for (const [name, module] of Object.entries(compatModules)) {
   d(name, function () {
     return module;
   });

--- a/tests/app-template/app/app.js
+++ b/tests/app-template/app/app.js
@@ -1,9 +1,17 @@
 import Application from '@ember/application';
+import '@embroider/core/entrypoint';
+import coreModules from '@embroider/core/entrypoint';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-import '@embroider/core/entrypoint';
+let d = window.define;
+
+for (const [name, module] of Object.entries(coreModules)) {
+  d(name, function () {
+    return module;
+  });
+}
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/tests/app-template/app/app.js
+++ b/tests/app-template/app/app.js
@@ -1,13 +1,12 @@
 import Application from '@ember/application';
-import '@embroider/core/entrypoint';
-import coreModules from '@embroider/core/entrypoint';
+import compatModules from '@embroider/core/entrypoint';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 let d = window.define;
 
-for (const [name, module] of Object.entries(coreModules)) {
+for (const [name, module] of Object.entries(compatModules)) {
   d(name, function () {
     return module;
   });

--- a/tests/scenarios/compat-stage2-test.ts
+++ b/tests/scenarios/compat-stage2-test.ts
@@ -246,33 +246,24 @@ stage2Scenarios
         expectModule.withContents(contents => {
           const result = /import \* as (\w+) from ".*in-repo-b\/_app_\/service\/in-repo.js.*/.exec(contents) ?? [];
           const [, amdModule] = result;
-          assert.codeContains(
-            contents,
-            `d("my-app/service/in-repo", function () {
-              return ${amdModule};
-            });`
+          assert.ok(
+            contents.includes(`"my-app/service/in-repo": ${amdModule}`),
+            'expected module is in the export list'
           );
           return true;
         }, 'module imports from the correct place');
         expectModule.withContents(contents => {
           const result = /import \* as (\w+) from ".*dep-b\/_app_\/service\/addon.js.*/.exec(contents) ?? [];
           const [, amdModule] = result;
-          assert.codeContains(
-            contents,
-            `d("my-app/service/addon", function () {
-              return ${amdModule};
-            });`
-          );
+          assert.ok(contents.includes(`"my-app/service/addon": ${amdModule}`), 'expected module is in the export list');
           return true;
         }, 'module imports from the correct place');
         expectModule.withContents(contents => {
           const result = /import \* as (\w+) from ".*dev-c\/_app_\/service\/dev-addon.js.*/.exec(contents) ?? [];
           const [, amdModule] = result;
-          assert.codeContains(
-            contents,
-            `d("my-app/service/dev-addon", function () {
-              return ${amdModule};
-            });`
+          assert.ok(
+            contents.includes(`"my-app/service/dev-addon": ${amdModule}`),
+            'expected module is in the export list'
           );
           return true;
         }, 'module imports from the correct place');
@@ -283,11 +274,9 @@ stage2Scenarios
           const result =
             /import \* as (\w+) from ".*dep-b\/_app_\/service\/dep-wins-over-dev.js.*/.exec(contents) ?? [];
           const [, amdModule] = result;
-          assert.codeContains(
-            contents,
-            `d("my-app/service/dep-wins-over-dev", function () {
-              return ${amdModule};
-            });`
+          assert.ok(
+            contents.includes(`"my-app/service/dep-wins-over-dev": ${amdModule}`),
+            'expected module is in the export list'
           );
           return true;
         });
@@ -298,11 +287,9 @@ stage2Scenarios
           const result =
             /import \* as (\w+) from ".*in-repo-a\/_app_\/service\/in-repo-over-deps.js.*/.exec(contents) ?? [];
           const [, amdModule] = result;
-          assert.codeContains(
-            contents,
-            `d("my-app/service/in-repo-over-deps", function () {
-              return ${amdModule};
-            });`
+          assert.ok(
+            contents.includes(`"my-app/service/in-repo-over-deps": ${amdModule}`),
+            'expected module is in the export list'
           );
           return true;
         });
@@ -312,11 +299,9 @@ stage2Scenarios
         resolveEntryPoint(expectAudit).withContents(contents => {
           const result = /import \* as (\w+) from ".*dev-d\/_app_\/service\/test-before.js.*/.exec(contents) ?? [];
           const [, amdModule] = result;
-          assert.codeContains(
-            contents,
-            `d("my-app/service/test-before", function () {
-              return ${amdModule};
-            });`
+          assert.ok(
+            contents.includes(`"my-app/service/test-before": ${amdModule}`),
+            'expected module is in the export list'
           );
           return true;
         });
@@ -326,11 +311,9 @@ stage2Scenarios
         resolveEntryPoint(expectAudit).withContents(contents => {
           const result = /import \* as (\w+) from ".*dev-b\/_app_\/service\/test-after.js.*/.exec(contents) ?? [];
           const [, amdModule] = result;
-          assert.codeContains(
-            contents,
-            `d("my-app/service/test-after", function () {
-              return ${amdModule};
-            });`
+          assert.ok(
+            contents.includes(`"my-app/service/test-after": ${amdModule}`),
+            'expected module is in the export list'
           );
           return true;
         });
@@ -845,12 +828,9 @@ stage2Scenarios
           }
 
           const [, amdModule] = result;
-
-          assert.codeContains(
-            contents,
-            `d("my-app/non-static-dir/another-library", function () {
-              return ${amdModule};
-            });`
+          assert.ok(
+            contents.includes(`"my-app/non-static-dir/another-library": ${amdModule}`),
+            'expected module is in the export list'
           );
           return true;
         });

--- a/tests/scenarios/compat-template-colocation-test.ts
+++ b/tests/scenarios/compat-template-colocation-test.ts
@@ -183,12 +183,9 @@ scenarios
           }
 
           const [, amdModule] = result;
-
-          assert.codeContains(
-            contents,
-            `d("my-app/components/has-colocated-template", function () {
-              return ${amdModule};
-            });`
+          assert.ok(
+            contents.includes(`"my-app/components/has-colocated-template": ${amdModule}`),
+            'expected module is in the export list'
           );
         });
       });
@@ -395,12 +392,9 @@ appScenarios
             }
 
             const [, podComponentAmd] = result;
-
-            assert.codeContains(
-              content,
-              `d("my-app/components/pod-component/component", function () {
-              return ${podComponentAmd};
-            });`
+            assert.ok(
+              content.includes(`"my-app/components/pod-component/component": ${podComponentAmd}`),
+              'expected module is in the export list'
             );
 
             result = /import \* as (\w+) from "\/components\/pod-component\/template\.hbs.*"/.exec(content);
@@ -410,12 +404,9 @@ appScenarios
             }
 
             const [, podComponentTemplateAmd] = result;
-
-            assert.codeContains(
-              content,
-              `d("my-app/components/pod-component/template", function () {
-              return ${podComponentTemplateAmd};
-            });`
+            assert.ok(
+              content.includes(`"my-app/components/pod-component/template": ${podComponentTemplateAmd}`),
+              'expected module is in the export list'
             );
 
             result = /import \* as (\w+) from "\/components\/template-only\/template\.hbs.*"/.exec(content);
@@ -425,12 +416,9 @@ appScenarios
             }
 
             const [, templateOnlyAmd] = result;
-
-            assert.codeContains(
-              content,
-              `d("my-app/components/template-only/template", function () {
-                return ${templateOnlyAmd};
-              });`
+            assert.ok(
+              content.includes(`"my-app/components/template-only/template": ${templateOnlyAmd}`),
+              'expected module is in the export list'
             );
 
             return true;

--- a/tests/ts-app-template/app/app.ts
+++ b/tests/ts-app-template/app/app.ts
@@ -1,9 +1,19 @@
 import Application from '@ember/application';
+import '@embroider/core/entrypoint';
+// @ts-ignore
+import coreModules from '@embroider/core/entrypoint';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'ts-app-template/config/environment';
 
-import '@embroider/core/entrypoint';
+// @ts-ignore
+let d = window.define;
+
+for (const [name, module] of Object.entries(coreModules)) {
+  d(name, function () {
+    return module;
+  });
+}
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/tests/ts-app-template/app/app.ts
+++ b/tests/ts-app-template/app/app.ts
@@ -1,7 +1,6 @@
 import Application from '@ember/application';
-import '@embroider/core/entrypoint';
 // @ts-ignore
-import coreModules from '@embroider/core/entrypoint';
+import compatModules from '@embroider/core/entrypoint';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'ts-app-template/config/environment';
@@ -9,7 +8,7 @@ import config from 'ts-app-template/config/environment';
 // @ts-ignore
 let d = window.define;
 
-for (const [name, module] of Object.entries(coreModules)) {
+for (const [name, module] of Object.entries(compatModules)) {
   d(name, function () {
     return module;
   });

--- a/tests/ts-app-template/app/app.ts
+++ b/tests/ts-app-template/app/app.ts
@@ -1,11 +1,9 @@
 import Application from '@ember/application';
-// @ts-ignore
 import compatModules from '@embroider/core/entrypoint';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'ts-app-template/config/environment';
 
-// @ts-ignore
 let d = window.define;
 
 for (const [name, module] of Object.entries(compatModules)) {

--- a/tests/ts-app-template/types/global.d.ts
+++ b/tests/ts-app-template/types/global.d.ts
@@ -1,1 +1,7 @@
 import '@glint/environment-ember-loose';
+
+declare global {
+  interface Window {
+    define: any;
+  }
+}

--- a/tests/ts-app-template/types/ts-app-template/entry.d.ts
+++ b/tests/ts-app-template/types/ts-app-template/entry.d.ts
@@ -1,0 +1,1 @@
+declare module '@embroider/core/entrypoint';


### PR DESCRIPTION
This PR follows #1957 and fixes #1960. It implements the second part of the issue:

> We don't want Embroider to rely on `define`. Using this method should rather be an implementation detail that belongs to the Ember app. Instead of _defining_ modules directly in the `entrypoint.js`, we would prefer this file to export modules, then the Ember app imports these modules and owns the `define` implementation.

- It moves the module definition from Embroider internals to the Ember `app.js`
- All modules to define now constitute the virtual `entrypoint.js` default export.
