### PR TITLE
Revert "Merge pull request #2271 from embroider-build/template-tag-co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,28 +116,30 @@ return require('@embroider/compat').compatBuild(app, Webpack, {
 
 ## Template Tag Codemod
 
+Edit `ember-cli-build.js`:
+```js
+return require('@embroider/compat').templateTagCodemod(app, {
+  shouldTransformPath: (path) => { return true; },
+  nameHint: (path) => { 
+    // example path: shared/my-button
+    return path; 
+  },
+  dryRun: true,
+});
+```
+Run a normal ember build to transform your hbs templates into template tag single file components.
 Requires optimized build (static* flags to be turned on)
 
-```bash
-  pnpm dlx @embroider/template-tag-codemod@alpha --help
-```
-Or equivalent
-```bash
-  npx @embroider/template-tag-codemod@alpha --help
-```
+### Options
 
-### Example runs
-```bash
-  # will will process only components 
-  npx @embroider/template-tag-codemod@alpha --routeTemplates false --renderTests false --components "app/components/**/*.{js,ts,hbs}"
-  # will will process only tests
-  npx @embroider/template-tag-codemod@alpha --routeTemplates false --renderTests "tests/**/*.{js,ts}" --components false
-  # will will process only route templates
-  npx @embroider/template-tag-codemod@alpha --routeTemplates "app/templates/**/*.hbs" --renderTests false --components false
+* `shouldTransformPath` - allows users to filter the templates that the code mod would run on
+* `nameHint` - optional function control the import name and template replacement values - valid JS identifier required or it will be coerced into one
+* `dryRun` - option can be used to obtain a summary of the changed the build would perform and which files it would act upon
 
-  # will will process only components the folder(s) you specify
-  npx @embroider/template-tag-codemod@alpha --routeTemplates false --renderTests false --components "app/components/some/path/*.{js,ts,hbs}" --components "app/components/some/other/path/*.{js,ts,hbs}"
-```
+### Limitations
+
+* App templates only
+* `@embroider/compat` >= 3.6.0
 
 ## Compatibility
 


### PR DESCRIPTION
…demod-stability-fixes"

This reverts commit 8e24dae0dc7f74e0bb363e204a100aa28213a943, reversing changes made to 2fb41fc122f17bf807de623f82b2edcd208480ae.

1. This breaks the test suite we were about to land in #2264.
2. We don't have consensus on the default behavior of the renaming.
3. This introduces subtle risks around mutating the package cache. 
4. This uses a hack to detect the embroider-working-dir version, when we should add a real version marker instead.