### PR TITLE
stop nullifying loader.js

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -675,7 +675,5 @@ interface Preprocessors {
 function forbiddenVendorPath(path: string) {
   // ember-source does not go in vendor under embroider (we always use the
   // separate ES modules)
-  //
-  // loader.js sets up AMD. We don't use AMD.
-  return !['./vendor/loader/loader.js', './vendor/ember/ember.js'].includes(path);
+  return !['./vendor/ember/ember.js'].includes(path);
 }


### PR DESCRIPTION
This is part of https://github.com/embroider-build/embroider/issues/2207 

We agreed that we would stop nullifying loader.js even though we don't use it any more for anything. This is to stop us from preventing other people using it for custom things.

Note: this won't mean that there are any of ember's entities in requirejs.entries, it just means that if you have custom code that is using this system it's not blocked from working any more.

Note: I considered adding tests for this but that would suggest that we support loader.js and could imply that we recommend using it. This PR just stops preventing people from using it which I think is ok without a test? thoughts? 