### PR TITLE
Re-add local/dev volta for folks not using corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,9 @@
       "unlabeled": ":question: Unlabeled"
     },
     "wildcardLabel": "unlabeled"
+  },
+  "volta": {
+    "node": "20.14.0",
+    "pnpm": "8.15.9"
   }
 }


### PR DESCRIPTION
_unless_ folks know of a way to only enable corepack for certain projects?

it's been problematic on my work repo, so I have it globally disabled.