### PR TITLE
Empty packages as valid v2 addons

### DIFF
--- a/packages/compat/src/empty-package-tree.ts
+++ b/packages/compat/src/empty-package-tree.ts
@@ -18,6 +18,12 @@ export default class extends Plugin {
       writeJSONSync(join(this.outputPath, 'package.json'), {
         name: this.originalPackage.name,
         version: this.originalPackage.version,
+        keywords: ['ember-addon'],
+        'ember-addon': {
+          version: 2,
+          type: 'addon',
+          'auto-upgraded': true,
+        },
         '//': 'This empty package was created by embroider. See https://github.com/embroider-build/embroider/blob/main/docs/empty-package-output.md',
       });
     }


### PR DESCRIPTION
The issue was initially raised by #1931.

**Problem**

In tests relying on ember-data 4.4, the rewritten-packages contain multiple copies of @ember-data/store. Only one copy has content, the others are empty. The only copy having content is the only "active" package.

During the build process, we expect requests for the empty packages to resolve to the corresponding "active" package; but instead, they resolved to the empty copy, which triggered a build error.

**Cause** 

This was because when the core module-resolver handles an empty package, it returns before the rehoming to the active package can happen. The condition that triggered the return was: `if (!pck.isV2Addon()) return /* ... */`: in other words, empty packages generated by the `EmptyPackageTree` plugin are not valid v2 addons, causing the module-resolver to give an unexpected answer.

**Solution** 

This PR changes the `EmptyPackageTree` plugin to add more information in the `package.json` of the empty package: it now has the keys that identify a package as a valid v2 package.

Once the module-resolver  recognizes an empty package as a valid v2 package, it continues the execution until it rehomes the request and resolve to the active package.