### PR TITLE
Fix type error on stable

### DIFF
--- a/packages/macros/tests/babel/helpers.ts
+++ b/packages/macros/tests/babel/helpers.ts
@@ -79,7 +79,7 @@ disabledTest.failing = disabledTest;
 
 export function allModes(fn: CreateModeTests): CreateTests {
   return function createTests(transform: Transform) {
-    for (let mode of ['build-time', 'run-time']) {
+    for (const mode of ['build-time', 'run-time']) {
       describe(mode, function () {
         function applyMode(macrosConfig: MacrosConfig) {
           if (mode === 'run-time') {


### PR DESCRIPTION
Stable is broken when running pnpm without the lockfile:

```
packages/macros/tests/babel/helpers.ts:85:15 - error TS2454: Variable 'mode' is used before being assigned.
```

Applying same fix as on `main`: https://github.com/embroider-build/embroider/pull/2184/commits/31ed2c223e446b744962d96ab58712199551fd37