### PR TITLE
template-tag-codemod test coverage and robustness fixes

### DIFF
--- a/packages/template-tag-codemod/src/cli.ts
+++ b/packages/template-tag-codemod/src/cli.ts
@@ -71,6 +71,11 @@ yargs(process.argv.slice(2))
 
     async argv => {
       await run(argv as Options);
+
+      // we need this to be explicit because our prebuild runs things like
+      // broccoli-babel-transpiler which leak worker processes and will
+      // otherwise prevent exit.🤮
+      process.exit(0);
     }
   )
   .parse();

--- a/packages/template-tag-codemod/src/extract-meta.ts
+++ b/packages/template-tag-codemod/src/extract-meta.ts
@@ -107,6 +107,7 @@ function extractMetaPlugin(_babel: typeof Babel): Babel.PluginObj<{ opts: Extrac
 export async function extractMeta(source: string, filename: string) {
   const meta: ExtractMetaOpts = { result: undefined };
   await transformAsync(source, {
+    configFile: false,
     filename,
     plugins: [[extractMetaPlugin, meta]],
   });

--- a/packages/template-tag-codemod/src/identify-render-tests.ts
+++ b/packages/template-tag-codemod/src/identify-render-tests.ts
@@ -20,6 +20,7 @@ export async function identifyRenderTests(
 ): Promise<{ renderTests: RenderTest[]; parsed: types.File }> {
   let renderTests: RenderTest[] = [];
   let parsed = await parseAsync(source, {
+    configFile: false,
     filename,
     plugins: [
       [require.resolve('@babel/plugin-syntax-decorators'), { legacy: true }],

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -238,6 +238,7 @@ async function locateTemplateInsertionPoint(
   opts: OptionsWithDefaults
 ): Promise<number> {
   let result = await parseAsync(jsSource, {
+    configFile: false,
     filename: jsPath,
     plugins: [
       [require.resolve('@babel/plugin-syntax-decorators'), { legacy: true }],
@@ -404,7 +405,7 @@ async function chooseImport(
       // this file is in an addon's app tree. Check whether it is just a
       // reexport.
       let content = load(targetFile);
-      let result = await parseAsync(content, { filename: targetFile });
+      let result = await parseAsync(content, { filename: targetFile, configFile: false });
       if (!result) {
         throw new Error(`unexpected failure to parse ${targetFile} with content\n${content}`);
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1405,6 +1405,9 @@ importers:
       qunit:
         specifier: ^2.16.0
         version: 2.24.1
+      scenario-tester:
+        specifier: ^4.1.1
+        version: 4.1.1
       typescript-memoize:
         specifier: ^1.0.1
         version: 1.1.1
@@ -1848,6 +1851,9 @@ importers:
       '@embroider/shared-internals':
         specifier: workspace:*
         version: link:../../packages/shared-internals
+      '@embroider/template-tag-codemod':
+        specifier: workspace:*
+        version: link:../../packages/template-tag-codemod
       '@embroider/test-support':
         specifier: workspace:*
         version: link:../../test-packages/support

--- a/test-packages/support/codemod-assertions.ts
+++ b/test-packages/support/codemod-assertions.ts
@@ -1,0 +1,66 @@
+import type { PreparedApp } from 'scenario-tester';
+import { resolve } from 'path';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { removeSync } from 'fs-extra';
+
+declare global {
+  interface Assert {
+    codeMod: (params: { from: Record<string, string>; to: Record<string, string>; via: string }) => Promise<void>;
+  }
+}
+
+export function codeModAssertions(hooks: NestedHooks, app: () => PreparedApp) {
+  let cleanup = new Set<string>();
+  hooks.beforeEach(assert => {
+    async function codeMod(
+      this: Assert,
+      params: { from: Record<string, string>; to: Record<string, string>; via: string }
+    ) {
+      for (let [name, content] of Object.entries(params.from)) {
+        cleanup.add(name);
+        writeFileSync(resolve(app().dir, name), content, 'utf8');
+      }
+      let result = await app().execute(params.via, {
+        env: {
+          EMBROIDER_VITE_COMMAND: 'prebuild',
+        },
+      });
+      assert.strictEqual(result.exitCode, 0, result.output);
+      if (result.exitCode !== 0) {
+        return;
+      }
+      for (let name of Object.keys(params.from)) {
+        this.ok(!existsSync(resolve(app().dir, name)), `${name} should have been removed`);
+      }
+      for (let [name, content] of Object.entries(params.to)) {
+        cleanup.add(name);
+        let actual: string;
+        try {
+          actual = readFileSync(resolve(app().dir, name), 'utf8');
+        } catch (err) {
+          if (err.code !== 'ENOENT') {
+            throw err;
+          }
+          actual = '<missing file>';
+        }
+        // we're not using code-equality-assertions (which would be nicer)
+        // because that doesn't do template tag.
+        this.strictEqual(normalizeWhitespace(actual), normalizeWhitespace(content));
+      }
+    }
+    assert.codeMod = codeMod;
+  });
+  hooks.afterEach(() => {
+    for (let name of cleanup) {
+      removeSync(resolve(app().dir, name));
+    }
+  });
+}
+
+function normalizeWhitespace(src: string): string {
+  return src
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .join('\n');
+}

--- a/test-packages/support/package.json
+++ b/test-packages/support/package.json
@@ -25,6 +25,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.10",
     "qunit": "^2.16.0",
+    "scenario-tester": "^4.1.1",
     "typescript-memoize": "^1.0.1",
     "webpack": "^5"
   },

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -7,6 +7,7 @@
     "@embroider/core": "workspace:*",
     "@embroider/sample-transforms": "workspace:*",
     "@embroider/shared-internals": "workspace:*",
+    "@embroider/template-tag-codemod": "workspace:*",
     "@embroider/test-support": "workspace:*",
     "@embroider/webpack": "workspace:*",
     "@types/qunit": "2.19.10",

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -1,0 +1,52 @@
+import { tsAppScenarios } from './scenarios';
+import { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+import { codeModAssertions } from '@embroider/test-support/codemod-assertions';
+
+const { module: Qmodule, test } = QUnit;
+
+tsAppScenarios
+  .only('release')
+  .map('template-tag-codemod', project => {
+    project.linkDevDependency('@embroider/template-tag-codemod', { baseDir: __dirname });
+  })
+  .forEachScenario(async scenario => {
+    Qmodule(`${scenario.name}`, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        // TODO: upstream a feature like this into scenario-tester itself. This
+        // makes it possible to rapidly iterate these tests without constantly
+        // rebuilding the scenario.
+        //
+        // 1. pnpm test:output --scenario release-template-tag-codemod --outdir ~/hacking/scenario
+        // 2. REUSE_SCENARIO=~/hacking/scenario pnpm qunit --require ts-node/register template-tag-codemod-test.ts
+        if (process.env.REUSE_SCENARIO) {
+          app = new PreparedApp(process.env.REUSE_SCENARIO);
+        } else {
+          app = await scenario.prepare();
+        }
+      });
+
+      codeModAssertions(hooks, () => app);
+
+      test('hbs only component to gjs', async function (assert) {
+        await assert.codeMod({
+          from: { 'app/components/example.hbs': 'Hello world' },
+          to: { 'app/components/example.gjs': '<template>Hello world</template>' },
+          via: './node_modules/.bin/template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs',
+        });
+      });
+
+      test('hbs only component to gts', async function (assert) {
+        await assert.codeMod({
+          from: { 'app/components/example.hbs': 'Hello world' },
+          to: {
+            'app/components/example.gts': `
+              import type { TemplateOnlyComponent } from '@ember/component/template-only';
+              export default <template>Hello world</template> satisfies TemplateOnlyComponent<{ Args: {} }>`,
+          },
+          via: './node_modules/.bin/template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs --defaultFormat gts',
+        });
+      });
+    });
+  });

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -33,7 +33,7 @@ tsAppScenarios
         await assert.codeMod({
           from: { 'app/components/example.hbs': 'Hello world' },
           to: { 'app/components/example.gjs': '<template>Hello world</template>' },
-          via: './node_modules/.bin/template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs',
+          via: 'npx template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs',
         });
       });
 
@@ -45,7 +45,7 @@ tsAppScenarios
               import type { TemplateOnlyComponent } from '@ember/component/template-only';
               export default <template>Hello world</template> satisfies TemplateOnlyComponent<{ Args: {} }>`,
           },
-          via: './node_modules/.bin/template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs --defaultFormat gts',
+          via: 'npx template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs --defaultFormat gts',
         });
       });
     });


### PR DESCRIPTION
- we were picking up ambient babel configs unintentionally
- we would fail to exit due to broccoli-babel-transpiler in the prebuild (sigh)