### PR TITLE
Adjust ember-qunit versions in test suite

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1603,8 +1603,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       ember-qunit:
-        specifier: ^7.0.0
-        version: 7.0.0(@ember/test-helpers@3.3.1)(ember-source@5.11.0)(qunit@2.22.0)
+        specifier: ^8.0.0
+        version: 8.1.0(@ember/test-helpers@3.3.1)(ember-source@5.11.0)(qunit@2.22.0)
       ember-resolver:
         specifier: ^10.1.0
         version: 10.1.1(@ember/string@3.1.1)(ember-source@5.11.0)
@@ -1887,9 +1887,9 @@ importers:
       ember-page-title:
         specifier: ^8.2.3
         version: 8.2.3(ember-source@3.28.12)
-      ember-qunit-7:
-        specifier: npm:ember-qunit@^7.0.0
-        version: /ember-qunit@7.0.0(@ember/test-helpers@2.9.4)(ember-source@3.28.12)(qunit@2.22.0)(webpack@5.94.0)
+      ember-qunit-6:
+        specifier: npm:ember-qunit@^6.0.0
+        version: /ember-qunit@6.2.0(@ember/test-helpers@2.9.4)(ember-source@3.28.12)(qunit@2.22.0)(webpack@5.94.0)
       ember-source:
         specifier: ~3.28.11
         version: 3.28.12(@babel/core@7.25.2)
@@ -15580,6 +15580,32 @@ packages:
       - webpack
     dev: true
 
+  /ember-qunit@6.2.0(@ember/test-helpers@2.9.4)(ember-source@3.28.12)(qunit@2.22.0)(webpack@5.94.0):
+    resolution: {integrity: sha512-mC+0bp8DwWzJLn8SW3GS8KDZIkl4yLsNYwMi5Dw6+aFllq7FM2crd/dfY4MuOIHK7GKdjtmWJTMGnjSpeSayaw==}
+    engines: {node: 14.* || 16.* || >= 18}
+    peerDependencies:
+      '@ember/test-helpers': ^2.9.3
+      ember-source: '>=3.28'
+      qunit: ^2.13.0
+    dependencies:
+      '@ember/test-helpers': 2.9.4(@babel/core@7.25.2)(ember-source@3.28.12)
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 3.0.2
+      common-tags: 1.8.2
+      ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-test-loader: 3.1.0
+      ember-source: 3.28.12(@babel/core@7.25.2)
+      qunit: 2.22.0
+      resolve-package-path: 4.0.3
+      silent-error: 1.1.1
+      validate-peer-dependencies: 2.2.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+    dev: true
+
   /ember-qunit@6.2.0(@ember/test-helpers@3.3.1)(@glint/template@1.4.0)(ember-source@4.6.0)(qunit@2.22.0)(webpack@5.94.0):
     resolution: {integrity: sha512-mC+0bp8DwWzJLn8SW3GS8KDZIkl4yLsNYwMi5Dw6+aFllq7FM2crd/dfY4MuOIHK7GKdjtmWJTMGnjSpeSayaw==}
     engines: {node: 14.* || 16.* || >= 18}
@@ -15632,32 +15658,6 @@ packages:
       - webpack
     dev: true
 
-  /ember-qunit@7.0.0(@ember/test-helpers@2.9.4)(ember-source@3.28.12)(qunit@2.22.0)(webpack@5.94.0):
-    resolution: {integrity: sha512-KhrndHYEXsHnXvmsGyJLJQ6VCudXaRs5dzPZBsdttZJIhsB6PmYAvq2Q+mh3GRDT/59T/sRDrB3FD3/lATS8aA==}
-    engines: {node: 16.* || >= 18}
-    peerDependencies:
-      '@ember/test-helpers': '>=3.0.3'
-      ember-source: '>=4.0.0'
-      qunit: ^2.13.0
-    dependencies:
-      '@ember/test-helpers': 2.9.4(@babel/core@7.25.2)(ember-source@3.28.12)
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 3.0.2
-      common-tags: 1.8.2
-      ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.94.0)
-      ember-cli-babel: 7.26.11
-      ember-cli-test-loader: 3.1.0
-      ember-source: 3.28.12(@babel/core@7.25.2)
-      qunit: 2.22.0
-      resolve-package-path: 4.0.3
-      silent-error: 1.1.1
-      validate-peer-dependencies: 2.2.0
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-      - webpack
-    dev: true
-
   /ember-qunit@7.0.0(@ember/test-helpers@3.3.1)(ember-source@4.6.0)(qunit@2.22.0)(webpack@5.94.0):
     resolution: {integrity: sha512-KhrndHYEXsHnXvmsGyJLJQ6VCudXaRs5dzPZBsdttZJIhsB6PmYAvq2Q+mh3GRDT/59T/sRDrB3FD3/lATS8aA==}
     engines: {node: 16.* || >= 18}
@@ -15684,32 +15684,6 @@ packages:
       - webpack
     dev: true
 
-  /ember-qunit@7.0.0(@ember/test-helpers@3.3.1)(ember-source@5.11.0)(qunit@2.22.0):
-    resolution: {integrity: sha512-KhrndHYEXsHnXvmsGyJLJQ6VCudXaRs5dzPZBsdttZJIhsB6PmYAvq2Q+mh3GRDT/59T/sRDrB3FD3/lATS8aA==}
-    engines: {node: 16.* || >= 18}
-    peerDependencies:
-      '@ember/test-helpers': '>=3.0.3'
-      ember-source: '>=4.0.0'
-      qunit: ^2.13.0
-    dependencies:
-      '@ember/test-helpers': 3.3.1(@babel/core@7.25.2)(ember-source@5.11.0)
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 3.0.2
-      common-tags: 1.8.2
-      ember-auto-import: 2.7.4
-      ember-cli-babel: 7.26.11
-      ember-cli-test-loader: 3.1.0
-      ember-source: 5.11.0(patch_hash=bo72463n2ws4z6rctmcukxpqeq)(@glimmer/component@1.1.2)
-      qunit: 2.22.0
-      resolve-package-path: 4.0.3
-      silent-error: 1.1.1
-      validate-peer-dependencies: 2.2.0
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-      - webpack
-    dev: true
-
   /ember-qunit@8.1.0(@ember/test-helpers@3.3.1)(@glint/template@1.4.0)(ember-source@5.3.0)(qunit@2.22.0):
     resolution: {integrity: sha512-55/xqvVQwhiNcnh/tCzWyvlYzrYqwDY0/cIPyDQbAxGKtkUt9jCfRUGllfyOofC6LX0fL/0fIi+5e9sg1m6vXw==}
     peerDependencies:
@@ -15722,6 +15696,25 @@ packages:
       '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-test-loader: 3.1.0
       ember-source: 5.3.0(@babel/core@7.25.2)(@glimmer/component@1.1.2)(@glint/template@1.4.0)(webpack@5.94.0)
+      qunit: 2.22.0
+      qunit-theme-ember: 1.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+    dev: true
+
+  /ember-qunit@8.1.0(@ember/test-helpers@3.3.1)(ember-source@5.11.0)(qunit@2.22.0):
+    resolution: {integrity: sha512-55/xqvVQwhiNcnh/tCzWyvlYzrYqwDY0/cIPyDQbAxGKtkUt9jCfRUGllfyOofC6LX0fL/0fIi+5e9sg1m6vXw==}
+    peerDependencies:
+      '@ember/test-helpers': '>=3.0.3'
+      ember-source: '>=4.0.0'
+      qunit: ^2.13.0
+    dependencies:
+      '@ember/test-helpers': 3.3.1(@babel/core@7.25.2)(ember-source@5.11.0)
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
+      ember-cli-test-loader: 3.1.0
+      ember-source: 5.11.0(patch_hash=bo72463n2ws4z6rctmcukxpqeq)(@glimmer/component@1.1.2)
       qunit: 2.22.0
       qunit-theme-ember: 1.0.0
     transitivePeerDependencies:

--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -61,7 +61,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^7.0.0",
-    "ember-qunit": "^7.0.0",
+    "ember-qunit": "^8.0.0",
     "ember-resolver": "^10.1.0",
     "ember-source": "5.11.0",
     "ember-template-lint": "^5.10.1",

--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -187,10 +187,28 @@ appScenarios
     let myAddon = baseAddon();
     myAddon.pkg.name = 'my-addon';
     merge(myAddon.files, {
+      'index.js': `
+        module.exports = {
+          name: require('./package').name,
+          included() {
+            this._super.included.apply(this, arguments);
+            this.import('vendor/my-addon/test-styles.css', {
+              type: 'test',
+            });
+          }
+        };
+      `,
       addon: {
         styles: {
           'addon.css': `
             .my-addon-p { color: blue; }
+          `,
+        },
+      },
+      vendor: {
+        'my-addon': {
+          'test-styles.css': `
+            #example-test-styles { background-color: red }
           `,
         },
       },
@@ -232,7 +250,7 @@ appScenarios
           })
         );
         assert.true(readResult.some(content => content.includes('.my-addon-p{color:#00f}')));
-        assert.true(readResult.some(content => content.includes('#qunit-tests')));
+        assert.true(readResult.some(content => content.includes('#example-test-styles')));
       });
 
       test('virtual styles are served in dev mode', async function (assert) {
@@ -246,7 +264,7 @@ appScenarios
 
           response = await fetch(`${url}/@embroider/virtual/test-support.css?direct`);
           text = await response.text();
-          assert.true(text.includes('#qunit-tests'));
+          assert.true(text.includes('#example-test-styles'));
         } finally {
           await server.shutdown();
         }

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -85,7 +85,7 @@
     "ember-inline-svg": "^0.2.1",
     "ember-modifier": "^4.0.0",
     "ember-page-title": "^8.2.3",
-    "ember-qunit-7": "npm:ember-qunit@^7.0.0",
+    "ember-qunit-6": "npm:ember-qunit@^6.0.0",
     "ember-source": "~3.28.11",
     "ember-source-4.12": "npm:ember-source@~4.12.0",
     "ember-source-4.4": "npm:ember-source@~4.4.0",

--- a/tests/scenarios/scenarios.ts
+++ b/tests/scenarios/scenarios.ts
@@ -6,6 +6,7 @@ export async function lts_3_28(project: Project) {
   project.linkDevDependency('ember-cli', { baseDir: __dirname, resolveName: 'ember-cli' });
   project.linkDevDependency('ember-data', { baseDir: __dirname, resolveName: 'ember-data-latest' });
   project.linkDevDependency('@ember/test-helpers', { baseDir: __dirname, resolveName: 'ember-test-helpers-2' });
+  project.linkDevDependency('ember-qunit', { baseDir: __dirname, resolveName: 'ember-qunit-6' });
 }
 
 async function lts_4_4(project: Project) {
@@ -47,7 +48,6 @@ async function release(project: Project) {
   project.linkDevDependency('ember-cli', { baseDir: __dirname, resolveName: 'ember-cli-latest' });
   project.linkDevDependency('ember-data', { baseDir: __dirname, resolveName: 'ember-data-latest' });
   project.linkDevDependency('@ember/test-waiters', { baseDir: __dirname, resolveName: '@ember/test-waiters' });
-  project.linkDevDependency('ember-qunit', { baseDir: __dirname, resolveName: 'ember-qunit-7' });
   project.linkDevDependency('ember-cli-babel', { baseDir: __dirname, resolveName: 'ember-cli-babel-latest' });
   project.linkDevDependency('@babel/core', { baseDir: __dirname });
 }
@@ -56,7 +56,6 @@ async function beta(project: Project) {
   project.linkDevDependency('ember-source', { baseDir: __dirname, resolveName: 'ember-source-beta' });
   project.linkDevDependency('ember-cli', { baseDir: __dirname, resolveName: 'ember-cli-beta' });
   project.linkDevDependency('ember-data', { baseDir: __dirname, resolveName: 'ember-data-latest' });
-  project.linkDevDependency('ember-qunit', { baseDir: __dirname, resolveName: 'ember-qunit-7' });
   project.linkDevDependency('ember-cli-babel', { baseDir: __dirname, resolveName: 'ember-cli-babel-latest' });
   project.linkDevDependency('@babel/core', { baseDir: __dirname });
 }
@@ -65,7 +64,6 @@ async function canary(project: Project) {
   project.linkDevDependency('ember-source', { baseDir: __dirname, resolveName: 'ember-source-canary' });
   project.linkDevDependency('ember-cli', { baseDir: __dirname, resolveName: 'ember-cli-beta' });
   project.linkDevDependency('ember-data', { baseDir: __dirname, resolveName: 'ember-data-latest' });
-  project.linkDevDependency('ember-qunit', { baseDir: __dirname, resolveName: 'ember-qunit-7' });
   project.linkDevDependency('ember-cli-babel', { baseDir: __dirname, resolveName: 'ember-cli-babel-latest' });
 }
 


### PR DESCRIPTION
This make 8.x the default and keeps 6.0 for the oldest scenario.