### PR TITLE
Fix package jsons

### DIFF
--- a/packages/broccoli-side-watch/package.json
+++ b/packages/broccoli-side-watch/package.json
@@ -5,6 +5,11 @@
   "keywords": [
     "ember"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/broccoli-side-watch"
+  },
   "main": "src/index.js",
   "files": [
     "src/**/*.js",

--- a/packages/reverse-exports/package.json
+++ b/packages/reverse-exports/package.json
@@ -2,6 +2,11 @@
   "name": "@embroider/reverse-exports",
   "version": "0.1.1-alpha.0",
   "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/reverse-exports"
+  },
   "main": "src/index.js",
   "scripts": {
     "test": "jest"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@embroider/vite",
   "version": "1.0.0-alpha.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/vite"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Resolves:
```
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag alpha and default access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=170689842
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@embroider%2fbroccoli-side-watch - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/embroider-build/embroider" from provenance
```
from: https://github.com/embroider-build/embroider/actions/runs/13290516592/job/37109900418