### PR TITLE
Further simplify ModuleRequest API

### DIFF
--- a/packages/core/src/node-resolve.ts
+++ b/packages/core/src/node-resolve.ts
@@ -28,28 +28,32 @@ export class NodeRequestAdapter implements RequestAdapter<Resolution<NodeResolut
     return 'node';
   }
 
-  async resolve(request: ModuleRequest<Resolution<NodeResolution, Error>>): Promise<Resolution<NodeResolution, Error>> {
-    if (request.isVirtual) {
-      return {
-        type: 'found',
-        filename: request.specifier,
-        isVirtual: true,
-        result: {
-          type: 'virtual' as 'virtual',
-          content: virtualContent(request.specifier, this.resolver).src,
-          filename: request.specifier,
-        },
-      };
-    }
-    if (request.isNotFound) {
-      let err = new Error(`module not found ${request.specifier}`);
-      (err as any).code = 'MODULE_NOT_FOUND';
-      return {
-        type: 'not_found',
-        err,
-      };
-    }
+  notFoundResponse(request: ModuleRequest<Resolution<NodeResolution, Error>>): Resolution<NodeResolution, Error> {
+    let err = new Error(`module not found ${request.specifier}`);
+    (err as any).code = 'MODULE_NOT_FOUND';
+    return {
+      type: 'not_found',
+      err,
+    };
+  }
 
+  virtualResponse(
+    _request: ModuleRequest<Resolution<NodeResolution, Error>>,
+    virtualFileName: string
+  ): Resolution<NodeResolution, Error> {
+    return {
+      type: 'found',
+      filename: virtualFileName,
+      isVirtual: true,
+      result: {
+        type: 'virtual' as 'virtual',
+        content: virtualContent(virtualFileName, this.resolver).src,
+        filename: virtualFileName,
+      },
+    };
+  }
+
+  async resolve(request: ModuleRequest<Resolution<NodeResolution, Error>>): Promise<Resolution<NodeResolution, Error>> {
     // require.resolve does not like when we resolve from virtual paths.
     // That is, a request like "../thing.js" from
     // "/a/real/path/VIRTUAL_SUBDIR/virtual.js" has an unambiguous target of

--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -55,27 +55,32 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
     return 'esbuild';
   }
 
+  notFoundResponse(
+    request: core.ModuleRequest<core.Resolution<OnResolveResult, OnResolveResult>>
+  ): core.Resolution<OnResolveResult, OnResolveResult> {
+    return {
+      type: 'not_found',
+      err: {
+        errors: [{ text: `module not found ${request.specifier}` }],
+      },
+    };
+  }
+
+  virtualResponse(
+    _request: core.ModuleRequest<core.Resolution<OnResolveResult, OnResolveResult>>,
+    virtualFileName: string
+  ): core.Resolution<OnResolveResult, OnResolveResult> {
+    return {
+      type: 'found',
+      filename: virtualFileName,
+      result: { path: virtualFileName, namespace: 'embroider-virtual' },
+      isVirtual: true,
+    };
+  }
+
   async resolve(
     request: ModuleRequest<Resolution<OnResolveResult, OnResolveResult>>
   ): Promise<Resolution<OnResolveResult, OnResolveResult>> {
-    if (request.isVirtual) {
-      return {
-        type: 'found',
-        filename: request.specifier,
-        result: { path: request.specifier, namespace: 'embroider-virtual' },
-        isVirtual: request.isVirtual,
-      };
-    }
-    if (request.isNotFound) {
-      // todo: make sure this looks correct to users
-      return {
-        type: 'not_found',
-        err: {
-          errors: [{ text: `module not found ${request.specifier}` }],
-        },
-      };
-    }
-
     requestStatus(request.specifier);
 
     let result = await this.context.resolve(request.specifier, {
@@ -129,7 +134,7 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
           };
         }
       }
-      return { type: 'found', filename: result.path, result, isVirtual: request.isVirtual };
+      return { type: 'found', filename: result.path, result, isVirtual: false };
     }
   }
 }


### PR DESCRIPTION
This moves the implementation of `notFound` and `virtualize` into precise hooks for implementations to provide, and eliminates the need for every `defaultResolve` to deal with those cases directly.

As we don't have webpack tests running currently, the changes to the webpack plugin here are typechecked but not tested.