### PR TITLE
Simplify virtual content rendering

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -23,6 +23,8 @@ import type { Options, EngineConfig } from './module-resolver-options';
 import { satisfies } from 'semver';
 import type { ModuleRequest, Resolution } from './module-request';
 import { virtualEntrypoint } from './virtual-entrypoint';
+import { virtualVendor } from './virtual-vendor';
+import { virtualVendorStyles } from './virtual-vendor-styles';
 
 const debug = makeDebug('embroider:resolver');
 
@@ -482,11 +484,7 @@ export class Resolver {
       );
     }
 
-    return logTransition(
-      'vendor-styles',
-      request,
-      request.virtualize({ type: 'vendor-css', specifier: resolve(pkg.root, '-embroider-vendor-styles.css') })
-    );
+    return logTransition('vendor-styles', request, request.virtualize(virtualVendorStyles(pkg)));
   }
 
   private resolveHelper<R extends ModuleRequest>(path: string, inEngine: EngineConfig, request: R): R {
@@ -948,11 +946,7 @@ export class Resolver {
       );
     }
 
-    return logTransition(
-      'vendor',
-      request,
-      request.virtualize({ type: 'vendor-js', specifier: resolve(pkg.root, '-embroider-vendor.js') })
-    );
+    return logTransition('vendor', request, request.virtualize(virtualVendor(pkg)));
   }
 
   private resolveWithinMovedPackage<R extends ModuleRequest>(request: R, pkg: Package): R {

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -401,14 +401,7 @@ export class Resolver {
   }
 
   private handleImplicitTestScripts<R extends ModuleRequest>(request: R): R {
-    //TODO move the extra forwardslash handling out into the vite plugin
-    const candidates = [
-      '@embroider/virtual/test-support.js',
-      '/@embroider/virtual/test-support.js',
-      './@embroider/virtual/test-support.js',
-    ];
-
-    if (!candidates.includes(request.specifier)) {
+    if (request.specifier !== '@embroider/virtual/test-support.js') {
       return request;
     }
 
@@ -427,14 +420,7 @@ export class Resolver {
   }
 
   private handleTestSupportStyles<R extends ModuleRequest>(request: R): R {
-    //TODO move the extra forwardslash handling out into the vite plugin
-    const candidates = [
-      '@embroider/virtual/test-support.css',
-      '/@embroider/virtual/test-support.css',
-      './@embroider/virtual/test-support.css',
-    ];
-
-    if (!candidates.includes(request.specifier)) {
+    if (request.specifier !== '@embroider/virtual/test-support.css') {
       return request;
     }
 
@@ -485,14 +471,7 @@ export class Resolver {
   }
 
   private handleVendorStyles<R extends ModuleRequest>(request: R): R {
-    //TODO move the extra forwardslash handling out into the vite plugin
-    const candidates = [
-      '@embroider/virtual/vendor.css',
-      '/@embroider/virtual/vendor.css',
-      './@embroider/virtual/vendor.css',
-    ];
-
-    if (!candidates.includes(request.specifier)) {
+    if (request.specifier !== '@embroider/virtual/vendor.css') {
       return request;
     }
 
@@ -958,14 +937,7 @@ export class Resolver {
   }
 
   private handleVendor<R extends ModuleRequest>(request: R): R {
-    //TODO move the extra forwardslash handling out into the vite plugin
-    const candidates = [
-      '@embroider/virtual/vendor.js',
-      '/@embroider/virtual/vendor.js',
-      './@embroider/virtual/vendor.js',
-    ];
-
-    if (!candidates.includes(request.specifier)) {
+    if (request.specifier !== '@embroider/virtual/vendor.js') {
       return request;
     }
 

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -25,6 +25,8 @@ import type { ModuleRequest, Resolution } from './module-request';
 import { virtualEntrypoint } from './virtual-entrypoint';
 import { virtualVendor } from './virtual-vendor';
 import { virtualVendorStyles } from './virtual-vendor-styles';
+import { testSupportStyles } from './virtual-test-support-styles';
+import { testSupport } from './virtual-test-support';
 
 const debug = makeDebug('embroider:resolver');
 
@@ -414,11 +416,7 @@ export class Resolver {
       );
     }
 
-    return logTransition(
-      'test-support',
-      request,
-      request.virtualize({ type: 'test-support-js', specifier: resolve(pkg.root, '-embroider-test-support.js') })
-    );
+    return logTransition('test-support', request, request.virtualize(testSupport(pkg)));
   }
 
   private handleTestSupportStyles<R extends ModuleRequest>(request: R): R {
@@ -433,14 +431,7 @@ export class Resolver {
       );
     }
 
-    return logTransition(
-      'test-support-styles',
-      request,
-      request.virtualize({
-        type: 'test-support-css',
-        specifier: resolve(pkg.root, '-embroider-test-support-styles.css'),
-      })
-    );
+    return logTransition('test-support-styles', request, request.virtualize(testSupportStyles(pkg)));
   }
 
   private async handleGlobalsCompat<R extends ModuleRequest>(request: R): Promise<R> {

--- a/packages/core/src/node-resolve.ts
+++ b/packages/core/src/node-resolve.ts
@@ -47,7 +47,7 @@ export class NodeRequestAdapter implements RequestAdapter<Resolution<NodeResolut
       virtual,
       result: {
         type: 'virtual' as const,
-        content: virtualContent(virtual.specifier, this.resolver).src,
+        content: virtualContent(virtual, this.resolver).src,
         filename: virtual.specifier,
       },
     };

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -1,4 +1,4 @@
-import { dirname, basename, resolve, posix, sep, join } from 'path';
+import { dirname, resolve, posix, sep, join } from 'path';
 import type { Resolver, AddonPackage, Package } from '.';
 import { extensionsPattern } from '.';
 import { compile } from './js-handlebars';
@@ -111,22 +111,6 @@ export interface VirtualPairResponse {
   hbsModule: string;
   jsModule: string | null;
   debugName: string;
-}
-
-export function virtualPairComponent(
-  appRoot: string,
-  hbsModule: string,
-  jsModule: string | undefined
-): VirtualPairResponse {
-  return {
-    type: 'component-pair',
-    hbsModule,
-    jsModule: jsModule ?? null,
-    debugName: basename(hbsModule).replace(/\.(js|hbs)$/, ''),
-    specifier: `${appRoot}/embroider-pair-component/${encodeURIComponent(hbsModule)}/__vpc__/${encodeURIComponent(
-      jsModule ?? ''
-    )}`,
-  };
 }
 
 const fastbootSwitchSuffix = '/embroider_fastboot_switch';

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -40,7 +40,8 @@ export interface VirtualContentResult {
 // this produces the corresponding contents. It's a static, stateless function
 // because we recognize that that process that did resolution might not be the
 // same one that loads the content.
-export function virtualContent(filename: string, resolver: Resolver): VirtualContentResult {
+export function virtualContent(response: VirtualResponse, resolver: Resolver): VirtualContentResult {
+  let filename = response.specifier;
   let entrypoint = decodeEntrypoint(filename);
   if (entrypoint) {
     return renderEntrypoint(resolver, entrypoint);

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -4,8 +4,8 @@ import { extensionsPattern } from '.';
 import { compile } from './js-handlebars';
 import { decodeImplicitTestScripts, renderImplicitTestScripts } from './virtual-test-support';
 import { decodeTestSupportStyles, renderTestSupportStyles } from './virtual-test-support-styles';
-import { decodeVirtualVendor, renderVendor } from './virtual-vendor';
-import { decodeVirtualVendorStyles, renderVendorStyles } from './virtual-vendor-styles';
+import { renderVendor, type VirtualVendorResponse } from './virtual-vendor';
+import { renderVendorStyles, type VirtualVendorStylesResponse } from './virtual-vendor-styles';
 
 import { type EntrypointResponse, renderEntrypoint } from './virtual-entrypoint';
 import { decodeRouteEntrypoint, renderRouteEntrypoint } from './virtual-route-entrypoint';
@@ -24,8 +24,8 @@ export type VirtualResponse = { specifier: string } & (
   | { type: 'route-entrypoint' }
   | { type: 'test-support-js' }
   | { type: 'test-support-css' }
-  | { type: 'vendor-js' }
-  | { type: 'vendor-css' }
+  | VirtualVendorResponse
+  | VirtualVendorStylesResponse
   | { type: 'component-pair' }
 );
 
@@ -42,6 +42,10 @@ export function virtualContent(response: VirtualResponse, resolver: Resolver): V
   switch (response.type) {
     case 'entrypoint':
       return renderEntrypoint(resolver, response);
+    case 'vendor-js':
+      return renderVendor(response, resolver);
+    case 'vendor-css':
+      return renderVendorStyles(response, resolver);
   }
 
   let filename = response.specifier;
@@ -66,19 +70,9 @@ export function virtualContent(response: VirtualResponse, resolver: Resolver): V
     return renderImplicitModules(im, resolver);
   }
 
-  let isVendor = decodeVirtualVendor(filename);
-  if (isVendor) {
-    return renderVendor(filename, resolver);
-  }
-
   let isImplicitTestScripts = decodeImplicitTestScripts(filename);
   if (isImplicitTestScripts) {
     return renderImplicitTestScripts(filename, resolver);
-  }
-
-  let isVendorStyles = decodeVirtualVendorStyles(filename);
-  if (isVendorStyles) {
-    return renderVendorStyles(filename, resolver);
   }
 
   let isTestSupportStyles = decodeTestSupportStyles(filename);

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -7,7 +7,7 @@ import { decodeTestSupportStyles, renderTestSupportStyles } from './virtual-test
 import { decodeVirtualVendor, renderVendor } from './virtual-vendor';
 import { decodeVirtualVendorStyles, renderVendorStyles } from './virtual-vendor-styles';
 
-import { decodeEntrypoint, renderEntrypoint } from './virtual-entrypoint';
+import { type EntrypointResponse, renderEntrypoint } from './virtual-entrypoint';
 import { decodeRouteEntrypoint, renderRouteEntrypoint } from './virtual-route-entrypoint';
 
 export type VirtualResponse = { specifier: string } & (
@@ -20,9 +20,7 @@ export type VirtualResponse = { specifier: string } & (
   | {
       type: 'implicit-test-modules';
     }
-  | {
-      type: 'entrypoint';
-    }
+  | EntrypointResponse
   | { type: 'route-entrypoint' }
   | { type: 'test-support-js' }
   | { type: 'test-support-css' }
@@ -41,11 +39,12 @@ export interface VirtualContentResult {
 // because we recognize that that process that did resolution might not be the
 // same one that loads the content.
 export function virtualContent(response: VirtualResponse, resolver: Resolver): VirtualContentResult {
-  let filename = response.specifier;
-  let entrypoint = decodeEntrypoint(filename);
-  if (entrypoint) {
-    return renderEntrypoint(resolver, entrypoint);
+  switch (response.type) {
+    case 'entrypoint':
+      return renderEntrypoint(resolver, response);
   }
+
+  let filename = response.specifier;
 
   let routeEntrypoint = decodeRouteEntrypoint(filename);
   if (routeEntrypoint) {

--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -2,8 +2,8 @@ import { dirname, basename, resolve, posix, sep, join } from 'path';
 import type { Resolver, AddonPackage, Package } from '.';
 import { extensionsPattern } from '.';
 import { compile } from './js-handlebars';
-import { decodeImplicitTestScripts, renderImplicitTestScripts } from './virtual-test-support';
-import { decodeTestSupportStyles, renderTestSupportStyles } from './virtual-test-support-styles';
+import { renderImplicitTestScripts } from './virtual-test-support';
+import { renderTestSupportStyles } from './virtual-test-support-styles';
 import { renderVendor, type VirtualVendorResponse } from './virtual-vendor';
 import { renderVendorStyles, type VirtualVendorStylesResponse } from './virtual-vendor-styles';
 
@@ -46,6 +46,10 @@ export function virtualContent(response: VirtualResponse, resolver: Resolver): V
       return renderVendor(response, resolver);
     case 'vendor-css':
       return renderVendorStyles(response, resolver);
+    case 'test-support-css':
+      return renderTestSupportStyles(response, resolver);
+    case 'test-support-js':
+      return renderImplicitTestScripts(response, resolver);
   }
 
   let filename = response.specifier;
@@ -68,16 +72,6 @@ export function virtualContent(response: VirtualResponse, resolver: Resolver): V
   let im = decodeImplicitModules(filename);
   if (im) {
     return renderImplicitModules(im, resolver);
-  }
-
-  let isImplicitTestScripts = decodeImplicitTestScripts(filename);
-  if (isImplicitTestScripts) {
-    return renderImplicitTestScripts(filename, resolver);
-  }
-
-  let isTestSupportStyles = decodeTestSupportStyles(filename);
-  if (isTestSupportStyles) {
-    return renderTestSupportStyles(filename, resolver);
   }
 
   throw new Error(`not an @embroider/core virtual file: ${filename}`);

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -23,14 +23,12 @@ export function virtualEntrypoint(
   request: ModuleRequest,
   packageCache: PackageCachePublicAPI
 ): VirtualResponse | undefined {
-  //TODO move the extra forwardslash handling out into the vite plugin
-  const candidates = [
-    '@embroider/virtual/compat-modules',
-    '/@embroider/virtual/compat-modules',
-    './@embroider/virtual/compat-modules',
-  ];
+  const compatModulesSpecifier = '@embroider/virtual/compat-modules';
 
-  if (!candidates.some(c => request.specifier.startsWith(c + '/') || request.specifier === c)) {
+  let isCompatModules =
+    request.specifier === compatModulesSpecifier || request.specifier.startsWith(compatModulesSpecifier + '/');
+
+  if (!isCompatModules) {
     return undefined;
   }
 

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -7,7 +7,6 @@ import { join, resolve, dirname } from 'path';
 import { extensionsPattern, type PackageCachePublicAPI, type Package } from '@embroider/shared-internals';
 import walkSync from 'walk-sync';
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
-import { encodePublicRouteEntrypoint } from './virtual-route-entrypoint';
 import escapeRegExp from 'escape-string-regexp';
 import { optionsWithDefaults } from './options';
 import { type ModuleRequest } from './module-request';
@@ -156,10 +155,10 @@ export function renderEntrypoint(
       (_: string, filename: string) => {
         requiredAppFiles.push([filename]);
       },
-      (routeNames: string[], _files: string[]) => {
+      (routeNames: string[]) => {
         lazyRoutes.push({
           names: routeNames,
-          path: encodePublicRouteEntrypoint(routeNames, _files),
+          path: `@embroider/core/route/${encodeURIComponent(routeNames[0])}`,
         });
       }
     );

--- a/packages/core/src/virtual-route-entrypoint.ts
+++ b/packages/core/src/virtual-route-entrypoint.ts
@@ -1,54 +1,20 @@
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { AppFiles } from './app-files';
 import type { Resolver } from './module-resolver';
-import { resolve } from 'path';
 import { compile } from './js-handlebars';
-import { extensionsPattern, type Package } from '@embroider/shared-internals';
+import { extensionsPattern } from '@embroider/shared-internals';
 import { partition } from 'lodash';
 import { getAppFiles, getFastbootFiles, importPaths, splitRoute, staticAppPathsPattern } from './virtual-entrypoint';
-import { exports as resolveExports } from 'resolve.exports';
 
-const entrypointPattern = /(?<filename>.*)[\\/]-embroider-route-entrypoint.js:route=(?<route>.*)/;
-
-export function encodeRouteEntrypoint(pkg: Package, routeName: string): string {
-  let matched = resolveExports(pkg.packageJSON, '-embroider-route-entrypoint.js', {
-    browser: true,
-    conditions: ['default', 'imports'],
-  });
-  let target = matched ? `${matched}:route=${routeName}` : `-embroider-route-entrypoint.js:route=${routeName}`;
-  return resolve(pkg.root, target);
-}
-
-export function decodeRouteEntrypoint(filename: string): { fromDir: string; route: string } | undefined {
-  // Performance: avoid paying regex exec cost unless needed
-  if (!filename.includes('-embroider-route-entrypoint')) {
-    return;
-  }
-  let m = entrypointPattern.exec(filename);
-  if (m) {
-    return {
-      fromDir: m.groups!.filename,
-      route: m.groups!.route,
-    };
-  }
-}
-
-export function encodePublicRouteEntrypoint(routeNames: string[], _files: string[]) {
-  return `@embroider/core/route/${encodeURIComponent(routeNames[0])}`;
-}
-
-export function decodePublicRouteEntrypoint(specifier: string): string | null {
-  const publicPrefix = '@embroider/core/route/';
-  if (!specifier.startsWith(publicPrefix)) {
-    return null;
-  }
-
-  return specifier.slice(publicPrefix.length);
+export interface RouteEntrypointResponse {
+  type: 'route-entrypoint';
+  fromDir: string;
+  route: string;
 }
 
 export function renderRouteEntrypoint(
-  resolver: Resolver,
-  { fromDir, route }: { fromDir: string; route: string }
+  { fromDir, route }: RouteEntrypointResponse,
+  resolver: Resolver
 ): { src: string; watches: string[] } {
   const owner = resolver.packageCache.ownerOfFile(fromDir);
 

--- a/packages/core/src/virtual-test-support-styles.ts
+++ b/packages/core/src/virtual-test-support-styles.ts
@@ -3,15 +3,22 @@ import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { readFileSync } from 'fs';
 import { sortBy } from 'lodash';
 import resolve from 'resolve';
+import { resolve as pathResolve } from 'path';
 import type { Engine } from './app-files';
 import type { Resolver } from './module-resolver';
 import type { VirtualContentResult } from './virtual-content';
 
-export function decodeTestSupportStyles(filename: string): boolean {
-  return filename.endsWith('-embroider-test-support-styles.css');
+export interface TestSupportStylesResponse {
+  type: 'test-support-css';
+  specifier: string;
 }
 
-export function renderTestSupportStyles(filename: string, resolver: Resolver): VirtualContentResult {
+export function testSupportStyles(pkg: Package): TestSupportStylesResponse {
+  return { type: 'test-support-css', specifier: pathResolve(pkg.root, '-embroider-test-support-styles.css') };
+}
+
+export function renderTestSupportStyles(response: TestSupportStylesResponse, resolver: Resolver): VirtualContentResult {
+  const filename = response.specifier;
   const owner = resolver.packageCache.ownerOfFile(filename);
   if (!owner) {
     throw new Error(`Failed to find a valid owner for ${filename}`);

--- a/packages/core/src/virtual-test-support-styles.ts
+++ b/packages/core/src/virtual-test-support-styles.ts
@@ -3,7 +3,6 @@ import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { readFileSync } from 'fs';
 import { sortBy } from 'lodash';
 import resolve from 'resolve';
-import { resolve as pathResolve } from 'path';
 import type { Engine } from './app-files';
 import type { Resolver } from './module-resolver';
 import type { VirtualContentResult } from './virtual-content';
@@ -11,10 +10,6 @@ import type { VirtualContentResult } from './virtual-content';
 export interface TestSupportStylesResponse {
   type: 'test-support-css';
   specifier: string;
-}
-
-export function testSupportStyles(pkg: Package): TestSupportStylesResponse {
-  return { type: 'test-support-css', specifier: pathResolve(pkg.root, '-embroider-test-support-styles.css') };
 }
 
 export function renderTestSupportStyles(response: TestSupportStylesResponse, resolver: Resolver): VirtualContentResult {

--- a/packages/core/src/virtual-test-support.ts
+++ b/packages/core/src/virtual-test-support.ts
@@ -2,15 +2,22 @@ import type { Package } from '@embroider/shared-internals';
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { readFileSync } from 'fs';
 import resolve from 'resolve';
+import { resolve as pathResolve } from 'path';
 import type { Engine } from './app-files';
 import type { Resolver } from './module-resolver';
 import type { VirtualContentResult } from './virtual-content';
 
-export function decodeImplicitTestScripts(filename: string): boolean {
-  return filename.endsWith('-embroider-test-support.js');
+export interface TestSupportResponse {
+  type: 'test-support-js';
+  specifier: string;
 }
 
-export function renderImplicitTestScripts(filename: string, resolver: Resolver): VirtualContentResult {
+export function testSupport(pkg: Package): TestSupportResponse {
+  return { type: 'test-support-js', specifier: pathResolve(pkg.root, '-embroider-test-support.js') };
+}
+
+export function renderImplicitTestScripts(response: TestSupportResponse, resolver: Resolver): VirtualContentResult {
+  const filename = response.specifier;
   const owner = resolver.packageCache.ownerOfFile(filename);
   if (!owner) {
     throw new Error(`Failed to find a valid owner for ${filename}`);

--- a/packages/core/src/virtual-test-support.ts
+++ b/packages/core/src/virtual-test-support.ts
@@ -2,7 +2,6 @@ import type { Package } from '@embroider/shared-internals';
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { readFileSync } from 'fs';
 import resolve from 'resolve';
-import { resolve as pathResolve } from 'path';
 import type { Engine } from './app-files';
 import type { Resolver } from './module-resolver';
 import type { VirtualContentResult } from './virtual-content';
@@ -10,10 +9,6 @@ import type { VirtualContentResult } from './virtual-content';
 export interface TestSupportResponse {
   type: 'test-support-js';
   specifier: string;
-}
-
-export function testSupport(pkg: Package): TestSupportResponse {
-  return { type: 'test-support-js', specifier: pathResolve(pkg.root, '-embroider-test-support.js') };
 }
 
 export function renderImplicitTestScripts(response: TestSupportResponse, resolver: Resolver): VirtualContentResult {

--- a/packages/core/src/virtual-vendor-styles.ts
+++ b/packages/core/src/virtual-vendor-styles.ts
@@ -1,17 +1,28 @@
 import type { Package } from '@embroider/shared-internals';
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { readFileSync } from 'fs';
+import { resolve as pathResolve } from 'path';
 import { sortBy } from 'lodash';
 import resolve from 'resolve';
 import type { Resolver } from './module-resolver';
 import type { VirtualContentResult } from './virtual-content';
 import type { Engine } from './app-files';
 
+export interface VirtualVendorStylesResponse {
+  type: 'vendor-css';
+  specifier: string;
+}
+
+export function virtualVendorStyles(pkg: Package): VirtualVendorStylesResponse {
+  return { type: 'vendor-css', specifier: pathResolve(pkg.root, '-embroider-vendor-styles.css') };
+}
+
 export function decodeVirtualVendorStyles(filename: string): boolean {
   return filename.endsWith('-embroider-vendor-styles.css');
 }
 
-export function renderVendorStyles(filename: string, resolver: Resolver): VirtualContentResult {
+export function renderVendorStyles(response: VirtualVendorStylesResponse, resolver: Resolver): VirtualContentResult {
+  const filename = response.specifier;
   const owner = resolver.packageCache.ownerOfFile(filename);
   if (!owner) {
     throw new Error(`Failed to find a valid owner for ${filename}`);

--- a/packages/core/src/virtual-vendor-styles.ts
+++ b/packages/core/src/virtual-vendor-styles.ts
@@ -1,7 +1,6 @@
 import type { Package } from '@embroider/shared-internals';
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { readFileSync } from 'fs';
-import { resolve as pathResolve } from 'path';
 import { sortBy } from 'lodash';
 import resolve from 'resolve';
 import type { Resolver } from './module-resolver';
@@ -11,10 +10,6 @@ import type { Engine } from './app-files';
 export interface VirtualVendorStylesResponse {
   type: 'vendor-css';
   specifier: string;
-}
-
-export function virtualVendorStyles(pkg: Package): VirtualVendorStylesResponse {
-  return { type: 'vendor-css', specifier: pathResolve(pkg.root, '-embroider-vendor-styles.css') };
 }
 
 export function decodeVirtualVendorStyles(filename: string): boolean {

--- a/packages/core/src/virtual-vendor.ts
+++ b/packages/core/src/virtual-vendor.ts
@@ -1,7 +1,7 @@
 import { type Package, locateEmbroiderWorkingDir } from '@embroider/shared-internals';
 import type { V2AddonPackage } from '@embroider/shared-internals/src/package';
 import { lstatSync, readFileSync, readJSONSync } from 'fs-extra';
-import { join, resolve as pathResolve } from 'path';
+import { join } from 'path';
 import resolve from 'resolve';
 import type { Resolver } from './module-resolver';
 import type { VirtualContentResult } from './virtual-content';
@@ -9,10 +9,6 @@ import type { VirtualContentResult } from './virtual-content';
 export interface VirtualVendorResponse {
   type: 'vendor-js';
   specifier: string;
-}
-
-export function virtualVendor(pkg: Package): VirtualVendorResponse {
-  return { type: 'vendor-js', specifier: pathResolve(pkg.root, '-embroider-vendor.js') };
 }
 
 export function renderVendor(response: VirtualVendorResponse, resolver: Resolver): VirtualContentResult {

--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -76,7 +76,7 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
     return {
       type: 'found',
       filename: virtual.specifier,
-      result: { path: virtual.specifier, namespace: 'embroider-virtual' },
+      result: { path: virtual.specifier, namespace: 'embroider-virtual', pluginData: { virtual } },
       virtual,
     };
   }

--- a/packages/vite/src/request.ts
+++ b/packages/vite/src/request.ts
@@ -30,6 +30,12 @@ export class RollupRequestAdapter implements RequestAdapter<Resolution<ResolveId
       let fromFile = cleanUrl(importer);
       let importerQueryParams = getUrlQueryParams(importer);
 
+      if (source.startsWith('/@embroider/virtual/')) {
+        // when our virtual paths are used in HTML they come into here with a /
+        // prefix. We still want them to resolve like packages.
+        source = source.slice(1);
+      }
+
       // strip query params off the source but keep track of them
       // we use regexp-based methods over a URL object because the
       // source can be a relative path.

--- a/packages/webpack/src/virtual-loader.ts
+++ b/packages/webpack/src/virtual-loader.ts
@@ -1,4 +1,4 @@
-import { ResolverLoader, virtualContent } from '@embroider/core';
+import { ResolverLoader, virtualContent, type VirtualResponse } from '@embroider/core';
 import type { LoaderContext } from 'webpack';
 
 let resolverLoader: ResolverLoader | undefined;
@@ -20,7 +20,9 @@ export default function virtualLoader(this: LoaderContext<unknown>): string | un
     }
     let { resolver } = setup(appRoot);
     this.resourcePath = filename;
-    return virtualContent(filename, resolver).src;
+    // @ts-expect-error unimplemented
+    let virtual: VirtualResponse = fixmeImplementVirtualResponse();
+    return virtualContent(virtual, resolver).src;
   }
   throw new Error(`@embroider/webpack/src/virtual-loader received unexpected request: ${this.query}`);
 }


### PR DESCRIPTION
This is followup to https://github.com/embroider-build/embroider/pull/2198.

Now that virtual responses are passed directly through the host build environment, we don't need to parse speciiers to get the parameters for virtual content rendering.