### PR TITLE
codemod: support all the legacy inline hbs module names

### DIFF
--- a/packages/template-tag-codemod/src/detect-inline-hbs.ts
+++ b/packages/template-tag-codemod/src/detect-inline-hbs.ts
@@ -1,0 +1,44 @@
+import { type NodePath } from '@babel/core';
+
+export function isLooseHBS(path: NodePath<unknown>): false | { supportsScope: boolean } {
+  let callee: NodePath<unknown> | undefined;
+  if (path.isTaggedTemplateExpression()) {
+    callee = path.get('tag');
+  } else if (path.isCallExpression()) {
+    callee = path.get('callee');
+  }
+
+  if (!callee?.isReferencedIdentifier()) {
+    return false;
+  }
+
+  if (callee.referencesImport('ember-cli-htmlbars', 'hbs')) {
+    return { supportsScope: false };
+  }
+
+  if (callee.referencesImport('ember-cli-htmlbars-inline-precompile', 'default')) {
+    return { supportsScope: false };
+  }
+
+  if (callee.referencesImport('htmlbars-inline-precompile', 'default')) {
+    return { supportsScope: false };
+  }
+
+  if (callee.referencesImport('@ember/template-compilation', 'precompileTemplate')) {
+    return { supportsScope: true };
+  }
+
+  return false;
+}
+
+export function allLegacyModules() {
+  return [
+    'ember-cli-htmlbars' as const,
+    'ember-cli-htmlbars-inline-precompile' as const,
+    'htmlbars-inline-precompile' as const,
+  ];
+}
+
+export function allHBSModules() {
+  return ['@ember/template-compilation', ...allLegacyModules()];
+}

--- a/packages/template-tag-codemod/src/identify-render-tests.ts
+++ b/packages/template-tag-codemod/src/identify-render-tests.ts
@@ -1,5 +1,6 @@
 import { type NodePath, traverse, type types } from '@babel/core';
 import codeFrame from '@babel/code-frame';
+import { isLooseHBS } from './detect-inline-hbs.js';
 
 const { codeFrameColumns } = codeFrame;
 
@@ -68,21 +69,6 @@ export async function identifyRenderTests(ast: types.File, source: string, filen
     },
   });
   return renderTests;
-}
-
-function isLooseHBS(path: NodePath<unknown>) {
-  let callee: NodePath<unknown> | undefined;
-  if (path.isTaggedTemplateExpression()) {
-    callee = path.get('tag');
-  } else if (path.isCallExpression()) {
-    callee = path.get('callee');
-  }
-
-  return (
-    callee?.isReferencedIdentifier() &&
-    (callee.referencesImport('ember-cli-htmlbars', 'hbs') ||
-      callee.referencesImport('@ember/template-compilation', 'precompileTemplate'))
-  );
 }
 
 function startOfScope(path: NodePath<unknown>): number {

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -14,6 +14,7 @@ import { ImportUtil } from 'babel-import-util';
 import { replaceThisTransform } from './replace-this-transform.js';
 // @ts-expect-error library ships types incompatible with moduleResolution:nodenext
 import { ModuleImporter } from '@humanwhocodes/module-importer';
+import { allHBSModules, allLegacyModules } from './detect-inline-hbs.js';
 
 const { explicitRelative, hbsToJS, ResolverLoader } = core;
 const { externalName } = reverseExports;
@@ -167,7 +168,7 @@ async function locateInvokables(
         templateCompilation,
         {
           targetFormat: 'hbs',
-          enableLegacyModules: ['ember-cli-htmlbars'],
+          enableLegacyModules: allLegacyModules(),
           transforms: [
             [
               require.resolve('@embroider/compat/src/resolver-transform'),
@@ -534,7 +535,7 @@ export async function processRenderTest(filename: string, opts: OptionsWithDefau
   edits.unshift({
     start: 0,
     end: 0,
-    replacement: extractImports(ast, path => !['@ember/template-compilation', 'ember-cli-htmlbars'].includes(path)),
+    replacement: extractImports(ast, path => !allHBSModules().includes(path)),
   });
   for (let [index, test] of renderTests.entries()) {
     let templateSource = finalTemplates[index].templateSource;
@@ -603,7 +604,7 @@ async function runResolverTransform(
         templateCompilation,
         {
           targetFormat: 'hbs',
-          enableLegacyModules: ['ember-cli-htmlbars'],
+          enableLegacyModules: allLegacyModules(),
           transforms: [
             [
               require.resolve('@embroider/compat/src/resolver-transform'),

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -396,5 +396,36 @@ tsAppScenarios
           via: 'npx template-tag-codemod  --renderTests ./tests/integration/components/example-test.js --routeTemplates false --components false --nativeLexicalThis false',
         });
       });
+
+      test('legacy hbs module name', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'tests/integration/components/example-test.js': `
+              import { module, test } from 'qunit';
+              import { render } from '@ember/test-helpers';
+              import hbs from 'htmlbars-inline-precompile';
+              module('Integration | Component | message-box', function (hooks) {
+                test('example', async function (assert) {
+                  await render(hbs\`<MessageBox />\`);
+                });
+              });
+            `,
+          },
+          to: {
+            'tests/integration/components/example-test.gjs': `
+              import { module, test } from 'qunit';
+              import { render } from '@ember/test-helpers';
+              import MessageBox from "../../../app/components/message-box.js";
+
+              module('Integration | Component | message-box', function (hooks) {
+                test('example', async function (assert) {
+                  await render(<template><MessageBox /></template>);
+                });
+              });
+            `,
+          },
+          via: 'npx template-tag-codemod  --renderTests ./tests/integration/components/example-test.js --routeTemplates false --components false',
+        });
+      });
     });
   });


### PR DESCRIPTION
This extends the codemod to support all the places one could historically have imported `hbs` from to define inline handlebars templates.