### PR TITLE
Run compatPrebuild in a separate output directory

### DIFF
--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -13,15 +13,23 @@ export function emberBuild(command: string, mode: string, resolvableExtensions: 
 
   if (command === 'build') {
     return new Promise((resolve, reject) => {
-      const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--environment', mode], { env });
+      const child = fork(
+        './node_modules/ember-cli/bin/ember',
+        ['build', '--environment', mode, '-o', 'tmp/compat-prebuild', '--suppress-sizes'],
+        { env }
+      );
       child.on('exit', code => (code === 0 ? resolve() : reject()));
     });
   }
   return new Promise((resolve, reject) => {
-    const child = fork('./node_modules/ember-cli/bin/ember', ['build', '--watch', '--environment', mode], {
-      silent: true,
-      env,
-    });
+    const child = fork(
+      './node_modules/ember-cli/bin/ember',
+      ['build', '--watch', '--environment', mode, '-o', 'tmp/compat-prebuild', '--suppress-sizes'],
+      {
+        silent: true,
+        env,
+      }
+    );
     child.on('exit', code => (code === 0 ? resolve() : reject(new Error('ember build --watch failed'))));
     child.on('spawn', () => {
       child.stderr?.on('data', data => {


### PR DESCRIPTION
I was running into an issue where `ember build` being invoked as part of the compatPrebuild plugin and vite itself would both run on the same `dist` folder in conflicting ways. I believe `ember build` is cleaning up its output directory (`dist` by default) before running the build. Which already is causing some conflicts, as I think Vite should own that directory, and it may or may not do that cleanup itself depending on its `emptyOutDir` config. 

I my case, the conflict was even larger as we were building to different targets inside of `dist`, like `dist/test` and `dist/production` (custom `outDir` vite config). These outputs were meant to persist, but when running the build in test mode first and then it production, the production build would make ember-cli clear `dist/**`, so after the build only `dist/production` is left.