### PR TITLE
Fix gjs/gts sourcemaps -- we accidentally unlocked really good DX

### DIFF
--- a/packages/addon-dev/package.json
+++ b/packages/addon-dev/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@embroider/core": "workspace:^",
     "@rollup/pluginutils": "^4.1.1",
-    "content-tag": "^2.0.1",
+    "content-tag": "^3.0.0",
     "fs-extra": "^10.0.0",
     "minimatch": "^3.0.4",
     "rollup-plugin-copy-assets": "^2.0.3",

--- a/packages/addon-dev/src/rollup-gjs-plugin.ts
+++ b/packages/addon-dev/src/rollup-gjs-plugin.ts
@@ -7,9 +7,7 @@ const PLUGIN_NAME = 'rollup-gjs-plugin';
 const processor = new Preprocessor();
 // import { parse as pathParse } from 'path';
 
-export default function rollupGjsPlugin(
-  { inline_source_map } = { inline_source_map: true }
-): Plugin {
+export default function rollupGjsPlugin(): Plugin {
   return {
     name: PLUGIN_NAME,
 
@@ -20,12 +18,12 @@ export default function rollupGjsPlugin(
         if (!gjsFilter(id)) {
           return null;
         }
-        let code = processor.process(input, {
+        let { code, map } = processor.process(input, {
           filename: id,
-          inline_source_map,
         });
         return {
           code,
+          map,
         };
       },
     },

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -59,8 +59,8 @@ export class Addon {
     return hbs(options);
   }
 
-  gjs(options?: { inline_source_map: boolean }) {
-    return gjs(options);
+  gjs() {
+    return gjs();
   }
 
   // this does incremental updates to the dist files and also deletes files that are not part of the generated bundle

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^4.1.1
         version: 4.2.1
       content-tag:
-        specifier: ^2.0.1
-        version: 2.0.2
+        specifier: ^3.0.0
+        version: 3.0.0
       fs-extra:
         specifier: ^10.0.0
         version: 10.1.0
@@ -3451,7 +3451,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0(supports-color@8.1.1)
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
   /@babel/plugin-transform-private-methods@7.25.9(@babel/core@7.26.0):
@@ -11997,6 +11997,10 @@ packages:
 
   /content-tag@2.0.2:
     resolution: {integrity: sha512-qHRyTp02dgzRK2tsCFxZ1H289bZOuSLNpupr6prvnSFq4SFPmNlBKbbE5PCMb+8+Z1a1z+yCVtXvQIGUCCa3lQ==}
+
+  /content-tag@3.0.0:
+    resolution: {integrity: sha512-HxWPmF9hzehv5PV7TSK7QSzlVBhmwQA8NgBrXmL+fqXfM3L1r3ResAPzeiGbxra3Zw6U3gdhw3cIDJADQnuCVQ==}
+    dev: false
 
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}


### PR DESCRIPTION
Alternative to:
- https://github.com/embroider-build/embroider/pull/2162
  (and see here for context)

Requires
- https://github.com/embroider-build/content-tag/pull/86
  I will need to upgrade content-tag in this (#2166) PR once released


Something that is quite surprising (in a good way), is that we can inspect live values _in templates_ (which makes sense, and really shows the power of the content-tag strategy we're using.

For example:
![image](https://github.com/user-attachments/assets/6931a3b7-3598-496f-8507-04c6afec15f1)
![image](https://github.com/user-attachments/assets/994035ed-5a33-4f9b-a690-25c85e90f8dd)
![image](https://github.com/user-attachments/assets/29e9c143-024c-4566-b625-fda7b71235d4)
