### PR TITLE
Move template-only component synthesis into core resolver

### DIFF
--- a/packages/core/src/module-request.ts
+++ b/packages/core/src/module-request.ts
@@ -121,3 +121,13 @@ export class ModuleRequest<Res extends Resolution = Resolution> implements Modul
     return new ModuleRequest(this.#adapter, this) as this;
   }
 }
+
+export async function extractResolution<Res extends Resolution = Resolution>(
+  res: Res | (() => Promise<Res>)
+): Promise<Res> {
+  if (typeof res === 'function') {
+    return await res();
+  } else {
+    return res;
+  }
+}

--- a/packages/shared-internals/src/colocation.ts
+++ b/packages/shared-internals/src/colocation.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs-extra';
-import { cleanUrl } from './paths';
+import { cleanUrl, explicitRelative } from './paths';
 import type PackageCache from './package-cache';
 import { sep } from 'path';
 import { resolve as resolveExports } from 'resolve.exports';
@@ -49,7 +49,7 @@ export function isInComponents(url: string, packageCache: Pick<PackageCache, 'ow
     conditions: ['default', 'imports'],
   });
   let componentsDir = tryResolve?.[0] ?? './components';
-  return ('.' + id.slice(pkg?.root.length).split(sep).join('/')).startsWith(componentsDir);
+  return explicitRelative(pkg.root, id).split(sep).join('/').startsWith(componentsDir);
 }
 
 export function templateOnlyComponentSource() {

--- a/packages/vite/src/esbuild-resolver.ts
+++ b/packages/vite/src/esbuild-resolver.ts
@@ -1,7 +1,7 @@
 import type { Plugin as EsBuildPlugin, OnLoadResult, PluginBuild, ResolveResult } from 'esbuild';
 import { transformAsync } from '@babel/core';
 import core, { ModuleRequest, type VirtualResponse } from '@embroider/core';
-const { ResolverLoader, virtualContent, needsSyntheticComponentJS, isInComponents } = core;
+const { ResolverLoader, virtualContent } = core;
 import fs from 'fs-extra';
 const { readFileSync } = fs;
 import { EsBuildRequestAdapter } from './esbuild-request.js';
@@ -9,9 +9,6 @@ import { assertNever } from 'assert-never';
 import { hbsToJS } from '@embroider/core';
 import { Preprocessor } from 'content-tag';
 import { extname } from 'path';
-
-const templateOnlyComponent =
-  `import templateOnly from '@ember/component/template-only';\n` + `export default templateOnly();\n`;
 
 export function esBuildResolver(): EsBuildPlugin {
   let resolverLoader = new ResolverLoader(process.cwd());
@@ -35,9 +32,7 @@ export function esBuildResolver(): EsBuildPlugin {
     pluginData?: { virtual: VirtualResponse };
   }): Promise<OnLoadResult> {
     let src: string;
-    if (namespace === 'embroider-template-only-component') {
-      src = templateOnlyComponent;
-    } else if (namespace === 'embroider-virtual') {
+    if (namespace === 'embroider-virtual') {
       // castin because response in our namespace are supposed to always have
       // this pluginData.
       src = virtualContent(pluginData!.virtual, resolverLoader.resolver).src;
@@ -85,38 +80,11 @@ export function esBuildResolver(): EsBuildPlugin {
         }
       });
 
-      // template-only-component synthesis
-      build.onResolve({ filter: /./ }, async ({ path, importer, namespace, resolveDir, pluginData, kind }) => {
-        if (pluginData?.embroiderHBSResolving) {
-          // reentrance
-          return null;
-        }
-
-        let result = await build.resolve(path, {
-          namespace,
-          resolveDir,
-          importer,
-          kind,
-          // avoid reentrance
-          pluginData: { ...pluginData, embroiderHBSResolving: true },
-        });
-
-        if (result.errors.length === 0 && !result.external) {
-          let syntheticPath = needsSyntheticComponentJS(path, result.path);
-          if (syntheticPath && isInComponents(result.path, resolverLoader.resolver.packageCache)) {
-            return { path: syntheticPath, namespace: 'embroider-template-only-component' };
-          }
-        }
-
-        return result;
-      });
-
       if (phase === 'bundling') {
         // during bundling phase, we need to provide our own extension
         // searching. We do it here in its own resolve plugin so that it's
-        // sitting beneath both embroider resolver and template-only-component
-        // synthesizer, since both expect the ambient system to have extension
-        // search.
+        // sitting beneath the embroider resolver since it expects the ambient
+        // system to have extension search.
         build.onResolve({ filter: /./ }, async ({ path, importer, namespace, resolveDir, pluginData, kind }) => {
           if (pluginData?.embroiderExtensionResolving) {
             // reentrance
@@ -148,8 +116,7 @@ export function esBuildResolver(): EsBuildPlugin {
         });
       }
 
-      // we need to handle everything from one of our three special namespaces:
-      build.onLoad({ namespace: 'embroider-template-only-component', filter: /./ }, onLoad);
+      // we need to handle everything from our special namespaces
       build.onLoad({ namespace: 'embroider-virtual', filter: /./ }, onLoad);
       build.onLoad({ namespace: 'embroider-template-tag', filter: /./ }, onLoad);
 

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -1,81 +1,14 @@
 import { createFilter } from '@rollup/pluginutils';
 import type { PluginContext } from 'rollup';
 import type { Plugin } from 'vite';
-import {
-  hbsToJS,
-  ResolverLoader,
-  needsSyntheticComponentJS,
-  isInComponents,
-  templateOnlyComponentSource,
-  syntheticJStoHBS,
-} from '@embroider/core';
+import { hbsToJS, templateOnlyComponentSource } from '@embroider/core';
 
-const resolverLoader = new ResolverLoader(process.cwd());
 const hbsFilter = createFilter('**/*.hbs?([?]*)');
 
 export function hbs(): Plugin {
   return {
     name: 'rollup-hbs-plugin',
     enforce: 'pre',
-    async resolveId(source: string, importer: string | undefined, options) {
-      if (options.custom?.depScan) {
-        // during depscan we have a corresponding esbuild plugin that is
-        // responsible for this stuff instead. We don't want to fight with it.
-        return null;
-      }
-
-      if (options.custom?.embroider?.isExtensionSearch) {
-        return null;
-      }
-
-      let resolution = await this.resolve(source, importer, {
-        skipSelf: true,
-      });
-
-      if (!resolution) {
-        // vite already has extension search fallback for extensionless imports.
-        // This is different, it covers an explicit .js import fallback to the
-        // corresponding hbs.
-        let hbsSource = syntheticJStoHBS(source);
-        if (hbsSource) {
-          resolution = await this.resolve(hbsSource, importer, {
-            skipSelf: true,
-            custom: {
-              embroider: {
-                // we don't want to recurse into the whole embroider compatbility
-                // resolver here. It has presumably already steered our request to the
-                // correct place. All we want to do is slightly modify the request we
-                // were given (changing the extension) and check if that would resolve
-                // instead.
-                //
-                // Currently this guard is only actually exercised in rollup, not in
-                // vite, due to https://github.com/vitejs/vite/issues/13852
-                enableCustomResolver: false,
-                isExtensionSearch: true,
-              },
-            },
-          });
-        }
-
-        if (!resolution) {
-          return null;
-        }
-      }
-
-      let syntheticId = needsSyntheticComponentJS(source, resolution.id);
-      if (syntheticId && isInComponents(resolution.id, resolverLoader.resolver.packageCache)) {
-        return {
-          id: syntheticId,
-          meta: {
-            'rollup-hbs-plugin': {
-              type: 'template-only-component-js',
-            },
-          },
-        };
-      }
-
-      return resolution;
-    },
 
     load(id: string) {
       if (getMeta(this, id)?.type === 'template-only-component-js') {

--- a/packages/vite/src/request.ts
+++ b/packages/vite/src/request.ts
@@ -1,5 +1,6 @@
 import type { ModuleRequest, RequestAdapter, RequestAdapterCreate, Resolution, VirtualResponse } from '@embroider/core';
 import core from '@embroider/core';
+import { resolve } from 'path';
 
 const { cleanUrl, getUrlQueryParams } = core;
 import type { PluginContext, ResolveIdResult } from 'rollup';
@@ -75,7 +76,10 @@ export class RollupRequestAdapter implements RequestAdapter<Resolution<ResolveId
       type: 'found',
       filename: virtual.specifier,
       result: {
-        id: this.specifierWithQueryParams(virtual.specifier),
+        // The `resolve` here is necessary on windows, where we might have
+        // unix-like specifiers but Vite needs to see a real windows path in the
+        // result.
+        id: resolve(this.specifierWithQueryParams(virtual.specifier)),
         resolvedBy: this.fromFileWithQueryParams(request.fromFile),
         meta: {
           'embroider-resolver': { virtual } satisfies ResponseMeta,


### PR DESCRIPTION
This moves the complicated rules for template-only-component-js synthesis into the core module resolver, so that it's not a separate problem for vite, esbuild, webpack, codemods, etc.

This should directly aid work on the template-tag codemod and the inverted-control webpack.