### PR TITLE
Set MiniCssExtractPlugin ignoreOrder to true for default config

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -610,6 +610,8 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
             // but in fastboot, we need to disable that in favor of doing our
             // own insertion of `<link>` tags in the HTML
             runtime: variant.runtime === 'browser',
+            // It's not reasonable to make assumptions about order when doing CSS via modules
+            ignoreOrder: true,
           }),
         ],
       };


### PR DESCRIPTION
As per @NullVoxPopuli  a stable branch target version of this PR: https://github.com/embroider-build/embroider/pull/2219 