### PR TITLE
read your browser targets from config/targets.js automatically

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -21,6 +21,7 @@
     "@embroider/reverse-exports": "workspace:*",
     "@rollup/pluginutils": "^5.1.0",
     "assert-never": "^1.2.1",
+    "browserslist": "*",
     "browserslist-to-esbuild": "^2.1.1",
     "content-tag": "^2.0.2",
     "debug": "^4.3.2",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -21,6 +21,7 @@
     "@embroider/reverse-exports": "workspace:*",
     "@rollup/pluginutils": "^5.1.0",
     "assert-never": "^1.2.1",
+    "browserslist-to-esbuild": "^2.1.1",
     "content-tag": "^2.0.2",
     "debug": "^4.3.2",
     "esbuild": "^0.17.19",

--- a/packages/vite/src/classic-ember-support.ts
+++ b/packages/vite/src/classic-ember-support.ts
@@ -7,6 +7,7 @@ import browserslistToEsbuild from 'browserslist-to-esbuild';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { mergeConfig, type UserConfig } from 'vite';
+import { pathToFileURL } from 'url';
 
 export function classicEmberSupport() {
   return [
@@ -20,7 +21,7 @@ export function classicEmberSupport() {
       async config(userConfig: UserConfig) {
         const targetsPath = join(process.cwd(), 'config/targets.js');
         if (existsSync(targetsPath)) {
-          const targets = await import(targetsPath);
+          const targets = await import(pathToFileURL(targetsPath).toString());
           if (targets.default.browsers) {
             return mergeConfig(
               {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1002,9 +1002,12 @@ importers:
       assert-never:
         specifier: ^1.2.1
         version: 1.3.0
+      browserslist:
+        specifier: ^4.14.0
+        version: 4.24.2
       browserslist-to-esbuild:
         specifier: ^2.1.1
-        version: 2.1.1
+        version: 2.1.1(browserslist@4.24.2)
       content-tag:
         specifier: ^2.0.2
         version: 2.0.3
@@ -11211,13 +11214,14 @@ packages:
   /browser-process-hrtime@1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
 
-  /browserslist-to-esbuild@2.1.1:
+  /browserslist-to-esbuild@2.1.1(browserslist@4.24.2):
     resolution: {integrity: sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
       browserslist: ^4.14.0
     dependencies:
+      browserslist: 4.24.2
       meow: 13.2.0
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1002,6 +1002,9 @@ importers:
       assert-never:
         specifier: ^1.2.1
         version: 1.3.0
+      browserslist-to-esbuild:
+        specifier: ^2.1.1
+        version: 2.1.1
       content-tag:
         specifier: ^2.0.2
         version: 2.0.3
@@ -3632,7 +3635,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0(supports-color@8.1.1)
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
   /@babel/plugin-transform-private-methods@7.25.9(@babel/core@7.26.0):
@@ -11207,6 +11210,16 @@ packages:
 
   /browser-process-hrtime@1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
+
+  /browserslist-to-esbuild@2.1.1:
+    resolution: {integrity: sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      browserslist: ^4.14.0
+    dependencies:
+      meow: 13.2.0
+    dev: false
 
   /browserslist@4.24.2:
     resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
@@ -21331,6 +21344,11 @@ packages:
       type-fest: 1.4.0
       yargs-parser: 20.2.9
     dev: true
+
+  /meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+    dev: false
 
   /merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}


### PR DESCRIPTION
We discussed this during the weekly meeting as an alternative to https://github.com/embroider-build/app-blueprint/pull/122

This implementation works, but we do have a problem. The set of supported targets has now changed. I tested out `ie 11` (just for laughs 😭) and I saw a lot of the following errors in the output: 

```
Transforming class syntax to the configured target environment ("chrome131", "firefox132", "ie11", "safari18.1" + 2 overrides) is not supported yet
```

I'm not exactly sure this is a blocker but it's probably something that we should mention in the RFC 🤔 thoughts? One way to work around it I think would be to setup preset-env yourself in babel which makes me think this isn't a dealbreaker