### PR TITLE
Document sideWatch usage with addon dummy app

### DIFF
--- a/packages/broccoli-side-watch/README.md
+++ b/packages/broccoli-side-watch/README.md
@@ -8,17 +8,29 @@ Let's assume you have a v2 addon with a package name of `grand-prix` somewhere i
 
 Every time you change something in the source of that addon, you can rebuild it by watching the addon's build (currently using rollup). However, by default the host Ember app doesn't rebuild automatically, so you have to restart the Ember app every time this happens which is a slog.
 
-With this library, you can add the following to your `ember-cli-build.js` to vastly improve your life as a developer:
+With this library, you can add the following to your `ember-cli-build.js` to vastly improve your life as a developer.
+
+For an Ember Application:
 
 ```js
 const sideWatch = require('@embroider/broccoli-side-watch');
 
-const app = new EmberApp(defaults, {  
+const app = new EmberApp(defaults, {
   trees: {
     app: sideWatch('app', { watching: [
       'grand-prix', // this will resolve the package by name and watch all its importable code
       '../grand-prix/dist', // or you point to a specific directory to be watched
       ] }),
+  },
+});
+```
+
+Or for an Ember Addon's dummy app:
+
+```js
+const app = new EmberAddon(defaults, {
+  trees: {
+    app: sideWatch('tests/dummy/app', { watching: [ ... ] },
   },
 });
 ```


### PR DESCRIPTION
If you try `app: sideWatch('app', ...)` with an Ember Addon's dummy app, you get an error regarding a missing index.html file. That's because [the app tree defaults](https://github.com/ember-cli/ember-cli/blob/7a93c9ee09f8c48be0a2d3905ef57bec4c2f76d6/lib/broccoli/ember-addon.js#L36) to the `tests/dummy/app` folder.