### PR TITLE
Esbuild fixes

### DIFF
--- a/packages/compat/src/audit/build.ts
+++ b/packages/compat/src/audit/build.ts
@@ -50,11 +50,11 @@ async function execute(
   let stderrBuffer: string[] = [];
   let stdoutBuffer: string[] = [];
   let combinedBuffer: string[] = [];
-  child.stderr.on('data', data => {
+  child.stderr!.on('data', data => {
     stderrBuffer.push(data);
     combinedBuffer.push(data);
   });
-  child.stdout.on('data', data => {
+  child.stdout!.on('data', data => {
     stdoutBuffer.push(data);
     combinedBuffer.push(data);
   });

--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -102,14 +102,12 @@ export class CompatAppBuilder {
   }
 
   private resolvableExtensions(): string[] {
-    // webpack's default is ['.wasm', '.mjs', '.js', '.json']. Keeping that
-    // subset in that order is sensible, since many third-party libraries will
-    // expect it to work that way.
-    //
-    // For TS, we defer to ember-cli-babel, and the setting for
-    // "enableTypescriptTransform" can be set with and without
-    // ember-cli-typescript
-    return ['.wasm', '.mjs', '.js', '.json', '.ts', '.hbs', '.hbs.js', '.gjs', '.gts'];
+    let fromEnv = process.env.EMBROIDER_RESOLVABLE_EXTENSIONS;
+    if (fromEnv) {
+      return fromEnv.split(',');
+    } else {
+      return ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.hbs.js', '.json'];
+    }
   }
 
   private modulePrefix(): string {

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -172,14 +172,14 @@ function decodeVirtualExternalCJSModule(filename: string) {
 }
 
 const pairComponentMarker = '-embroider-pair-component';
-const pairComponentPattern = /^(?<hbsModule>.*)\/(?<jsModule>[^\/]*)-embroider-pair-component$/;
+const pairComponentPattern = /^(?<hbsModule>.*)__vpc__(?<jsModule>[^\/]*)-embroider-pair-component$/;
 
 export function virtualPairComponent(hbsModule: string, jsModule: string | undefined): string {
   let relativeJSModule = '';
   if (jsModule) {
-    relativeJSModule = explicitRelative(hbsModule, jsModule);
+    relativeJSModule = explicitRelative(dirname(hbsModule), jsModule);
   }
-  return `${hbsModule}/${encodeURIComponent(relativeJSModule)}${pairComponentMarker}`;
+  return `${hbsModule}__vpc__${encodeURIComponent(relativeJSModule)}${pairComponentMarker}`;
 }
 
 function decodeVirtualPairComponent(

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.22.9",
     "@embroider/macros": "workspace:*",
+    "@embroider/reverse-exports": "workspace:*",
     "@rollup/pluginutils": "^4.1.1",
     "assert-never": "^1.2.1",
     "content-tag": "^2.0.1",

--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -1,25 +1,26 @@
 import { fork } from 'child_process';
 import type { Plugin } from 'vite';
 
-export function emberBuild(command: string, mode: string): Promise<void> {
+export function emberBuild(command: string, mode: string, resolvableExtensions: string[] | undefined): Promise<void> {
+  let env: Record<string, string> = {
+    ...process.env,
+    EMBROIDER_PREBUILD: 'true',
+  };
+
+  if (resolvableExtensions) {
+    env['EMBROIDER_RESOLVABLE_EXTENSIONS'] = resolvableExtensions?.join(',');
+  }
+
   if (command === 'build') {
     return new Promise((resolve, reject) => {
-      const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--environment', mode], {
-        env: {
-          ...process.env,
-          EMBROIDER_PREBUILD: 'true',
-        },
-      });
+      const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--environment', mode], { env });
       child.on('exit', code => (code === 0 ? resolve() : reject()));
     });
   }
   return new Promise((resolve, reject) => {
     const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--watch', '--environment', mode], {
       silent: true,
-      env: {
-        ...process.env,
-        EMBROIDER_PREBUILD: 'true',
-      },
+      env,
     });
     child.on('exit', code => (code === 0 ? resolve() : reject(new Error('ember build --watch failed'))));
     child.on('spawn', () => {
@@ -39,13 +40,15 @@ export function emberBuild(command: string, mode: string): Promise<void> {
 export function compatPrebuild(): Plugin {
   let viteCommand: string | undefined;
   let viteMode: string | undefined;
+  let resolvableExtensions: string[] | undefined;
 
   return {
     name: 'embroider-builder',
     enforce: 'pre',
-    config(_config, { mode, command }) {
+    config(config, { mode, command }) {
       viteCommand = command;
       viteMode = mode;
+      resolvableExtensions = config.resolve?.extensions;
     },
     async buildStart() {
       if (!viteCommand) {
@@ -54,7 +57,7 @@ export function compatPrebuild(): Plugin {
       if (!viteMode) {
         throw new Error(`bug: embroider compatPrebuild did not detect Vite's mode`);
       }
-      await emberBuild(viteCommand, viteMode);
+      await emberBuild(viteCommand, viteMode, resolvableExtensions);
     },
   };
 }

--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -1,11 +1,21 @@
-import { type ModuleRequest, cleanUrl } from '@embroider/core';
-import type { ImportKind, OnResolveResult, PluginBuild } from 'esbuild';
-import { dirname } from 'path';
+import { type ModuleRequest, cleanUrl, packageName } from '@embroider/core';
+import type { ImportKind, OnResolveResult, PluginBuild, ResolveResult } from 'esbuild';
+import { dirname, extname } from 'path';
 
-import type { Resolution } from '@embroider/core';
+import type { PackageCache as _PackageCache, Resolution } from '@embroider/core';
+import { externalName } from '@embroider/reverse-exports';
+
+// TODO: make this share with vite config. We may need to pass it directly as an
+// argument to our esbuild plugin, or perhaps share it via embroider's
+// resolver-config.json
+const extensions = ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.json'];
+
+type PublicAPI<T> = { [K in keyof T]: T[K] };
+type PackageCache = PublicAPI<_PackageCache>;
 
 export class EsBuildModuleRequest implements ModuleRequest {
   static from(
+    packageCache: PackageCache,
     context: PluginBuild,
     kind: ImportKind,
     source: string,
@@ -19,6 +29,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
     if (source && importer && source[0] !== '\0' && !source.startsWith('virtual-module:')) {
       let fromFile = cleanUrl(importer);
       return new EsBuildModuleRequest(
+        packageCache,
         context,
         kind,
         source,
@@ -32,6 +43,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
   }
 
   private constructor(
+    private packageCache: PackageCache,
     private context: PluginBuild,
     private kind: ImportKind,
     readonly specifier: string,
@@ -40,7 +52,16 @@ export class EsBuildModuleRequest implements ModuleRequest {
     readonly isVirtual: boolean,
     readonly isNotFound: boolean,
     readonly resolvedTo: Resolution<OnResolveResult, OnResolveResult> | undefined
-  ) {}
+  ) {
+    let plugins = (this.context.initialOptions.plugins ?? []).map(p => p.name);
+    if (plugins.includes('vite:dep-pre-bundle')) {
+      this.phase = 'bundling';
+    } else if (plugins.includes('vite:dep-scan')) {
+      this.phase = 'scanning';
+    } else {
+      throw new Error(`cannot identify what phase vite is in. Saw plugins: ${plugins.join(', ')}`);
+    }
+  }
 
   get debugType() {
     return 'esbuild';
@@ -48,6 +69,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
 
   alias(newSpecifier: string) {
     return new EsBuildModuleRequest(
+      this.packageCache,
       this.context,
       this.kind,
       newSpecifier,
@@ -63,6 +85,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
       return this;
     } else {
       return new EsBuildModuleRequest(
+        this.packageCache,
         this.context,
         this.kind,
         this.specifier,
@@ -76,6 +99,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
   }
   virtualize(filename: string) {
     return new EsBuildModuleRequest(
+      this.packageCache,
       this.context,
       this.kind,
       filename,
@@ -88,6 +112,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
   }
   withMeta(meta: Record<string, any> | undefined): this {
     return new EsBuildModuleRequest(
+      this.packageCache,
       this.context,
       this.kind,
       this.specifier,
@@ -100,6 +125,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
   }
   notFound(): this {
     return new EsBuildModuleRequest(
+      this.packageCache,
       this.context,
       this.kind,
       this.specifier,
@@ -113,6 +139,7 @@ export class EsBuildModuleRequest implements ModuleRequest {
 
   resolveTo(resolution: Resolution<OnResolveResult, OnResolveResult>): this {
     return new EsBuildModuleRequest(
+      this.packageCache,
       this.context,
       this.kind,
       this.specifier,
@@ -122,6 +149,24 @@ export class EsBuildModuleRequest implements ModuleRequest {
       this.isNotFound,
       resolution
     ) as this;
+  }
+
+  private phase: 'bundling' | 'scanning';
+
+  private *extensionSearch(specifier: string): Generator<string> {
+    yield specifier;
+    // when there's no explicit extension, we may do extension search
+    if (extname(specifier) === '') {
+      // during the bundling phase, esbuild is not configured with any extension
+      // search of its own, so we need to do it. (During the scanning phase, all
+      // of vite's resolver is plugged into esbuild, which *does* already handle
+      // the resolvable extensions.)
+      if (this.phase === 'bundling') {
+        for (let ext of extensions) {
+          yield specifier + ext;
+        }
+      }
+    }
   }
 
   async defaultResolve(): Promise<Resolution<OnResolveResult, OnResolveResult>> {
@@ -144,29 +189,73 @@ export class EsBuildModuleRequest implements ModuleRequest {
       };
     }
 
-    requestStatus(request.specifier);
+    let firstResult: ResolveResult | undefined;
 
-    let result = await this.context.resolve(request.specifier, {
-      importer: request.fromFile,
-      resolveDir: dirname(request.fromFile),
-      kind: this.kind,
-      pluginData: {
-        embroider: {
-          enableCustomResolver: false,
-          meta: request.meta,
+    for (let requestName of this.extensionSearch(request.specifier)) {
+      requestStatus(requestName);
+
+      let result = await this.context.resolve(requestName, {
+        importer: request.fromFile,
+        resolveDir: dirname(request.fromFile),
+        kind: this.kind,
+        pluginData: {
+          embroider: {
+            enableCustomResolver: false,
+            meta: request.meta,
+          },
         },
-      },
-    });
+      });
 
-    let status = readStatus(request.specifier);
+      let status = readStatus(requestName);
 
-    if (result.errors.length > 0 || status === 'not_found') {
-      return { type: 'not_found', err: result };
-    } else if (result.external) {
-      return { type: 'ignored', result };
-    } else {
-      return { type: 'found', filename: result.path, result, isVirtual: this.isVirtual };
+      if (result.errors.length > 0 || status === 'not_found') {
+        if (!firstResult) {
+          // if extension search fails, we want to let the first failure be the
+          // one that propagates, so that the error message makes sense.
+          firstResult = result;
+        }
+        // let extension search continue
+      } else if (result.external) {
+        return { type: 'ignored', result };
+      } else {
+        if (this.phase === 'bundling') {
+          // we need to ensure that we don't traverse back into the app while
+          // doing dependency pre-bundling. There are multiple ways an addon can
+          // resolve things from the app, due to the existince of both app-js
+          // (modules in addons that are logically part of the app's namespace)
+          // and non-strict handlebars (which resolves
+          // components/helpers/modifiers against the app's global pool).
+          let pkg = this.packageCache.ownerOfFile(result.path);
+          if (pkg?.root === this.packageCache.appRoot) {
+            let externalizedName = requestName;
+            if (!packageName(externalizedName)) {
+              // the request was a relative path. This won't remain valid once
+              // it has been bundled into vite/deps. But we know it targets the
+              // app, so we can always convert it into a non-relative import
+              // from the app's namespace
+              //
+              // IMPORTANT: whenever an addon resolves a relative path to the
+              // app, it does so because our code in the core resolver has
+              // rewritten the request to be relative to the app's root. So here
+              // we will only ever encounter relative paths that are already
+              // relative to the app's root directory.
+              externalizedName = externalName(pkg.packageJSON, externalizedName) || externalizedName;
+            }
+            return {
+              type: 'ignored',
+              result: {
+                path: externalizedName,
+                external: true,
+              },
+            };
+          }
+        }
+        return { type: 'found', filename: result.path, result, isVirtual: this.isVirtual };
+      }
     }
+
+    // cast is safe because we know extensionSearch always yields >0 entries
+    return { type: 'not_found', err: firstResult! };
   }
 }
 

--- a/packages/vite/src/esbuild-resolver.ts
+++ b/packages/vite/src/esbuild-resolver.ts
@@ -114,7 +114,7 @@ export function esBuildResolver(): EsBuildPlugin {
 
           let firstResult: ResolveResult | undefined;
 
-          for (let requestName of extensionSearch(path)) {
+          for (let requestName of extensionSearch(path, resolverLoader.resolver.options.resolvableExtensions)) {
             let result = await build.resolve(requestName, {
               namespace,
               resolveDir,
@@ -162,12 +162,7 @@ function detectPhase(build: PluginBuild): 'bundling' | 'scanning' {
   }
 }
 
-// TODO: make this share with vite config. We may need to pass it directly as an
-// argument to our esbuild plugin, or perhaps share it via embroider's
-// resolver-config.json
-const extensions = ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.json'];
-
-function* extensionSearch(specifier: string): Generator<string> {
+function* extensionSearch(specifier: string, extensions: string[]): Generator<string> {
   yield specifier;
   // when there's no explicit extension, we may do extension search
   if (extname(specifier) === '') {

--- a/packages/vite/src/esbuild-resolver.ts
+++ b/packages/vite/src/esbuild-resolver.ts
@@ -1,4 +1,4 @@
-import type { Plugin as EsBuildPlugin, OnLoadResult } from 'esbuild';
+import type { Plugin as EsBuildPlugin, OnLoadResult, PluginBuild, ResolveResult } from 'esbuild';
 import { transform } from '@babel/core';
 import { ResolverLoader, virtualContent, needsSyntheticComponentJS } from '@embroider/core';
 import { readFileSync } from 'fs-extra';
@@ -6,6 +6,7 @@ import { EsBuildModuleRequest } from './esbuild-request';
 import assertNever from 'assert-never';
 import { hbsToJS } from '@embroider/core';
 import { Preprocessor } from 'content-tag';
+import { extname } from 'path';
 
 const templateOnlyComponent =
   `import templateOnly from '@ember/component/template-only';\n` + `export default templateOnly();\n`;
@@ -45,10 +46,13 @@ export function esBuildResolver(): EsBuildPlugin {
   return {
     name: 'embroider-esbuild-resolver',
     setup(build) {
+      const phase = detectPhase(build);
+
       // Embroider Resolver
       build.onResolve({ filter: /./ }, async ({ path, importer, pluginData, kind }) => {
         let request = EsBuildModuleRequest.from(
           resolverLoader.resolver.packageCache,
+          phase,
           build,
           kind,
           path,
@@ -72,7 +76,7 @@ export function esBuildResolver(): EsBuildPlugin {
 
       // template-only-component synthesis
       build.onResolve({ filter: /./ }, async ({ path, importer, namespace, resolveDir, pluginData, kind }) => {
-        if (pluginData?.embroiderExtensionResolving) {
+        if (pluginData?.embroiderHBSResolving) {
           // reentrance
           return null;
         }
@@ -83,7 +87,7 @@ export function esBuildResolver(): EsBuildPlugin {
           importer,
           kind,
           // avoid reentrance
-          pluginData: { ...pluginData, embroiderExtensionResolving: true },
+          pluginData: { ...pluginData, embroiderHBSResolving: true },
         });
 
         if (result.errors.length === 0 && !result.external) {
@@ -95,6 +99,43 @@ export function esBuildResolver(): EsBuildPlugin {
 
         return result;
       });
+
+      if (phase === 'bundling') {
+        // during bundling phase, we need to provide our own extension
+        // searching. We do it here in its own resolve plugin so that it's
+        // sitting beneath both embroider resolver and template-only-component
+        // synthesizer, since both expect the ambient system to have extension
+        // search.
+        build.onResolve({ filter: /./ }, async ({ path, importer, namespace, resolveDir, pluginData, kind }) => {
+          if (pluginData?.embroiderExtensionResolving) {
+            // reentrance
+            return null;
+          }
+
+          let firstResult: ResolveResult | undefined;
+
+          for (let requestName of extensionSearch(path)) {
+            let result = await build.resolve(requestName, {
+              namespace,
+              resolveDir,
+              importer,
+              kind,
+              // avoid reentrance
+              pluginData: { ...pluginData, embroiderExtensionResolving: true },
+            });
+
+            if (result.errors.length > 0) {
+              // if extension search fails, we want to let the first failure be the
+              // one that propagates, so that the error message makes sense.
+              firstResult = result;
+            } else {
+              return result;
+            }
+          }
+
+          return firstResult;
+        });
+      }
 
       // we need to handle everything from one of our three special namespaces:
       build.onLoad({ namespace: 'embroider-template-only-component', filter: /./ }, onLoad);
@@ -108,4 +149,30 @@ export function esBuildResolver(): EsBuildPlugin {
       build.onLoad({ filter: /\.g?[jt]s$/ }, onLoad);
     },
   };
+}
+
+function detectPhase(build: PluginBuild): 'bundling' | 'scanning' {
+  let plugins = (build.initialOptions.plugins ?? []).map(p => p.name);
+  if (plugins.includes('vite:dep-pre-bundle')) {
+    return 'bundling';
+  } else if (plugins.includes('vite:dep-scan')) {
+    return 'scanning';
+  } else {
+    throw new Error(`cannot identify what phase vite is in. Saw plugins: ${plugins.join(', ')}`);
+  }
+}
+
+// TODO: make this share with vite config. We may need to pass it directly as an
+// argument to our esbuild plugin, or perhaps share it via embroider's
+// resolver-config.json
+const extensions = ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.json'];
+
+function* extensionSearch(specifier: string): Generator<string> {
+  yield specifier;
+  // when there's no explicit extension, we may do extension search
+  if (extname(specifier) === '') {
+    for (let ext of extensions) {
+      yield specifier + ext;
+    }
+  }
 }

--- a/packages/vite/src/esbuild-resolver.ts
+++ b/packages/vite/src/esbuild-resolver.ts
@@ -47,7 +47,14 @@ export function esBuildResolver(): EsBuildPlugin {
     setup(build) {
       // Embroider Resolver
       build.onResolve({ filter: /./ }, async ({ path, importer, pluginData, kind }) => {
-        let request = EsBuildModuleRequest.from(build, kind, path, importer, pluginData);
+        let request = EsBuildModuleRequest.from(
+          resolverLoader.resolver.packageCache,
+          build,
+          kind,
+          path,
+          importer,
+          pluginData
+        );
         if (!request) {
           return null;
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,6 +953,9 @@ importers:
       '@embroider/macros':
         specifier: workspace:*
         version: link:../macros
+      '@embroider/reverse-exports':
+        specifier: workspace:*
+        version: link:../reverse-exports
       '@rollup/pluginutils':
         specifier: ^4.1.1
         version: 4.2.1
@@ -1886,9 +1889,6 @@ importers:
       execa:
         specifier: ^5.1.1
         version: 5.1.1
-      http-proxy:
-        specifier: ^1.18.1
-        version: 1.18.1
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0
@@ -2441,7 +2441,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.24.7
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -2679,7 +2679,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.0(@babel/core@7.25.2):
@@ -2688,7 +2688,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.25.2):
@@ -2788,7 +2788,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
 
   /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.25.2):
     resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
@@ -2810,7 +2810,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.25.2):
@@ -2827,7 +2827,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.2):
@@ -2836,7 +2836,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.25.2):
@@ -2861,7 +2861,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.25.2):
@@ -2870,7 +2870,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.25.2):
@@ -2879,7 +2879,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.2):
@@ -2887,7 +2887,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.2):
@@ -2895,7 +2895,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2):
@@ -2913,7 +2913,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.2):
@@ -2921,7 +2921,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.2):
@@ -2929,7 +2929,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.2):
@@ -2937,7 +2937,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.2):
@@ -2945,7 +2945,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.2):
@@ -2962,7 +2962,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.2):
@@ -2971,7 +2971,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.25.2):
@@ -2989,7 +2989,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -2999,7 +2999,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-async-generator-functions@7.25.4(@babel/core@7.25.2):
@@ -3064,7 +3064,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-block-scoping@7.25.0(@babel/core@7.25.2):
@@ -3167,7 +3167,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.25.0
 
@@ -3177,7 +3177,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.25.2):
@@ -3186,7 +3186,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3196,7 +3196,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.0(@babel/core@7.25.2):
@@ -3205,7 +3205,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3215,7 +3215,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
 
@@ -3250,7 +3250,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
 
@@ -3312,7 +3312,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
 
@@ -3322,7 +3322,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.25.2):
@@ -3331,7 +3331,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
 
@@ -3341,7 +3341,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.25.2):
@@ -3456,7 +3456,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3466,7 +3466,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.25.2):
@@ -3475,7 +3475,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
 
@@ -3485,7 +3485,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
 
@@ -3504,7 +3504,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
@@ -3541,7 +3541,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
 
@@ -3641,7 +3641,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.25.2):
@@ -3650,7 +3650,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
@@ -3660,7 +3660,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-runtime@7.25.4(@babel/core@7.25.2):
@@ -3685,7 +3685,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-spread@7.24.7(@babel/core@7.25.2):
@@ -3719,7 +3719,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.25.2):
@@ -3728,7 +3728,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-typeof-symbol@7.24.8(@babel/core@7.25.2):
@@ -3737,7 +3737,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-typescript@7.25.2(@babel/core@7.25.2):
@@ -3783,7 +3783,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.25.2):
@@ -3792,7 +3792,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3802,7 +3802,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3812,7 +3812,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -4015,7 +4015,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/types': 7.25.4
       esutils: 2.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1259,6 +1259,9 @@ importers:
       fs-extra:
         specifier: ^7.0.0
         version: 7.0.1
+      http-proxy:
+        specifier: ^1.18.1
+        version: 1.18.1
       loader.js:
         specifier: ^4.7.0
         version: 4.7.0
@@ -1284,9 +1287,15 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.18.5
         version: 7.20.6
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
       '@types/fs-extra':
         specifier: ^9.0.12
         version: 9.0.13
+      '@types/http-proxy':
+        specifier: ^1.17.15
+        version: 1.17.15
       '@types/lodash':
         specifier: ^4.14.170
         version: 4.17.7
@@ -1877,6 +1886,9 @@ importers:
       execa:
         specifier: ^5.1.1
         version: 5.1.1
+      http-proxy:
+        specifier: ^1.18.1
+        version: 1.18.1
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0
@@ -1886,6 +1898,9 @@ importers:
       strip-ansi:
         specifier: ^6.0.0
         version: 6.0.1
+      testem:
+        specifier: ^3.10.1
+        version: 3.15.1
       tslib:
         specifier: ^2.6.0
         version: 2.6.3
@@ -2426,7 +2441,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.24.7
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -2664,7 +2679,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.0(@babel/core@7.25.2):
@@ -2673,7 +2688,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.25.2):
@@ -2773,7 +2788,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
 
   /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.25.2):
     resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
@@ -2795,7 +2810,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.25.2):
@@ -2812,7 +2827,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.2):
@@ -2821,7 +2836,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.25.2):
@@ -2846,7 +2861,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.25.2):
@@ -2855,7 +2870,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.25.2):
@@ -2864,7 +2879,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.2):
@@ -2872,7 +2887,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.2):
@@ -2880,7 +2895,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2):
@@ -2898,7 +2913,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.2):
@@ -2906,7 +2921,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.2):
@@ -2914,7 +2929,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.2):
@@ -2922,7 +2937,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.2):
@@ -2930,7 +2945,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.2):
@@ -2947,7 +2962,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.2):
@@ -2956,7 +2971,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.25.2):
@@ -2974,7 +2989,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -2984,7 +2999,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-async-generator-functions@7.25.4(@babel/core@7.25.2):
@@ -3049,7 +3064,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-block-scoping@7.25.0(@babel/core@7.25.2):
@@ -3152,7 +3167,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.25.0
 
@@ -3162,7 +3177,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.25.2):
@@ -3171,7 +3186,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3181,7 +3196,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.0(@babel/core@7.25.2):
@@ -3190,7 +3205,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3200,7 +3215,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
 
@@ -3235,7 +3250,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
 
@@ -3297,7 +3312,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
 
@@ -3307,7 +3322,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.25.2):
@@ -3316,7 +3331,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
 
@@ -3326,7 +3341,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.25.2):
@@ -3441,7 +3456,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3451,7 +3466,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.25.2):
@@ -3460,7 +3475,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
 
@@ -3470,7 +3485,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
 
@@ -3489,7 +3504,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
@@ -3526,7 +3541,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
 
@@ -3626,7 +3641,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.25.2):
@@ -3635,7 +3650,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
@@ -3645,7 +3660,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-runtime@7.25.4(@babel/core@7.25.2):
@@ -3670,7 +3685,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-spread@7.24.7(@babel/core@7.25.2):
@@ -3704,7 +3719,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.25.2):
@@ -3713,7 +3728,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-typeof-symbol@7.24.8(@babel/core@7.25.2):
@@ -3722,7 +3737,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-typescript@7.25.2(@babel/core@7.25.2):
@@ -3768,7 +3783,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.25.2):
@@ -3777,7 +3792,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3787,7 +3802,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -3797,7 +3812,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -4000,7 +4015,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.25.2(supports-color@8.1.1)
+      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/types': 7.25.4
       esutils: 2.0.3
@@ -8485,6 +8500,12 @@ packages:
 
   /@types/http-errors@2.0.4:
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  /@types/http-proxy@1.17.15:
+    resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
+    dependencies:
+      '@types/node': 15.14.9
+    dev: true
 
   /@types/istanbul-lib-coverage@2.0.6:
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 8.10.0(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.27.5
-        version: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)
+        version: 2.30.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
@@ -192,10 +192,10 @@ importers:
         version: 7.25.4(@babel/core@7.25.2)
       '@babel/runtime':
         specifier: ^7.18.6
-        version: 7.25.4
+        version: 7.25.6
       '@babel/traverse':
         specifier: ^7.14.5
-        version: 7.25.4(supports-color@8.1.1)
+        version: 7.25.6(supports-color@8.1.1)
       '@embroider/macros':
         specifier: workspace:*
         version: link:../macros
@@ -252,7 +252,7 @@ importers:
         version: 4.1.2
       debug:
         specifier: ^4.3.2
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       fast-sourcemap-concat:
         specifier: ^2.1.1
         version: 2.1.1
@@ -382,10 +382,10 @@ importers:
         version: 7.25.2
       '@babel/parser':
         specifier: ^7.14.5
-        version: 7.25.4
+        version: 7.25.6
       '@babel/traverse':
         specifier: ^7.14.5
-        version: 7.25.4(supports-color@8.1.1)
+        version: 7.25.6(supports-color@8.1.1)
       '@embroider/macros':
         specifier: workspace:*
         version: link:../macros
@@ -415,7 +415,7 @@ importers:
         version: 3.0.1
       debug:
         specifier: ^4.3.2
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       escape-string-regexp:
         specifier: ^4.0.0
         version: 4.0.0
@@ -424,7 +424,7 @@ importers:
         version: 2.1.1
       filesize:
         specifier: ^10.0.7
-        version: 10.1.4
+        version: 10.1.6
       fs-extra:
         specifier: ^9.1.0
         version: 9.1.0
@@ -561,7 +561,7 @@ importers:
         version: 7.24.7(@babel/core@7.25.2)
       '@babel/traverse':
         specifier: ^7.14.5
-        version: 7.25.4(supports-color@8.1.1)
+        version: 7.25.6(supports-color@8.1.1)
       '@embroider/core':
         specifier: workspace:*
         version: link:../core
@@ -640,7 +640,7 @@ importers:
         version: 5.3.1(@babel/core@7.25.2)(rollup@3.29.4)
       '@rollup/plugin-typescript':
         specifier: ^11.1.2
-        version: 11.1.6(rollup@3.29.4)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.5.4)
       '@tsconfig/ember':
         specifier: ^1.0.0
         version: 1.0.1
@@ -682,7 +682,7 @@ importers:
         version: 3.29.4
       tslib:
         specifier: ^2.6.0
-        version: 2.6.3
+        version: 2.7.0
       typescript:
         specifier: ^5.4.5
         version: 5.5.4
@@ -694,7 +694,7 @@ importers:
         version: 2.1.1
       debug:
         specifier: ^4.3.2
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       ember-rfc176-data:
         specifier: ^0.3.17
         version: 0.3.18
@@ -967,7 +967,7 @@ importers:
         version: 2.0.1
       debug:
         specifier: ^4.3.2
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       esbuild:
         specifier: ^0.17.19
         version: 0.17.19
@@ -1010,10 +1010,10 @@ importers:
         version: 0.17.4
       rollup:
         specifier: ^4.18.0
-        version: 4.21.0
+        version: 4.21.2
       vite:
         specifier: ^5.3.3
-        version: 5.4.2(terser@5.31.6)
+        version: 5.4.3(terser@5.31.6)
 
   packages/webpack:
     dependencies:
@@ -1049,7 +1049,7 @@ importers:
         version: 4.2.0
       debug:
         specifier: ^4.3.2
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       escape-string-regexp:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1462,7 +1462,7 @@ importers:
         version: 2.0.0
       vite:
         specifier: ^5.2.8
-        version: 5.4.2(terser@5.31.6)
+        version: 5.4.3(terser@5.31.6)
       webpack:
         specifier: ^5.74.0
         version: 5.94.0
@@ -1615,7 +1615,7 @@ importers:
         version: 3.3.0
       vite:
         specifier: ^5.0.9
-        version: 5.4.2(terser@5.31.6)
+        version: 5.4.3(terser@5.31.6)
 
   tests/fixtures: {}
 
@@ -1714,7 +1714,7 @@ importers:
         version: 7.25.4(@babel/core@7.25.2)
       '@babel/runtime':
         specifier: ^7.18.6
-        version: 7.25.4
+        version: 7.25.6
       '@ember/legacy-built-in-components':
         specifier: ^0.4.1
         version: 0.4.2(ember-source@3.28.12)
@@ -1741,7 +1741,7 @@ importers:
         version: 5.3.1(@babel/core@7.25.2)(rollup@3.29.4)
       '@rollup/plugin-typescript':
         specifier: ^11.1.2
-        version: 11.1.6(rollup@3.29.4)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.5.4)
       '@tsconfig/ember':
         specifier: 1.0.1
         version: 1.0.1
@@ -1903,7 +1903,7 @@ importers:
         version: 3.15.1
       tslib:
         specifier: ^2.6.0
-        version: 2.6.3
+        version: 2.7.0
       typescript:
         specifier: ^5.4.5
         version: 5.5.4
@@ -2068,7 +2068,7 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.1.5
-        version: 5.4.2(terser@5.31.6)
+        version: 5.4.3(terser@5.31.6)
       webpack:
         specifier: ^5.88.2
         version: 5.94.0
@@ -2230,7 +2230,7 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.1.5
-        version: 5.4.2(terser@5.31.6)
+        version: 5.4.3(terser@5.31.6)
       webpack:
         specifier: ^5.88.2
         version: 5.94.0
@@ -2289,7 +2289,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
+      picocolors: 1.1.0
 
   /@babel/compat-data@7.25.4:
     resolution: {integrity: sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==}
@@ -2301,16 +2301,16 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.4
+      '@babel/generator': 7.25.6
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
-      '@babel/helpers': 7.25.0
-      '@babel/parser': 7.25.4
+      '@babel/helpers': 7.25.6
+      '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
       convert-source-map: 2.0.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2323,16 +2323,16 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.4
+      '@babel/generator': 7.25.6
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)(supports-color@8.1.1)
-      '@babel/helpers': 7.25.0
-      '@babel/parser': 7.25.4
+      '@babel/helpers': 7.25.6
+      '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
       convert-source-map: 2.0.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2366,11 +2366,11 @@ packages:
       semver: 6.3.1
     dev: true
 
-  /@babel/generator@7.25.4:
-    resolution: {integrity: sha512-NFtZmZsyzDPJnk9Zg3BbTfKKc9UlHYzD0E//p2Z3B9nCwwtJW9T0gVbCz8+fBngnn4zf1Dr3IK8PHQQHq0lDQw==}
+  /@babel/generator@7.25.6:
+    resolution: {integrity: sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -2379,14 +2379,14 @@ packages:
     resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.24.7(supports-color@8.1.1):
     resolution: {integrity: sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -2412,7 +2412,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.24.7
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7(supports-color@8.1.1)
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -2429,7 +2429,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.24.7
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)(supports-color@8.1.1)
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7(supports-color@8.1.1)
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -2454,7 +2454,7 @@ packages:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -2468,7 +2468,7 @@ packages:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -2479,8 +2479,8 @@ packages:
     resolution: {integrity: sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -2488,8 +2488,8 @@ packages:
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -2503,7 +2503,7 @@ packages:
       '@babel/helper-module-imports': 7.24.7(supports-color@8.1.1)
       '@babel/helper-simple-access': 7.24.7(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2517,7 +2517,7 @@ packages:
       '@babel/helper-module-imports': 7.24.7(supports-color@8.1.1)
       '@babel/helper-simple-access': 7.24.7(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2525,7 +2525,7 @@ packages:
     resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
 
   /@babel/helper-plugin-utils@7.24.8:
     resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
@@ -2540,7 +2540,7 @@ packages:
       '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-wrap-function': 7.25.0(supports-color@8.1.1)
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2553,7 +2553,7 @@ packages:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-wrap-function': 7.25.0(supports-color@8.1.1)
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2567,7 +2567,7 @@ packages:
       '@babel/core': 7.25.2
       '@babel/helper-member-expression-to-functions': 7.24.8(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2580,7 +2580,7 @@ packages:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-member-expression-to-functions': 7.24.8(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2589,8 +2589,8 @@ packages:
     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -2598,8 +2598,8 @@ packages:
     resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -2620,17 +2620,17 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/helpers@7.25.0:
-    resolution: {integrity: sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==}
+  /@babel/helpers@7.25.6:
+    resolution: {integrity: sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
 
   /@babel/highlight@7.24.7:
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
@@ -2639,14 +2639,14 @@ packages:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.0
 
-  /@babel/parser@7.25.4:
-    resolution: {integrity: sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==}
+  /@babel/parser@7.25.6:
+    resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
 
   /@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.3(@babel/core@7.25.2):
     resolution: {integrity: sha512-wUrcsxZg6rqBXG05HG1FPYgsP6EvwF4WpBbxIpWIIYnH8wG0gzx3yZY3dtEHas4sTAOGkbTsc9EGPxwff8lRoA==}
@@ -2656,7 +2656,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2668,7 +2668,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2726,7 +2726,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2738,7 +2738,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2864,8 +2864,8 @@ packages:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
-  /@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.25.2):
-    resolution: {integrity: sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==}
+  /@babel/plugin-syntax-import-assertions@7.25.6(@babel/core@7.25.2):
+    resolution: {integrity: sha512-aABl0jHw9bZ2karQ/uUD6XP4u0SG22SJrOHFoL6XB1R7dTovOP4TzTlsxOYC5yQ1pdscVK2JTUnF6QL3ARoAiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2873,8 +2873,8 @@ packages:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
-  /@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.25.2):
-    resolution: {integrity: sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==}
+  /@babel/plugin-syntax-import-attributes@7.25.6(@babel/core@7.25.2):
+    resolution: {integrity: sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3012,7 +3012,7 @@ packages:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.25.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3026,7 +3026,7 @@ packages:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.25.2)(supports-color@8.1.1)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3139,7 +3139,7 @@ packages:
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3155,7 +3155,7 @@ packages:
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)(supports-color@8.1.1)
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3288,7 +3288,7 @@ packages:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3301,7 +3301,7 @@ packages:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3406,7 +3406,7 @@ packages:
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3420,7 +3420,7 @@ packages:
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3845,8 +3845,8 @@ packages:
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.2)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-syntax-import-assertions': 7.25.6(@babel/core@7.25.2)
+      '@babel/plugin-syntax-import-attributes': 7.25.6(@babel/core@7.25.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
@@ -3938,8 +3938,8 @@ packages:
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.2)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-syntax-import-assertions': 7.25.6(@babel/core@7.25.2)
+      '@babel/plugin-syntax-import-attributes': 7.25.6(@babel/core@7.25.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
@@ -4017,7 +4017,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.2(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
       esutils: 2.0.3
 
   /@babel/regjsgen@0.8.0:
@@ -4028,8 +4028,8 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  /@babel/runtime@7.25.4:
-    resolution: {integrity: sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==}
+  /@babel/runtime@7.25.6:
+    resolution: {integrity: sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
@@ -4039,25 +4039,25 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.25.4
-      '@babel/types': 7.25.4
+      '@babel/parser': 7.25.6
+      '@babel/types': 7.25.6
 
-  /@babel/traverse@7.25.4(supports-color@8.1.1):
-    resolution: {integrity: sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==}
+  /@babel/traverse@7.25.6(supports-color@8.1.1):
+    resolution: {integrity: sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.4
-      '@babel/parser': 7.25.4
+      '@babel/generator': 7.25.6
+      '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.4
-      debug: 4.3.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
+      debug: 4.3.7(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/types@7.25.4:
-    resolution: {integrity: sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==}
+  /@babel/types@7.25.6:
+    resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.24.8
@@ -4151,7 +4151,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.3(ember-source@3.28.12)
@@ -4191,7 +4191,7 @@ packages:
       '@ember-data/store': 4.8.8(@babel/core@7.25.2)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(ember-source@3.28.12)(webpack@5.94.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
@@ -4213,7 +4213,7 @@ packages:
       '@ember-data/private-build-infra': 5.3.0
       '@ember-data/store': 5.3.0(@babel/core@7.25.2)(@ember-data/tracking@5.3.0)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.3(ember-source@3.28.12)
@@ -4236,7 +4236,7 @@ packages:
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-path-utils: 1.0.0
@@ -4271,7 +4271,7 @@ packages:
     resolution: {integrity: sha512-pmHrbPPqwMINDhfW+Hd0KR39X3baSwQf0Fk19YCzxxGYQ2wrcanOdlKhL4U/T6UUN8AXpRtqe6+YcDg5eVJkZg==}
     engines: {node: ^14.8.0 || 16.* || >= 18.*}
     dependencies:
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -4304,7 +4304,7 @@ packages:
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -4340,7 +4340,7 @@ packages:
       '@ember-data/private-build-infra': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -4361,7 +4361,7 @@ packages:
       '@ember-data/store': 5.3.0(@babel/core@7.25.2)(@ember-data/tracking@5.3.0)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       webpack: 5.94.0
@@ -4387,7 +4387,7 @@ packages:
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -4404,7 +4404,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -4420,7 +4420,7 @@ packages:
       '@ember-data/private-build-infra': 5.3.0
       '@ember-data/store': 5.3.0(@babel/core@7.25.2)(@ember-data/tracking@5.3.0)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4436,7 +4436,7 @@ packages:
       '@warp-drive/core-types': 0.0.0-beta.11
     dependencies:
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -4455,7 +4455,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -4476,7 +4476,7 @@ packages:
       '@ember-data/request-utils': 5.3.0(@babel/core@7.25.2)
       '@ember-data/store': 5.3.0(@babel/core@7.25.2)(@ember-data/tracking@5.3.0)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-inflector: 4.0.3(ember-source@3.28.12)
     transitivePeerDependencies:
@@ -4497,7 +4497,7 @@ packages:
       '@ember-data/graph': 5.4.0-beta.11(@ember-data/store@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -4522,7 +4522,7 @@ packages:
       '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)
       '@ember-data/private-build-infra': 4.12.8
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -4546,7 +4546,7 @@ packages:
       '@ember-data/json-api': 5.3.0(@babel/core@7.25.2)(@ember-data/graph@5.3.0)(@ember-data/request-utils@5.3.0)(@ember-data/store@5.3.0)(ember-inflector@4.0.3)
       '@ember-data/private-build-infra': 5.3.0
       '@ember-data/request': 5.3.0(@babel/core@7.25.2)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4577,7 +4577,7 @@ packages:
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -4635,7 +4635,7 @@ packages:
       '@ember-data/tracking': 4.12.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
@@ -4693,7 +4693,7 @@ packages:
       '@ember-data/tracking': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 7.26.11
@@ -4739,7 +4739,7 @@ packages:
       '@ember-data/tracking': 5.3.0(@babel/core@7.25.2)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-cli-string-utils: 1.1.0
@@ -4777,7 +4777,7 @@ packages:
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/tracking': 5.4.0-beta.11(@warp-drive/core-types@0.0.0-beta.11)(ember-source@3.28.12)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-string-utils: 1.1.0
@@ -4829,9 +4829,9 @@ packages:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.25.2)
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.25.6
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       babel-import-util: 1.4.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.25.2)
       babel-plugin-filter-imports: 4.0.0
@@ -4898,10 +4898,10 @@ packages:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.25.2)
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.25.6
       '@ember-data/canary-features': 4.8.8
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       babel-import-util: 1.4.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.25.2)
       babel-plugin-filter-imports: 4.0.0
@@ -4935,9 +4935,9 @@ packages:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.25.2)
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.25.6
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       babel-import-util: 1.4.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.25.2)
       babel-plugin-filter-imports: 4.0.0
@@ -5005,7 +5005,7 @@ packages:
       '@ember-data/private-build-infra': 4.8.8
       '@ember-data/store': 4.8.8(@babel/core@7.25.2)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(ember-source@3.28.12)(webpack@5.94.0)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -5038,7 +5038,7 @@ packages:
         optional: true
     dependencies:
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -5052,7 +5052,7 @@ packages:
     dependencies:
       '@ember-data/private-build-infra': 4.12.8
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -5065,7 +5065,7 @@ packages:
     dependencies:
       '@ember-data/private-build-infra': 5.3.0
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -5080,7 +5080,7 @@ packages:
       '@warp-drive/core-types': 0.0.0-beta.11
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -5116,7 +5116,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/store': 4.12.8(@babel/core@7.25.2)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-source@3.28.12)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.3(ember-source@3.28.12)
@@ -5153,7 +5153,7 @@ packages:
       '@ember-data/private-build-infra': 4.8.8
       '@ember-data/store': 4.8.8(@babel/core@7.25.2)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(ember-source@3.28.12)(webpack@5.94.0)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
@@ -5173,7 +5173,7 @@ packages:
     dependencies:
       '@ember-data/private-build-infra': 5.3.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.3(ember-source@3.28.12)
@@ -5196,7 +5196,7 @@ packages:
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/store': 5.4.0-beta.11(@ember-data/request-utils@5.4.0-beta.11)(@ember-data/request@5.4.0-beta.11)(@ember-data/tracking@5.4.0-beta.11)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-path-utils: 1.0.0
@@ -5252,7 +5252,7 @@ packages:
       '@ember-data/private-build-infra': 4.12.8
       '@ember-data/tracking': 4.12.8
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -5303,7 +5303,7 @@ packages:
       '@ember-data/record-data': 4.8.8(@ember-data/store@4.8.8)(webpack@5.94.0)
       '@ember-data/tracking': 4.8.8
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 7.26.11
@@ -5326,7 +5326,7 @@ packages:
       '@ember-data/private-build-infra': 5.3.0
       '@ember-data/tracking': 5.3.0(@babel/core@7.25.2)
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.2)(ember-source@3.28.12)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
@@ -5348,7 +5348,7 @@ packages:
       '@ember-data/request': 5.4.0-beta.11(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/request-utils': 5.4.0-beta.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)
       '@ember-data/tracking': 5.4.0-beta.11(@warp-drive/core-types@0.0.0-beta.11)(ember-source@3.28.12)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
@@ -5361,7 +5361,7 @@ packages:
     engines: {node: 16.* || >= 18}
     dependencies:
       '@ember-data/private-build-infra': 4.12.8
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@glint/template'
@@ -5383,7 +5383,7 @@ packages:
     engines: {node: 16.* || >= 18}
     dependencies:
       '@ember-data/private-build-infra': 5.3.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -5398,7 +5398,7 @@ packages:
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-source: '>= 3.28.12'
     dependencies:
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       ember-source: 3.28.12(@babel/core@7.25.2)
@@ -5440,10 +5440,10 @@ packages:
     resolution: {integrity: sha512-US8VKnetBOl8KfKz+rXGsosz6rIETNwSz2F2frM8hIoJfF/d6ME1Iz1K7tPYZEE6SoKqZFlBs5XZPSmzRnabjA==}
     engines: {node: 10.* || 12.* || >= 14}
     dependencies:
-      '@types/eslint': 8.56.11
+      '@types/eslint': 8.56.12
       fs-extra: 9.1.0
       slash: 3.0.0
-      tslib: 2.6.3
+      tslib: 2.7.0
     dev: true
 
   /@ember/edition-utils@1.2.0:
@@ -5468,7 +5468,7 @@ packages:
     peerDependencies:
       ember-source: '*'
     dependencies:
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-typescript: 4.2.1
@@ -5518,7 +5518,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.25.2)
       ember-source: 3.28.12(@babel/core@7.25.2)
@@ -5542,7 +5542,7 @@ packages:
       ember-source: '>=3.8.0'
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@embroider/util': 1.13.2(ember-source@3.28.12)
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5564,7 +5564,7 @@ packages:
       ember-source: ^4.0.0 || ^5.0.0
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5587,7 +5587,7 @@ packages:
       ember-source: ^4.0.0 || ^5.0.0
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5610,7 +5610,7 @@ packages:
       ember-source: ^4.0.0 || ^5.0.0
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5633,7 +5633,7 @@ packages:
       ember-source: ^4.0.0 || ^5.0.0
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -5664,7 +5664,7 @@ packages:
     resolution: {integrity: sha512-qyN64T1jMHZ99ihlk7VFHCWHYZHLE1DOdHi0J7lmn5waV1DoW7gD8JLi1i7FregzXtKhbDc7shyEmTmWPTs8MQ==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@embroider/shared-internals': 2.6.2
+      '@embroider/shared-internals': 2.6.3
       broccoli-funnel: 3.0.8
       common-ancestor-path: 1.0.1
       semver: 7.6.3
@@ -5672,8 +5672,8 @@ packages:
       - supports-color
     dev: true
 
-  /@embroider/macros@1.16.5(@glint/template@1.4.0):
-    resolution: {integrity: sha512-Oz8bUZvZzOV1Gk3qSgIzZJJzs6acclSTcEFyB+KdKbKqjTC3uebn53aU2gAlLU7/YdTRZrg2gNbQuwAp+tGkGg==}
+  /@embroider/macros@1.16.6(@glint/template@1.4.0):
+    resolution: {integrity: sha512-aSdRetg0vY3c70G/3K85fOSlGtDzSV4ozwF9qD8ToQB+4RLZusxwItnctWEa+MKkhAYB6rbFiQ+bhFwEnaEazg==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
       '@glint/template': ^1.0.0
@@ -5681,7 +5681,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/shared-internals': 2.6.2
+      '@embroider/shared-internals': 2.6.3
       '@glint/template': 1.4.0
       assert-never: 1.3.0
       babel-import-util: 2.1.1
@@ -5693,12 +5693,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@embroider/shared-internals@2.6.2:
-    resolution: {integrity: sha512-jL3Bjn8C73AUBlTex+VixP7YmqvPNN/BZFB85odTstzLFOuR8y2mmGiuWbq17qNuFyoxc6xtndMnAeqwCXBNkA==}
+  /@embroider/shared-internals@2.6.3:
+    resolution: {integrity: sha512-wyFQNSqN+RZWg5ckqsk0Qfun433aEd70L6sc16sY4FFf/AzDnolmc0t3eR7lkdyxltYSrO5eqkFN7hW7l/glaw==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
       babel-import-util: 2.1.1
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ember-rfc176-data: 0.3.18
       fs-extra: 9.1.0
       js-string-escape: 1.0.1
@@ -5723,7 +5723,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-source: 3.28.12(@babel/core@7.25.2)
@@ -6166,7 +6166,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -6183,7 +6183,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -7055,7 +7055,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7067,7 +7067,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7166,7 +7166,7 @@ packages:
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-ansi: 6.0.1
@@ -7313,7 +7313,7 @@ packages:
       jest-haste-map: 29.7.0
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
@@ -7374,12 +7374,12 @@ packages:
     resolution: {integrity: sha512-F5z53uvRIF4dYfFfJP3a2Cqg+4P1dgJchJsFnsZE0eZp0LK8X7g2J0CsJHRgns+skpXOlM7n5vFGwkWCWj8qJg==}
     engines: {node: 12.* || >= 14}
     dependencies:
-      '@types/eslint': 8.56.11
+      '@types/eslint': 8.56.12
       find-up: 5.0.0
       fs-extra: 9.1.0
       proper-lockfile: 4.1.2
       slash: 3.0.0
-      tslib: 2.6.3
+      tslib: 2.7.0
       upath: 2.0.1
     dev: true
 
@@ -7738,7 +7738,7 @@ packages:
       '@pnpm/logger': 5.2.0
       '@pnpm/render-peer-issues': 5.0.2
       '@pnpm/types': 10.1.0
-      ansi-diff: 1.1.1
+      ansi-diff: 1.2.0
       boxen: 5.1.2
       chalk: 4.1.2
       cli-truncate: 2.1.0
@@ -8065,7 +8065,7 @@ packages:
       - supports-color
     dev: true
 
-  /@rollup/plugin-typescript@11.1.6(rollup@3.29.4)(tslib@2.6.3)(typescript@5.5.4):
+  /@rollup/plugin-typescript@11.1.6(rollup@3.29.4)(tslib@2.7.0)(typescript@5.5.4):
     resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -8081,7 +8081,7 @@ packages:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       resolve: 1.22.8
       rollup: 3.29.4
-      tslib: 2.6.3
+      tslib: 2.7.0
       typescript: 5.5.4
     dev: true
 
@@ -8120,133 +8120,137 @@ packages:
       rollup: 3.29.4
     dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.21.0:
-    resolution: {integrity: sha512-WTWD8PfoSAJ+qL87lE7votj3syLavxunWhzCnx3XFxFiI/BA/r3X7MUM8dVrH8rb2r4AiO8jJsr3ZjdaftmnfA==}
+  /@rollup/rollup-android-arm-eabi@4.21.2:
+    resolution: {integrity: sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.21.0:
-    resolution: {integrity: sha512-a1sR2zSK1B4eYkiZu17ZUZhmUQcKjk2/j9Me2IDjk1GHW7LB5Z35LEzj9iJch6gtUfsnvZs1ZNyDW2oZSThrkA==}
+  /@rollup/rollup-android-arm64@4.21.2:
+    resolution: {integrity: sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.21.0:
-    resolution: {integrity: sha512-zOnKWLgDld/svhKO5PD9ozmL6roy5OQ5T4ThvdYZLpiOhEGY+dp2NwUmxK0Ld91LrbjrvtNAE0ERBwjqhZTRAA==}
+  /@rollup/rollup-darwin-arm64@4.21.2:
+    resolution: {integrity: sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.21.0:
-    resolution: {integrity: sha512-7doS8br0xAkg48SKE2QNtMSFPFUlRdw9+votl27MvT46vo44ATBmdZdGysOevNELmZlfd+NEa0UYOA8f01WSrg==}
+  /@rollup/rollup-darwin-x64@4.21.2:
+    resolution: {integrity: sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.21.0:
-    resolution: {integrity: sha512-pWJsfQjNWNGsoCq53KjMtwdJDmh/6NubwQcz52aEwLEuvx08bzcy6tOUuawAOncPnxz/3siRtd8hiQ32G1y8VA==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.21.2:
+    resolution: {integrity: sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf@4.21.0:
-    resolution: {integrity: sha512-efRIANsz3UHZrnZXuEvxS9LoCOWMGD1rweciD6uJQIx2myN3a8Im1FafZBzh7zk1RJ6oKcR16dU3UPldaKd83w==}
+  /@rollup/rollup-linux-arm-musleabihf@4.21.2:
+    resolution: {integrity: sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.21.0:
-    resolution: {integrity: sha512-ZrPhydkTVhyeGTW94WJ8pnl1uroqVHM3j3hjdquwAcWnmivjAwOYjTEAuEDeJvGX7xv3Z9GAvrBkEzCgHq9U1w==}
+  /@rollup/rollup-linux-arm64-gnu@4.21.2:
+    resolution: {integrity: sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.21.0:
-    resolution: {integrity: sha512-cfaupqd+UEFeURmqNP2eEvXqgbSox/LHOyN9/d2pSdV8xTrjdg3NgOFJCtc1vQ/jEke1qD0IejbBfxleBPHnPw==}
+  /@rollup/rollup-linux-arm64-musl@4.21.2:
+    resolution: {integrity: sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.21.0:
-    resolution: {integrity: sha512-ZKPan1/RvAhrUylwBXC9t7B2hXdpb/ufeu22pG2psV7RN8roOfGurEghw1ySmX/CmDDHNTDDjY3lo9hRlgtaHg==}
+  /@rollup/rollup-linux-powerpc64le-gnu@4.21.2:
+    resolution: {integrity: sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.21.0:
-    resolution: {integrity: sha512-H1eRaCwd5E8eS8leiS+o/NqMdljkcb1d6r2h4fKSsCXQilLKArq6WS7XBLDu80Yz+nMqHVFDquwcVrQmGr28rg==}
+  /@rollup/rollup-linux-riscv64-gnu@4.21.2:
+    resolution: {integrity: sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.21.0:
-    resolution: {integrity: sha512-zJ4hA+3b5tu8u7L58CCSI0A9N1vkfwPhWd/puGXwtZlsB5bTkwDNW/+JCU84+3QYmKpLi+XvHdmrlwUwDA6kqw==}
+  /@rollup/rollup-linux-s390x-gnu@4.21.2:
+    resolution: {integrity: sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.21.0:
-    resolution: {integrity: sha512-e2hrvElFIh6kW/UNBQK/kzqMNY5mO+67YtEh9OA65RM5IJXYTWiXjX6fjIiPaqOkBthYF1EqgiZ6OXKcQsM0hg==}
+  /@rollup/rollup-linux-x64-gnu@4.21.2:
+    resolution: {integrity: sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.21.0:
-    resolution: {integrity: sha512-1vvmgDdUSebVGXWX2lIcgRebqfQSff0hMEkLJyakQ9JQUbLDkEaMsPTLOmyccyC6IJ/l3FZuJbmrBw/u0A0uCQ==}
+  /@rollup/rollup-linux-x64-musl@4.21.2:
+    resolution: {integrity: sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.21.0:
-    resolution: {integrity: sha512-s5oFkZ/hFcrlAyBTONFY1TWndfyre1wOMwU+6KCpm/iatybvrRgmZVM+vCFwxmC5ZhdlgfE0N4XorsDpi7/4XQ==}
+  /@rollup/rollup-win32-arm64-msvc@4.21.2:
+    resolution: {integrity: sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.21.0:
-    resolution: {integrity: sha512-G9+TEqRnAA6nbpqyUqgTiopmnfgnMkR3kMukFBDsiyy23LZvUCpiUwjTRx6ezYCjJODXrh52rBR9oXvm+Fp5wg==}
+  /@rollup/rollup-win32-ia32-msvc@4.21.2:
+    resolution: {integrity: sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.21.0:
-    resolution: {integrity: sha512-2jsCDZwtQvRhejHLfZ1JY6w6kEuEtfF9nzYsZxzSlNVKDX+DpsDJ+Rbjkm74nvg2rdx0gwBS+IMdvwJuq3S9pQ==}
+  /@rollup/rollup-win32-x64-msvc@4.21.2:
+    resolution: {integrity: sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
+
+  /@rtsao/scc@1.1.0:
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+    dev: true
 
   /@simple-dom/document@1.4.0:
     resolution: {integrity: sha512-/RUeVH4kuD3rzo5/91+h4Z1meLSLP66eXqpVAw/4aZmYozkeqUkMprq0znL4psX/adEed5cBgiNJcfMz/eKZLg==}
@@ -8343,8 +8347,8 @@ packages:
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
-      '@babel/parser': 7.25.4
-      '@babel/types': 7.25.4
+      '@babel/parser': 7.25.6
+      '@babel/types': 7.25.6
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
@@ -8353,20 +8357,20 @@ packages:
   /@types/babel__generator@7.6.8:
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
     dev: true
 
   /@types/babel__template@7.4.4:
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
     dependencies:
-      '@babel/parser': 7.25.4
-      '@babel/types': 7.25.4
+      '@babel/parser': 7.25.6
+      '@babel/types': 7.25.6
     dev: true
 
   /@types/babel__traverse@7.20.6:
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
     dev: true
 
   /@types/babylon@6.16.9:
@@ -8379,7 +8383,7 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 15.14.9
+      '@types/node': 10.17.60
 
   /@types/broccoli-plugin@3.0.0:
     resolution: {integrity: sha512-f+TcsARR2PovfFRKFdCX0kfH/QoM3ZVD2h1rl2mNvrKO0fq2uBNCBsTU3JanfU4COCt5cXpTfARyUsERlC8vIw==}
@@ -8393,10 +8397,10 @@ packages:
   /@types/chai-as-promised@7.1.8:
     resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
     dependencies:
-      '@types/chai': 4.3.17
+      '@types/chai': 4.3.19
 
-  /@types/chai@4.3.17:
-    resolution: {integrity: sha512-zmZ21EWzR71B4Sscphjief5djsLre50M6lI622OSySTmn9DB3j+C3kWroHfBQWXbOBwbgg/M8CG/hUxDLIloow==}
+  /@types/chai@4.3.19:
+    resolution: {integrity: sha512-2hHHvQBVE2FiSK4eN0Br6snX9MtolHaTo/batnLjlGRhoQzlCL61iVpxoqO7SfFyOw+P/pwv+0zNHzKoGWz9Cw==}
 
   /@types/common-ancestor-path@1.0.2:
     resolution: {integrity: sha512-8llyULydTb7nM9yfiW78n6id3cet+qnATPV3R44yIywxgBaa8QXFSM9QTMf4OH64QOB45BlgZ3/oL4mmFLztQw==}
@@ -8405,7 +8409,7 @@ packages:
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 15.14.9
+      '@types/node': 10.17.60
 
   /@types/cookie@0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
@@ -8431,8 +8435,8 @@ packages:
       '@types/ms': 0.7.34
     dev: true
 
-  /@types/eslint@8.56.11:
-    resolution: {integrity: sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==}
+  /@types/eslint@8.56.12:
+    resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
@@ -8448,7 +8452,7 @@ packages:
   /@types/express-serve-static-core@4.19.5:
     resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
     dependencies:
-      '@types/node': 15.14.9
+      '@types/node': 10.17.60
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -8504,7 +8508,7 @@ packages:
   /@types/http-proxy@1.17.15:
     resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
     dependencies:
-      '@types/node': 15.14.9
+      '@types/node': 10.17.60
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.6:
@@ -8598,7 +8602,6 @@ packages:
 
   /@types/node@10.17.60:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
-    dev: true
 
   /@types/node@15.14.9:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
@@ -8664,7 +8667,7 @@ packages:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 15.14.9
+      '@types/node': 10.17.60
       '@types/send': 0.17.4
 
   /@types/ssri@7.1.5:
@@ -8719,7 +8722,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -8747,7 +8750,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -8772,7 +8775,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 7.32.0
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -8792,7 +8795,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -8819,7 +8822,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 7.32.0
       tsutils: 3.21.0(typescript@5.5.4)
       typescript: 5.5.4
@@ -8839,7 +8842,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.5.4)
       typescript: 5.5.4
@@ -8863,7 +8866,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -8930,7 +8933,7 @@ packages:
     engines: {node: '>= 18.20.3'}
     dependencies:
       '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       babel-import-util: 2.1.1
       broccoli-funnel: 3.0.8
       semver: 7.6.3
@@ -8943,7 +8946,7 @@ packages:
     resolution: {integrity: sha512-GHQE+woaGdRDGj6VG3Qt0uGBNog1zq5XO2Ccce35cYPpM3FOCOdmqB4Wt0miD1bBdbAuWQZmmQOIYAMSMCOdZQ==}
     engines: {node: '>= 18.20.3'}
     dependencies:
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
     transitivePeerDependencies:
       - '@glint/template'
@@ -9133,7 +9136,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9221,10 +9224,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /ansi-diff@1.1.1:
-    resolution: {integrity: sha512-XnTdFDQzbEewrDx8epWXdw7oqHMvv315vEtfqDiEhhWghIf4++h26c3/FMz7iTLhNrnj56DNIXpbxHZq+3s6qw==}
+  /ansi-diff@1.2.0:
+    resolution: {integrity: sha512-BIXwHKpjzghBjcwEV10Y4b17tjHfK4nhEqK3LqyQ3JgcMcjmi3DIevozNgrOpfvBMmrq9dfvrPJSu5/5vNUBQg==}
     dependencies:
       ansi-split: 1.0.1
+      wcwidth: 1.0.1
     dev: false
 
   /ansi-escapes@3.2.0:
@@ -9517,7 +9521,7 @@ packages:
     resolution: {integrity: sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       heimdalljs: 0.2.6
       istextorbinary: 2.6.0
       mkdirp: 0.5.6
@@ -9602,9 +9606,9 @@ packages:
       eslint: '>= 4.12.1'
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.25.4
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
-      '@babel/types': 7.25.4
+      '@babel/parser': 7.25.6
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
       eslint: 7.32.0
       eslint-visitor-keys: 1.3.0
       resolve: 1.22.8
@@ -9869,7 +9873,7 @@ packages:
     resolution: {integrity: sha512-jDLlxI8QnfKd7PtieH6pl4tZJzymzfCDCPGdTq/grgbiYAikwDPp/oL0IlFJn0HQjLpcLkyYhPKkUVneRESw5w==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
       lodash: 4.17.21
 
   /babel-plugin-htmlbars-inline-precompile@5.3.1:
@@ -9900,7 +9904,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
     dev: true
@@ -9929,7 +9933,7 @@ packages:
     resolution: {integrity: sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==}
     engines: {node: '>= 16'}
     dependencies:
-      find-babel-config: 2.1.1
+      find-babel-config: 2.1.2
       glob: 8.1.0
       pkg-up: 3.1.0
       reselect: 4.1.8
@@ -10230,7 +10234,7 @@ packages:
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.25.2)
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.2)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-syntax-import-attributes': 7.25.6(@babel/core@7.25.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
@@ -10811,7 +10815,7 @@ packages:
     dependencies:
       array-equal: 1.0.2
       broccoli-plugin: 4.0.7
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       fs-tree-diff: 2.0.1
       heimdalljs: 0.2.6
       minimatch: 3.1.2
@@ -11067,7 +11071,7 @@ packages:
       broccoli-persistent-filter: 2.3.1
       broccoli-plugin: 2.1.0
       chalk: 2.4.2
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ensure-posix-path: 1.1.1
       fs-extra: 8.1.0
       minimatch: 3.1.2
@@ -11085,7 +11089,7 @@ packages:
       async-promise-queue: 1.0.5
       broccoli-plugin: 4.0.7
       convert-source-map: 2.0.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash.defaultsdeep: 4.6.1
       matcher-collection: 2.0.1
       symlink-or-copy: 1.3.1
@@ -11159,7 +11163,7 @@ packages:
     resolution: {integrity: sha512-sWi3b3fTUSVPDsz5KsQ5eCQNVAtLgkIE/HYFkEZXR/07clqmd4E/gFiuwSaqa9b+QTXc1Uemfb7TVWbEIURWDg==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      '@types/chai': 4.3.17
+      '@types/chai': 4.3.19
       '@types/chai-as-promised': 7.1.8
       '@types/express': 4.17.21
       ansi-html: 0.0.7
@@ -11194,8 +11198,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001651
-      electron-to-chromium: 1.5.13
+      caniuse-lite: 1.0.30001658
+      electron-to-chromium: 1.5.18
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
 
@@ -11363,8 +11367,8 @@ packages:
       path-temp: 2.1.0
     dev: false
 
-  /caniuse-lite@1.0.30001651:
-    resolution: {integrity: sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==}
+  /caniuse-lite@1.0.30001658:
+    resolution: {integrity: sha512-N2YVqWbJELVdrnsW5p+apoQyYt51aBMSsBZki1XZEfeBCexcM/sf4xiAHcXQBkuOwJBXtWF7aW1sYX6tKebPHw==}
 
   /capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -11440,8 +11444,8 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
-  /cjs-module-lexer@1.3.1:
-    resolution: {integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==}
+  /cjs-module-lexer@1.4.1:
+    resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
     dev: true
 
   /class-utils@0.3.6:
@@ -12160,13 +12164,13 @@ packages:
     peerDependencies:
       webpack: ^4.27.0 || ^5.0.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.41)
+      icss-utils: 5.1.0(postcss@8.4.45)
       loader-utils: 2.0.4
-      postcss: 8.4.41
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.41)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.41)
-      postcss-modules-scope: 3.2.0(postcss@8.4.41)
-      postcss-modules-values: 4.0.0(postcss@8.4.41)
+      postcss: 8.4.45
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.45)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.45)
+      postcss-modules-scope: 3.2.0(postcss@8.4.45)
+      postcss-modules-values: 4.0.0(postcss@8.4.45)
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.6.3
@@ -12312,7 +12316,7 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.25.6
     dev: true
 
   /debug@2.6.9:
@@ -12335,8 +12339,8 @@ packages:
     dependencies:
       ms: 2.1.3
 
-  /debug@4.3.6(supports-color@8.1.1):
-    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
+  /debug@4.3.7(supports-color@8.1.1):
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -12344,7 +12348,7 @@ packages:
       supports-color:
         optional: true
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
       supports-color: 8.1.1
 
   /decamelize-keys@1.1.1:
@@ -12598,7 +12602,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.7.0
     dev: true
 
   /dot-prop@5.3.0:
@@ -12629,8 +12633,8 @@ packages:
   /ee-first@1.1.1:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
 
-  /electron-to-chromium@1.5.13:
-    resolution: {integrity: sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==}
+  /electron-to-chromium@1.5.18:
+    resolution: {integrity: sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ==}
 
   /ember-asset-loader@0.6.1:
     resolution: {integrity: sha512-e2zafQJBMLhzl69caTG/+mQMH20uMHYrm7KcmdbmnX0oY2dZ48bhm0Wh1SPLXS/6G2T9NsNMWX6J2pVSnI+xyA==}
@@ -12657,8 +12661,8 @@ packages:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.25.2)
       '@babel/preset-env': 7.25.4(@babel/core@7.25.2)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
-      '@embroider/shared-internals': 2.6.2
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/shared-internals': 2.6.3
       babel-loader: 8.3.0(@babel/core@7.25.2)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.2.5
@@ -12670,7 +12674,7 @@ packages:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       css-loader: 5.2.7(webpack@5.94.0)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       fs-extra: 10.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.8
@@ -12701,8 +12705,8 @@ packages:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.25.2)
       '@babel/preset-env': 7.25.4(@babel/core@7.25.2)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
-      '@embroider/shared-internals': 2.6.2
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
+      '@embroider/shared-internals': 2.6.3
       babel-loader: 8.3.0(@babel/core@7.25.2)(webpack@5.94.0)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.2.5
@@ -12714,7 +12718,7 @@ packages:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       css-loader: 5.2.7(webpack@5.94.0)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       fs-extra: 10.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.8
@@ -12741,7 +12745,7 @@ packages:
       ember-source: '>=3.24'
     dependencies:
       '@ember/render-modifiers': 2.1.0(@babel/core@7.25.2)(ember-source@3.28.12)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@embroider/util': 1.13.2(ember-source@3.28.12)
       '@glimmer/component': 1.1.2(@babel/core@7.25.2)
       '@glimmer/tracking': 1.1.2
@@ -12812,7 +12816,7 @@ packages:
     peerDependencies:
       ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
     dependencies:
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@glimmer/tracking': 1.1.2
       babel-import-util: 1.4.1
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.25.2)
@@ -13172,7 +13176,7 @@ packages:
     engines: {node: 16.* || >= 18}
     dependencies:
       broccoli-funnel: 3.0.8
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13229,7 +13233,7 @@ packages:
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.2)
       '@babel/plugin-transform-typescript': 7.4.5(@babel/core@7.25.2)
       ansi-to-html: 0.6.15
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ember-cli-babel-plugin-helpers: 1.1.1
       execa: 1.0.0
       fs-extra: 7.0.1
@@ -13249,7 +13253,7 @@ packages:
     dependencies:
       '@babel/plugin-transform-typescript': 7.5.5(@babel/core@7.25.2)
       ansi-to-html: 0.6.15
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ember-cli-babel-plugin-helpers: 1.1.1
       execa: 2.1.0
       fs-extra: 8.1.0
@@ -13268,7 +13272,7 @@ packages:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.8
@@ -13286,7 +13290,7 @@ packages:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.8
@@ -13544,7 +13548,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.4
+      filesize: 10.1.6
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -13581,7 +13585,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -13736,7 +13740,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 3.1.0
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -13892,7 +13896,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -14048,7 +14052,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -14161,7 +14165,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.4
+      filesize: 10.1.6
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14198,7 +14202,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -14311,7 +14315,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.4
+      filesize: 10.1.6
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14346,7 +14350,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -14458,7 +14462,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.4
+      filesize: 10.1.6
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14493,7 +14497,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -14605,7 +14609,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.4
+      filesize: 10.1.6
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14641,7 +14645,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -14753,7 +14757,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.4
+      filesize: 10.1.6
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14788,7 +14792,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -14900,7 +14904,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       express: 4.19.2
-      filesize: 10.1.4
+      filesize: 10.1.6
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
       fixturify-project: 2.1.1
@@ -14935,7 +14939,7 @@ packages:
       remove-types: 1.0.0
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.6.3
       silent-error: 1.1.1
@@ -15025,7 +15029,7 @@ packages:
     engines: {node: 10.* || 12.* || 14.* || >= 16}
     dependencies:
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
       '@glimmer/tracking': 1.1.2
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
@@ -15080,7 +15084,7 @@ packages:
       '@ember-data/tracking': 4.12.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@glimmer/env': 0.1.7
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
@@ -15136,7 +15140,7 @@ packages:
       '@ember-data/tracking': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@glimmer/env': 0.1.7
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
@@ -15171,7 +15175,7 @@ packages:
       '@ember-data/tracking': 5.3.0(@babel/core@7.25.2)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
@@ -15218,7 +15222,7 @@ packages:
       '@ember/edition-utils': 1.2.0
       '@ember/test-helpers': 2.9.4(@babel/core@7.25.2)(ember-source@3.28.12)
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       '@warp-drive/build-config': 0.0.0-beta.6
       '@warp-drive/core-types': 0.0.0-beta.11
       qunit: 2.22.0
@@ -15282,7 +15286,7 @@ packages:
       ember-source: ^3.12 || 4
     dependencies:
       '@ember/legacy-built-in-components': 0.4.2(ember-source@3.28.12)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       amd-name-resolver: 1.3.1
       babel-plugin-compact-reexports: 1.1.0
       broccoli-babel-transpiler: 7.8.1
@@ -15313,7 +15317,7 @@ packages:
       '@ember/legacy-built-in-components': '*'
       ember-source: ^3.12 || 4
     dependencies:
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       amd-name-resolver: 1.3.1
       babel-plugin-compact-reexports: 1.1.0
       broccoli-babel-transpiler: 7.8.1
@@ -15378,7 +15382,7 @@ packages:
     resolution: {integrity: sha512-eHs+7D7PuQr8a1DPqsJTsEyo3FZ1XuH6WEZaEBPDa9s0xLlwByCNKl8hi1EbXOgvgEZNHHi9Rh0vjxyfakrlgg==}
     engines: {node: 10.* || >= 12}
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-version-checker: 5.1.2
@@ -15729,7 +15733,7 @@ packages:
     dependencies:
       '@ember/test-helpers': 3.3.1(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@5.3.0)(webpack@5.94.0)
       '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       ember-cli-test-loader: 3.1.0
       ember-source: 5.3.0(@babel/core@7.25.2)(@glimmer/component@1.1.2)(@glint/template@1.4.0)(webpack@5.94.0)
       qunit: 2.22.0
@@ -15834,8 +15838,8 @@ packages:
     resolution: {integrity: sha512-89oVHVJwmLDvGvAUWgS87KpBoRhy3aZ6U0Ql6HOmU4TrPkyaa8pM0W81wj9cIwjYprcQtN9EwzZMHnq46+oUyw==}
     engines: {node: 8.* || 10.* || >= 12}
     dependencies:
-      '@babel/parser': 7.25.4
-      '@babel/traverse': 7.25.4(supports-color@8.1.1)
+      '@babel/parser': 7.25.6
+      '@babel/traverse': 7.25.6(supports-color@8.1.1)
       recast: 0.18.10
     transitivePeerDependencies:
       - supports-color
@@ -16467,7 +16471,7 @@ packages:
       get-stdin: 8.0.0
       globby: 11.1.0
       is-glob: 4.0.3
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       requireindex: 1.2.0
       resolve: 1.22.8
       v8-compile-cache: 2.4.0
@@ -16494,7 +16498,7 @@ packages:
       globby: 13.2.2
       is-glob: 4.0.3
       language-tags: 1.0.9
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       resolve: 1.22.8
       v8-compile-cache: 2.4.0
       yargs: 17.7.2
@@ -16521,7 +16525,7 @@ packages:
       globby: 13.2.2
       is-glob: 4.0.3
       language-tags: 1.0.9
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       resolve: 1.22.8
       v8-compile-cache: 2.4.0
       yargs: 17.7.2
@@ -16608,7 +16612,7 @@ packages:
       chalk: 4.1.2
       cli-table3: 0.6.5
       core-object: 3.1.5
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ember-try-config: 4.0.0
       execa: 4.1.0
       fs-extra: 9.1.0
@@ -16677,7 +16681,7 @@ packages:
       base64id: 2.0.0
       cookie: 0.4.2
       cors: 2.8.5
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.17.1
     transitivePeerDependencies:
@@ -16892,8 +16896,8 @@ packages:
       '@esbuild/win32-x64': 0.21.5
     dev: true
 
-  /escalade@3.1.2:
-    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+  /escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   /escape-html@1.0.3:
@@ -16964,8 +16968,8 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
-    resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
+  /eslint-module-utils@2.11.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    resolution: {integrity: sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -17118,8 +17122,8 @@ packages:
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0)(eslint@8.57.0):
-    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
+  /eslint-plugin-import@2.30.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0):
+    resolution: {integrity: sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -17128,6 +17132,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
+      '@rtsao/scc': 1.1.0
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -17137,7 +17142,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -17163,7 +17168,7 @@ packages:
       builtins: 5.1.0
       eslint: 8.57.0
       eslint-plugin-es-x: 7.8.0(eslint@8.57.0)
-      get-tsconfig: 4.7.6
+      get-tsconfig: 4.8.0
       globals: 13.24.0
       ignore: 5.3.2
       is-builtin-module: 3.2.1
@@ -17325,7 +17330,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -17379,7 +17384,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -17700,7 +17705,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.7
+      micromatch: 4.0.8
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -17763,7 +17768,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       cookie: 0.4.2
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       jsdom: 19.0.0
       resolve: 1.22.8
       simple-dom: 1.4.0
@@ -17781,7 +17786,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       cookie: 0.4.2
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       jsdom: 19.0.0
       resolve: 1.22.8
       simple-dom: 1.4.0
@@ -17839,8 +17844,8 @@ packages:
       flat-cache: 3.2.0
     dev: true
 
-  /filesize@10.1.4:
-    resolution: {integrity: sha512-ryBwPIIeErmxgPnm6cbESAzXjuEFubs+yKYLBZvg3CaiNcmkJChoOGcBSrZ6IwkMwPABwPpVXE6IlNdGJJrvEg==}
+  /filesize@10.1.6:
+    resolution: {integrity: sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==}
     engines: {node: '>= 10.4.0'}
 
   /filesize@6.4.0:
@@ -17907,11 +17912,10 @@ packages:
       json5: 1.0.2
       path-exists: 3.0.0
 
-  /find-babel-config@2.1.1:
-    resolution: {integrity: sha512-5Ji+EAysHGe1OipH7GN4qDjok5Z1uw5KAwDCbicU/4wyTZY7CqOCzcWbG7J5ad9mazq67k89fXlbc1MuIfl9uA==}
+  /find-babel-config@2.1.2:
+    resolution: {integrity: sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==}
     dependencies:
       json5: 2.2.3
-      path-exists: 4.0.0
     dev: true
 
   /find-cache-dir@3.3.2:
@@ -17978,7 +17982,7 @@ packages:
   /find-yarn-workspace-root@2.0.0:
     resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
     dependencies:
-      micromatch: 4.0.7
+      micromatch: 4.0.8
 
   /findup-sync@2.0.0:
     resolution: {integrity: sha512-vs+3unmJT45eczmcAZ6zMJtxN3l/QXeccaXQx5cu/MeJMhewVfoWZqibRkOxPnmoR59+Zy5hjabfQc6JLSah4g==}
@@ -17998,7 +18002,7 @@ packages:
     dependencies:
       detect-file: 1.0.0
       is-glob: 4.0.3
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       resolve-dir: 1.0.1
 
   /findup-sync@5.0.0:
@@ -18007,7 +18011,7 @@ packages:
     dependencies:
       detect-file: 1.0.0
       is-glob: 4.0.3
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       resolve-dir: 1.0.1
     dev: true
 
@@ -18043,7 +18047,7 @@ packages:
       fixturify: 3.0.0
       resolve-package-path: 4.0.3
       tmp: 0.0.33
-      type-fest: 4.25.0
+      type-fest: 4.26.1
       walk-sync: 3.0.0
     dev: true
 
@@ -18051,7 +18055,7 @@ packages:
     resolution: {integrity: sha512-Dyns5nXY9LEvqnUBzfejnb7w1JfabduNvXmYXfnbqmro4QxkF0vgs3eBu2X8kVR3geL+LmPZwXb4aKy6k5gtvQ==}
     engines: {node: '>= 14.*'}
     dependencies:
-      '@embroider/shared-internals': 2.6.2
+      '@embroider/shared-internals': 2.6.3
       '@pnpm/find-workspace-dir': 7.0.1
       '@pnpm/fs.packlist': 2.0.0
       '@pnpm/logger': 5.2.0
@@ -18062,7 +18066,7 @@ packages:
       fs-extra: 10.1.0
       resolve-package-path: 4.0.3
       tmp: 0.0.33
-      type-fest: 4.25.0
+      type-fest: 4.26.1
       walk-sync: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -18126,8 +18130,8 @@ packages:
       tabbable: 5.3.3
     dev: true
 
-  /follow-redirects@1.15.6:
-    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+  /follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -18445,8 +18449,8 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
 
-  /get-tsconfig@4.7.6:
-    resolution: {integrity: sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==}
+  /get-tsconfig@4.8.0:
+    resolution: {integrity: sha512-Pgba6TExTZ0FJAn1qkJAjIeKoDJ3CsI2ChuLohJnZl/tTU8MVrq3b+2t5UOPfRa4RMsorClBjJALkJUMjG1PAw==}
     dependencies:
       resolve-pkg-maps: 1.0.0
     dev: true
@@ -18738,7 +18742,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.19.2
+      uglify-js: 3.19.3
 
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -18980,7 +18984,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18990,7 +18994,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18999,7 +19003,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.9
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -19009,7 +19013,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19047,13 +19051,13 @@ packages:
     dependencies:
       safer-buffer: 2.1.2
 
-  /icss-utils@5.1.0(postcss@8.4.41):
+  /icss-utils@5.1.0(postcss@8.4.45):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.4.45
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -19449,7 +19453,7 @@ packages:
   /is-language-code@3.1.0:
     resolution: {integrity: sha512-zJdQ3QTeLye+iphMeK3wks+vXSRFKh68/Pnlw7aOfApFSEIOhYa8P9vwwa6QrImNNBMJTiL1PpYF0f4BxDuEgA==}
     dependencies:
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.25.6
     dev: true
 
   /is-negative-zero@2.0.3:
@@ -19641,7 +19645,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/parser': 7.25.4
+      '@babel/parser': 7.25.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -19654,7 +19658,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/parser': 7.25.4
+      '@babel/parser': 7.25.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.6.3
@@ -19675,7 +19679,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -19818,7 +19822,7 @@ packages:
       jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       parse-json: 5.2.0
       pretty-format: 29.7.0
       slash: 3.0.0
@@ -19884,7 +19888,7 @@ packages:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       jest-worker: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -19916,7 +19920,7 @@ packages:
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -20014,7 +20018,7 @@ packages:
       '@jest/types': 29.6.3
       '@types/node': 15.14.9
       chalk: 4.1.2
-      cjs-module-lexer: 1.3.1
+      cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
       glob: 7.2.3
       graceful-fs: 4.2.11
@@ -20036,10 +20040,10 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/generator': 7.25.4
+      '@babel/generator': 7.25.6
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
       '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.25.2)
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -20407,8 +20411,8 @@ packages:
     resolution: {integrity: sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ==}
     dev: true
 
-  /ky@1.7.1:
-    resolution: {integrity: sha512-KJ/IXXkFhTDqxcN8wKqMXk1/UoOpc0UnOB6H7QcqlPInh/M2B5Mlj+i9exez1w4RSwJhNFmHiUDPriAYFwb5VA==}
+  /ky@1.7.2:
+    resolution: {integrity: sha512-OzIvbHKKDpi60TnF9t7UUVAF1B4mcqc02z5PIvrm08Wyb+yOcz63GRvEuVxNT18a9E1SrNouhB4W2NNLeD7Ykg==}
     engines: {node: '>=18'}
     dev: true
 
@@ -20691,7 +20695,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.7.0
     dev: true
 
   /lowercase-keys@1.0.0:
@@ -21014,8 +21018,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /micromatch@4.0.7:
-    resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
+  /micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.3
@@ -21261,9 +21265,6 @@ packages:
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
-  /ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -21348,7 +21349,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.3
+      tslib: 2.7.0
     dev: true
 
   /node-fetch@2.7.0:
@@ -21919,7 +21920,7 @@ packages:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
     dependencies:
-      ky: 1.7.1
+      ky: 1.7.2
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
       semver: 7.6.3
@@ -22079,8 +22080,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  /picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
+  /picocolors@1.1.0:
+    resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -22160,54 +22161,54 @@ packages:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
 
-  /postcss-modules-extract-imports@3.1.0(postcss@8.4.41):
+  /postcss-modules-extract-imports@3.1.0(postcss@8.4.45):
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.4.45
 
-  /postcss-modules-local-by-default@4.0.5(postcss@8.4.41):
+  /postcss-modules-local-by-default@4.0.5(postcss@8.4.45):
     resolution: {integrity: sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.41)
-      postcss: 8.4.41
+      icss-utils: 5.1.0(postcss@8.4.45)
+      postcss: 8.4.45
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
-  /postcss-modules-scope@3.2.0(postcss@8.4.41):
+  /postcss-modules-scope@3.2.0(postcss@8.4.45):
     resolution: {integrity: sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.4.45
       postcss-selector-parser: 6.1.2
 
-  /postcss-modules-values@4.0.0(postcss@8.4.41):
+  /postcss-modules-values@4.0.0(postcss@8.4.45):
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.41)
-      postcss: 8.4.41
+      icss-utils: 5.1.0(postcss@8.4.45)
+      postcss: 8.4.45
 
   /postcss-resolve-nested-selector@0.1.6:
     resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
     dev: true
 
-  /postcss-safe-parser@6.0.0(postcss@8.4.41):
+  /postcss-safe-parser@6.0.0(postcss@8.4.45):
     resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
-      postcss: 8.4.41
+      postcss: 8.4.45
     dev: true
 
   /postcss-selector-parser@6.1.2:
@@ -22220,12 +22221,12 @@ packages:
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  /postcss@8.4.41:
-    resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
+  /postcss@8.4.45:
+    resolution: {integrity: sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       source-map-js: 1.2.0
 
   /prelude-ls@1.2.1:
@@ -22685,7 +22686,7 @@ packages:
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
     dependencies:
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.25.6
 
   /regex-not@1.0.2:
     resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==}
@@ -23022,29 +23023,29 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /rollup@4.21.0:
-    resolution: {integrity: sha512-vo+S/lfA2lMS7rZ2Qoubi6I5hwZwzXeUIctILZLbHI+laNtvhhOIon2S1JksA5UEDQ7l3vberd0fxK44lTYjbQ==}
+  /rollup@4.21.2:
+    resolution: {integrity: sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.21.0
-      '@rollup/rollup-android-arm64': 4.21.0
-      '@rollup/rollup-darwin-arm64': 4.21.0
-      '@rollup/rollup-darwin-x64': 4.21.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.21.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.21.0
-      '@rollup/rollup-linux-arm64-gnu': 4.21.0
-      '@rollup/rollup-linux-arm64-musl': 4.21.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.21.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.21.0
-      '@rollup/rollup-linux-s390x-gnu': 4.21.0
-      '@rollup/rollup-linux-x64-gnu': 4.21.0
-      '@rollup/rollup-linux-x64-musl': 4.21.0
-      '@rollup/rollup-win32-arm64-msvc': 4.21.0
-      '@rollup/rollup-win32-ia32-msvc': 4.21.0
-      '@rollup/rollup-win32-x64-msvc': 4.21.0
+      '@rollup/rollup-android-arm-eabi': 4.21.2
+      '@rollup/rollup-android-arm64': 4.21.2
+      '@rollup/rollup-darwin-arm64': 4.21.2
+      '@rollup/rollup-darwin-x64': 4.21.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.21.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.21.2
+      '@rollup/rollup-linux-arm64-gnu': 4.21.2
+      '@rollup/rollup-linux-arm64-musl': 4.21.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.21.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.21.2
+      '@rollup/rollup-linux-s390x-gnu': 4.21.2
+      '@rollup/rollup-linux-x64-gnu': 4.21.2
+      '@rollup/rollup-linux-x64-musl': 4.21.2
+      '@rollup/rollup-win32-arm64-msvc': 4.21.2
+      '@rollup/rollup-win32-ia32-msvc': 4.21.2
+      '@rollup/rollup-win32-x64-msvc': 4.21.2
       fsevents: 2.3.3
     dev: true
 
@@ -23107,7 +23108,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.7.0
 
   /safe-array-concat@1.1.2:
     resolution: {integrity: sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==}
@@ -23149,8 +23150,8 @@ packages:
     dependencies:
       ret: 0.1.15
 
-  /safe-stable-stringify@2.4.3:
-    resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
+  /safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
     dev: true
 
@@ -23186,7 +23187,7 @@ packages:
       exec-sh: 0.3.6
       execa: 4.1.0
       fb-watchman: 2.0.2
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       minimist: 1.2.8
       walker: 1.0.8
     dev: true
@@ -23444,7 +23445,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.7.0
     dev: true
 
   /snapdragon-node@2.1.1:
@@ -23479,7 +23480,7 @@ packages:
   /socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -23491,7 +23492,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23502,7 +23503,7 @@ packages:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       engine.io: 6.5.5
       socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.4
@@ -23516,7 +23517,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -23698,7 +23699,7 @@ packages:
     resolution: {integrity: sha512-GqXBq2SPWv9hTXDFKS8WrKK1aISB0aKGHZzH+uD4ShAgs+Fz20ZfoerLOm8U+f62iRWLrw6nimOY/uYuTcVhvg==}
     engines: {node: 6.* || 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23986,7 +23987,7 @@ packages:
       cosmiconfig: 8.3.6(typescript@5.5.4)
       css-functions-list: 3.2.2
       css-tree: 2.3.1
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 7.0.2
@@ -24001,12 +24002,12 @@ packages:
       known-css-properties: 0.29.0
       mathml-tag-names: 2.1.3
       meow: 10.1.5
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       normalize-path: 3.0.0
-      picocolors: 1.0.1
-      postcss: 8.4.41
+      picocolors: 1.1.0
+      postcss: 8.4.45
       postcss-resolve-nested-selector: 0.1.6
-      postcss-safe-parser: 6.0.0(postcss@8.4.41)
+      postcss-safe-parser: 6.0.0(postcss@8.4.45)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
@@ -24108,7 +24109,7 @@ packages:
     resolution: {integrity: sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       heimdalljs: 0.2.6
       mkdirp: 0.5.6
       rimraf: 3.0.2
@@ -24510,7 +24511,7 @@ packages:
     resolution: {integrity: sha512-OLWW+Nd99NOM53aZ8ilT/YpEiOo6mXD3F4/wLbARqybSZ3Jb8IxHK5UGVbZaae0wtXAyQshVV+SeqVBik+Fbmw==}
     engines: {node: '>=8'}
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       fs-tree-diff: 2.0.1
       mkdirp: 0.5.6
       quick-temp: 0.1.8
@@ -24570,8 +24571,8 @@ packages:
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
-  /tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
+  /tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   /tsutils@3.21.0(typescript@5.5.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -24618,8 +24619,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest@4.25.0:
-    resolution: {integrity: sha512-bRkIGlXsnGBRBQRAY56UXBm//9qH4bmJfFvq83gSz41N282df+fjy8ofcEgc1sM8geNt5cl6mC2g9Fht1cs8Aw==}
+  /type-fest@4.26.1:
+    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
     engines: {node: '>=16'}
 
   /type-is@1.6.18:
@@ -24685,8 +24686,8 @@ packages:
   /uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
 
-  /uglify-js@3.19.2:
-    resolution: {integrity: sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==}
+  /uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
@@ -24804,8 +24805,8 @@ packages:
       browserslist: ^4.14.0
     dependencies:
       browserslist: 4.23.3
-      escalade: 3.1.2
-      picocolors: 1.0.1
+      escalade: 3.2.0
+      picocolors: 1.1.0
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -24945,8 +24946,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /vite@5.4.2(terser@5.31.6):
-    resolution: {integrity: sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==}
+  /vite@5.4.3(terser@5.31.6):
+    resolution: {integrity: sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -24977,8 +24978,8 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.41
-      rollup: 4.21.0
+      postcss: 8.4.45
+      rollup: 4.21.2
       terser: 5.31.6
     optionalDependencies:
       fsevents: 2.3.3
@@ -25427,7 +25428,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cliui: 7.0.4
-      escalade: 3.1.2
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -25439,7 +25440,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.2
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3

--- a/test-packages/support/package.json
+++ b/test-packages/support/package.json
@@ -21,6 +21,7 @@
     "execa": "^4.0.3",
     "fastest-levenshtein": "^1.0.16",
     "fs-extra": "^7.0.0",
+    "http-proxy": "^1.18.1",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.10",
     "qunit": "^2.16.0",
@@ -31,8 +32,15 @@
     "@glimmer/syntax": "^0.84.2",
     "@types/babel__core": "^7.1.14",
     "@types/babel__traverse": "^7.18.5",
+    "@types/express": "^4.17.21",
     "@types/fs-extra": "^9.0.12",
+    "@types/http-proxy": "^1.17.15",
     "@types/lodash": "^4.14.170",
     "@types/node": "^10.5.2"
-  }
+  },
+  "files": [
+    "**/*.js",
+    "**/*.d.ts",
+    "**/*.js.map"
+  ]
 }

--- a/test-packages/support/testem-proxy.ts
+++ b/test-packages/support/testem-proxy.ts
@@ -1,0 +1,36 @@
+import httpProxy from 'http-proxy';
+import type { Application } from 'express';
+
+/*
+  This can be installed as a testem middleware to make testem run against an
+  arbitrary real webserver at targetURL.
+
+  It allows testem to handle the well-known testem-specific paths and proxies
+  everything else, while rewriting the testem-added prefix out of your
+  "/tests/index.html" URL.
+*/
+
+export function testemProxy(targetURL: string) {
+  return function testemProxyHandler(app: Application) {
+    const proxy = httpProxy.createProxyServer({
+      changeOrigin: true,
+      ignorePath: true,
+    });
+
+    proxy.on('error', (err, _req, res: any) => {
+      res && res.status && res.status(500).json(err);
+    });
+
+    app.all('*', (req, res, next) => {
+      let url = req.url;
+      if (url === '/testem.js' || url.startsWith('/testem/')) {
+        return next();
+      }
+      let m = /^(\/\d+)\/tests\/index.html/.exec(url);
+      if (m) {
+        url = url.slice(m[1].length);
+      }
+      proxy.web(req, res, { target: targetURL + url });
+    });
+  };
+}

--- a/tests/addon-template/vite.config.mjs
+++ b/tests/addon-template/vite.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => {
         ".gts",
         ".ts",
         ".hbs",
+        ".hbs.js",
         ".json",
       ],
     },

--- a/tests/app-template/vite.config.mjs
+++ b/tests/app-template/vite.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => {
         ".gts",
         ".ts",
         ".hbs",
+        ".hbs.js",
         ".json",
       ],
     },

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -192,13 +192,13 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "../hello-world.hbs";
-            import component from "../../../components/hello-world.js";
+            import template from "./hello-world.hbs";
+            import component from "../../components/hello-world.js";
             export default setComponentTemplate(template, component);
           `);
 
-          pairModule.resolves('../hello-world.hbs').to('./templates/components/hello-world.hbs');
-          pairModule.resolves('../../../components/hello-world.js').to('./components/hello-world.js');
+          pairModule.resolves('./hello-world.hbs').to('./templates/components/hello-world.hbs');
+          pairModule.resolves('../../components/hello-world.js').to('./components/hello-world.js');
         });
 
         test('hbs-only component', async function () {
@@ -216,12 +216,12 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "../hello-world.hbs";
+            import template from "./hello-world.hbs";
             import templateOnlyComponent from "@ember/component/template-only";
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "hello-world"));
           `);
 
-          pairModule.resolves('../hello-world.hbs').to('./templates/components/hello-world.hbs');
+          pairModule.resolves('./hello-world.hbs').to('./templates/components/hello-world.hbs');
         });
 
         test('explicitly namedspaced component', async function () {
@@ -314,12 +314,12 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "../template.hbs";
+            import template from "./template.hbs";
             import templateOnlyComponent from "@ember/component/template-only";
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "template"));
           `);
 
-          pairModule.resolves('../template.hbs').to('./components/hello-world/template.hbs');
+          pairModule.resolves('./template.hbs').to('./components/hello-world/template.hbs');
         });
 
         test('podded hbs-only component with non-blank podModulePrefix', async function () {
@@ -337,12 +337,12 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "../template.hbs";
+            import template from "./template.hbs";
             import templateOnlyComponent from "@ember/component/template-only";
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "template"));
           `);
 
-          pairModule.resolves('../template.hbs').to('./pods/components/hello-world/template.hbs');
+          pairModule.resolves('./template.hbs').to('./pods/components/hello-world/template.hbs');
         });
 
         test('podded js-and-hbs component with blank podModulePrefix', async function () {
@@ -361,13 +361,13 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "../template.hbs";
-            import component from "../component.js";
+            import template from "./template.hbs";
+            import component from "./component.js";
             export default setComponentTemplate(template, component);
           `);
 
-          pairModule.resolves('../template.hbs').to('./components/hello-world/template.hbs');
-          pairModule.resolves('../component.js').to('./components/hello-world/component.js');
+          pairModule.resolves('./template.hbs').to('./components/hello-world/template.hbs');
+          pairModule.resolves('./component.js').to('./components/hello-world/component.js');
         });
 
         test('podded js-and-hbs component with non-blank podModulePrefix', async function () {
@@ -386,13 +386,13 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "../template.hbs";
-            import component from "../component.js";
+            import template from "./template.hbs";
+            import component from "./component.js";
             export default setComponentTemplate(template, component);
           `);
 
-          pairModule.resolves('../template.hbs').to('./pods/components/hello-world/template.hbs');
-          pairModule.resolves('../component.js').to('./pods/components/hello-world/component.js');
+          pairModule.resolves('./template.hbs').to('./pods/components/hello-world/template.hbs');
+          pairModule.resolves('./component.js').to('./pods/components/hello-world/component.js');
         });
 
         test('plain helper', async function () {

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -90,9 +90,9 @@
     "ember-source-4.12": "npm:ember-source@~4.12.0",
     "ember-source-4.4": "npm:ember-source@~4.4.0",
     "ember-source-4.8": "npm:ember-source@~4.8.0",
+    "ember-source-5.11": "npm:ember-source@5.11.0",
     "ember-source-5.4": "npm:ember-source@~5.4.0",
     "ember-source-5.8": "npm:ember-source@~5.8.0",
-    "ember-source-5.11": "npm:ember-source@5.11.0",
     "ember-source-beta": "npm:ember-source@beta",
     "ember-source-canary": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/370cf34f9e86df17b880f11fef35a5a0f24ff38a.tgz",
     "ember-source-latest": "npm:ember-source@latest",
@@ -103,6 +103,7 @@
     "node-fetch": "2.7.0",
     "popper.js": "^1.16.1",
     "strip-ansi": "^6.0.0",
+    "testem": "^3.10.1",
     "tslib": "^2.6.0",
     "typescript": "^5.4.5",
     "webpack": "^5.90.3"

--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -106,9 +106,9 @@ appScenarios
               import { setupRenderingTest } from 'app-template/tests/helpers';
               import { render } from '@ember/test-helpers';
               import { hbs } from 'ember-cli-htmlbars';
-              import { appLibOne as libOneViaAddon, appLibTwo as libTwoViaAddon } from '../v1-example-addon';
-              import appLibOne from '../lib/app-lib-one';
-              import appLibTwo from '../lib/app-lib-two';
+              import { appLibOne as libOneViaAddon, appLibTwo as libTwoViaAddon } from 'app-template/v1-example-addon';
+              import appLibOne from 'app-template/lib/app-lib-one';
+              import appLibTwo from 'app-template/lib/app-lib-two';
 
               module('Integration | Component | example', function (hooks) {
                 setupRenderingTest(hooks);

--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -74,6 +74,7 @@ appScenarios
           'gamma.hbs': `
             <div class="gamma">{{this.message}}</div>
           `,
+          'epsilon.hbs': `<div class="epsilon">Epsilon</div>`,
           'fancy-button.hbs': `<h1>I'm fancy</h1>`,
         },
         templates: {
@@ -86,6 +87,16 @@ appScenarios
             <WelcomePage />
           `,
         },
+        lib: {
+          'app-lib-one.js': `
+            globalThis.appLibOneLoaded = (globalThis.appLibOneLoaded ?? 0) + 1;
+            export default function() { return 'app-lib-one'; }
+          `,
+          'app-lib-two.js': `
+            globalThis.appLibTwoLoaded = (globalThis.appLibTwoLoaded ?? 0) + 1;
+            export default function() { return 'app-lib-two'; }
+          `,
+        },
       },
       tests: {
         integration: {
@@ -95,6 +106,9 @@ appScenarios
               import { setupRenderingTest } from 'app-template/tests/helpers';
               import { render } from '@ember/test-helpers';
               import { hbs } from 'ember-cli-htmlbars';
+              import { appLibOne as libOneViaAddon, appLibTwo as libTwoViaAddon } from '../v1-example-addon';
+              import appLibOne from '../lib/app-lib-one';
+              import appLibTwo from '../lib/app-lib-two';
 
               module('Integration | Component | example', function (hooks) {
                 setupRenderingTest(hooks);
@@ -117,15 +131,19 @@ appScenarios
                 });
 
                 test("addon depends on an app's hbs-only component", async function (assert) {
-                  assert.ok(false, 'not implemented');
+                  await render(hbs\`<Zeta />\`);
+                  assert.dom('.zeta').hasText('Zeta');
+                  assert.dom('.epsilon').hasText('Epsilon');
                 });
 
                 test("addon depends on an app's module via relative import", async function (assert) {
-                  assert.ok(false, 'not implemented');
+                  assert.strictEqual(appLibOne(), libOneViaAddon(), 'lib one works the same');
+                  assert.strictEqual(globalThis.appLibOneLoaded, 1, 'app lib one loaded once');
                 });
 
                 test("addon depends on an app's module via named import", async function (assert) {
-                  assert.ok(false, 'not implemented');
+                  assert.strictEqual(appLibTwo(), libTwoViaAddon(), 'lib two works the same');
+                  assert.strictEqual(globalThis.appLibTwoLoaded, 1, 'app lib two loaded once');
                 });
               });
             `,
@@ -149,12 +167,24 @@ appScenarios
             <div class="beta">{{this.message}}</div>
             <Gamma />
           `,
+          'zeta.hbs': `
+            <div class="zeta">Zeta</div>
+            <Epsilon />
+          `,
         },
       },
       app: {
+        'v1-example-addon.js': `
+          import appLibOne from './lib/app-lib-one';
+          import appLibTwo from 'app-template/lib/app-lib-two';
+          export { appLibOne, appLibTwo };
+        `,
         components: {
           'beta.js': `
             export { default } from 'v1-example-addon/components/beta';
+          `,
+          'zeta.js': `
+            export { default } from 'v1-example-addon/components/zeta';
           `,
         },
       },

--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -1,4 +1,4 @@
-import { appScenarios } from './scenarios';
+import { appScenarios, baseAddon } from './scenarios';
 import type { PreparedApp } from 'scenario-tester';
 import QUnit from 'qunit';
 import fetch from 'node-fetch';
@@ -8,25 +8,158 @@ import { setupAuditTest } from '@embroider/test-support/audit-assertions';
 const { module: Qmodule, test } = QUnit;
 
 appScenarios
-  .only('canary')
+  .only('release')
   .map('vite-internals', app => {
+    // These are for a custom testem setup that will let us do runtime tests
+    // inside `vite dev` rather than only against the output of `vite build`.
+    //
+    // Most apps should run their CI against `vite build`, as that's closer to
+    // production. And they can do development tests directly in brower against
+    // `vite dev` at `/tests/index.html`. We're doing `vite dev` in CI here
+    // because we're testing the development experience itself.
+    app.linkDevDependency('testem', { baseDir: __dirname });
+    app.linkDevDependency('@embroider/test-support', { baseDir: __dirname });
+
     app.linkDevDependency('ember-page-title', { baseDir: __dirname });
     app.linkDevDependency('ember-welcome-page', { baseDir: __dirname });
     app.mergeFiles({
+      'testem-dev.js': `
+        'use strict';
+
+        module.exports = {
+          test_page: 'tests/index.html?hidepassed',
+          disable_watching: true,
+          launch_in_ci: ['Chrome'],
+          launch_in_dev: ['Chrome'],
+          browser_start_timeout: 120,
+          browser_args: {
+            Chrome: {
+              ci: [
+                // --no-sandbox is needed when running Chrome inside a container
+                process.env.CI ? '--no-sandbox' : null,
+                '--headless',
+                '--disable-dev-shm-usage',
+                '--disable-software-rasterizer',
+                '--mute-audio',
+                '--remote-debugging-port=0',
+                '--window-size=1440,900',
+              ].filter(Boolean),
+            },
+          },
+          middleware: [
+            require('@embroider/test-support/testem-proxy').testemProxy('http://localhost:4200')
+          ],
+        };
+      `,
+
       app: {
         components: {
+          'alpha.js': `
+            import Component from '@glimmer/component';
+            export default class extends Component {
+              message = "alpha";
+            }
+          `,
+          'alpha.hbs': `
+            <div class="alpha">{{this.message}}</div>
+            <Beta />
+          `,
+          'gamma.js': `
+            globalThis.gammaLoaded = (globalThis.gammaLoaded ?? 0) + 1;
+            import Component from '@glimmer/component';
+            export default class extends Component {
+              message = "gamma";
+            }
+          `,
+          'gamma.hbs': `
+            <div class="gamma">{{this.message}}</div>
+          `,
           'fancy-button.hbs': `<h1>I'm fancy</h1>`,
         },
         templates: {
-          'application.hbs': `{{page-title "MyApp"}}
+          'application.hbs': `
+            {{page-title "MyApp"}}
+            {{outlet}}
+          `,
+          'index.hbs': `
+            <FancyButton />
+            <WelcomePage />
+          `,
+        },
+      },
+      tests: {
+        integration: {
+          components: {
+            'example-test.js': `
+              import { module, test } from 'qunit';
+              import { setupRenderingTest } from 'app-template/tests/helpers';
+              import { render } from '@ember/test-helpers';
+              import { hbs } from 'ember-cli-htmlbars';
 
-          <FancyButton />
-          {{outlet}}
+              module('Integration | Component | example', function (hooks) {
+                setupRenderingTest(hooks);
 
-          <WelcomePage />`,
+                test('nesting between app and addon components', async function (assert) {
+                  await render(hbs\`<Alpha /><Gamma />\`);
+
+                  // Alpha in the app...
+                  assert.dom('.alpha').hasText('alpha');
+
+                  // calls beta in the addon...
+                  assert.dom('.beta').hasText('beta');
+
+                  // which calls gamma in the app
+                  // while the app itself also directly galls Gamma.
+                  // We want to ensure that we get the same copy of Gamma via both paths.
+                  assert.dom('.gamma').exists({ count: 2 })
+
+                  assert.strictEqual(globalThis.gammaLoaded, 1, 'gamma only evaluated once');
+                });
+
+                test("addon depends on an app's hbs-only component", async function (assert) {
+                  assert.ok(false, 'not implemented');
+                });
+
+                test("addon depends on an app's module via relative import", async function (assert) {
+                  assert.ok(false, 'not implemented');
+                });
+
+                test("addon depends on an app's module via named import", async function (assert) {
+                  assert.ok(false, 'not implemented');
+                });
+              });
+            `,
+          },
         },
       },
     });
+
+    let v1ExampleAddon = baseAddon();
+    v1ExampleAddon.name = 'v1-example-addon';
+    v1ExampleAddon.mergeFiles({
+      addon: {
+        components: {
+          'beta.js': `
+            import Component from '@glimmer/component';
+            export default class extends Component {
+              message = "beta";
+            }
+          `,
+          'beta.hbs': `
+            <div class="beta">{{this.message}}</div>
+            <Gamma />
+          `,
+        },
+      },
+      app: {
+        components: {
+          'beta.js': `
+            export { default } from 'v1-example-addon/components/beta';
+          `,
+        },
+      },
+    });
+    app.addDevDependency(v1ExampleAddon);
   })
   .forEachScenario(scenario => {
     Qmodule(scenario.name, function (hooks) {
@@ -36,46 +169,67 @@ appScenarios
 
       hooks.before(async () => {
         app = await scenario.prepare();
-        server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
-        [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
       });
 
-      let expectAudit = setupAuditTest(hooks, () => ({
-        appURL,
-        startingFrom: ['index.html'],
-        fetch: fetch as unknown as typeof globalThis.fetch,
-      }));
+      Qmodule('vite dev', function (hooks) {
+        hooks.before(async () => {
+          server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+          [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+        });
 
-      hooks.after(async () => {
-        await server?.shutdown();
+        let expectAudit = setupAuditTest(hooks, () => ({
+          appURL,
+          startingFrom: ['index.html'],
+          fetch: fetch as unknown as typeof globalThis.fetch,
+        }));
+
+        hooks.after(async () => {
+          await server?.shutdown();
+        });
+
+        test(`dep optimization of a v2 addon`, async function (assert) {
+          expectAudit
+            .module('./index.html')
+            .resolves(/\/index.html.*/) // in-html app-boot script
+            .toModule()
+            .resolves(/\/app\.js.*/)
+            .toModule()
+            .resolves(/.*\/-embroider-entrypoint.js/)
+            .toModule()
+            .withContents((_src, imports) => {
+              let pageTitleImports = imports.filter(imp => /page-title/.test(imp.source));
+              assert.ok(pageTitleImports.length > 0, 'should have at least one import from page-title');
+              for (let pageTitleImport of pageTitleImports) {
+                assert.ok(
+                  /\.vite\/deps/.test(pageTitleImport.source),
+                  `expected ${pageTitleImport.source} to be in vite deps`
+                );
+              }
+              return true;
+            });
+        });
+
+        test('run test suite against vite dev', async function (assert) {
+          let result = await app.execute('pnpm testem --file testem-dev.js ci');
+          assert.equal(result.exitCode, 0, result.output);
+        });
       });
 
-      test(`dep optimization of a v2 addon`, async function (assert) {
-        expectAudit
-          .module('./index.html')
-          .resolves(/\/index.html.*/) // in-html app-boot script
-          .toModule()
-          .resolves(/\/app\.js.*/)
-          .toModule()
-          .resolves(/.*\/-embroider-entrypoint.js/)
-          .toModule()
-          .withContents((_src, imports) => {
-            let pageTitleImports = imports.filter(imp => /page-title/.test(imp.source));
-            assert.ok(pageTitleImports.length > 0, 'should have at least one import from page-title');
-            for (let pageTitleImport of pageTitleImports) {
-              assert.ok(
-                /\.vite\/deps/.test(pageTitleImport.source),
-                `expected ${pageTitleImport.source} to be in vite deps`
-              );
-            }
-            return true;
-          });
+      Qmodule('vite optimize', function () {
+        test('vite optimize should succeed', async function (assert) {
+          let result = await app.execute('pnpm vite optimize --force');
+
+          assert.equal(result.exitCode, 0, result.output);
+        });
       });
 
-      test('vite optimize should succeed', async function (assert) {
-        let result = await app.execute('pnpm vite optimize --force');
-
-        assert.equal(result.exitCode, 0, result.output);
+      Qmodule('vite build', function () {
+        test('run tests suite against vite build output', async function (assert) {
+          let result = await app.execute('pnpm vite build --mode test');
+          assert.equal(result.exitCode, 0, result.output);
+          result = await app.execute('pnpm ember test --path dist');
+          assert.equal(result.exitCode, 0, result.output);
+        });
       });
     });
   });

--- a/tests/ts-app-template-classic/vite.config.mjs
+++ b/tests/ts-app-template-classic/vite.config.mjs
@@ -6,7 +6,7 @@ import { babel } from '@rollup/plugin-babel';
 export default defineConfig({
   cacheDir: resolve('node_modules', '.vite'),
   resolve: {
-    extensions: ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.json'],
+    extensions: ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.hbs.js', '.json'],
   },
 
   plugins: [

--- a/tests/ts-app-template/vite.config.mjs
+++ b/tests/ts-app-template/vite.config.mjs
@@ -6,7 +6,7 @@ import { babel } from '@rollup/plugin-babel';
 export default defineConfig({
   cacheDir: resolve('node_modules', '.vite'),
   resolve: {
-    extensions: ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.json'],
+    extensions: ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.hbs.js', '.json'],
   },
 
   plugins: [


### PR DESCRIPTION
- expands our vite-internals so that they do full end-to-end app testing under *both* `vite dev` and `vite build`.
- prevents app code from getting sucked into vite deps (similar to the problem being solved in https://github.com/embroider-build/embroider/pull/2078, thank you @patricklx for the experimentation in this area).
- allows non-owned modules (meaning vite/deps) to resolve from the app's namespace, so that externalized references to the app can work
- allows non-owned modules (meaning vite/deps) to use the handleRenaming rules, so that virtual pair components that get synthesized "within" .vite/deps can resolve fake dependencies like `@ember/component`.
- changes the naming strategy for virtual pair components so there is no notional directory. This fixes the problem of esbuild not wanting to resolve from a notional directory.

Remamining steps:
- [x] implement the new stubbed tests to cover the rest of the backlink cases
- [x] rationalize all the resolvableExtensions to use the same config

