### PR TITLE
add missing resolve extension config to other vite.config files

### DIFF
--- a/tests/addon-template/vite.config.mjs
+++ b/tests/addon-template/vite.config.mjs
@@ -20,6 +20,18 @@ export default defineConfig(({ mode }) => {
     // esbuild in vite does not support decorators
     esbuild: false,
     cacheDir: resolve("node_modules", ".vite"),
+    resolve: {
+      extensions: [
+        ".mjs",
+        ".gjs",
+        ".js",
+        ".mts",
+        ".gts",
+        ".ts",
+        ".hbs",
+        ".json",
+      ],
+    },
     plugins: [
       hbs(),
       templateTag(),

--- a/tests/ts-app-template-classic/vite.config.mjs
+++ b/tests/ts-app-template-classic/vite.config.mjs
@@ -10,6 +10,10 @@ export default defineConfig({
   // esbuild in vite does not support decorators
   esbuild: false,
   cacheDir: resolve('node_modules', '.vite'),
+  resolve: {
+    extensions: ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.json'],
+  },
+
   plugins: [
     hbs(),
     templateTag(),

--- a/tests/ts-app-template/vite.config.mjs
+++ b/tests/ts-app-template/vite.config.mjs
@@ -10,6 +10,10 @@ export default defineConfig({
   // esbuild in vite does not support decorators
   esbuild: false,
   cacheDir: resolve('node_modules', '.vite'),
+  resolve: {
+    extensions: ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.json'],
+  },
+
   plugins: [
     hbs(),
     templateTag(),


### PR DESCRIPTION
Note: this PR is targeting the branch for https://github.com/embroider-build/embroider/pull/2029

In https://github.com/embroider-build/embroider/pull/2029 we now 100% rely on the vite config for finding extra extension searching, this PR just adds the missing config to the other vite config files in the test scenarios 👍 