### PR TITLE
codemod printer bug

### DIFF
--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -427,5 +427,24 @@ tsAppScenarios
           via: 'npx template-tag-codemod  --renderTests ./tests/integration/components/example-test.js --routeTemplates false --components false',
         });
       });
+
+      test('template compiler printer quoting bug', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'app/components/example.hbs': `
+              <MessageBox @copyText='{{@crate.name}} = "{{@crate.default_version}}"' />
+            `,
+          },
+          to: {
+            'app/components/example.gjs': `
+            import MessageBox from "./message-box.js";
+            <template>
+              <MessageBox @copyText='{{@crate.name}} = "{{@crate.default_version}}"' />
+            </template>
+            `,
+          },
+          via: 'npx template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs',
+        });
+      });
     });
   });


### PR DESCRIPTION
This is a failing test for a case I found in the wild that the codemod breaks.

The underlying cause is https://github.com/glimmerjs/glimmer-vm/pull/1720