### PR TITLE
add macros plugins with default config rather than no plugins at all

### DIFF
--- a/packages/compat/src/babel.ts
+++ b/packages/compat/src/babel.ts
@@ -10,6 +10,7 @@ import { join } from 'path';
 import type { Transform } from 'babel-plugin-ember-template-compilation';
 import type { Options as ResolverTransformOptions } from './resolver-transform';
 import type { Options as AdjustImportsOptions } from './babel-plugin-adjust-imports';
+import MacrosConfig from '@embroider/macros/src/macros-config';
 
 export interface CompatBabelState {
   plugins: PluginItem[];
@@ -24,11 +25,15 @@ function loadCompatConfig(): CompatBabelState {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require(compatFile);
   }
+  let macros = MacrosConfig.for({}, process.cwd());
+  let { plugins: templateMacros, setConfig } = MacrosConfig.transforms();
+  setConfig(macros);
+  macros.finalize();
   return {
     plugins: [],
     templateTransforms: [],
-    babelMacros: [],
-    templateMacros: [],
+    babelMacros: macros.babelPluginConfig(),
+    templateMacros: templateMacros as any,
   };
 }
 

--- a/packages/compat/src/babel.ts
+++ b/packages/compat/src/babel.ts
@@ -28,6 +28,10 @@ function loadCompatConfig(): CompatBabelState {
   let macros = MacrosConfig.for({}, process.cwd());
   let { plugins: templateMacros, setConfig } = MacrosConfig.transforms();
   setConfig(macros);
+  if (process.env.NODE_ENV === 'development') {
+    macros.enablePackageDevelopment(process.cwd());
+    macros.enableRuntimeMode();
+  }
   macros.finalize();
   return {
     plugins: [],

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -2112,10 +2112,11 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('components/my-thing.hbs').equalsCode(`
           window.define("my-app/components/alpha", function () {
-            return importSync("@embroider/virtual/components/alpha");
+            return esc(_importSync0);
           });
           import { precompileTemplate } from "@ember/template-compilation";
-          import { importSync } from "@embroider/macros";
+          import esc from  "../node_modules/@embroider/compat/node_modules/@embroider/macros/src/addon/es-compat2";
+          import * as _importSync0 from "@embroider/virtual/components/alpha";
           export default precompileTemplate("{{component this.which}}", {
             moduleName: "my-app/components/my-thing.hbs"
           });
@@ -2141,10 +2142,11 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('templates/index.hbs').equalsCode(`
           window.define("my-app/components/alpha", function () {
-            return importSync("@embroider/virtual/components/alpha");
+            return esc(_importSync0);
           });
           import { precompileTemplate } from "@ember/template-compilation";
-          import { importSync } from "@embroider/macros";
+          import esc from "../node_modules/@embroider/compat/node_modules/@embroider/macros/src/addon/es-compat2";
+          import * as _importSync0 from "@embroider/virtual/components/alpha";
           export default precompileTemplate("{{component this.which}}", {
             moduleName: "my-app/templates/index.hbs"
           });


### PR DESCRIPTION
This prevents build failures on missing `@embroider/macros` if you're running with no compatibility prebuild. It doesn't yet expose a way to send additional configuration into the macro system under those conditions, that can be a followup.

(The [default vite conventions for mode and NODE_ENV](https://vitejs.dev/guide/env-and-mode.html) mean that we could in theory make this babel config figure out the isDeveloping status via process.NODE_ENV, but `vite build --mode=development` unfortunately still defaults to NODE_ENV=production, and that's not when we're building test suites for CI.)