### PR TITLE
Update test matrix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
       "babel-plugin-module-resolver@5.0.1": "5.0.0"
     },
     "patchedDependencies": {
-      "ember-source@5.8.0": "patches/ember-source@5.8.0.patch"
+      "ember-source@5.8.0": "patches/ember-source@5.8.0.patch",
+      "ember-source@5.11.0": "patches/ember-source@5.11.0.patch"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ overrides:
   babel-plugin-module-resolver@5.0.1: 5.0.0
 
 patchedDependencies:
+  ember-source@5.11.0:
+    hash: bo72463n2ws4z6rctmcukxpqeq
+    path: patches/ember-source@5.11.0.patch
   ember-source@5.8.0:
     hash: qsivfx5huurlb5tuvochap65l4
     path: patches/ember-source@5.8.0.patch
@@ -1844,6 +1847,9 @@ importers:
       ember-source-4.8:
         specifier: npm:ember-source@~4.8.0
         version: /ember-source@4.8.6(@babel/core@7.25.2)(webpack@5.94.0)
+      ember-source-5.11:
+        specifier: npm:ember-source@5.11.0
+        version: /ember-source@5.11.0(patch_hash=bo72463n2ws4z6rctmcukxpqeq)(webpack@5.94.0)
       ember-source-5.4:
         specifier: npm:ember-source@~5.4.0
         version: /ember-source@5.4.1(@babel/core@7.25.2)(webpack@5.94.0)
@@ -1858,7 +1864,7 @@ importers:
         version: '@s3.amazonaws.com/builds.emberjs.com/canary/shas/370cf34f9e86df17b880f11fef35a5a0f24ff38a.tgz(@babel/core@7.25.2)(webpack@5.94.0)'
       ember-source-latest:
         specifier: npm:ember-source@latest
-        version: /ember-source@5.11.0(webpack@5.94.0)
+        version: /ember-source@5.11.0(patch_hash=bo72463n2ws4z6rctmcukxpqeq)(webpack@5.94.0)
       ember-test-helpers-2:
         specifier: npm:@ember/test-helpers@^2.0.0
         version: /@ember/test-helpers@2.9.4(@babel/core@7.25.2)(ember-source@3.28.12)
@@ -16051,7 +16057,7 @@ packages:
       - webpack
     dev: true
 
-  /ember-source@5.11.0(webpack@5.94.0):
+  /ember-source@5.11.0(patch_hash=bo72463n2ws4z6rctmcukxpqeq)(webpack@5.94.0):
     resolution: {integrity: sha512-ufjjTyyaVKBpgTf0NrX7HQqzphcgpNQdkMss2SENkHkM9cidcdEPxulqcMNFxjHCsLBE7rGxmPFSci3x7LdIzA==}
     engines: {node: '>= 18.*'}
     peerDependencies:
@@ -16104,6 +16110,7 @@ packages:
       - supports-color
       - webpack
     dev: true
+    patched: true
 
   /ember-source@5.12.0-beta.1(webpack@5.94.0):
     resolution: {integrity: sha512-bPOK0XELQ4Chwa9zTyt1ge6Y1knLpjgNLXLzB8RDjzbTgj6IxjhEf3BkXkMpaXv752iHNAJXzl1Rw167n0+h2Q==}

--- a/tests/scenarios/engines-test.ts
+++ b/tests/scenarios/engines-test.ts
@@ -81,11 +81,7 @@ let engineScenarios = appScenarios.map('engines', project => {
 });
 
 engineScenarios
-  .skip('lts_3_28-engines') // this skip should be removed before https://github.com/embroider-build/embroider/pull/1435 is merged
-  .skip('lts_4_4-engines') // this skip should be removed before https://github.com/embroider-build/embroider/pull/1435 is merged
-  .skip('release-engines') // this skip should be removed before https://github.com/embroider-build/embroider/pull/1435 is merged
-  .skip('lts_5_8-engines') // this shouldn't be run
-  .skip('canary-engines') // this shouldn't be run
+  .skip()
   .map('without-fastboot', () => {})
   .forEachScenario(scenario => {
     Qmodule(scenario.name, function (hooks) {

--- a/tests/scenarios/fastboot-app-test.ts
+++ b/tests/scenarios/fastboot-app-test.ts
@@ -83,8 +83,7 @@ appScenarios
     merge(project.files, loadFromFixtureData('fastboot-app'));
   })
   // TODO remove once https://github.com/ember-fastboot/ember-cli-fastboot/issues/925 is fixed
-  .skip('lts_5_8-fastboot-app-test')
-  .skip('canary-fastboot-app-test')
+  .skip()
   .forEachScenario(scenario => {
     Qmodule(scenario.name, function (hooks) {
       let app: PreparedApp;

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -92,6 +92,7 @@
     "ember-source-4.8": "npm:ember-source@~4.8.0",
     "ember-source-5.4": "npm:ember-source@~5.4.0",
     "ember-source-5.8": "npm:ember-source@~5.8.0",
+    "ember-source-5.11": "npm:ember-source@5.11.0",
     "ember-source-beta": "npm:ember-source@beta",
     "ember-source-canary": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/370cf34f9e86df17b880f11fef35a5a0f24ff38a.tgz",
     "ember-source-latest": "npm:ember-source@latest",

--- a/tests/scenarios/scenarios.ts
+++ b/tests/scenarios/scenarios.ts
@@ -43,7 +43,7 @@ async function lts_5_8(project: Project) {
 }
 
 async function release(project: Project) {
-  project.linkDevDependency('ember-source', { baseDir: __dirname, resolveName: 'ember-source-latest' });
+  project.linkDevDependency('ember-source', { baseDir: __dirname, resolveName: 'ember-source-5.11' });
   project.linkDevDependency('ember-cli', { baseDir: __dirname, resolveName: 'ember-cli-latest' });
   project.linkDevDependency('ember-data', { baseDir: __dirname, resolveName: 'ember-data-latest' });
   project.linkDevDependency('@ember/test-waiters', { baseDir: __dirname, resolveName: '@ember/test-waiters' });
@@ -83,7 +83,7 @@ export function supportMatrix(scenarios: Scenarios) {
       // new vite based system is working as we like
       .skip('lts_3_28')
       .skip('lts_4_4')
-      .skip('release')
+      .skip('lts_5_8')
   );
 }
 

--- a/tests/scenarios/watch-mode-test.ts
+++ b/tests/scenarios/watch-mode-test.ts
@@ -9,15 +9,12 @@ import CommandWatcher, { DEFAULT_TIMEOUT } from './helpers/command-watcher';
 
 const { module: Qmodule, test } = QUnit;
 
-let app = appScenarios
-  .skip('canary')
-  .skip('lts_5_8')
-  .map('watch-mode', () => {
-    /**
-     * We will create files as a part of the watch-mode tests,
-     * because creating files should cause appropriate watch/update behavior
-     */
-  });
+let app = appScenarios.skip().map('watch-mode', () => {
+  /**
+   * We will create files as a part of the watch-mode tests,
+   * because creating files should cause appropriate watch/update behavior
+   */
+});
 
 class File {
   constructor(readonly label: string, readonly fullPath: string) {}


### PR DESCRIPTION
This switching our tests from "lts_5_8" to "release" and locks the release into 5.11 plus my bugfix backport PR https://github.com/emberjs/ember.js/pull/20743.

I'm doing this because the circularity problems continue to be obnoxious, and some of the things I need to test are 5.x behaviors that are removed at 6.x.