### PR TITLE
Fix v1 app self import

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1223,7 +1223,7 @@ export class Resolver {
       }
       if (!entry) {
         throw new Error(
-          `A module tried to resolve "${request.specifier}" and didn't find it (${label}).
+          `[${request.debugType}] A module tried to resolve "${request.specifier}" and didn't find it (${label}).
 
  - Maybe a dependency declaration is missing?
  - Remember that v1 addons can only import non-Ember-addon NPM dependencies if they include ember-auto-import in their dependencies.

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1007,15 +1007,21 @@ export class Resolver {
         // supported fancy package.json exports features so this direct mapping
         // to the root is always right.
 
-        // "my-package/foo" -> "./foo"
-        // "my-package" -> "./" (this can't be just "." because node's require.resolve doesn't reliable support that)
-        let selfImportPath = request.specifier === pkg.name ? './' : request.specifier.replace(pkg.name, '.');
+        // "my-app/foo" -> "./foo" from app's package.json
+        // "my-addon/foo" -> "my-addon/foo" from a package that's guaranteed to be able to resolve my-addon
 
-        return logTransition(
-          `v1 self-import`,
-          request,
-          request.alias(selfImportPath).rehome(resolve(pkg.root, 'package.json'))
-        );
+        let owningEngine = this.owningEngine(pkg);
+        let addonConfig = owningEngine.activeAddons.find(a => a.root === pkg.root);
+        if (addonConfig) {
+          return logTransition(`v1 addon self-import`, request, request.rehome(addonConfig.canResolveFromFile));
+        } else {
+          let selfImportPath = request.specifier === pkg.name ? './' : request.specifier.replace(pkg.name, '.');
+          return logTransition(
+            `v1 app self-import`,
+            request,
+            request.alias(selfImportPath).rehome(resolve(pkg.root, 'package.json'))
+          );
+        }
       } else {
         // v2 packages are supposed to use package.json `exports` to enable
         // self-imports, but not all build tools actually follow the spec. This

--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -16,7 +16,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
       return;
     }
 
-    if (source && importer && source[0] !== '\0') {
+    if (source && importer && source[0] !== '\0' && !source.startsWith('virtual-module:')) {
       let fromFile = cleanUrl(importer);
       return new EsBuildModuleRequest(
         context,


### PR DESCRIPTION
This pulls the fixes out of https://github.com/embroider-build/embroider/pull/1997 that we know will fix a lot of people using vite. I'm not merging https://github.com/embroider-build/embroider/pull/1997 yet because it adds a test that will still fail because the work hasn't gone far enough

I don't want to block these fixes on solving the harder issues