### PR TITLE
throw an error if anyone sets skipBabel

### DIFF
--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -141,6 +141,12 @@ export function optionsWithDefaults(options?: Options): CompatOptionsType {
     );
   }
 
+  if ((options as any)?.skipBabel !== undefined) {
+    throw new Error(
+      `You have set 'skipBabel' on your Embroider options. This setting has been removed and you can now configure your babel ignores directly in the babel config in your repo https://babeljs.io/docs/options#ignore`
+    );
+  }
+
   return Object.assign({}, defaults, options);
 }
 

--- a/tests/addon-template/ember-cli-build.js
+++ b/tests/addon-template/ember-cli-build.js
@@ -15,11 +15,5 @@ module.exports = function (defaults) {
   */
 
   const { maybeEmbroider } = require('@embroider/test-setup');
-  return maybeEmbroider(app, {
-    skipBabel: [
-      {
-        package: 'qunit',
-      },
-    ],
-  });
+  return maybeEmbroider(app);
 };

--- a/tests/fixtures/blacklisted-addon-build-options/ember-cli-build.js
+++ b/tests/fixtures/blacklisted-addon-build-options/ember-cli-build.js
@@ -10,12 +10,5 @@ module.exports = function (defaults) {
     },
   });
 
-  return maybeEmbroider(app, {
-
-    skipBabel: [
-      {
-        package: 'qunit',
-      },
-    ],
-  });
+  return maybeEmbroider(app);
 };

--- a/tests/fixtures/macro-sample-addon/ember-cli-build.js
+++ b/tests/fixtures/macro-sample-addon/ember-cli-build.js
@@ -18,10 +18,5 @@ module.exports = function(defaults) {
   return maybeEmbroider(app, {
     useAddonAppBoot: false,
     useAddonConfigModule: false,
-    skipBabel: [
-      {
-        package: 'qunit',
-      },
-    ],
   });
 };

--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -52,11 +52,6 @@ appScenarios
 
           return maybeEmbroider(app, {
             availableContentForTypes: ['custom'],
-            skipBabel: [
-              {
-                package: 'qunit',
-              },
-            ],
           });
         };
       `,

--- a/tests/scenarios/compat-exclude-dot-files-test.ts
+++ b/tests/scenarios/compat-exclude-dot-files-test.ts
@@ -23,11 +23,6 @@ appScenarios
 
         return maybeEmbroider(app, {
           staticAddonTrees: false,
-          skipBabel: [
-            {
-              package: 'qunit',
-            },
-          ],
         });
       };
       `,

--- a/tests/scenarios/router-test.ts
+++ b/tests/scenarios/router-test.ts
@@ -36,11 +36,6 @@ function setupScenario(project: Project) {
             staticAddonTrees: true,
             staticInvokables: true,
             splitAtRoutes: ['split-me'],
-            skipBabel: [
-              {
-                package: 'qunit',
-              },
-            ],
           });
         };
       `,

--- a/tests/scenarios/stage1-test.ts
+++ b/tests/scenarios/stage1-test.ts
@@ -30,11 +30,6 @@ appScenarios
             staticComponents: false,
             staticHelpers: false,
             staticModifiers: false,
-            skipBabel: [
-              {
-                package: 'qunit',
-              },
-            ],
           });
         };
       `,

--- a/tests/scenarios/static-app-test.ts
+++ b/tests/scenarios/static-app-test.ts
@@ -390,7 +390,6 @@ wideAppScenarios
                 },
               },
             ],
-            skipBabel: [{ package: 'qunit' }, { package: 'macro-decorators' }],
           });
         };
 

--- a/tests/ts-app-template-classic/ember-cli-build.js
+++ b/tests/ts-app-template-classic/ember-cli-build.js
@@ -8,11 +8,5 @@ module.exports = function (defaults) {
     'ember-cli-babel': { enableTypeScriptTransform: true },
   });
 
-  return maybeEmbroider(app, {
-    skipBabel: [
-      {
-        package: 'qunit',
-      },
-    ],
-  });
+  return maybeEmbroider(app);
 };

--- a/tests/ts-app-template/ember-cli-build.js
+++ b/tests/ts-app-template/ember-cli-build.js
@@ -8,11 +8,5 @@ module.exports = function (defaults) {
     'ember-cli-babel': { enableTypeScriptTransform: true },
   });
 
-  return maybeEmbroider(app, {
-    skipBabel: [
-      {
-        package: 'qunit',
-      },
-    ],
-  });
+  return maybeEmbroider(app);
 };


### PR DESCRIPTION
This is part of https://github.com/embroider-build/embroider/issues/2207

This PR adds an error whenever someone still has the `skipBabel` config set. This setting has already been removed in https://github.com/embroider-build/embroider/pull/2102 and this error is just informing people that they should remove the setting since it no longer does anything.