### PR TITLE
ensure its a file specifier

### DIFF
--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -112,6 +112,10 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
         let pkg = this.packageCache.ownerOfFile(result.path);
         if (
           pkg?.root === this.packageCache.appRoot &&
+          // vite provides node built-in polyfills under a custom namespace and we dont 
+          // want to interrupt that. We'd prefer they get bundled in the dep optimizer normally,
+          // rather than getting deferred to the app build (which also works, but means they didn't
+          // get pre-optimized).
           (result.namespace === 'file' || result.namespace.startsWith('embroider-'))
         ) {
           let externalizedName = request.specifier;

--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -105,7 +105,10 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
         // and non-strict handlebars (which resolves
         // components/helpers/modifiers against the app's global pool).
         let pkg = this.packageCache.ownerOfFile(result.path);
-        if (pkg?.root === this.packageCache.appRoot) {
+        if (
+          pkg?.root === this.packageCache.appRoot &&
+          (result.namespace === 'file' || result.namespace.startsWith('embroider-'))
+        ) {
           let externalizedName = request.specifier;
           if (!packageName(externalizedName)) {
             // the request was a relative path. This won't remain valid once


### PR DESCRIPTION
partly for #2168 

otherwise it will also match build-ins like `path`, that are handled by vite with a custom namespace