### PR TITLE
Update ember standard modules to include @ember/renderer and @ember/-internals and ember-testing

### DIFF
--- a/packages/shared-internals/src/ember-standard-modules.ts
+++ b/packages/shared-internals/src/ember-standard-modules.ts
@@ -45,6 +45,13 @@ emberVirtualPeerDeps.add('ember-source');
 // the modules-api-polyfill. Newer APIs need to be added here.
 emberVirtualPackages.add('@ember/owner');
 
+// Added in ember-source 4.5.0-beta.1
+emberVirtualPackages.add('@ember/renderer');
+
+// Not provided by rfc176-data, but is needed for special librarys
+// that know the dangers of importing private APIs
+emberVirtualPackages.add('@ember/-internals');
+
 // these are not public API but they're included in ember-source, so for
 // correctness we still want to understand that they come from there.
 emberVirtualPackages.add('@glimmer/validator');

--- a/packages/shared-internals/src/ember-standard-modules.ts
+++ b/packages/shared-internals/src/ember-standard-modules.ts
@@ -31,6 +31,7 @@ emberVirtualPeerDeps.add('@ember/string');
 // (like snowpack) not to worry about these packages.
 emberVirtualPackages.add('@glimmer/env');
 emberVirtualPackages.add('ember');
+emberVirtualPackages.add('ember-testing');
 
 // this is a real package and even though most of its primary API is implemented
 // as transforms, it does include some runtime code.


### PR DESCRIPTION
Ran in to this over on `@ember/test-helpers` v4 -- https://github.com/emberjs/ember-test-helpers/pull/1486/commits/0631b497dea8585f5d097a22d90508b9acff9d92

We have an escape hatch for addons to use, but these modules should probably be defined here.

Docs:
- https://api.emberjs.com/ember/release/modules/@ember%2Frenderer
  - (tho, these are incomplete, because renderSettled comes from here)
