### PR TITLE
remove staticAddonTrees and staticAddonTestSupportTrees

### DIFF
--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -8,46 +8,6 @@ import type { PackageRules } from './dependency-rules';
 // the cost of slower or bigger builds. As you eliminate sources of legacy
 // behavior you can benefit from the more aggressive modes.
 export default interface Options extends CoreOptions {
-  /**
-   * Controls whether your addon's "addon" trees should be resolved statically
-   * at build time.
-   *
-   * Note: This setting will be removed in the next version of Embroider and
-   * will effectively default to true
-   *
-   *   false (the current default): implies maximum backward compatibility at
-   *   the cost of bigger builds. In this mode, we force every file into the
-   *   Ember app, which is the legacy behavior.
-   *
-   *   true: produces smaller builds. The addon files must be imported from
-   *   somewhere we can statically see during the build. In this mode, your app
-   *   will only include files that are actually imported from somewhere.
-   *
-   * Commentary: most v1 addons already work well with this set to true, because
-   * they tend to either offer Javascript that users are supposed to directly
-   * `import` or components / helpers / services that get directly imported and
-   * re-exported by code in App Javascript. The exceptions are addons that do
-   * runtime shenanigans with `require` or scoped runtime resolutions.
-   *
-   * To workaround an addon that is preventing you from enabling this flag, you
-   * can use addonDependencyRules.
-   */
-  staticAddonTrees?: boolean;
-
-  // Controls whether your addon's "addonTestSupport" trees should be resolved
-  // statically at build time.
-  //
-  //   false (the default): implies maximum backward compatibility at the cost
-  //   of bigger builds. All test support files will be forced into your Ember
-  //   app, which is the legacy behavior.
-  //
-  //   true: produces smaller builds. Only files that are explicitly imported
-  //   will end up in your app.
-  //
-  // Commentary: this is analogous to staticAddonTrees and the same guidelines
-  // apply.
-  staticAddonTestSupportTrees?: boolean;
-
   // Allows you to override how specific addons will build. Like:
   //
   //   import V1Addon from '@embroider/compat'; let compatAdapters = new Map();
@@ -129,16 +89,40 @@ export function optionsWithDefaults(options?: Options): CompatOptionsType {
     );
   }
 
-  if (!options?.staticAddonTrees) {
-    console.log(
-      `The setting 'staticAddonTrees' will default to true in the next version of Embroider and can't be turned off. To prepare for this you should set 'staticAddonTrees: true' in your Embroider config.`
-    );
+  if ((options as any)?.staticEmberSource !== undefined) {
+    if ((options as any).staticEmberSource === false) {
+      throw new Error(
+        `You have set 'staticEmberSource' to 'false' in your Embroider options. This option has been removed is always considered to have the value 'true'. Please remove this setting to continue.`
+      );
+    } else {
+      console.log(
+        `You have set 'staticEmberSource' in your Embroider options. This can safely be removed now and it defaults to true.`
+      );
+    }
   }
 
-  if (!options?.staticAddonTestSupportTrees) {
-    console.log(
-      `The setting 'staticAddonTestSupportTrees' will default to true in the next version of Embroider and can't be turned off. To prepare for this you should set 'staticAddonTestSupportTrees: true' in your Embroider config.`
-    );
+  if ((options as any)?.staticAddonTrees !== undefined) {
+    if ((options as any).staticAddonTrees === false) {
+      throw new Error(
+        `You have set 'staticAddonTrees' to 'false' in your Embroider options. This option has been removed is always considered to have the value 'true'. Please remove this setting to continue.`
+      );
+    } else {
+      console.log(
+        `You have set 'staticAddonTrees' in your Embroider options. This can safely be removed now and it defaults to true.`
+      );
+    }
+  }
+
+  if ((options as any)?.staticAddonTestSupportTrees !== undefined) {
+    if ((options as any).staticAddonTestSupportTrees === false) {
+      throw new Error(
+        `You have set 'staticAddonTestSupportTrees' to 'false' in your Embroider options. This option has been removed is always considered to have the value 'true'. Please remove this setting to continue.`
+      );
+    } else {
+      console.log(
+        `You have set 'staticAddonTestSupportTrees' in your Embroider options. This can safely be removed now and it defaults to true.`
+      );
+    }
   }
 
   return Object.assign({}, defaults, options);

--- a/tests/scenarios/compat-exclude-dot-files-test.ts
+++ b/tests/scenarios/compat-exclude-dot-files-test.ts
@@ -21,9 +21,7 @@ appScenarios
       module.exports = function (defaults) {
         let app = new EmberApp(defaults, {});
 
-        return maybeEmbroider(app, {
-          staticAddonTrees: false,
-        });
+        return maybeEmbroider(app);
       };
       `,
       app: {
@@ -95,17 +93,6 @@ appScenarios
             // we are relying on the assertinos here so we always return true
             return true;
           });
-      });
-
-      test('dot files are not included as addon implicit-modules', function () {
-        // Dot files should exist on disk
-        expectFile('./node_modules/my-addon/.fooaddon.js').exists();
-        expectFile('./node_modules/my-addon/baraddon.js').exists();
-
-        let myAddonPackage = expectFile('./node_modules/my-addon/package.json').json();
-
-        // dot files are not included as implicit-modules
-        myAddonPackage.get(['ember-addon', 'implicit-modules']).deepEquals(['./baraddon']);
       });
     });
   });

--- a/tests/scenarios/compat-template-colocation-test.ts
+++ b/tests/scenarios/compat-template-colocation-test.ts
@@ -95,7 +95,6 @@ scenarios
           let app = new EmberApp(defaults, {});
           return prebuild(app, {
             staticInvokables: false,
-            staticAddonTrees: false,
           });
         };
       `,
@@ -229,12 +228,9 @@ module('Integration | Component | addon-component-one', function (hooks) {
         );
       });
 
-      test(`addon's colocated components are correct in implicit-modules`, function () {
+      test(`addon's colocated components are not in implicit-modules`, function () {
         let assertFile = expectFile('./node_modules/my-addon/package.json').json();
-        assertFile.get(['ember-addon', 'implicit-modules']).includes('./components/component-one');
-        assertFile.get(['ember-addon', 'implicit-modules']).includes('./components/component-two');
-        assertFile.get(['ember-addon', 'implicit-modules']).doesNotInclude('./components/component-one.hbs');
-        assertFile.get(['ember-addon', 'implicit-modules']).doesNotInclude('./components/component-two.hbs');
+        assertFile.get(['ember-addon', 'implicit-modules']).equals(undefined);
       });
 
       // TODO running pnpm test in this scenario is causing rollup to build things in a strange order

--- a/tests/scenarios/stage1-test.ts
+++ b/tests/scenarios/stage1-test.ts
@@ -25,8 +25,6 @@ appScenarios
           });
 
           return maybeEmbroider(app, {
-            staticAddonTestSupportTrees: false,
-            staticAddonTrees: false,
             staticComponents: false,
             staticHelpers: false,
             staticModifiers: false,
@@ -129,20 +127,6 @@ appScenarios
         myAddonPkg
           .get('ember-addon.app-js')
           .deepEquals({ './components/hello-world.js': './_app_/components/hello-world.js' });
-
-        myAddonPkg
-          .get('ember-addon.implicit-modules')
-          .includes(
-            './components/hello-world',
-            'staticAddonTrees is off so we should include the component implicitly'
-          );
-
-        myAddonPkg
-          .get('ember-addon.implicit-modules')
-          .includes(
-            './templates/components/hello-world.hbs',
-            'staticAddonTrees is off so we should include the template implicitly'
-          );
 
         myAddonPkg.get('ember-addon.version').deepEquals(2);
       });


### PR DESCRIPTION
This is part of https://github.com/embroider-build/embroider/issues/2207

This removes the settings staticAddonTrees and staticAddonTestSupportTrees, and throws an error if someone sets them.

I was surprised that we hadn't already removed these settings 🤔 and I removed the code that was no longer reachable since the settings were removed as a clean up 👍 