### PR TITLE
Expose macros config in babel

### DIFF
--- a/packages/compat/src/babel.ts
+++ b/packages/compat/src/babel.ts
@@ -79,8 +79,8 @@ function loadCompatConfig(options?: CompatOptions): CompatBabelState {
 
 const resolverLoader = new ResolverLoader(process.cwd());
 
-export function pluginsFromV1Addons() {
-  let config = loadCompatConfig();
+export function pluginsFromV1Addons(options?: CompatOptions) {
+  let config = loadCompatConfig(options);
   return config.plugins;
 }
 
@@ -187,8 +187,8 @@ export function templateColocation(): PluginItem {
   return [templateColocationPluginPath, colocationOptions];
 }
 
-export function babelCompatSupport(): PluginItem[] {
-  return [...babelMacros(), ...oldDebugMacros(), templateColocation(), ...pluginsFromV1Addons()];
+export function babelCompatSupport(options?: CompatOptions): PluginItem[] {
+  return [...babelMacros(), ...oldDebugMacros(), templateColocation(), ...pluginsFromV1Addons(options)];
 }
 
 export function templateCompatSupport(): Transform[] {

--- a/packages/compat/src/babel.ts
+++ b/packages/compat/src/babel.ts
@@ -84,8 +84,8 @@ export function pluginsFromV1Addons(options?: CompatOptions) {
   return config.plugins;
 }
 
-export function transformsFromV1Addons() {
-  let config = loadCompatConfig();
+export function transformsFromV1Addons(options?: CompatOptions) {
+  let config = loadCompatConfig(options);
   return config.templateTransforms;
 }
 
@@ -98,13 +98,13 @@ export function looseModeSupport(): Transform {
   return [require.resolve('./resolver-transform'), opts];
 }
 
-export function templateMacros() {
-  let config = loadCompatConfig();
+export function templateMacros(options?: CompatOptions) {
+  let config = loadCompatConfig(options);
   return config.templateMacros;
 }
 
-export function babelMacros() {
-  let config = loadCompatConfig();
+export function babelMacros(options?: CompatOptions) {
+  let config = loadCompatConfig(options);
   return config.babelMacros;
 }
 
@@ -188,9 +188,9 @@ export function templateColocation(): PluginItem {
 }
 
 export function babelCompatSupport(options?: CompatOptions): PluginItem[] {
-  return [...babelMacros(), ...oldDebugMacros(), templateColocation(), ...pluginsFromV1Addons(options)];
+  return [...babelMacros(options), ...oldDebugMacros(), templateColocation(), ...pluginsFromV1Addons(options)];
 }
 
-export function templateCompatSupport(): Transform[] {
-  return [...transformsFromV1Addons(), ...templateMacros(), looseModeSupport()];
+export function templateCompatSupport(options?: CompatOptions): Transform[] {
+  return [...transformsFromV1Addons(options), ...templateMacros(options), looseModeSupport()];
 }

--- a/packages/compat/src/babel.ts
+++ b/packages/compat/src/babel.ts
@@ -58,11 +58,25 @@ function loadCompatConfig(options?: CompatOptions): CompatBabelState {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require(compatFile);
   }
-  let macros = MacrosConfig.for({}, process.cwd());
+  let root = process.cwd();
+  let macros = MacrosConfig.for({}, root);
   let { plugins: templateMacros, setConfig } = MacrosConfig.transforms();
   setConfig(macros);
 
-  options?.['@embroider/macros']?.configure?.(macros);
+  if (options?.['@embroider/macros']) {
+    let { setOwnConfig, setConfig, configure } = options['@embroider/macros'];
+    if (setOwnConfig) {
+      macros.setOwnConfig(root, setOwnConfig);
+    }
+
+    if (setConfig) {
+      for (let [packageName, config] of Object.entries(setConfig)) {
+        macros.setConfig(root, packageName, config as object);
+      }
+    }
+
+    configure?.(macros);
+  }
 
   if (process.env.NODE_ENV === 'development') {
     macros.enablePackageDevelopment(process.cwd());

--- a/packages/compat/src/babel.ts
+++ b/packages/compat/src/babel.ts
@@ -10,7 +10,6 @@ import { join } from 'path';
 import type { Transform } from 'babel-plugin-ember-template-compilation';
 import type { Options as ResolverTransformOptions } from './resolver-transform';
 import { buildMacros } from '@embroider/macros/babel';
-import type { Options as MacrosOptions } from '@embroider/macros/babel';
 
 export interface CompatBabelState {
   plugins: PluginItem[];
@@ -19,21 +18,14 @@ export interface CompatBabelState {
   templateMacros: Transform[];
 }
 
-interface CompatOptions {
-  /**
-   * Options for @embroider/macros
-   */
-  '@embroider/macros': MacrosOptions;
-}
-
-function loadCompatConfig(options?: CompatOptions): CompatBabelState {
+function loadCompatConfig(): CompatBabelState {
   let compatFile = join(locateEmbroiderWorkingDir(process.cwd()), '_babel_compat_.js');
   if (existsSync(compatFile)) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require(compatFile);
   }
 
-  let macros = buildMacros(options?.['@embroider/macros']);
+  let macros = buildMacros();
 
   return {
     plugins: [],
@@ -45,13 +37,13 @@ function loadCompatConfig(options?: CompatOptions): CompatBabelState {
 
 const resolverLoader = new ResolverLoader(process.cwd());
 
-export function pluginsFromV1Addons(options?: CompatOptions) {
-  let config = loadCompatConfig(options);
+export function pluginsFromV1Addons() {
+  let config = loadCompatConfig();
   return config.plugins;
 }
 
-export function transformsFromV1Addons(options?: CompatOptions) {
-  let config = loadCompatConfig(options);
+export function transformsFromV1Addons() {
+  let config = loadCompatConfig();
   return config.templateTransforms;
 }
 
@@ -64,13 +56,13 @@ export function looseModeSupport(): Transform {
   return [require.resolve('./resolver-transform'), opts];
 }
 
-export function templateMacros(options?: CompatOptions) {
-  let config = loadCompatConfig(options);
+export function templateMacros() {
+  let config = loadCompatConfig();
   return config.templateMacros;
 }
 
-export function babelMacros(options?: CompatOptions) {
-  let config = loadCompatConfig(options);
+export function babelMacros() {
+  let config = loadCompatConfig();
   return config.babelMacros;
 }
 
@@ -153,10 +145,10 @@ export function templateColocation(): PluginItem {
   return [templateColocationPluginPath, colocationOptions];
 }
 
-export function babelCompatSupport(options?: CompatOptions): PluginItem[] {
-  return [...babelMacros(options), ...oldDebugMacros(), templateColocation(), ...pluginsFromV1Addons(options)];
+export function babelCompatSupport(): PluginItem[] {
+  return [...babelMacros(), ...oldDebugMacros(), templateColocation(), ...pluginsFromV1Addons()];
 }
 
-export function templateCompatSupport(options?: CompatOptions): Transform[] {
-  return [...transformsFromV1Addons(options), ...templateMacros(options), looseModeSupport()];
+export function templateCompatSupport(): Transform[] {
+  return [...transformsFromV1Addons(), ...templateMacros(), looseModeSupport()];
 }

--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -40,11 +40,6 @@ module.exports = {
       "babel-plugin-ember-template-compilation",
       {
         compilerPath: "ember-source/dist/ember-template-compiler.js",
-        enableLegacyModules: [
-          "ember-cli-htmlbars",
-          "ember-cli-htmlbars-inline-precompile",
-          "htmlbars-inline-precompile",
-        ],
         transforms: [...macros.templateMacros],
       },
     ],

--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -10,6 +10,50 @@ The [Embroider package spec](../../docs/spec.md) proposes fixing this by making 
 
 This package works in both Embroider and Classical builds, so that addon authors can switch to this newer pattern without disruption.
 
+## Setting Configuration: from a babel config
+
+1. Add `@embroider/macros` as `devDependency`.
+2. In your babel config, do:
+
+```js
+const { buildMacros } = require('@embroider/macros/babel'); 
+
+const macros = buildMacros({
+  // this is how you configure your own package
+  setOwnConfig: {
+    // your config goes here
+  },
+  // this is how you can optionally send configuration into your
+  // dependencies, if those dependencies choose to use
+  // @embroider/macros configs.
+  setConfig: {
+    'some-dependency': {
+      // config for some-dependency
+    },
+  },
+});
+
+module.exports = {
+  plugins: [
+   // ... 
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        compilerPath: "ember-source/dist/ember-template-compiler.js",
+        enableLegacyModules: [
+          "ember-cli-htmlbars",
+          "ember-cli-htmlbars-inline-precompile",
+          "htmlbars-inline-precompile",
+        ],
+        transforms: [...macros.templateMacros],
+      },
+    ],
+    ...macros.babelMacros,
+  ],
+  // ...
+};
+```
+
 ## Setting Configuration: from an Ember app
 
 1. Add `@embroider/macros` as `devDependency`.

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": "./src/index.js",
     "./babel": "./src/babel.js",
-    "./src/*": "./src/*"
+    "./src/*": "./src/*.js"
   },
   "files": [
     "src/**/*.js",

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -14,6 +14,11 @@
   "license": "MIT",
   "author": "Edward Faulkner",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./babel": "./src/babel.js",
+    "./src/*": "./src/*"
+  },
   "files": [
     "src/**/*.js",
     "src/**/*.d.ts",

--- a/packages/macros/src/babel.ts
+++ b/packages/macros/src/babel.ts
@@ -1,0 +1,65 @@
+import MacrosConfig from './macros-config';
+
+export interface Options {
+  /**
+   * How you configure your own package / app
+   */
+  setOwnConfig?: object;
+  /**
+   * This is how you can optionally send configuration into
+   * your dependencies, if those dependencies choose to use
+   * @embroider/macros configs.
+   *
+   * @example
+   * ```js
+   * setConfig: {
+   *   'some-dependency': {
+   *      // config for some-dependency
+   *   }
+   * }
+   * ```
+   */
+  setConfig?: Record<string, object>;
+
+  /**
+   * Callback for further manipulation of the macros' configuration instance.
+   *
+   * Useful for libraries to provide their own config with defaults shared between sub-dependencies of those libraries.
+   */
+  configure?: (macrosInstance: MacrosConfig) => void;
+}
+
+export function buildMacros(options: Options = {}) {
+  let root = process.cwd();
+  let macros = MacrosConfig.for({}, root);
+
+  let transforms = MacrosConfig.transforms();
+
+  transforms.setConfig(macros);
+
+  let { setOwnConfig, setConfig, configure } = options;
+
+  if (setOwnConfig) {
+    macros.setOwnConfig(root, setOwnConfig);
+  }
+
+  if (setConfig) {
+    for (let [packageName, config] of Object.entries(setConfig)) {
+      macros.setConfig(root, packageName, config as object);
+    }
+  }
+
+  configure?.(macros);
+
+  if (process.env.NODE_ENV === 'development') {
+    macros.enablePackageDevelopment(process.cwd());
+    macros.enableRuntimeMode();
+  }
+
+  macros.finalize();
+
+  return {
+    babelMacros: macros.babelPluginConfig(),
+    templateMacros: transforms.plugins,
+  };
+}

--- a/packages/macros/src/babel.ts
+++ b/packages/macros/src/babel.ts
@@ -27,10 +27,28 @@ export interface Options {
    * Useful for libraries to provide their own config with defaults shared between sub-dependencies of those libraries.
    */
   configure?: (macrosInstance: MacrosConfig) => void;
+
+  /**
+   * Override the default directory used for the MacrosConfig
+   *
+   * defaults to the CWD, via process.cwd()
+   */
+  dir?: string;
 }
 
-export function buildMacros(options: Options = {}) {
-  let root = process.cwd();
+interface ConfiguredMacros {
+  /**
+   * Array of plugins to add to the babel config plugins array
+   */
+  babelMacros: ReturnType<MacrosConfig['babelPluginConfig']>;
+  /**
+   * Array of template transforms to pass to the transforms array of the babel-plugin-ember-template-compilation babel plugin
+   */
+  templateMacros: ReturnType<(typeof MacrosConfig)['transforms']>['plugins'];
+}
+
+export function buildMacros(options: Options = {}): ConfiguredMacros {
+  let root = options.dir || process.cwd();
   let macros = MacrosConfig.for({}, root);
 
   let transforms = MacrosConfig.transforms();

--- a/packages/macros/tests/babel/dependency-satisfies.test.ts
+++ b/packages/macros/tests/babel/dependency-satisfies.test.ts
@@ -1,7 +1,7 @@
 import { allBabelVersions, runDefault } from '@embroider/test-support';
 import { Project } from 'scenario-tester';
 import { join } from 'path';
-import { MacrosConfig } from '../../src/node';
+import { buildMacros } from '../../src/babel';
 
 const ROOT = process.cwd();
 
@@ -21,11 +21,14 @@ describe(`dependencySatisfies`, function () {
     includePresetsTests: true,
     babelConfig() {
       project.write();
-      let config = MacrosConfig.for({}, project.baseDir);
-      config.finalize();
+
+      let config = buildMacros({
+        dir: project.baseDir,
+      });
+
       return {
         filename: join(project.baseDir, 'sample.js'),
-        plugins: config.babelPluginConfig(),
+        plugins: config.babelMacros,
       };
     },
 


### PR DESCRIPTION
@embroider/macros were not configurable in main/vite before this change.

Proposed way of configuring macros is similar to how we've been doing so in ember-cli-build.js

<details><summary>removed from this PR</summary>

## If we do end up needing this in the future,

we should have compat-macros output their combined options to compat-app-builder -> addBabelCompat

rather than the output,

and then have the babel plugin from compat read that in and it could then merge the options.

----------

For example, in the babel config:
```js
const {
  babelCompatSupport,
  templateCompatSupport,
} = require("@embroider/compat/babel");

module.exports = {
  plugins: [
   // ... 
    ...babelCompatSupport({
      '@embroider/macros': {
        setOwnConfig: {},
        setConfig: {
          'library-name': {}
        },
      }
    }),
  ],
  // ...
};
```

</details>

However, this doesn't solve the problem of configuring macros for the minimal app over in https://github.com/embroider-build/embroider/pull/2205

For the minimal app blueprint, we'd have folks do this in their babel config:

```js
const {
  babelCompatSupport,
  templateCompatSupport,
} = require("@embroider/compat/babel");

const { MacrosConfig } = require('@embroider/macros/src/macros-config');

let root = process.cwd();
let macros = MacrosConfig.for({}, root);
let { plugins: templateMacros, setConfig } = MacrosConfig.transforms();

setConfig(macros);

macros.setOwnConfig(root, { /* ... */ });
macros.setConfig(root, 'library-a', { /* ... */ });
macros.setConfig(root, 'library-b', { /* ... */ });

if (process.env.NODE_ENV === 'development') {
  macros.enablePackageDevelopment(process.cwd());
  macros.enableRuntimeMode();
}

macros.finalize();


module.exports = {
  plugins: [
    [
      "babel-plugin-ember-template-compilation",
      {
        compilerPath: "ember-source/dist/ember-template-compiler.js",
        transforms: [...templateMacros],
      },
    ],

   // ... 
   macros.babelPluginConfig();
  ],
  // ...
};
```
which.... could be better...

So.... I've done added to macros to allow for:
```js
const { buildMacros } = require('@embroider/macros/babel'); 

const macros = buildMacros({
  // this is how you configure your own package
  setOwnConfig: {
    // your config goes here
  },
  // this is how you can optionally send configuration into your
  // dependencies, if those dependencies choose to use
  // @embroider/macros configs.
  setConfig: {
    'some-dependency': {
      // config for some-dependency
    },
  },
});

module.exports = {
  plugins: [
   // ... 
    [
      "babel-plugin-ember-template-compilation",
      {
        compilerPath: "ember-source/dist/ember-template-compiler.js",
        transforms: [...macros.templateMacros],
      },
    ],
    ...macros.babelMacros,
  ],
  // ...
};

```

Which should be nice for the minimal blueprint in https://github.com/embroider-build/embroider/pull/2205
