### PR TITLE
Fix broken default export when required from CJS

### DIFF
--- a/packages/broccoli-side-watch/src/index.ts
+++ b/packages/broccoli-side-watch/src/index.ts
@@ -27,7 +27,7 @@ interface SideWatchOptions {
   dependencies that you're actively developing. For example, right now
   @embroider/webpack doesn't rebuild itself when non-ember libraries change.
 */
-export default function sideWatch(actualTree: InputNode, opts: SideWatchOptions = {}) {
+function sideWatch(actualTree: InputNode, opts: SideWatchOptions = {}) {
   const cwd = opts.cwd ?? process.cwd();
 
   if (!opts.watching || !Array.isArray(opts.watching)) {
@@ -65,3 +65,6 @@ export default function sideWatch(actualTree: InputNode, opts: SideWatchOptions 
       }),
   ]);
 }
+
+// We expose this as CJS, so make sure this transpiles to module.exports = sideWatch
+export = sideWatch;


### PR DESCRIPTION
When this package was converted to TS, `module.exports = ` was converted to `export default`, without taking into account that this would make TS emit this as a named export of "default" (`exports.default = sideWatch`), so CJS consumers would have to call it as `require('@embroider/broccoli-side-watch').default()` (aka "double default" problem). As we are only targeting CJS consumers, this changes makes the compiled js have a single main export as `module.exports = sideWatch`.

Tests weren't able to catch this, as TS was providing the interoperability, while node.js does not.