### PR TITLE
Cleanup v2 addon rollup warnings, update virtual parkages list

### DIFF
--- a/packages/addon-dev/src/rollup-gjs-plugin.ts
+++ b/packages/addon-dev/src/rollup-gjs-plugin.ts
@@ -1,5 +1,5 @@
 import { createFilter } from '@rollup/pluginutils';
-import type { Plugin } from 'rollup';
+import type { LogLevel, Plugin, RollupLog } from 'rollup';
 import { Preprocessor } from 'content-tag';
 
 const PLUGIN_NAME = 'rollup-gjs-plugin';
@@ -26,6 +26,12 @@ export default function rollupGjsPlugin(): Plugin {
           map,
         };
       },
+    },
+
+    onLog(_level: LogLevel, log: RollupLog): boolean | void {
+      if (log.code === 'EVAL' && gjsFilter(log.id)) {
+        return false;
+      }
     },
   };
 }

--- a/packages/shared-internals/src/ember-standard-modules.ts
+++ b/packages/shared-internals/src/ember-standard-modules.ts
@@ -44,10 +44,15 @@ emberVirtualPeerDeps.add('ember-source');
 
 // rfc176-data only covers things up to the point where Ember stopped needing
 // the modules-api-polyfill. Newer APIs need to be added here.
-emberVirtualPackages.add('@ember/owner');
 
 // Added in ember-source 4.5.0-beta.1
 emberVirtualPackages.add('@ember/renderer');
+
+// Added in ember-source 4.10.0-beta.1
+emberVirtualPackages.add('@ember/owner');
+
+// Added in ember-source 6.1.0-beta.1
+emberVirtualPackages.add('@ember/template-compiler');
 
 // Not provided by rfc176-data, but is needed for special librarys
 // that know the dangers of importing private APIs


### PR DESCRIPTION
Context: https://github.com/embroider-build/addon-blueprint/issues/327

<img width="1518" alt="image" src="https://github.com/user-attachments/assets/fa00f1ed-2a0b-4b5c-85f1-492633169c67" />

<img width="1514" alt="image" src="https://github.com/user-attachments/assets/b2fee336-7ee8-44b6-a90c-489e0bdc4fe4" />

1. standard modules is missing the new template compiler API, causing an unresolved import warning

2. gjs publish format uses `eval()` which rollup understandably doesn't like, but we know what we are doing™, so we can hide that warning for our users

The eval warning suppression is perhaps a little broad, since it suppresses the warning for other uses of evals in any gjs/gts files, but it would be challenging to be more precise than this.

Realistically, if this isn't already covered by your eslint rules, you have bigger problems than this.