### PR TITLE
Eliminate 'ignored' case from module resolver

### DIFF
--- a/packages/core/src/module-request.ts
+++ b/packages/core/src/module-request.ts
@@ -3,14 +3,6 @@
 export type Resolution<T = unknown, E = unknown> =
   | { type: 'found'; filename: string; isVirtual: boolean; result: T }
 
-  // used for requests that are special and don't represent real files that
-  // embroider can possibly do anything custom with.
-  //
-  // the motivating use case for introducing this is Vite's depscan which marks
-  // almost everything as "external" as a way to tell esbuild to stop traversing
-  // once it has been seen the first time.
-  | { type: 'ignored'; result: T }
-
   // the important thing about this Resolution is that embroider should do its
   // fallback behaviors here.
   | { type: 'not_found'; err: E };

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -159,7 +159,6 @@ export class Resolver {
 
     switch (resolution.type) {
       case 'found':
-      case 'ignored':
         return resolution;
       case 'not_found':
         break;
@@ -585,10 +584,6 @@ export class Resolver {
         })
       );
 
-      if (resolution.type === 'ignored') {
-        return logTransition(`resolving to ignored component`, request, request.resolveTo(resolution));
-      }
-
       // .hbs is a resolvable extension for us, so we need to exclude it here.
       // It matches as a priority lower than .js, so finding an .hbs means
       // there's definitely not a .js.
@@ -631,10 +626,7 @@ export class Resolver {
       })
     );
 
-    // for the case of 'ignored' that means that esbuild found this helper in an external
-    // package so it should be considered found in this case and we should not look for a
-    // component with this name
-    if (helperMatch.type === 'found' || helperMatch.type === 'ignored') {
+    if (helperMatch.type === 'found') {
       return logTransition('resolve to ambiguous case matched a helper', request, request.resolveTo(helperMatch));
     }
 

--- a/packages/core/src/node-resolve.ts
+++ b/packages/core/src/node-resolve.ts
@@ -125,10 +125,6 @@ export async function nodeResolve(
       return resolution;
     case 'found':
       return resolution.result;
-    case 'ignored':
-      throw new Error(
-        `bug: this is supposed to be impossible because NodeModuleRequest.prototype.defaultResove does not use "ignored"`
-      );
     default:
       throw assertNever(resolution);
   }

--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -142,9 +142,19 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
         }
       }
 
+      let filename: string;
+      if (status.type === 'found' && result.external) {
+        // when we know that the file was really found, but vite has
+        // externalized it, report the true filename that was found, not the
+        // externalized request path.
+        filename = status.filename;
+      } else {
+        filename = result.path;
+      }
+
       return {
         type: 'found',
-        filename: status.type === 'found' ? status.filename : result.path,
+        filename,
         result,
         isVirtual: false,
       };

--- a/packages/vite/src/esbuild-resolver.ts
+++ b/packages/vite/src/esbuild-resolver.ts
@@ -67,7 +67,6 @@ export function esBuildResolver(): EsBuildPlugin {
         let resolution = await resolverLoader.resolver.resolve(request);
         switch (resolution.type) {
           case 'found':
-          case 'ignored':
             return resolution.result;
           case 'not_found':
             return resolution.err;

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -86,8 +86,6 @@ export function resolver(): Plugin {
           } else {
             return await maybeCaptureNewOptimizedDep(this, resolverLoader.resolver, resolution.result, notViteDeps);
           }
-        case 'ignored':
-          return resolution.result;
         case 'not_found':
           return null;
         default:
@@ -159,7 +157,7 @@ async function observeDepScan(context: PluginContext, source: string, importer: 
     ...options,
     skipSelf: true,
   });
-  writeStatus(source, result ? 'found' : 'not_found');
+  writeStatus(source, result ? { type: 'found', filename: result.id } : { type: 'not_found' });
   return result;
 }
 

--- a/packages/webpack/src/webpack-resolver-plugin.ts
+++ b/packages/webpack/src/webpack-resolver-plugin.ts
@@ -62,7 +62,6 @@ export class EmbroiderPlugin {
                   callback(resolution.err);
                   break;
                 case 'found':
-                case 'ignored':
                   callback(null, undefined);
                   break;
                 default:


### PR DESCRIPTION
The ignored result was created to deal with the weird way vite resolves many things as "external" during dependency prescanning. But it was still complicating our ability to properly detect components during prescan.

This refactor manages to use the state capture we were already relying on to identify true "not_found" that vite was ignoring to also provide the true "found" that vite is ignoring, so our own use of the resolver never needs to deal with an "ignored" state.