### PR TITLE
Add semver to power select with create

### DIFF
--- a/packages/compat/src/addon-dependency-rules/ember-power-select-with-create.ts
+++ b/packages/compat/src/addon-dependency-rules/ember-power-select-with-create.ts
@@ -3,6 +3,7 @@ import type { PackageRules } from '..';
 const rules: PackageRules[] = [
   {
     package: 'ember-power-select-with-create',
+    semverRange: '<3.0.0',
     components: {
       '<PowerSelectWithCreate/>': {
         acceptsComponentArguments: ['powerSelectComponentName', 'suggestedOptionComponent'],


### PR DESCRIPTION
As we have shipped `ember-power-select-with-create` as a v2 addon, the custom rule should not anymore necessary beginning with version v3

See release https://github.com/cibernox/ember-power-select-with-create/releases/tag/v3.0.0