### PR TITLE
Introduce `EMBROIDER_WORKING_DIRECTORY` env var for concurrent builds

### DIFF
--- a/packages/shared-internals/src/working-dir.ts
+++ b/packages/shared-internals/src/working-dir.ts
@@ -9,7 +9,10 @@ export function locateEmbroiderWorkingDir(appRoot: string): string {
   if (cache.has(appRoot)) {
     return cache.get(appRoot);
   }
-  if (existsSync(resolve(appRoot, 'package.json'))) {
+  if (process.env.EMBROIDER_WORKING_DIRECTORY) {
+    let path = resolve(appRoot, process.env.EMBROIDER_WORKING_DIRECTORY);
+    return path;
+  } else if (existsSync(resolve(appRoot, 'package.json'))) {
     // the normal case
     let path = resolve(appRoot, 'node_modules', '.embroider');
     cache.set(appRoot, path);


### PR DESCRIPTION
Currently Embroider will write rewritten packages and other build meta data into `node_modules/.embroider`. That location is hardcoded. Usually not a problem, but when running more than one build for the same app concurrently, builds will step on each others toes by trying to write into the same dir. The optional environment variable introduced here will allow to specify that directory for each build to isolate them.

Fixes #2086