### PR TITLE
Workaround babel evaluation bug

### DIFF
--- a/packages/macros/tests/babel/eval.test.ts
+++ b/packages/macros/tests/babel/eval.test.ts
@@ -116,6 +116,15 @@ describe('evaluation', function () {
         expect(code).toMatch(`a: 1`);
         expect(code).toMatch(`b: unknownValue`);
       });
+
+      test('not subject to https://github.com/babel/babel/issues/14197', () => {
+        let code = transform(`
+          const state = { a: 1 };
+          state.a = 2;
+          const result = state.a;
+        `);
+        expect(code).toMatch('result = state.a');
+      });
     },
   });
 });


### PR DESCRIPTION
Fix #2212
Fix #1812
Supersedes #2215

We were already doing most of the evaluation ourselves. Of all the cases we test, the only spot we were relying on babel's `evaluate` was for the undefined keyword, which was easy to add to our own Evaluator.