### PR TITLE
Fix windows tests

### DIFF
--- a/packages/shared-internals/src/paths.ts
+++ b/packages/shared-internals/src/paths.ts
@@ -12,7 +12,7 @@ export function explicitRelative(fromDir: string, toFile: string) {
   if (!isAbsolute(result) && !result.startsWith('.')) {
     result = './' + result;
   }
-  if (isAbsolute(toFile) && result.endsWith(toFile)) {
+  if (isAbsolute(toFile) && result.split(sep).join('/').endsWith(toFile)) {
     // this prevents silly "relative" paths like
     // "../../../../../Users/you/projects/your/stuff" when we could have just
     // said "/Users/you/projects/your/stuff". The silly path isn't incorrect,

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -1,6 +1,6 @@
 import type { AddonMeta, AppMeta, RewrittenPackageIndex } from '@embroider/shared-internals';
 import { outputFileSync, readJsonSync, writeJSONSync } from 'fs-extra';
-import { resolve, sep } from 'path';
+import { resolve } from 'path';
 import QUnit from 'qunit';
 import type { PreparedApp } from 'scenario-tester';
 import { Project, Scenarios } from 'scenario-tester';
@@ -616,7 +616,7 @@ Scenarios.fromProject(() => new Project())
             'app.js': `import "rsvp"`,
           });
           await configure({});
-          expectAudit.module('./app.js').resolves('rsvp').to(resolve('/@embroider/ext-cjs/rsvp').split(sep).join('/'));
+          expectAudit.module('./app.js').resolves('rsvp').to('/@embroider/ext-cjs/rsvp');
         });
 
         test(`known ember-source-provided virtual packages are not externalized when explicitly included in deps`, async function () {


### PR DESCRIPTION
It turns out that explicitRelative doesn't work correctly on windows if we have a simple endsWith check 🙈 