### PR TITLE
add a simple deprecation for the skipBabel setting

### DIFF
--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -87,12 +87,16 @@ export default interface Options {
   // route templates, and controllers which are governed by splitAtRoutes).
   staticAppPaths?: string[];
 
-  // By default, all modules that get imported into the app go through Babel, so
-  // that all code will conform with your Babel targets. This option allows you
-  // to turn Babel off for a particular package. You might need this to work
-  // around a transpiler bug or you might use this as a build-performance
-  // optimization if you've manually verified that a particular package doesn't
-  // need transpilation to be safe in your target browsers.
+  /**
+   * By default, all modules that get imported into the app go through Babel, so
+   * that all code will conform with your Babel targets. This option allows you
+   * to turn Babel off for a particular package. You might need this to work
+   * around a transpiler bug or you might use this as a build-performance
+   * optimization if you've manually verified that a particular package doesn't
+   * need transpilation to be safe in your target browsers.
+   *
+   * @deprecated this setting will be removed in the next version of Embroider
+   */
   skipBabel?: { package: string; semverRange?: string }[];
 
   // This is a performance optimization that can help you avoid the "Your build
@@ -158,6 +162,13 @@ export type CoreOptionsType = Required<
   Pick<Options, 'staticHelpers' | 'staticModifiers' | 'staticComponents' | 'staticInvokables'>;
 
 export function optionsWithDefaults(options?: Options): CoreOptionsType {
+  if (options?.skipBabel) {
+    console.error(
+      `Setting 'skipBabel' will not be possible in the next version of Embroider.
+You should resolve any issue that required you to set this manually or after you upgrade you should configure your babel.config.js as required.`
+    );
+  }
+
   let defaults = {
     splitAtRoutes: [],
     staticAppPaths: [],


### PR DESCRIPTION
This is part of https://github.com/embroider-build/embroider/issues/2207

This PR just adds a simple deprecation for the `skipBabel` setting. I didn't exactly know what to put in the message since people are going to need to fix this manually **after** upgrading rather than getting rid of the "deprecation" before upgrading 🤔 