### PR TITLE
Include version in prebuild output

### DIFF
--- a/packages/compat/src/compat-app-builder.ts
+++ b/packages/compat/src/compat-app-builder.ts
@@ -3,7 +3,7 @@ import { locateEmbroiderWorkingDir } from '@embroider/core';
 import type { CompatResolverOptions } from './resolver-transform';
 import type { PackageRules } from './dependency-rules';
 import { activePackageRules } from './dependency-rules';
-import { outputJSONSync, writeFileSync } from 'fs-extra';
+import { outputJSONSync, readJSONSync, writeFileSync, writeJSONSync } from 'fs-extra';
 import type { PortableHint } from '@embroider/core/src/portable';
 import { maybeNodeModuleVersion, Portable } from '@embroider/core/src/portable';
 import { Memoize } from 'typescript-memoize';
@@ -80,6 +80,7 @@ export class CompatAppBuilder {
     this.addEmberEnvConfig(config.EmberENV);
     this.outputAppBootError(config.modulePrefix, config.APP, contentForConfig);
     this.addBabelCompat();
+    this.addVersionMarker();
   }
 
   @Memoize()
@@ -128,6 +129,16 @@ export class CompatAppBuilder {
       module.exports = new Portable().hydrate(${JSON.stringify(portableConfig.value, null, 2)});
       `,
       'utf8'
+    );
+  }
+
+  private addVersionMarker() {
+    writeJSONSync(
+      join(locateEmbroiderWorkingDir(this.compatApp.root), 'version.json'),
+      {
+        '@embroider/core': readJSONSync(require.resolve('@embroider/core/package.json')).version,
+      },
+      { spaces: 2 }
     );
   }
 

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -1,13 +1,13 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { globSync } from 'glob';
-import core, { type Package } from '@embroider/core';
+import core, { locateEmbroiderWorkingDir, type Package } from '@embroider/core';
 import { traverse, parseAsync, type types, transformFromAstAsync } from '@babel/core';
 import * as babel from '@babel/core';
 import templateCompilation, { type Options as EtcOptions } from 'babel-plugin-ember-template-compilation';
 import { createRequire } from 'module';
 import { extractTemplates, locateTemplates } from './extract-meta.js';
 import reverseExports from '@embroider/reverse-exports';
-import { dirname } from 'path';
+import { dirname, relative, resolve } from 'path';
 import type { ResolverTransformOptions } from '@embroider/compat';
 import { identifyRenderTests } from './identify-render-tests.js';
 import { ImportUtil } from 'babel-import-util';
@@ -86,14 +86,25 @@ export function optionsWithDefaults(options?: Options): OptionsWithDefaults {
 type OptionsWithDefaults = Required<Options>;
 
 export async function ensurePrebuild() {
-  if (!existsSync('node_modules/.embroider')) {
-    console.log(`Running addon prebuild...`);
-    let { prebuild } = await import('./prebuild.js');
-    await prebuild();
-    console.log(`Completed addon prebuild.`);
-  } else {
-    console.log(`Reusing addon prebuild in node_modules/.embroider`);
+  let working = locateEmbroiderWorkingDir(process.cwd());
+  let versions: Record<string, string> = {};
+  try {
+    versions = JSON.parse(readFileSync(resolve(working, 'version.json'), 'utf8'));
+  } catch (err) {}
+
+  if (
+    versions['@embroider/core'] &&
+    versions['@embroider/core'] ===
+      JSON.parse(readFileSync(require.resolve('@embroider/core/package.json'), 'utf8')).version
+  ) {
+    console.log(`Reusing addon prebuild in ${relative(process.cwd(), working)}`);
+    return;
   }
+
+  console.log(`Running addon prebuild...`);
+  let { prebuild } = await import('./prebuild.js');
+  await prebuild();
+  console.log(`Completed addon prebuild.`);
 }
 
 export async function ensureAppSetup() {

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { globSync } from 'glob';
-import core, { locateEmbroiderWorkingDir, type Package } from '@embroider/core';
+import core, { locateEmbroiderWorkingDir } from '@embroider/core';
 import { traverse, parseAsync, type types, transformFromAstAsync } from '@babel/core';
 import * as babel from '@babel/core';
 import templateCompilation, { type Options as EtcOptions } from 'babel-plugin-ember-template-compilation';


### PR DESCRIPTION
Normal builds don't get skew here because the embroider working dir gets deleted when you start a fresh build. But template-tag-codemod is attempting to reuse the prebuild to make it easier to iterate on codemod runs. This ensures that the prebuild was made on the exact same @embroider/core version.