### PR TITLE
vite deps: correctly handle addon templates and addon app files

### DIFF
--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -90,11 +90,17 @@ appScenarios
         lib: {
           'app-lib-one.js': `
             globalThis.appLibOneLoaded = (globalThis.appLibOneLoaded ?? 0) + 1;
-            export default function() { return 'app-lib-one'; }
+            const localObject = {
+              message: 'app-lib-one'
+            };
+            export default function() { return localObject; }
           `,
           'app-lib-two.js': `
             globalThis.appLibTwoLoaded = (globalThis.appLibTwoLoaded ?? 0) + 1;
-            export default function() { return 'app-lib-two'; }
+            const localObject = {
+              message: 'app-lib-two'
+            };
+            export default function() { return localObject; }
           `,
         },
       },


### PR DESCRIPTION
* makes external templates ignored
* optimised templates do not get a pairing
* hbs extension search during bundle 
* externalize app files during bundling 
  * since the request comes from a dep file we cannot know the original addon file. Which is why the from file will be encoded into the specifier.
  * This is required because the resolution can change during development 
* stage2 tests now correctly uses optmized deps