### PR TITLE
fix v2 addon watch test

### DIFF
--- a/packages/addon-dev/src/rollup-app-reexports.ts
+++ b/packages/addon-dev/src/rollup-app-reexports.ts
@@ -3,6 +3,12 @@ import { extname } from 'path';
 import minimatch from 'minimatch';
 import type { Plugin } from 'rollup';
 
+function symmetricDifference(arr1: any[], arr2: any[]) {
+  return arr1
+    .filter((x) => !arr2.includes(x))
+    .concat(arr2.filter((x) => !arr1.includes(x)));
+}
+
 export default function appReexports(opts: {
   from: string;
   to: string;
@@ -42,7 +48,10 @@ export default function appReexports(opts: {
       }
       let originalAppJS = pkg['ember-addon']?.['app-js'];
 
-      let hasChanges = JSON.stringify(originalAppJS) !== JSON.stringify(appJS);
+      let hasChanges = !!symmetricDifference(
+        Object.keys(originalAppJS),
+        Object.keys(appJS)
+      ).length;
 
       // Don't cause a file i/o event unless something actually changed
       if (hasChanges) {

--- a/tests/scenarios/helpers/v2-addon.ts
+++ b/tests/scenarios/helpers/v2-addon.ts
@@ -2,9 +2,11 @@ import path from 'path';
 import type { PreparedApp } from 'scenario-tester';
 import { loadConfigFile } from 'rollup/loadConfigFile';
 import rollup from 'rollup';
-import type { RollupOptions } from 'rollup';
+import type { RollupOptions, Plugin } from 'rollup';
 
 export class DevWatcher {
+  #counter: number;
+  #expectedBuilds: number;
   #addon: PreparedApp;
   #watcher?: ReturnType<(typeof rollup)['watch']>;
   #waitForBuildPromise?: Promise<unknown>;
@@ -15,12 +17,16 @@ export class DevWatcher {
   constructor(addon: PreparedApp) {
     this.#addon = addon;
     this.#originalDirectory = process.cwd();
+    this.#counter = 1;
+    this.#expectedBuilds = 1;
   }
 
-  start = async () => {
+  start = async (expectedBuilds = 1) => {
     if (this.#watcher) {
       throw new Error(`.start() may only be called once`);
     }
+
+    this.#expectedBuilds = expectedBuilds;
 
     let buildDirectory = this.#addon.dir;
 
@@ -39,6 +45,13 @@ export class DevWatcher {
         options.watch = {
           buildDelay: 20,
         };
+        // for local debugging
+        (options.plugins as Plugin[]).push({
+          name: 'watch change',
+          watchChange(id: string) {
+            console.log('changed:', id);
+          },
+        });
         return options;
       })
     );
@@ -51,11 +64,16 @@ export class DevWatcher {
     this.#watcher.on('event', args => {
       switch (args.code) {
         case 'START': {
-          this.#defer();
+          console.log('start');
           break;
         }
         case 'END': {
+          console.log('end');
           this.#forceResolve?.('end');
+          break;
+        }
+        case 'BUNDLE_END': {
+          args.result.close();
           break;
         }
         case 'ERROR': {
@@ -67,29 +85,33 @@ export class DevWatcher {
 
     this.#watcher.on('close', () => this.#forceResolve?.('close'));
 
-    return this.settled();
+    return this.nextBuild();
   };
 
   #defer = () => {
     if (this.#waitForBuildPromise) {
       // Need to finish prior work before deferring again
       // if we hit this use case, we may have mis-configured
-      // the previosu deferral
+      // the previous deferral
       return;
     }
+    this.#counter = this.#expectedBuilds;
     this.#waitForBuildPromise = new Promise<unknown>((_resolve, _reject) => {
-      this.#resolve = _resolve;
+      this.#resolve = (...args) => {
+        this.#counter -= 1;
+        if (this.#counter === 0) {
+          _resolve(...args);
+        }
+      };
       this.#reject = _reject;
     });
   };
 
   #forceResolve(state: unknown) {
     this.#resolve?.(state);
-    this.#waitForBuildPromise = undefined;
   }
   #forceReject(error: unknown) {
     this.#reject?.(error);
-    this.#waitForBuildPromise = undefined;
   }
 
   stop = async () => {
@@ -97,12 +119,17 @@ export class DevWatcher {
     process.chdir(this.#originalDirectory);
   };
 
-  nextBuild = async () => {
+  nextBuild = async (expectedBuilds = 1) => {
+    this.#expectedBuilds = expectedBuilds;
     this.#defer();
-    await this.settled();
+    try {
+      await this.settled();
+    } finally {
+      this.#waitForBuildPromise = undefined;
+    }
   };
 
-  settled = async (timeout = 5_000) => {
+  settled = async (timeout = 8_000) => {
     if (!this.#waitForBuildPromise) {
       console.debug(`There is nothing to wait for`);
       return;


### PR DESCRIPTION
1. bug
in public entrypoints we only add watch files. not dirs. When a file is removed, rollup also stops watching that file and ignores it if its re-created.
We need to watch previous detected files.

2. Testing Bug 
Package.json is updated during the process which triggers a new build, we need to wait


Other things:
. Need to call result.close https://rollupjs.org/javascript-api/#rollup-watch
Not sure about https://github.com/nodejs/node/issues/4760

