### PR TITLE
Add ability to configure MiniCssExtractPlugin

### DIFF
--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -614,7 +614,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
             runtime: variant.runtime === 'browser',
             // It's not reasonable to make assumptions about order when doing CSS via modules
             ignoreOrder: true,
-            ...this.extraCssPluginOptions
+            ...this.extraCssPluginOptions,
           }),
         ],
       };

--- a/packages/webpack/src/ember-webpack.ts
+++ b/packages/webpack/src/ember-webpack.ts
@@ -110,6 +110,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
   private extraThreadLoaderOptions: object | false | undefined;
   private extraBabelLoaderOptions: BabelLoaderOptions | undefined;
   private extraCssLoaderOptions: object | undefined;
+  private extraCssPluginOptions: object | undefined;
   private extraStyleLoaderOptions: object | undefined;
   private _bundleSummary: BundleSummary | undefined;
   private beginBarrier: BeginFn;
@@ -133,6 +134,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
     this.extraThreadLoaderOptions = options?.threadLoaderOptions;
     this.extraBabelLoaderOptions = options?.babelLoaderOptions;
     this.extraCssLoaderOptions = options?.cssLoaderOptions;
+    this.extraCssPluginOptions = options?.cssPluginOptions;
     this.extraStyleLoaderOptions = options?.styleLoaderOptions;
     [this.beginBarrier, this.incrementBarrier] = createBarrier();
     warmUp(this.extraThreadLoaderOptions);
@@ -612,6 +614,7 @@ const Webpack: PackagerConstructor<Options> = class Webpack implements Packager 
             runtime: variant.runtime === 'browser',
             // It's not reasonable to make assumptions about order when doing CSS via modules
             ignoreOrder: true,
+            ...this.extraCssPluginOptions
           }),
         ],
       };

--- a/packages/webpack/src/options.ts
+++ b/packages/webpack/src/options.ts
@@ -65,6 +65,11 @@ export interface Options {
   cssLoaderOptions?: object;
 
   /**
+   * Options for [`mini-css-extract-plugin`](https://webpack.js.org/plugins/mini-css-extract-plugin/)
+   */
+  cssPluginOptions?: object;
+
+  /**
    * Options for [`style-loader`](https://webpack.js.org/loaders/style-loader/).
    *
    * Note that [`mini-css-extract-plugin`](https://webpack.js.org/plugins/mini-css-extract-plugin/)


### PR DESCRIPTION
Often times developers need the ability to configure the MiniCssExtractPlugin and we haven't been able to. Adding a simple option to pass into Embroider's webpack config so we can configure it now. 
Can change the name if we'd rather it be something different.