### PR TITLE
Add `disableCssProcessing` option for webpack

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -111,6 +111,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
   private extraThreadLoaderOptions: object | false | undefined;
   private extraBabelLoaderOptions: BabelLoaderOptions | undefined;
   private extraCssLoaderOptions: object | undefined;
+  private disableCssProcessing: boolean | undefined;
   private extraStyleLoaderOptions: object | undefined;
   private _bundleSummary: BundleSummary | undefined;
   private beginBarrier: BeginFn;
@@ -134,6 +135,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
     this.extraThreadLoaderOptions = options?.threadLoaderOptions;
     this.extraBabelLoaderOptions = options?.babelLoaderOptions;
     this.extraCssLoaderOptions = options?.cssLoaderOptions;
+    this.disableCssProcessing = options?.disableCssProcessing;
     this.extraStyleLoaderOptions = options?.styleLoaderOptions;
     [this.beginBarrier, this.incrementBarrier] = createBarrier();
     warmUp(this.extraThreadLoaderOptions);
@@ -192,7 +194,14 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
       }
     }
 
-    let { plugins: stylePlugins, loaders: styleLoaders } = this.setupStyleConfig(variant);
+    let stylePlugins: WebpackPluginInstance[] = [];
+    let styleLoaders: RuleSetUseItem[] = [];
+
+    if (!this.disableCssProcessing) {
+      const { plugins, loaders } = this.setupStyleConfig(variant);
+      stylePlugins = plugins;
+      styleLoaders = loaders;
+    }
 
     let babelLoaderOptions = makeBabelLoaderOptions(
       variant,
@@ -247,10 +256,14 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
               makeBabelLoaderOptions(variant, join(this.appRoot, 'babel.config.cjs'), this.extraBabelLoaderOptions),
             ]),
           },
-          {
-            test: isCSS,
-            use: styleLoaders,
-          },
+          ...[
+            this.disableCssProcessing
+              ? {}
+              : {
+                  test: isCSS,
+                  use: styleLoaders,
+                },
+          ],
         ],
       },
       output: {

--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -71,4 +71,10 @@ export interface Options {
    * is used instead of `style-loader` in production builds.
    */
   styleLoaderOptions?: object;
+
+  /**
+   * Option to opt out of the default CSS processing.
+   * You must provide your own webpack loaders to process your styles.
+   */
+  disableCssProcessing?: boolean;
 }


### PR DESCRIPTION
When an app provides it's own webpack css pipeline there is no reason for the default webpack config to also process css files, you can end up with multiple versions of the same file output into the build (eg. renaming the css files by configuring MiniCssExtractPlugin yourself).

I'm not sure how to add a test for this, some guidance here would be helpful. Do I add a new scenario? Do I just add a test to an existing scenario?

Some documentation should be added to explain this option.