### PR TITLE
Virtual response namespace unification

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,7 +16,7 @@ export { Resolver } from './module-resolver';
 export { ModuleRequest, type Resolution, type RequestAdapter, type RequestAdapterCreate } from './module-request';
 export type { Options as ResolverOptions } from './module-resolver-options';
 export { ResolverLoader } from './resolver-loader';
-export { virtualContent } from './virtual-content';
+export { virtualContent, type VirtualResponse } from './virtual-content';
 export type { Engine } from './app-files';
 
 // this is reexported because we already make users manage a peerDep from some

--- a/packages/core/src/module-request.ts
+++ b/packages/core/src/module-request.ts
@@ -1,7 +1,9 @@
+import type { VirtualResponse } from './virtual-content';
+
 // This is generic because different build systems have different ways of
 // representing a found module, and we just pass those values through.
 export type Resolution<T = unknown, E = unknown> =
-  | { type: 'found'; filename: string; isVirtual: boolean; result: T }
+  | { type: 'found'; filename: string; virtual: VirtualResponse | false; result: T }
 
   // used for requests that are special and don't represent real files that
   // embroider can possibly do anything custom with.
@@ -27,7 +29,7 @@ export interface RequestAdapter<Res extends Resolution> {
   // plugins are a pain in the butt. Integrators are encouraged to use the plain
   // Response-returning variants in all sane build environments.
   notFoundResponse(request: ModuleRequest<Res>): Res | (() => Promise<Res>);
-  virtualResponse(request: ModuleRequest<Res>, virtualFileName: string): Res | (() => Promise<Res>);
+  virtualResponse(request: ModuleRequest<Res>, response: VirtualResponse): Res | (() => Promise<Res>);
 }
 
 export interface InitialRequestState {
@@ -98,8 +100,8 @@ export class ModuleRequest<Res extends Resolution = Resolution> implements Modul
     return result;
   }
 
-  virtualize(virtualFileName: string): this {
-    return this.resolveTo(this.#adapter.virtualResponse(this, virtualFileName));
+  virtualize(virtualResponse: VirtualResponse): this {
+    return this.resolveTo(this.#adapter.virtualResponse(this, virtualResponse));
   }
 
   withMeta(meta: Record<string, any> | undefined): this {

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -534,11 +534,7 @@ export class Resolver {
     for (let candidate of this.componentTemplateCandidates(target.packageName)) {
       let candidateSpecifier = `${target.packageName}${candidate.prefix}${target.memberName}${candidate.suffix}`;
 
-      let resolution = await this.resolve(
-        request.alias(candidateSpecifier).rehome(target.from).withMeta({
-          runtimeFallback: false,
-        })
-      );
+      let resolution = await this.resolve(request.alias(candidateSpecifier).rehome(target.from));
 
       if (resolution.type === 'found') {
         hbsModule = resolution;
@@ -550,11 +546,7 @@ export class Resolver {
     for (let candidate of this.componentJSCandidates(target.packageName)) {
       let candidateSpecifier = `${target.packageName}${candidate.prefix}${target.memberName}${candidate.suffix}`;
 
-      let resolution = await this.resolve(
-        request.alias(candidateSpecifier).rehome(target.from).withMeta({
-          runtimeFallback: false,
-        })
-      );
+      let resolution = await this.resolve(request.alias(candidateSpecifier).rehome(target.from));
 
       if (resolution.type === 'ignored') {
         return logTransition(`resolving to ignored component`, request, request.resolveTo(resolution));
@@ -599,11 +591,7 @@ export class Resolver {
     // component, so here to resolve the ambiguity we need to actually resolve
     // that candidate to see if it works.
     let helperCandidate = this.resolveHelper(path, inEngine, request);
-    let helperMatch = await this.resolve(
-      request.alias(helperCandidate.specifier).rehome(helperCandidate.fromFile).withMeta({
-        runtimeFallback: false,
-      })
-    );
+    let helperMatch = await this.resolve(request.alias(helperCandidate.specifier).rehome(helperCandidate.fromFile));
 
     // for the case of 'ignored' that means that esbuild found this helper in an external
     // package so it should be considered found in this case and we should not look for a
@@ -1317,9 +1305,7 @@ export class Resolver {
         return request.alias(matched.entry['fastboot-js'].specifier).rehome(matched.entry['fastboot-js'].fromFile);
       case 'both':
         let foundAppJS = await this.resolve(
-          request.alias(matched.entry['app-js'].specifier).rehome(matched.entry['app-js'].fromFile).withMeta({
-            runtimeFallback: false,
-          })
+          request.alias(matched.entry['app-js'].specifier).rehome(matched.entry['app-js'].fromFile)
         );
         if (foundAppJS.type !== 'found') {
           throw new Error(

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -535,15 +535,6 @@ export class Resolver {
 
       let resolution = await this.resolve(request.alias(candidateSpecifier).rehome(target.from));
 
-      // we're seeing ignored here during depscan, which causes us to not
-      // produce a pair component, which means we will produce it later inside
-      // the vite-deps folder and blow up.
-      //
-      // I think we can adjust the layering of our observeDepScan hack so that
-      // it gives correct answers out of vite's defaultResolve, not esbuild's
-      // default resolve. The esbuild one is too high level to help our internal
-      // searching for components.
-
       if (resolution.type === 'found') {
         hbsModule = resolution;
         break;

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -536,6 +536,15 @@ export class Resolver {
 
       let resolution = await this.resolve(request.alias(candidateSpecifier).rehome(target.from));
 
+      // we're seeing ignored here during depscan, which causes us to not
+      // produce a pair component, which means we will produce it later inside
+      // the vite-deps folder and blow up.
+      //
+      // I think we can adjust the layering of our observeDepScan hack so that
+      // it gives correct answers out of vite's defaultResolve, not esbuild's
+      // default resolve. The esbuild one is too high level to help our internal
+      // searching for components.
+
       if (resolution.type === 'found') {
         hbsModule = resolution;
         break;

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -567,7 +567,7 @@ export class Resolver {
         request,
         request.virtualize({
           type: 'component-pair',
-          specifier: virtualPairComponent(hbsModule.filename, jsModule?.filename),
+          specifier: virtualPairComponent(this.options.appRoot, hbsModule.filename, jsModule?.filename),
         })
       );
     } else if (jsModule) {

--- a/packages/core/src/node-resolve.ts
+++ b/packages/core/src/node-resolve.ts
@@ -46,7 +46,7 @@ export class NodeRequestAdapter implements RequestAdapter<Resolution<NodeResolut
       filename: virtual.specifier,
       virtual,
       result: {
-        type: 'virtual' as 'virtual',
+        type: 'virtual' as const,
         content: virtualContent(virtual.specifier, this.resolver).src,
         filename: virtual.specifier,
       },

--- a/packages/core/src/node-resolve.ts
+++ b/packages/core/src/node-resolve.ts
@@ -1,4 +1,4 @@
-import { virtualContent } from './virtual-content';
+import { virtualContent, type VirtualResponse } from './virtual-content';
 import { dirname, resolve, isAbsolute } from 'path';
 import { explicitRelative } from '@embroider/shared-internals';
 import assertNever from 'assert-never';
@@ -39,16 +39,16 @@ export class NodeRequestAdapter implements RequestAdapter<Resolution<NodeResolut
 
   virtualResponse(
     _request: ModuleRequest<Resolution<NodeResolution, Error>>,
-    virtualFileName: string
+    virtual: VirtualResponse
   ): Resolution<NodeResolution, Error> {
     return {
       type: 'found',
-      filename: virtualFileName,
-      isVirtual: true,
+      filename: virtual.specifier,
+      virtual,
       result: {
         type: 'virtual' as 'virtual',
-        content: virtualContent(virtualFileName, this.resolver).src,
-        filename: virtualFileName,
+        content: virtualContent(virtual.specifier, this.resolver).src,
+        filename: virtual.specifier,
       },
     };
   }
@@ -92,7 +92,7 @@ export class NodeRequestAdapter implements RequestAdapter<Resolution<NodeResolut
 
         continue;
       }
-      return { type: 'found', filename, result: { type: 'real' as 'real', filename }, isVirtual: false };
+      return { type: 'found', filename, result: { type: 'real' as 'real', filename }, virtual: false };
     }
 
     return { type: 'not_found', err: initialError };

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -10,6 +10,27 @@ import { decodeVirtualVendorStyles, renderVendorStyles } from './virtual-vendor-
 import { decodeEntrypoint, renderEntrypoint } from './virtual-entrypoint';
 import { decodeRouteEntrypoint, renderRouteEntrypoint } from './virtual-route-entrypoint';
 
+export type VirtualResponse = { specifier: string } & (
+  | {
+      type: 'fastboot-switch';
+    }
+  | {
+      type: 'implicit-modules';
+    }
+  | {
+      type: 'implicit-test-modules';
+    }
+  | {
+      type: 'entrypoint';
+    }
+  | { type: 'route-entrypoint' }
+  | { type: 'test-support-js' }
+  | { type: 'test-support-css' }
+  | { type: 'vendor-js' }
+  | { type: 'vendor-css' }
+  | { type: 'component-pair' }
+);
+
 export interface VirtualContentResult {
   src: string;
   watches: string[];

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -134,7 +134,7 @@ const pairComponentMarker = '/embroider-pair-component/';
 const pairComponentPattern = /\/embroider-pair-component\/(?<hbsModule>[^\/]*)\/__vpc__\/(?<jsModule>[^\/]*)$/;
 
 export function virtualPairComponent(appRoot: string, hbsModule: string, jsModule: string | undefined): string {
-  return `${appRoot}/embroider-pair-component${encodeURIComponent(hbsModule)}/__vpc__${encodeURIComponent(
+  return `${appRoot}/embroider-pair-component/${encodeURIComponent(hbsModule)}/__vpc__/${encodeURIComponent(
     jsModule ?? ''
   )}`;
 }
@@ -154,7 +154,7 @@ function decodeVirtualPairComponent(
   return {
     hbsModule: decodeURIComponent(hbsModule),
     jsModule: jsModule ? decodeURIComponent(jsModule) : null,
-    debugName: basename(hbsModule).replace(/\.(js|hbs)$/, ''),
+    debugName: basename(decodeURIComponent(hbsModule)).replace(/\.(js|hbs)$/, ''),
   };
 }
 

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -3,15 +3,63 @@ import { compile } from './js-handlebars';
 import type { Resolver } from './module-resolver';
 import type { CompatResolverOptions } from '../../compat/src/resolver-transform';
 import { flatten, partition } from 'lodash';
-import { join } from 'path';
-import { extensionsPattern } from '@embroider/shared-internals';
+import { join, resolve } from 'path';
+import { extensionsPattern, type PackageCachePublicAPI, type Package } from '@embroider/shared-internals';
 import walkSync from 'walk-sync';
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { encodePublicRouteEntrypoint } from './virtual-route-entrypoint';
 import escapeRegExp from 'escape-string-regexp';
 import { optionsWithDefaults } from './options';
+import { type ModuleRequest } from './module-request';
+import { exports as resolveExports } from 'resolve.exports';
+import { type VirtualResponse } from './virtual-content';
 
 const entrypointPattern = /(?<filename>.*)[\\/]-embroider-entrypoint.js/;
+
+export function virtualEntrypoint(
+  request: ModuleRequest,
+  packageCache: PackageCachePublicAPI
+): VirtualResponse | undefined {
+  //TODO move the extra forwardslash handling out into the vite plugin
+  const candidates = [
+    '@embroider/virtual/compat-modules',
+    '/@embroider/virtual/compat-modules',
+    './@embroider/virtual/compat-modules',
+  ];
+
+  if (!candidates.some(c => request.specifier.startsWith(c + '/') || request.specifier === c)) {
+    return undefined;
+  }
+
+  const result = /\.?\/?@embroider\/virtual\/compat-modules(?:\/(?<packageName>.*))?/.exec(request.specifier);
+
+  if (!result) {
+    throw new Error('bug: entrypoint does not match pattern' + request.specifier);
+  }
+
+  const { packageName } = result.groups!;
+
+  const requestingPkg = packageCache.ownerOfFile(request.fromFile);
+
+  if (!requestingPkg?.isV2Ember()) {
+    throw new Error(`bug: found entrypoint import in non-ember package at ${request.fromFile}`);
+  }
+  let pkg: Package;
+
+  if (packageName) {
+    pkg = packageCache.resolve(packageName, requestingPkg);
+  } else {
+    pkg = requestingPkg;
+  }
+  let matched = resolveExports(pkg.packageJSON, '-embroider-entrypoint.js', {
+    browser: true,
+    conditions: ['default', 'imports'],
+  });
+  return {
+    type: 'entrypoint',
+    specifier: resolve(pkg.root, matched?.[0] ?? '-embroider-entrypoint.js'),
+  };
+}
 
 export function decodeEntrypoint(filename: string): { fromDir: string } | undefined {
   // Performance: avoid paying regex exec cost unless needed

--- a/packages/core/src/virtual-route-entrypoint.ts
+++ b/packages/core/src/virtual-route-entrypoint.ts
@@ -3,17 +3,20 @@ import { AppFiles } from './app-files';
 import type { Resolver } from './module-resolver';
 import { resolve } from 'path';
 import { compile } from './js-handlebars';
-import { extensionsPattern } from '@embroider/shared-internals';
+import { extensionsPattern, type Package } from '@embroider/shared-internals';
 import { partition } from 'lodash';
 import { getAppFiles, getFastbootFiles, importPaths, splitRoute, staticAppPathsPattern } from './virtual-entrypoint';
+import { exports as resolveExports } from 'resolve.exports';
 
 const entrypointPattern = /(?<filename>.*)[\\/]-embroider-route-entrypoint.js:route=(?<route>.*)/;
 
-export function encodeRouteEntrypoint(packagePath: string, matched: string | undefined, routeName: string): string {
-  return resolve(
-    packagePath,
-    matched ? `${matched}:route=${routeName}` : `-embroider-route-entrypoint.js:route=${routeName}`
-  );
+export function encodeRouteEntrypoint(pkg: Package, routeName: string): string {
+  let matched = resolveExports(pkg.packageJSON, '-embroider-route-entrypoint.js', {
+    browser: true,
+    conditions: ['default', 'imports'],
+  });
+  let target = matched ? `${matched}:route=${routeName}` : `-embroider-route-entrypoint.js:route=${routeName}`;
+  return resolve(pkg.root, target);
 }
 
 export function decodeRouteEntrypoint(filename: string): { fromDir: string; route: string } | undefined {

--- a/packages/shared-internals/src/index.ts
+++ b/packages/shared-internals/src/index.ts
@@ -9,7 +9,7 @@ export {
 } from './paths';
 export { getOrCreate } from './get-or-create';
 export { default as Package, V2AddonPackage as AddonPackage, V2AppPackage as AppPackage, V2Package } from './package';
-export { default as PackageCache } from './package-cache';
+export { default as PackageCache, type PackageCachePublicAPI } from './package-cache';
 export type { RewrittenPackageIndex } from './rewritten-package-cache';
 export { RewrittenPackageCache } from './rewritten-package-cache';
 export { default as packageName } from './package-name';

--- a/packages/shared-internals/src/package-cache.ts
+++ b/packages/shared-internals/src/package-cache.ts
@@ -68,11 +68,6 @@ export default class PackageCache {
 
   ownerOfFile(filename: string): Package | undefined {
     let candidate = filename;
-    const virtualPrefix = 'embroider_virtual:';
-
-    if (candidate.includes(virtualPrefix)) {
-      candidate = candidate.replace(/^.*embroider_virtual:/, '');
-    }
 
     // first we look through our cached packages for any that are rooted right
     // at or above the file.

--- a/packages/shared-internals/src/package-cache.ts
+++ b/packages/shared-internals/src/package-cache.ts
@@ -111,3 +111,9 @@ export default class PackageCache {
 }
 
 const shared: Map<string, PackageCache> = new Map();
+
+// without this, using a class as an interface forces you to have the same
+// private and protected methods too (since people trying to extend from you
+// could see all of those)
+type PublicAPI<T> = { [K in keyof T]: T[K] };
+export type PackageCachePublicAPI = PublicAPI<PackageCache>;

--- a/packages/shared-internals/src/rewritten-package-cache.ts
+++ b/packages/shared-internals/src/rewritten-package-cache.ts
@@ -1,4 +1,4 @@
-import PackageCache from './package-cache';
+import PackageCache, { type PackageCachePublicAPI } from './package-cache';
 import type { V2AddonPackage, V2AppPackage, V2Package } from './package';
 import Package from './package';
 import { existsSync, readJSONSync, realpathSync } from 'fs-extra';
@@ -25,12 +25,9 @@ export interface RewrittenPackageIndex {
   extraResolutions: Record<string, string[]>;
 }
 
-// without this, using a class as an interface forces you to have the same
-// private and protected methods too (since people trying to extend from you
-// could see all of those)
 type PublicAPI<T> = { [K in keyof T]: T[K] };
 
-export class RewrittenPackageCache implements PublicAPI<PackageCache> {
+export class RewrittenPackageCache implements PackageCachePublicAPI {
   constructor(private plainCache: PackageCache) {}
 
   get appRoot(): string {

--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -3,11 +3,14 @@ const { cleanUrl, packageName } = core;
 import type { ImportKind, OnResolveResult, PluginBuild } from 'esbuild';
 import { dirname } from 'path';
 
-import type { PackageCache as _PackageCache, Resolution, ModuleRequest, RequestAdapter } from '@embroider/core';
+import type {
+  PackageCachePublicAPI as PackageCache,
+  Resolution,
+  ModuleRequest,
+  RequestAdapter,
+  VirtualResponse,
+} from '@embroider/core';
 import { externalName } from '@embroider/reverse-exports';
-
-type PublicAPI<T> = { [K in keyof T]: T[K] };
-type PackageCache = PublicAPI<_PackageCache>;
 
 export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolveResult, OnResolveResult>> {
   static create({
@@ -68,13 +71,13 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
 
   virtualResponse(
     _request: core.ModuleRequest<core.Resolution<OnResolveResult, OnResolveResult>>,
-    virtualFileName: string
+    virtual: VirtualResponse
   ): core.Resolution<OnResolveResult, OnResolveResult> {
     return {
       type: 'found',
-      filename: virtualFileName,
-      result: { path: virtualFileName, namespace: 'embroider-virtual' },
-      isVirtual: true,
+      filename: virtual.specifier,
+      result: { path: virtual.specifier, namespace: 'embroider-virtual' },
+      virtual,
     };
   }
 
@@ -134,7 +137,7 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
           };
         }
       }
-      return { type: 'found', filename: result.path, result, isVirtual: false };
+      return { type: 'found', filename: result.path, result, virtual: false };
     }
   }
 }

--- a/packages/vite/src/request.ts
+++ b/packages/vite/src/request.ts
@@ -1,5 +1,6 @@
-import type { ModuleRequest, RequestAdapter, RequestAdapterCreate, Resolution } from '@embroider/core';
+import type { ModuleRequest, RequestAdapter, RequestAdapterCreate, Resolution, VirtualResponse } from '@embroider/core';
 import core from '@embroider/core';
+
 const { cleanUrl, getUrlQueryParams } = core;
 import type { PluginContext, ResolveIdResult } from 'rollup';
 
@@ -67,9 +68,9 @@ export class RollupRequestAdapter implements RequestAdapter<Resolution<ResolveId
 
   virtualResponse(
     request: ModuleRequest<Resolution<ResolveIdResult>>,
-    virtualFileName: string
+    virtual: VirtualResponse
   ): Resolution<ResolveIdResult> {
-    let specifier = virtualPrefix + virtualFileName;
+    let specifier = virtualPrefix + virtual.specifier;
     return {
       type: 'found',
       filename: specifier,
@@ -77,7 +78,7 @@ export class RollupRequestAdapter implements RequestAdapter<Resolution<ResolveId
         id: this.specifierWithQueryParams(specifier),
         resolvedBy: this.fromFileWithQueryParams(request.fromFile),
       },
-      isVirtual: true,
+      virtual,
     };
   }
 
@@ -103,7 +104,7 @@ export class RollupRequestAdapter implements RequestAdapter<Resolution<ResolveId
     );
     if (result) {
       let { pathname } = new URL(result.id, 'http://example.com');
-      return { type: 'found', filename: pathname, result, isVirtual: false };
+      return { type: 'found', filename: pathname, result, virtual: false };
     } else {
       return { type: 'not_found', err: undefined };
     }

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -111,7 +111,7 @@ export function resolver(): Plugin {
     },
 
     load(id) {
-      let meta = responseMetas.get(id);
+      let meta = responseMetas.get(normalizePath(id));
       if (meta?.virtual) {
         let { src, watches } = virtualContent(cleanUrl(id), resolverLoader.resolver);
         virtualDeps.set(id, watches);

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -1,4 +1,4 @@
-import type { Plugin, ViteDevServer } from 'vite';
+import { type Plugin, type ViteDevServer, normalizePath } from 'vite';
 import core, { ModuleRequest, type Resolver } from '@embroider/core';
 const { virtualContent, ResolverLoader, explicitRelative, cleanUrl, tmpdir } = core;
 import { type ResponseMeta, RollupRequestAdapter } from './request.js';
@@ -87,7 +87,7 @@ export function resolver(): Plugin {
         return resolution;
       }
       if (resolution && resolution.meta?.['embroider-resolver']) {
-        responseMetas.set(resolution.id, resolution.meta['embroider-resolver'] as ResponseMeta);
+        responseMetas.set(normalizePath(resolution.id), resolution.meta['embroider-resolver'] as ResponseMeta);
       }
       return resolution;
     },

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -61,7 +61,7 @@ export function resolver(): Plugin {
       let resolution = await resolverLoader.resolver.resolve(request);
       switch (resolution.type) {
         case 'found':
-          if (resolution.isVirtual) {
+          if (resolution.virtual) {
             return resolution.result;
           } else {
             return await maybeCaptureNewOptimizedDep(this, resolverLoader.resolver, resolution.result, notViteDeps);

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -1,5 +1,5 @@
 import { dirname, resolve } from 'path';
-import { ModuleRequest, type RequestAdapter, type Resolution } from '@embroider/core';
+import { ModuleRequest, type VirtualResponse, type RequestAdapter, type Resolution } from '@embroider/core';
 import { Resolver as EmbroiderResolver, ResolverOptions as EmbroiderResolverOptions } from '@embroider/core';
 import type { Compiler, Module, ResolveData } from 'webpack';
 import assertNever from 'assert-never';
@@ -214,36 +214,39 @@ class WebpackRequestAdapter implements RequestAdapter<WebpackResolution> {
 
   virtualResponse(
     request: ModuleRequest<WebpackResolution>,
-    virtualFileName: string
+    virtual: VirtualResponse
   ): () => Promise<WebpackResolution> {
     return () => {
-      return this._resolve(request, virtualFileName);
+      return this._resolve(request, virtual);
     };
   }
 
   async resolve(request: ModuleRequest<WebpackResolution>): Promise<WebpackResolution> {
-    return this._resolve(request, undefined);
+    return this._resolve(request, false);
   }
 
   async _resolve(
     request: ModuleRequest<WebpackResolution>,
-    virtualFileName: string | undefined
+    virtualResponse: VirtualResponse | false
   ): Promise<WebpackResolution> {
     return await new Promise(resolve =>
-      this.resolveFunction(this.toWebpackResolveData(request, virtualFileName), err => {
-        if (err) {
-          // unfortunately webpack doesn't let us distinguish between Not Found
-          // and other unexpected exceptions here.
-          resolve({ type: 'not_found', err });
-        } else {
-          resolve({
-            type: 'found',
-            result: this.originalState.createData,
-            isVirtual: Boolean(virtualFileName),
-            filename: this.originalState.createData.resource!,
-          });
+      this.resolveFunction(
+        this.toWebpackResolveData(request, virtualResponse ? virtualResponse.specifier : request.specifier),
+        err => {
+          if (err) {
+            // unfortunately webpack doesn't let us distinguish between Not Found
+            // and other unexpected exceptions here.
+            resolve({ type: 'not_found', err });
+          } else {
+            resolve({
+              type: 'found',
+              result: this.originalState.createData,
+              virtual: virtualResponse,
+              filename: this.originalState.createData.resource!,
+            });
+          }
         }
-      })
+      )
     );
   }
 }

--- a/tests/scenarios/compat-route-split-test.ts
+++ b/tests/scenarios/compat-route-split-test.ts
@@ -226,43 +226,40 @@ splitScenarios
       });
 
       test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        inEntrypoint(/import\("\/@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/);
+        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has split controllers in route entrypoint', function () {
         inEntrypoint(
           ['app/controllers/people', 'app/controllers/people/show'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has split route templates in route entrypoint', function () {
         inEntrypoint(
           ['app/templates/people', 'app/templates/people/index', 'app/templates/people/show'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has split routes in route entrypoint', function () {
         inEntrypoint(
           ['app/routes/people', 'app/routes/people/show'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has no components in route entrypoint', function () {
-        notInEntrypoint(
-          ['all-people', 'welcome', 'unused'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
-        );
+        notInEntrypoint(['all-people', 'welcome', 'unused'], /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no helpers in route entrypoint', function () {
-        notInEntrypoint('capitalize', /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/);
+        notInEntrypoint('capitalize', /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no helpers in route entrypoint', function () {
-        notInEntrypoint('auto-focus', /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/);
+        notInEntrypoint('auto-focus', /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no issues', function () {
@@ -400,43 +397,40 @@ splitScenarios
       });
 
       test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        inEntrypoint(/import\("\/@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people\?import"\)/);
+        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people\?import"\)/);
       });
 
       test('has split controllers in route entrypoint', function () {
         inEntrypoint(
           ['pods/people/controller', 'pods/people/show/controller'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has split route templates in route entrypoint', function () {
         inEntrypoint(
           ['pods/people/template', 'pods/people/index/template', 'pods/people/show/template'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has split routes in route entrypoint', function () {
         inEntrypoint(
           ['pods/people/route', 'pods/people/show/route'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has no components in route entrypoint', function () {
-        notInEntrypoint(
-          ['all-people', 'welcome', 'unused'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
-        );
+        notInEntrypoint(['all-people', 'welcome', 'unused'], /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no helpers in route entrypoint', function () {
-        notInEntrypoint('capitalize', /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/);
+        notInEntrypoint('capitalize', /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no modifiers in route entrypoint', function () {
-        notInEntrypoint('auto-focus', /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/);
+        notInEntrypoint('auto-focus', /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no issues', function () {
@@ -574,43 +568,40 @@ splitScenarios
       });
 
       test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        inEntrypoint(/import\("\/@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people\?import"\)/);
+        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people\?import"\)/);
       });
 
       test('has split controllers in route entrypoint', function () {
         inEntrypoint(
           ['routes/people/controller', 'routes/people/show/controller'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has split route templates in route entrypoint', function () {
         inEntrypoint(
           ['routes/people/template', 'routes/people/index/template', 'routes/people/show/template'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has split routes in route entrypoint', function () {
         inEntrypoint(
           ['routes/people/route', 'routes/people/show/route'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
+          /\/app\/-embroider-route-entrypoint.js:route=people/
         );
       });
 
       test('has no components in route entrypoint', function () {
-        notInEntrypoint(
-          ['all-people', 'welcome', 'unused'],
-          /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/
-        );
+        notInEntrypoint(['all-people', 'welcome', 'unused'], /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no helpers in route entrypoint', function () {
-        notInEntrypoint('capitalize', /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/);
+        notInEntrypoint('capitalize', /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no modifiers in route entrypoint', function () {
-        notInEntrypoint('auto-focus', /@id\/embroider_virtual:.*-embroider-route-entrypoint.js:route=people/);
+        notInEntrypoint('auto-focus', /\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has no issues', function () {

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -245,7 +245,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${templateFile}";
+            import template from "${esc(templateFile)}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'hello-world'.",
@@ -261,7 +261,7 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "${componentFile}";
+            import component from "${esc(componentFile)}";
             export default setComponentTemplate(template, component);
           `);
 
@@ -285,7 +285,7 @@ Scenarios.fromProject(() => new Project())
           let templateFile = normalizePath(`${app.dir}/templates/components/hello-world.hbs`);
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${templateFile}";
+            import template from "${esc(templateFile)}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'hello-world'.",
@@ -400,7 +400,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${templateFile}";
+            import template from "${esc(templateFile)}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -440,7 +440,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${templateFile}";
+            import template from "${esc(templateFile)}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -482,7 +482,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${templateFile}";
+            import template from "${esc(templateFile)}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -498,7 +498,7 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "${componentFile}";
+            import component from "${esc(componentFile)}";
             export default setComponentTemplate(template, component);
           `);
 
@@ -525,7 +525,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${templateFile}";
+            import template from "${esc(templateFile)}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -541,7 +541,7 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "${componentFile}";
+            import component from "${esc(componentFile)}";
             export default setComponentTemplate(template, component);
           `);
           pairModule.resolves(templateFile).to('./pods/components/hello-world/template.hbs');
@@ -1003,8 +1003,12 @@ Scenarios.fromProject(() => new Project())
 
 function normalizePath(s: string): string {
   if (process.platform === 'win32') {
-    return s.replace('/', '\\');
+    return s.replace(/\//g, '\\');
   } else {
     return s;
   }
+}
+
+function esc(s: string): string {
+  return s.replace(/\\/g, '\\\\');
 }

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -242,7 +242,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "./hello-world.hbs";
+            import template from "${app.dir}/templates/components/hello-world.hbs";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'hello-world'.",
@@ -258,12 +258,14 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "../../components/hello-world.js";
+            import component from "${app.dir}/components/hello-world.js";
             export default setComponentTemplate(template, component);
           `);
 
-          pairModule.resolves('./hello-world.hbs').to('./templates/components/hello-world.hbs');
-          pairModule.resolves('../../components/hello-world.js').to('./components/hello-world.js');
+          pairModule
+            .resolves(`${app.dir}/templates/components/hello-world.hbs`)
+            .to('./templates/components/hello-world.hbs');
+          pairModule.resolves(`${app.dir}/components/hello-world.js`).to('./components/hello-world.js');
         });
 
         test('hbs-only component', async function () {
@@ -281,7 +283,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "./hello-world.hbs";
+            import template from "${app.dir}/templates/components/hello-world.hbs";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'hello-world'.",
@@ -301,7 +303,9 @@ Scenarios.fromProject(() => new Project())
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "hello-world"));
           `);
 
-          pairModule.resolves('./hello-world.hbs').to('./templates/components/hello-world.hbs');
+          pairModule
+            .resolves(`${app.dir}/templates/components/hello-world.hbs`)
+            .to('./templates/components/hello-world.hbs');
         });
 
         test('explicitly namedspaced component', async function () {
@@ -394,7 +398,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "./template.hbs";
+            import template from "${app.dir}/components/hello-world/template.hbs";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -414,7 +418,9 @@ Scenarios.fromProject(() => new Project())
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "template"));
           `);
 
-          pairModule.resolves('./template.hbs').to('./components/hello-world/template.hbs');
+          pairModule
+            .resolves(`${app.dir}/components/hello-world/template.hbs`)
+            .to('./components/hello-world/template.hbs');
         });
 
         test('podded hbs-only component with non-blank podModulePrefix', async function () {
@@ -432,7 +438,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "./template.hbs";
+            import template from "${app.dir}/pods/components/hello-world/template.hbs";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -452,7 +458,9 @@ Scenarios.fromProject(() => new Project())
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "template"));
           `);
 
-          pairModule.resolves('./template.hbs').to('./pods/components/hello-world/template.hbs');
+          pairModule
+            .resolves(`${app.dir}/pods/components/hello-world/template.hbs`)
+            .to('./pods/components/hello-world/template.hbs');
         });
 
         test('podded js-and-hbs component with blank podModulePrefix', async function () {
@@ -471,7 +479,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "./template.hbs";
+            import template from "${app.dir}/components/hello-world/template.hbs";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -487,12 +495,16 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "./component.js";
+            import component from "${app.dir}/components/hello-world/component.js";
             export default setComponentTemplate(template, component);
           `);
 
-          pairModule.resolves('./template.hbs').to('./components/hello-world/template.hbs');
-          pairModule.resolves('./component.js').to('./components/hello-world/component.js');
+          pairModule
+            .resolves(`${app.dir}/components/hello-world/template.hbs`)
+            .to('./components/hello-world/template.hbs');
+          pairModule
+            .resolves(`${app.dir}/components/hello-world/component.js`)
+            .to('./components/hello-world/component.js');
         });
 
         test('podded js-and-hbs component with non-blank podModulePrefix', async function () {
@@ -511,7 +523,7 @@ Scenarios.fromProject(() => new Project())
 
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "./template.hbs";
+            import template from "${app.dir}/pods/components/hello-world/template.hbs";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -527,12 +539,15 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "./component.js";
+            import component from "${app.dir}/pods/components/hello-world/component.js";
             export default setComponentTemplate(template, component);
           `);
-
-          pairModule.resolves('./template.hbs').to('./pods/components/hello-world/template.hbs');
-          pairModule.resolves('./component.js').to('./pods/components/hello-world/component.js');
+          pairModule
+            .resolves(`${app.dir}/pods/components/hello-world/template.hbs`)
+            .to('./pods/components/hello-world/template.hbs');
+          pairModule
+            .resolves(`${app.dir}/pods/components/hello-world/component.js`)
+            .to('./pods/components/hello-world/component.js');
         });
 
         test('plain helper', async function () {

--- a/tests/scenarios/core-resolver-test.ts
+++ b/tests/scenarios/core-resolver-test.ts
@@ -240,9 +240,12 @@ Scenarios.fromProject(() => new Project())
             .resolves('@embroider/virtual/components/hello-world')
             .toModule();
 
+          let templateFile = normalizePath(`${app.dir}/templates/components/hello-world.hbs`);
+          let componentFile = normalizePath(`${app.dir}/components/hello-world.js`);
+
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${app.dir}/templates/components/hello-world.hbs";
+            import template from "${templateFile}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'hello-world'.",
@@ -258,14 +261,12 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "${app.dir}/components/hello-world.js";
+            import component from "${componentFile}";
             export default setComponentTemplate(template, component);
           `);
 
-          pairModule
-            .resolves(`${app.dir}/templates/components/hello-world.hbs`)
-            .to('./templates/components/hello-world.hbs');
-          pairModule.resolves(`${app.dir}/components/hello-world.js`).to('./components/hello-world.js');
+          pairModule.resolves(templateFile).to('./templates/components/hello-world.hbs');
+          pairModule.resolves(componentFile).to('./components/hello-world.js');
         });
 
         test('hbs-only component', async function () {
@@ -281,9 +282,10 @@ Scenarios.fromProject(() => new Project())
             .resolves('@embroider/virtual/components/hello-world')
             .toModule();
 
+          let templateFile = normalizePath(`${app.dir}/templates/components/hello-world.hbs`);
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${app.dir}/templates/components/hello-world.hbs";
+            import template from "${templateFile}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'hello-world'.",
@@ -303,9 +305,7 @@ Scenarios.fromProject(() => new Project())
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "hello-world"));
           `);
 
-          pairModule
-            .resolves(`${app.dir}/templates/components/hello-world.hbs`)
-            .to('./templates/components/hello-world.hbs');
+          pairModule.resolves(templateFile).to('./templates/components/hello-world.hbs');
         });
 
         test('explicitly namedspaced component', async function () {
@@ -396,9 +396,11 @@ Scenarios.fromProject(() => new Project())
             .resolves('@embroider/virtual/components/hello-world')
             .toModule();
 
+          let templateFile = normalizePath(`${app.dir}/components/hello-world/template.hbs`);
+
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${app.dir}/components/hello-world/template.hbs";
+            import template from "${templateFile}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -418,9 +420,7 @@ Scenarios.fromProject(() => new Project())
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "template"));
           `);
 
-          pairModule
-            .resolves(`${app.dir}/components/hello-world/template.hbs`)
-            .to('./components/hello-world/template.hbs');
+          pairModule.resolves(templateFile).to('./components/hello-world/template.hbs');
         });
 
         test('podded hbs-only component with non-blank podModulePrefix', async function () {
@@ -436,9 +436,11 @@ Scenarios.fromProject(() => new Project())
             .resolves('@embroider/virtual/components/hello-world')
             .toModule();
 
+          let templateFile = normalizePath(`${app.dir}/pods/components/hello-world/template.hbs`);
+
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${app.dir}/pods/components/hello-world/template.hbs";
+            import template from "${templateFile}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -458,9 +460,7 @@ Scenarios.fromProject(() => new Project())
             export default setComponentTemplate(template, templateOnlyComponent(undefined, "template"));
           `);
 
-          pairModule
-            .resolves(`${app.dir}/pods/components/hello-world/template.hbs`)
-            .to('./pods/components/hello-world/template.hbs');
+          pairModule.resolves(templateFile).to('./pods/components/hello-world/template.hbs');
         });
 
         test('podded js-and-hbs component with blank podModulePrefix', async function () {
@@ -477,9 +477,12 @@ Scenarios.fromProject(() => new Project())
             .resolves('@embroider/virtual/components/hello-world')
             .toModule();
 
+          let templateFile = normalizePath(`${app.dir}/components/hello-world/template.hbs`);
+          let componentFile = normalizePath(`${app.dir}/components/hello-world/component.js`);
+
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${app.dir}/components/hello-world/template.hbs";
+            import template from "${templateFile}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -495,16 +498,12 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "${app.dir}/components/hello-world/component.js";
+            import component from "${componentFile}";
             export default setComponentTemplate(template, component);
           `);
 
-          pairModule
-            .resolves(`${app.dir}/components/hello-world/template.hbs`)
-            .to('./components/hello-world/template.hbs');
-          pairModule
-            .resolves(`${app.dir}/components/hello-world/component.js`)
-            .to('./components/hello-world/component.js');
+          pairModule.resolves(templateFile).to('./components/hello-world/template.hbs');
+          pairModule.resolves(componentFile).to('./components/hello-world/component.js');
         });
 
         test('podded js-and-hbs component with non-blank podModulePrefix', async function () {
@@ -521,9 +520,12 @@ Scenarios.fromProject(() => new Project())
             .resolves('@embroider/virtual/components/hello-world')
             .toModule();
 
+          let templateFile = normalizePath(`${app.dir}/pods/components/hello-world/template.hbs`);
+          let componentFile = normalizePath(`${app.dir}/pods/components/hello-world/component.js`);
+
           pairModule.codeEquals(`
             import { setComponentTemplate } from "@ember/component";
-            import template from "${app.dir}/pods/components/hello-world/template.hbs";
+            import template from "${templateFile}";
             import { deprecate } from "@ember/debug";
             true && !false && deprecate(
               "Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup 'template'.",
@@ -539,15 +541,11 @@ Scenarios.fromProject(() => new Project())
                 },
               }
             );
-            import component from "${app.dir}/pods/components/hello-world/component.js";
+            import component from "${componentFile}";
             export default setComponentTemplate(template, component);
           `);
-          pairModule
-            .resolves(`${app.dir}/pods/components/hello-world/template.hbs`)
-            .to('./pods/components/hello-world/template.hbs');
-          pairModule
-            .resolves(`${app.dir}/pods/components/hello-world/component.js`)
-            .to('./pods/components/hello-world/component.js');
+          pairModule.resolves(templateFile).to('./pods/components/hello-world/template.hbs');
+          pairModule.resolves(componentFile).to('./pods/components/hello-world/component.js');
         });
 
         test('plain helper', async function () {
@@ -1002,3 +1000,11 @@ Scenarios.fromProject(() => new Project())
       });
     });
   });
+
+function normalizePath(s: string): string {
+  if (process.platform === 'win32') {
+    return s.replace('/', '\\');
+  } else {
+    return s;
+  }
+}


### PR DESCRIPTION
At present, it's not possible to generate a virtual response whose path is in the same namespace as the real modules. Integrations like vite are allowed to keep their virtual responses in a different namespace.

But I think we can rely on other forms of metadata propagation in all supported build systems, so that whether a response is virtual doesn't need to depend solely on its path.

This would make it possible to emit virtual modules that live in the same namespace as all the real files, which would also make things like component template colocation possible to implement entirely within the core module resolver.