### PR TITLE
remove the last few references to staticAddonTrees

### DIFF
--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -65,8 +65,6 @@ export default interface Options extends CoreOptions {
 }
 
 const defaults = Object.assign(coreWithDefaults(), {
-  staticAddonTrees: false,
-  staticAddonTestSupportTrees: false,
   compatAdapters: new Map(),
   extraPublicTrees: [],
   workspaceDir: null,
@@ -144,8 +142,6 @@ export function optionsWithDefaults(options?: Options): CompatOptionsType {
 export const recommendedOptions: { [name: string]: Options } = Object.freeze({
   safe: Object.freeze({}),
   optimized: Object.freeze({
-    staticAddonTrees: true,
-    staticAddonTestSupportTrees: true,
     allowUnsafeDynamicComponents: false,
     staticInvokables: true,
   }),

--- a/tests/scenarios/compat-route-split-test.ts
+++ b/tests/scenarios/compat-route-split-test.ts
@@ -20,8 +20,6 @@ let splitScenarios = appScenarios.map('compat-splitAtRoutes', app => {
       module.exports = function (defaults) {
         let app = new EmberApp(defaults, {});
         return maybeEmbroider(app, {
-          staticAddonTrees: true,
-          staticAddonTestSupportTrees: true,
           staticInvokables: true,
           splitAtRoutes: ['people'],
         });

--- a/tests/scenarios/router-test.ts
+++ b/tests/scenarios/router-test.ts
@@ -32,8 +32,6 @@ function setupScenario(project: Project) {
           });
 
           return maybeEmbroider(app, {
-            staticAddonTestSupportTrees: true,
-            staticAddonTrees: true,
             staticInvokables: true,
             splitAtRoutes: ['split-me'],
           });


### PR DESCRIPTION
This was causing a deprecation warning on a newly generated app: 

```
You have set 'staticAddonTrees' in your Embroider options. This can safely be removed now and it defaults to true.

You have set 'staticAddonTestSupportTrees' in your Embroider options. This can safely be removed now and it defaults to true.
```