### PR TITLE
Fix bug in import deduplication in template-tag-codemod

### DIFF
--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -470,7 +470,10 @@ function renderScopeImports(scope: MetaResult['scope']) {
         sections.push(def[0]);
       }
 
-      let named = entries.filter(e => e[1] !== 'default');
+      // it's possible to have more than one local name for the default export,
+      // so this filter must only ignore the entry that we handled above, not
+      // any others that happen to use `default` as their imported name.
+      let named = entries.filter(e => e !== def);
       if (named.length > 0) {
         sections.push(
           '{' +


### PR DESCRIPTION
The import deduplication in template-tag-codemod fails if you have two different local names for the same default export of a module.

(Separately, there's another bug I'm looking at now that causes us to introduce multiple different local names for the same default export of a module. But regardless, this bug also should be fixed since users could manually cause it.)