### PR TITLE
handle empty pojo arg to precompileTemplate

### DIFF
--- a/packages/template-tag-codemod/src/extract-meta.ts
+++ b/packages/template-tag-codemod/src/extract-meta.ts
@@ -45,6 +45,13 @@ function extractMetaPlugin(_babel: typeof Babel): Babel.PluginObj<{ opts: Extrac
           }
 
           let prop0 = arg1.properties[0];
+          if (!prop0) {
+            state.opts.result.push({
+              templateSource: arg0.value,
+            });
+            return;
+          }
+
           if (prop0.type !== 'ObjectProperty') {
             throw new Error(`unexpected source: ${String(path)}`);
           }

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -328,6 +328,25 @@ tsAppScenarios
         });
       });
 
+      test('empty pojo argument to precompileTemplate', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'tests/integration/components/example-test.js': `
+              import { precompileTemplate } from '@ember/template-compilation';
+              import { render } from '@ember/test-helpers';
+              render(precompileTemplate('<div></div>', {}));
+            `,
+          },
+          to: {
+            'tests/integration/components/example-test.gjs': `
+              import { render } from '@ember/test-helpers';
+              render(<template><div></div></template>);
+            `,
+          },
+          via: 'npx template-tag-codemod  --renderTests ./tests/integration/components/example-test.js --routeTemplates false --components false',
+        });
+      });
+
       test('convert rendering test without native lexical this', async function (assert) {
         await assert.codeMod({
           from: {


### PR DESCRIPTION
This corner case in the codemod was unhandled before.