### PR TITLE
add --disable-gpu to testem.js for chrome

### DIFF
--- a/packages/util/testem.js
+++ b/packages/util/testem.js
@@ -9,6 +9,7 @@ module.exports = {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
+        '--disable-gpu',
         '--headless',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',

--- a/test-packages/sample-transforms/testem.js
+++ b/test-packages/sample-transforms/testem.js
@@ -9,6 +9,7 @@ module.exports = {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
+        '--disable-gpu',
         '--headless',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',

--- a/tests/addon-template/testem.js
+++ b/tests/addon-template/testem.js
@@ -11,6 +11,7 @@ module.exports = {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
+        '--disable-gpu',
         '--headless',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',

--- a/tests/app-template/testem.js
+++ b/tests/app-template/testem.js
@@ -12,6 +12,7 @@ if (typeof module !== 'undefined') {
         ci: [
           // --no-sandbox is needed when running Chrome inside a container
           process.env.CI ? '--no-sandbox' : null,
+          '--disable-gpu',
           '--headless',
           '--disable-dev-shm-usage',
           '--disable-software-rasterizer',

--- a/tests/ts-app-template-classic/testem.js
+++ b/tests/ts-app-template-classic/testem.js
@@ -11,6 +11,7 @@ module.exports = {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
+        '--disable-gpu',
         '--headless',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',

--- a/tests/ts-app-template/testem.js
+++ b/tests/ts-app-template/testem.js
@@ -12,6 +12,7 @@ if (typeof module !== 'undefined') {
         ci: [
           // --no-sandbox is needed when running Chrome inside a container
           process.env.CI ? '--no-sandbox' : null,
+          '--disable-gpu',
           '--headless',
           '--disable-dev-shm-usage',
           '--disable-software-rasterizer',


### PR DESCRIPTION
In a lot of our CI recently we are having issues with windows and there is often this output in the build: 


```
Created TensorFlow Lite XNNPACK delegate for CPU.
Attempting to use a delegate that only supports static-sized tensors with a graph that has dynamic-sized tensors (tensor#58 is a dynamic-sized tensor).
```

From what I can see this has something to do with the fact that Chrome added tensorflow and I have also seen something to suggest that the GPU initialisation can sometimes go wrong. My theory is that adding `--disable-gpu` might solve this 🤷 