### PR TITLE
Pass along options to resolve

### DIFF
--- a/packages/addon-dev/src/rollup-hbs-plugin.ts
+++ b/packages/addon-dev/src/rollup-hbs-plugin.ts
@@ -24,11 +24,13 @@ export default function rollupHbsPlugin({
       }
 
       let resolution = await this.resolve(source, importer, {
+        ...options,
         skipSelf: true,
       });
 
       if (!resolution && extname(source) === '') {
         resolution = await this.resolve(source + '.hbs', importer, {
+          ...options,
           skipSelf: true,
         });
       }
@@ -37,6 +39,7 @@ export default function rollupHbsPlugin({
         let hbsSource = syntheticJStoHBS(source);
         if (hbsSource) {
           resolution = await this.resolve(hbsSource, importer, {
+            ...options,
             skipSelf: true,
             custom: {
               embroider: {


### PR DESCRIPTION
closes #2236 

There seems to be a convention for rollup plugins which implement the `resolveId` method to pass along _all_ the options they received in the 3rd argument when calling `this.resolve`.

The `@rollup/commonjs` plugin checks for this and throws a warning, stating it might cause some trouble. 

This is the full warning: 
```
[plugin commonjs--resolver] It appears a plugin has implemented a "resolveId" hook that uses "this.resolve" without forwarding the third "options" parameter of "resolveId". This is problematic as it can lead to wrong module resolutions especially for the node-resolve plugin and in certain cases cause early exit errors for the commonjs plugin.
In rare cases, this warning can appear if the same file is both imported and required from the same mixed ES/CommonJS module, in which case it can be ignored.
```

I will admit, the minutiae of this go way over my head, but I can understand the need for making sure plugins can expect any custom stuff they may have added to options to remain there.

It also seemed like it couldn't really break things for the hbs plugin.

This was also suggested by rollup's maintainer here: https://github.com/lightyen/typescript-paths/issues/3#issue-1206676674 

**uncertainty**: lukas suggests spreading the options _after_ the attributes you set yourself, which seems strange to me. I went with the safer approach for embroider. It still fixes the warning in my local testing.