### PR TITLE
Remove deprecations warnings in resolver transform

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -777,7 +777,7 @@ class TemplateResolver implements ASTPlugin {
       if (node.path.type !== 'PathExpression') {
         return;
       }
-      let rootName = node.path.parts[0];
+      let rootName = headOf(node.path);
       if (this.scopeStack.inScope(rootName, path)) {
         return;
       }
@@ -819,7 +819,7 @@ class TemplateResolver implements ASTPlugin {
       if (node.path.this === true) {
         return;
       }
-      if (this.scopeStack.inScope(node.path.parts[0], path)) {
+      if (this.scopeStack.inScope(headOf(node.path), path)) {
         return;
       }
       if (node.path.original === 'component' && node.params.length > 0) {
@@ -855,7 +855,7 @@ class TemplateResolver implements ASTPlugin {
         if (node.path.type !== 'PathExpression') {
           return;
         }
-        let rootName = node.path.parts[0];
+        let rootName = headOf(node.path);
         if (this.scopeStack.inScope(rootName, path)) {
           return;
         }
@@ -917,7 +917,7 @@ class TemplateResolver implements ASTPlugin {
       if (node.path.type !== 'PathExpression') {
         return;
       }
-      if (this.scopeStack.inScope(node.path.parts[0], path)) {
+      if (this.scopeStack.inScope(headOf(node.path), path)) {
         return;
       }
       if (node.path.this === true) {
@@ -1156,4 +1156,10 @@ function appendArrays(objValue: any, srcValue: any) {
   if (Array.isArray(objValue)) {
     return objValue.concat(srcValue);
   }
+}
+
+function headOf(path: any) {
+  if (!path) return;
+
+  return 'head' in path ? path.head.name : path.parts[0];
 }

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -781,7 +781,7 @@ class TemplateResolver implements ASTPlugin {
       if (this.scopeStack.inScope(rootName, path)) {
         return;
       }
-      if (node.path.this === true) {
+      if (isThisHead(node.path)) {
         return;
       }
       if (node.path.parts.length > 1) {
@@ -816,7 +816,7 @@ class TemplateResolver implements ASTPlugin {
       if (node.path.type !== 'PathExpression') {
         return;
       }
-      if (node.path.this === true) {
+      if (isThisHead(node.path)) {
         return;
       }
       if (this.scopeStack.inScope(headOf(node.path), path)) {
@@ -859,7 +859,7 @@ class TemplateResolver implements ASTPlugin {
         if (this.scopeStack.inScope(rootName, path)) {
           return;
         }
-        if (node.path.this === true) {
+        if (isThisHead(node.path)) {
           return;
         }
         if (node.path.parts.length > 1) {
@@ -920,7 +920,7 @@ class TemplateResolver implements ASTPlugin {
       if (this.scopeStack.inScope(headOf(node.path), path)) {
         return;
       }
-      if (node.path.this === true) {
+      if (isThisHead(node.path)) {
         return;
       }
       if (node.path.data === true) {
@@ -1162,4 +1162,14 @@ function headOf(path: any) {
   if (!path) return;
 
   return 'head' in path ? path.head.name : path.parts[0];
+}
+
+function isThisHead(path: any) {
+  if (!path) return;
+
+  if ('head' in path) {
+    return path.head.type === 'ThisHead';
+  }
+
+  return path.this === true;
 }

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -923,7 +923,7 @@ class TemplateResolver implements ASTPlugin {
       if (isThisHead(node.path)) {
         return;
       }
-      if (node.path.data === true) {
+      if (isAtHead(node.path)) {
         return;
       }
       if (node.path.parts.length > 1) {
@@ -1172,4 +1172,14 @@ function isThisHead(path: any) {
   }
 
   return path.this === true;
+}
+
+function isAtHead(path: any) {
+  if (!path) return;
+
+  if ('head' in path) {
+    return path.head.type === 'AtHead';
+  }
+
+  return path.data === true;
 }

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -784,7 +784,7 @@ class TemplateResolver implements ASTPlugin {
       if (isThisHead(node.path)) {
         return;
       }
-      if (node.path.parts.length > 1) {
+      if (parts(node.path).length > 1) {
         // paths with a dot in them (which therefore split into more than
         // one "part") are classically understood by ember to be contextual
         // components, which means there's nothing to resolve at this
@@ -862,7 +862,7 @@ class TemplateResolver implements ASTPlugin {
         if (isThisHead(node.path)) {
           return;
         }
-        if (node.path.parts.length > 1) {
+        if (parts(node.path).length > 1) {
           // paths with a dot in them (which therefore split into more than
           // one "part") are classically understood by ember to be contextual
           // components, which means there's nothing to resolve at this
@@ -926,7 +926,7 @@ class TemplateResolver implements ASTPlugin {
       if (isAtHead(node.path)) {
         return;
       }
-      if (node.path.parts.length > 1) {
+      if (parts(node.path).length > 1) {
         // paths with a dot in them (which therefore split into more than
         // one "part") are classically understood by ember to be contextual
         // components. With the introduction of `Template strict mode` in Ember 3.25
@@ -1182,4 +1182,10 @@ function isAtHead(path: any) {
   }
 
   return path.data === true;
+}
+
+function parts(path: any) {
+  if (!path) return;
+
+  return 'original' in path ? path.original.split('.') : path.parts;
 }


### PR DESCRIPTION
Since ember v5.9 there are deprecation warnings while build

```
DEPRECATION: The this property on path nodes is deprecated, use head.type instead
DEPRECATION: The parts property on path nodes is deprecated, use head and tail instead
```

As described in https://github.com/embroider-build/embroider/pull/1967#issuecomment-2207031045, we should replace all `.parts` and `.this` with non deprecated code.

fix #2031