### PR TITLE
Implement ember's component-template-resolving deprecation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
     "lodash": "^4.17.21",
     "resolve": "^1.20.0",
     "resolve-package-path": "^4.0.1",
+    "semver": "^7.3.5",
     "typescript-memoize": "^1.0.1",
     "walk-sync": "^3.0.0"
   },
@@ -59,6 +60,7 @@
     "@types/lodash": "^4.14.170",
     "@types/node": "^15.12.2",
     "@types/resolve": "^1.20.0",
+    "@types/semver": "^7.3.5",
     "@types/tmp": "^0.1.0",
     "fixturify": "^2.1.1",
     "tmp": "^0.1.0",

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -67,6 +67,22 @@ function renderESExternalShim({ moduleName, exports }: { moduleName: string; exp
 const pairedComponentShim = compile(`
 import { setComponentTemplate } from "@ember/component";
 import template from "{{{js-string-escape relativeHBSModule}}}";
+import { deprecate } from "@ember/debug";
+
+
+deprecate("Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup '{{debugName}}'.",
+  false, {
+    id: 'component-template-resolving',
+    url: 'https://deprecations.emberjs.com/id/component-template-resolving',
+    until: '6.0.0',
+    for: 'ember-source',
+    since: {
+      available: '5.10.0',
+      enabled: '5.10.0',
+    },
+  }
+);
+
 {{#if relativeJSModule}}
 import component from "{{{js-string-escape relativeJSModule}}}";
 export default setComponentTemplate(template, component);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
       resolve-package-path:
         specifier: ^4.0.1
         version: 4.0.3
+      semver:
+        specifier: ^7.3.5
+        version: 7.6.2
       typescript-memoize:
         specifier: ^1.0.1
         version: 1.1.1
@@ -467,6 +470,9 @@ importers:
       '@types/resolve':
         specifier: ^1.20.0
         version: 1.20.6
+      '@types/semver':
+        specifier: ^7.3.5
+        version: 7.5.8
       '@types/tmp':
         specifier: ^0.1.0
         version: 0.1.0
@@ -8899,9 +8905,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.16.0
 

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -13,6 +13,8 @@ const { module: Qmodule, test } = QUnit;
 
 Scenarios.fromProject(() => new Project())
   .map('core-resolver-test', app => {
+    app.linkDevDependency('ember-source', { baseDir: __dirname });
+
     let appMeta: AppMeta = {
       type: 'app',
       version: 2,
@@ -182,6 +184,21 @@ Scenarios.fromProject(() => new Project())
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
             import template from "../hello-world.hbs";
+            import { deprecate } from "@ember/debug";
+            deprecate(
+              "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'hello-world'.",
+              false,
+              {
+                id: "component-template-resolving",
+                url: "https://deprecations.emberjs.com/id/component-template-resolving",
+                until: "6.0.0",
+                for: "ember-source",
+                since: {
+                  available: "5.10.0",
+                  enabled: "5.10.0",
+                },
+              }
+            );
             import component from "../../../components/hello-world.js";
             export default setComponentTemplate(template, component);
           `);
@@ -206,6 +223,21 @@ Scenarios.fromProject(() => new Project())
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
             import template from "../hello-world.hbs";
+            import { deprecate } from "@ember/debug";
+            deprecate(
+              "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'hello-world'.",
+              false,
+              {
+                id: "component-template-resolving",
+                url: "https://deprecations.emberjs.com/id/component-template-resolving",
+                until: "6.0.0",
+                for: "ember-source",
+                since: {
+                  available: "5.10.0",
+                  enabled: "5.10.0",
+                },
+              }
+            );
             import templateOnlyComponent from "@ember/component/template-only";
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "hello-world"));
           `);
@@ -304,6 +336,21 @@ Scenarios.fromProject(() => new Project())
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
             import template from "../template.hbs";
+            import { deprecate } from "@ember/debug";
+            deprecate(
+              "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
+              false,
+              {
+                id: "component-template-resolving",
+                url: "https://deprecations.emberjs.com/id/component-template-resolving",
+                until: "6.0.0",
+                for: "ember-source",
+                since: {
+                  available: "5.10.0",
+                  enabled: "5.10.0",
+                },
+              }
+            );
             import templateOnlyComponent from "@ember/component/template-only";
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "template"));
           `);
@@ -327,6 +374,21 @@ Scenarios.fromProject(() => new Project())
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
             import template from "../template.hbs";
+            import { deprecate } from "@ember/debug";
+            deprecate(
+              "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
+              false,
+              {
+                id: "component-template-resolving",
+                url: "https://deprecations.emberjs.com/id/component-template-resolving",
+                until: "6.0.0",
+                for: "ember-source",
+                since: {
+                  available: "5.10.0",
+                  enabled: "5.10.0",
+                },
+              }
+            );
             import templateOnlyComponent from "@ember/component/template-only";
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "template"));
           `);
@@ -351,6 +413,21 @@ Scenarios.fromProject(() => new Project())
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
             import template from "../template.hbs";
+            import { deprecate } from "@ember/debug";
+            deprecate(
+              "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
+              false,
+              {
+                id: "component-template-resolving",
+                url: "https://deprecations.emberjs.com/id/component-template-resolving",
+                until: "6.0.0",
+                for: "ember-source",
+                since: {
+                  available: "5.10.0",
+                  enabled: "5.10.0",
+                },
+              }
+            );
             import component from "../component.js";
             export default setComponentTemplate(template, component);
           `);
@@ -376,6 +453,21 @@ Scenarios.fromProject(() => new Project())
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
             import template from "../template.hbs";
+            import { deprecate } from "@ember/debug";
+            deprecate(
+              "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
+              false,
+              {
+                id: "component-template-resolving",
+                url: "https://deprecations.emberjs.com/id/component-template-resolving",
+                until: "6.0.0",
+                for: "ember-source",
+                since: {
+                  available: "5.10.0",
+                  enabled: "5.10.0",
+                },
+              }
+            );
             import component from "../component.js";
             export default setComponentTemplate(template, component);
           `);


### PR DESCRIPTION
When using embroider with staticComponents enabled, users will never see Ember's [component-template-resolving](https://deprecations.emberjs.com/id/component-template-resolving/) deprecation, since Embroider takes care of implementing the whole feature at build time before Ember can see it at runtime.

This implements the same deprecation logic in Embroider apps so everybody can stay consistent.