### PR TITLE
Set MiniCssExtractPlugin ignoreOrder to true for default config

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -606,6 +606,8 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
             // but in fastboot, we need to disable that in favor of doing our
             // own insertion of `<link>` tags in the HTML
             runtime: variant.runtime === 'browser',
+            // It's not reasonable to make assumptions about order when doing CSS via modules
+            ignoreOrder: true,
           }),
         ],
       };


### PR DESCRIPTION
From this discussion in the Ember Discord: https://discord.com/channels/480462759797063690/1308128146058514474/1319687395024830507 with @ef4 

The warnings don't particularly mean much when handling CSS via modules, so it should be safe to make the base config ignore them.