### PR TITLE
Fix hbs plugin not resolving .hbs due to broken Regex

### DIFF
--- a/packages/shared-internals/src/colocation.ts
+++ b/packages/shared-internals/src/colocation.ts
@@ -7,7 +7,7 @@ export function syntheticJStoHBS(source: string): string | null {
   // only ever JS (never TS or anything else). And extensionless imports are
   // handled by the default resolving system doing extension search.
   if (cleanUrl(source).endsWith('.js')) {
-    return source.replace(/.js(\?.*)?/, '.hbs$1');
+    return source.replace(/\.js(\?.*)?$/, '.hbs$1');
   }
 
   return null;

--- a/packages/shared-internals/tests/colocation.test.ts
+++ b/packages/shared-internals/tests/colocation.test.ts
@@ -1,0 +1,25 @@
+import { syntheticJStoHBS } from '../src';
+
+describe('colocation utils', function () {
+  describe('syntheticJStoHBS', function () {
+    test('it returns .hbs files for .js', function () {
+      const testCases = [
+        ['foo.js', 'foo.hbs'],
+        ['foo.js?qp', 'foo.hbs?qp'],
+        ['foo/json.js', 'foo/json.hbs'],
+      ];
+
+      for (const [from, to] of testCases) {
+        expect(syntheticJStoHBS(from)).toEqual(to);
+      }
+    });
+
+    test('it ignores non .js files', function () {
+      const testCases = ['foo.ts', 'foo.hbs', 'foo.js.xxx'];
+
+      for (const from of testCases) {
+        expect(syntheticJStoHBS(from)).toEqual(null);
+      }
+    });
+  });
+});


### PR DESCRIPTION
The Regex in `syntheticJStoHBS` was broken, introduced in #2121. /cc @patricklx 

Given a single .hbs file (TO) such as `components/json/index.hbs`, the hbs rollup would need to resolve that from a module id of `components/json/index.js` to the actual `components/json/index.hbs` file on disk. But with the broken regex, it would instead try to resolve to `components.hbson/index.js`!

Added some unit tests (that failed without the fix) to prevent regressions.

🚨 Note that the same bug exists on `main` already, given that #1855 was done before backporting to `stable`! So maybe https://github.com/embroider-build/embroider/pull/2144 should also include this and the other recent changes on `stable`? /cc @mansona