### PR TITLE
Fix declarations plugin to cover import()

### DIFF
--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -46,5 +46,9 @@ async function fixDeclarationsInMatchingFiles(dir: string) {
 // Strip any .gts extension from imports in d.ts files, as these won't resolve. See https://github.com/typed-ember/glint/issues/628
 // Once Glint v2 is available, this shouldn't be needed anymore.
 function fixDeclarations(content: string) {
-  return content.replace(/from\s+['"]([^'"]+)\.gts['"]/g, `from '$1'`);
+  return content
+    .replace(/from\s+'([^']+)\.gts'/g, `from '$1'`)
+    .replace(/from\s+"([^"]+)\.gts"/g, `from '$1'`)
+    .replace(/import\("([^"]+)\.gts"\)/g, `import('$1')`)
+    .replace(/import\('([^']+)\.gts'\)/g, `import('$1')`);
 }

--- a/packages/addon-dev/tests/declarations.test.ts
+++ b/packages/addon-dev/tests/declarations.test.ts
@@ -10,6 +10,8 @@ const projectBoilerplate = {
   'tsconfig.json': JSON.stringify({
     include: ['src/**/*'],
     compilerOptions: {
+      target: 'es2022',
+      module: 'esnext',
       declaration: true,
       declarationDir: 'declarations',
       emitDeclarationOnly: true,
@@ -90,6 +92,10 @@ describe('declarations', function () {
         import bar from './bar.gts';
         import baz from './baz.ts';
         export { foo, bar, baz };
+
+        export class Foo {
+          bar = import('./bar.gts')
+        }
       `,
       'foo.gts': 'export default 123',
       'bar.gts': 'export default 234',
@@ -108,5 +114,6 @@ describe('declarations', function () {
     expect(output).toContain(`import foo from './foo';`);
     expect(output).toContain(`import bar from './bar';`);
     expect(output).toContain(`import baz from './baz.ts';`);
+    expect(output).toContain(`import('./bar')`);
   });
 });


### PR DESCRIPTION
#2200 did not cover the case where Glint/TS would emit that TS-specific `import()` function sometimes, which might also import .gts files.