### PR TITLE
Fix vendor ember-template-compiler.js on v2 ember-source

### DIFF
--- a/packages/compat/src/compat-app.ts
+++ b/packages/compat/src/compat-app.ts
@@ -362,7 +362,7 @@ export default class CompatApp {
       trees.push(writeFile('vendor/ember/ember.js', () => ''));
       trees.push(writeFile('vendor/ember/ember-testing.js', () => ''));
       const templateCompilerSrc = readFileSync(join(emberSource.root, 'dist/ember-template-compiler.js'), 'utf8');
-      trees.push(writeFile('vendor/ember/ember-testing.js', () => templateCompilerSrc));
+      trees.push(writeFile('vendor/ember/ember-template-compiler.js', () => templateCompilerSrc));
     }
 
     if (this.vendorTree) {


### PR DESCRIPTION
This fixes a typo pointed out by @chancancode.

This code exists to allow people to `app.import('vendor/ember-template-compiler.js')` after upgrading to ember-source >= 6.2.

It's not clear whether anybody actually *does* that, and the forward-looking plan for this area is that v2 apps can't do `app.import`, rendering the question moot.