### PR TITLE
Fix staticInvokables resolution of ts components

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -280,7 +280,7 @@ export class Resolver {
           },
         };
       }
-      return nodeResolve(request.specifier, request.fromFile);
+      return nodeResolve(request.specifier, request.fromFile, this.options.resolvableExtensions);
     });
 
     switch (resolution.type) {

--- a/packages/core/src/node-resolve.ts
+++ b/packages/core/src/node-resolve.ts
@@ -3,7 +3,8 @@ import { explicitRelative } from '@embroider/shared-internals';
 
 export function resolve(
   specifier: string,
-  fromFile: string
+  fromFile: string,
+  extensions = ['.hbs.js', '.hbs']
 ): { type: 'found'; result: { type: 'real'; filename: string } } | { type: 'not_found'; err: Error } {
   // require.resolve does not like when we resolve from virtual paths.
   // That is, a request like "../thing.js" from
@@ -25,7 +26,7 @@ export function resolve(
 
   let initialError;
 
-  for (let candidate of candidates(specifier, defaultExtensions)) {
+  for (let candidate of candidates(specifier, extensions)) {
     let filename;
     try {
       filename = require.resolve(candidate, {
@@ -66,5 +67,3 @@ function* candidates(specifier: string, extensions: string[]) {
     yield `${specifier}${ext}`;
   }
 }
-
-const defaultExtensions = ['.hbs.js', '.hbs'];

--- a/tests/scenarios/typescript-app-test.ts
+++ b/tests/scenarios/typescript-app-test.ts
@@ -71,22 +71,26 @@ typescriptApp.forEachScenario(scenario => {
       app = await scenario.prepare();
     });
 
-    test(`pnpm ember test`, async function (assert) {
-      let result = await app.execute(`ember test`);
-      assert.equal(result.exitCode, 0, result.output);
-    });
-  });
-});
-
-typescriptApp.forEachScenario(scenario => {
-  Qmodule(scenario.name, function (hooks) {
-    let app: PreparedApp;
-    hooks.before(async () => {
-      app = await scenario.prepare();
-    });
-
     test(`check types`, async function (assert) {
       let result = await app.execute(`pnpm tsc`);
+      assert.equal(result.exitCode, 0, result.output);
+    });
+
+    test(`pnpm ember test safe`, async function (assert) {
+      let result = await app.execute(`ember test`, {
+        env: {
+          EMBROIDER_TEST_SETUP_OPTIONS: 'safe',
+        },
+      });
+      assert.equal(result.exitCode, 0, result.output);
+    });
+
+    test(`pnpm ember test optimized`, async function (assert) {
+      let result = await app.execute(`ember test`, {
+        env: {
+          EMBROIDER_TEST_SETUP_OPTIONS: 'optimized',
+        },
+      });
       assert.equal(result.exitCode, 0, result.output);
     });
   });


### PR DESCRIPTION
This got broken in the previous patch release while fixing the lack of package.json `exports` support.

This PR fixes the bug and expands test coverage of our typescript-app scenario so that it runs under "optimized" defaults, which would have revealed the bug.

(Fixes bug reported by @ijlee2 in #dev-embroider discord channel today.)