### PR TITLE
Hide base path from public URL of rollup-public-assets

### DIFF
--- a/packages/addon-dev/src/rollup-public-assets.ts
+++ b/packages/addon-dev/src/rollup-public-assets.ts
@@ -51,7 +51,7 @@ export default function publicAssets(
       });
       const publicAssets: Record<string, string> = filenames.reduce(
         (acc: Record<string, string>, v): Record<string, string> => {
-          const namespace = opts?.namespace ?? join(pkg.name, path);
+          const namespace = opts?.namespace ?? pkg.name;
 
           acc[`./${path}/${v}`] = resolve('/' + join(namespace, v));
           return acc;

--- a/tests/scenarios/v2-addon-dev-test.ts
+++ b/tests/scenarios/v2-addon-dev-test.ts
@@ -393,7 +393,7 @@ export { SingleFileComponent as default };
           let expectNoNamespaceFile = expectFilesAt(inDependency(app, 'v2-addon-no-namespace').dir, { qunit: assert });
 
           expectFile('package.json').json('ember-addon.public-assets').deepEquals({
-            './public/thing.txt': '/v2-addon/public/thing.txt',
+            './public/thing.txt': '/v2-addon/thing.txt',
           });
           expectNoNamespaceFile('package.json').json('ember-addon.public-assets').deepEquals({
             './public/other.txt': '/other.txt',


### PR DESCRIPTION
As discussed in yesterday's team meeting, after some previous back and forth and confusion around where breaking changes should go into (`main` vs. `stable`), this PR is applying the same (breaking!) change that landed in `main` (https://github.com/embroider-build/embroider/pull/1972) to stable, so we can get this published (as yet another new major unfortunately) without waiting for `main` to stabilize.

More context in https://github.com/embroider-build/embroider/pull/1697#issuecomment-2122890065...