### PR TITLE
add some defensive programming to fix cases where babel is run without a filename

### DIFF
--- a/packages/shared-internals/src/package-cache.ts
+++ b/packages/shared-internals/src/package-cache.ts
@@ -67,6 +67,12 @@ export default class PackageCache {
   }
 
   ownerOfFile(filename: string): Package | undefined {
+    // this can arise if anyone is using @embroider/macros with babel on an explicit
+    // string (not a file on disk). We should never even try to check owner of the
+    // file since there is no file that can be owned
+    if (!filename) {
+      return undefined;
+    }
     let candidate = filename;
     const virtualPrefix = 'embroider_virtual:';
 

--- a/packages/shared-internals/src/paths.ts
+++ b/packages/shared-internals/src/paths.ts
@@ -48,6 +48,12 @@ const postfixRE = /[?#].*$/s;
 // cache-busting query params from leaking where they shouldn't.
 // includeHashSign true means #my-specifier is considered part of the pathname
 export function cleanUrl(url: string): string {
+  // a tiny bit of defensive programming to make sure that things won't explode
+  // a simple example is executing babel with @embroider/macros on a file without
+  // a filename (not on disk) will cause an error here
+  if (!url) {
+    return url;
+  }
   const regexp = postfixRE;
   return url.replace(regexp, '');
 }


### PR DESCRIPTION
I got a report that generators aren't working on the new app blueprint so I added a test to make sure we don't miss issues like this again: https://github.com/embroider-build/app-blueprint/pull/74

Essentially I ran the blueprint locally and tracked down these two places in this PR where we could do with a bit of defensive programming. The real issue is that ember-cli really shouldn't be initialising our babel config when running `ember generate` but that's not something we can fix in every version of ember-cli out there, it's better to be a tiny bit defensive 👍 