### PR TITLE
throw an error if someone has set staticEmberSource=false

### DIFF
--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -123,10 +123,16 @@ export type CompatOptionsType = Required<
   Pick<Options, 'staticHelpers' | 'staticModifiers' | 'staticComponents' | 'staticInvokables'>;
 
 export function optionsWithDefaults(options?: Options): CompatOptionsType {
-  if (!(options as any)?.staticEmberSource) {
-    console.log(
-      `The setting 'staticEmberSource' will default to true in the next version of Embroider and can't be turned off. To prepare for this you should set 'staticEmberSource: true' in your Embroider config.`
-    );
+  if ((options as any)?.staticEmberSource !== undefined) {
+    if ((options as any).staticEmberSource === false) {
+      throw new Error(
+        `You have set 'staticEmberSource' to 'false' in your Embroider options. This option has been removed is always considered to have the value 'true'. Please remove this setting to continue.`
+      );
+    } else {
+      console.log(
+        `You have set 'staticEmberSource' in your Embroider options. This can safely be removed now and it defaults to true.`
+      );
+    }
   }
 
   if (!options?.staticAddonTrees) {


### PR DESCRIPTION
This is part of https://github.com/embroider-build/embroider/issues/2207

This is following up from https://github.com/embroider-build/embroider/pull/2245 throwing an error if someone has set staticEmberSource to `false` or just warning someone if they still have the setting set to true 👍 

I have verified this locally to make sure it has the right behaviour