### PR TITLE
Revert "Add just the necessary files to rollup watch mode"

### DIFF
--- a/packages/addon-dev/package.json
+++ b/packages/addon-dev/package.json
@@ -25,6 +25,14 @@
   "scripts": {
     "test": "jest"
   },
+  "peerDependencies": {
+    "rollup": "^4.6.0"
+  },
+  "peerDependenciesMeta": {
+    "rollup": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@embroider/core": "workspace:^",
     "@rollup/pluginutils": "^4.1.1",

--- a/packages/addon-dev/package.json
+++ b/packages/addon-dev/package.json
@@ -25,14 +25,6 @@
   "scripts": {
     "test": "jest"
   },
-  "peerDependencies": {
-    "rollup": "^4.6.0"
-  },
-  "peerDependenciesMeta": {
-    "rollup": {
-      "optional": true
-    }
-  },
   "dependencies": {
     "@embroider/core": "workspace:^",
     "@rollup/pluginutils": "^4.1.1",

--- a/packages/addon-dev/src/rollup-keep-assets.ts
+++ b/packages/addon-dev/src/rollup-keep-assets.ts
@@ -14,6 +14,12 @@ export default function keepAssets({
   return {
     name: 'copy-assets',
 
+    // Prior to https://github.com/rollup/rollup/pull/5270, we cannot call this
+    // from within `generateBundle`
+    buildStart() {
+      this.addWatchFile(from);
+    },
+
     // imports of assets should be left alone in the source code. This can cover
     // the case of .css as defined in the embroider v2 addon spec.
     async resolveId(source, importer, options) {
@@ -38,8 +44,6 @@ export default function keepAssets({
         globs: include,
         directories: false,
       })) {
-        this.addWatchFile(join(from, name));
-
         this.emitFile({
           type: 'asset',
           fileName: name,

--- a/packages/addon-dev/src/rollup-public-entrypoints.ts
+++ b/packages/addon-dev/src/rollup-public-entrypoints.ts
@@ -16,14 +16,14 @@ export default function publicEntrypoints(args: {
   return {
     name: 'addon-modules',
     async buildStart() {
+      this.addWatchFile(args.srcDir);
+
       let matches = walkSync(args.srcDir, {
         globs: [...args.include, '**/*.hbs', '**/*.ts', '**/*.gts', '**/*.gjs'],
         ignore: args.exclude,
       });
 
       for (let name of matches) {
-        this.addWatchFile(path.join(args.srcDir, name));
-
         // the matched file, but with the extension swapped with .js
         let normalizedName = normalizeFileExt(name);
 


### PR DESCRIPTION
Reverts embroider-build/embroider#2007

this was not correct, now its not detecting new added files. This means rollup will not include any new files in the entrypoint.
I think the right solution would have been to either setup watch exlcude or watch include
https://rollupjs.org/configuration-options/#watch-exclude

and was giving me a headache why #1855 was suddenly failing after merging stable...