### PR TITLE
template-tag-codemod: only reuse ember prebuild if you explicitly pass the option to do so

### DIFF
--- a/packages/template-tag-codemod/src/cli.ts
+++ b/packages/template-tag-codemod/src/cli.ts
@@ -72,6 +72,11 @@ yargs(process.argv.slice(2))
           type: 'string',
           default: optionsWithDefaults().renamingRules,
           describe: `The name of a module that will provide a renaming strategy for picking the names of components, helpers, and modifiers in rewritten templates`,
+        })
+        .option('reusePrebuild', {
+          type: 'boolean',
+          default: optionsWithDefaults().reusePrebuild,
+          describe: `Allows you to reuse prebuild between runs of this codemod. While this speeds things up it is not what most people should be doing, use with caution.`,
         }),
 
     async argv => {

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -78,6 +78,14 @@ export interface Options {
   // need to install `@embroider/template-tag-codemod` as a dependency to access
   // it in this way)
   renamingRules?: 'string';
+
+  /**
+   * This allows you to reuse the ember-prebuild if you are running the codemod multiple times.
+   *
+   * You should only set this setting if you know that any changes you're making will not influence
+   * the prebuild in any way. Most people should leave this set to its default `false` value
+   */
+  reusePrebuild?: boolean;
 }
 
 export function optionsWithDefaults(options?: Options): OptionsWithDefaults {
@@ -95,6 +103,7 @@ export function optionsWithDefaults(options?: Options): OptionsWithDefaults {
       templateOnlyComponentSignature: `{ Args: {} }`,
       templateInsertion: 'beginning',
       renamingRules: '@embroider/template-tag-codemod/default-renaming',
+      reusePrebuild: false,
     },
     options
   );
@@ -102,20 +111,22 @@ export function optionsWithDefaults(options?: Options): OptionsWithDefaults {
 
 type OptionsWithDefaults = Required<Options>;
 
-export async function ensurePrebuild() {
-  let working = locateEmbroiderWorkingDir(process.cwd());
-  let versions: Record<string, string> = {};
-  try {
-    versions = JSON.parse(readFileSync(resolve(working, 'version.json'), 'utf8'));
-  } catch (err) {}
+export async function ensurePrebuild(opts: OptionsWithDefaults) {
+  if (opts.reusePrebuild) {
+    let working = locateEmbroiderWorkingDir(process.cwd());
+    let versions: Record<string, string> = {};
+    try {
+      versions = JSON.parse(readFileSync(resolve(working, 'version.json'), 'utf8'));
+    } catch (err) {}
 
-  if (
-    versions['@embroider/core'] &&
-    versions['@embroider/core'] ===
-      JSON.parse(readFileSync(require.resolve('@embroider/core/package.json'), 'utf8')).version
-  ) {
-    console.log(`Reusing addon prebuild in ${relative(process.cwd(), working)}`);
-    return;
+    if (
+      versions['@embroider/core'] &&
+      versions['@embroider/core'] ===
+        JSON.parse(readFileSync(require.resolve('@embroider/core/package.json'), 'utf8')).version
+    ) {
+      console.log(`Reusing addon prebuild in ${relative(process.cwd(), working)}`);
+      return;
+    }
   }
 
   console.log(`Running addon prebuild...`);
@@ -682,9 +693,11 @@ function applyEdits(source: string, edits: { start: number; end: number; replace
 }
 
 export async function run(partialOpts: Options) {
+  // this makes sure that we don't fight with other versions of embroider currently running on the system
+  process.env.EMBROIDER_WORKING_DIRECTORY = 'node_modules/.template-tag-codemod';
   let opts = optionsWithDefaults(partialOpts);
   await ensureAppSetup();
-  await ensurePrebuild();
+  await ensurePrebuild(opts);
   await processRouteTemplates(opts);
   await processComponents(opts);
   await processRenderTests(opts);

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -162,6 +162,14 @@ export async function processRouteTemplates(opts: OptionsWithDefaults) {
   }
 }
 
+// this makes sure that we don't fight with other versions of embroider currently running on the system
+// we will only pick our template-tag-codemod specific working directory if there hasn't been one set
+// already. Also note that this is first read with the ResolverLoader below so this is the perfect place
+// to apply this setting
+if (!process.env.EMBROIDER_WORKING_DIRECTORY) {
+  process.env['EMBROIDER_WORKING_DIRECTORY'] = 'node_modules/.template-tag-codemod';
+}
+
 const resolverLoader = new ResolverLoader(process.cwd());
 
 async function locateInvokables(
@@ -693,8 +701,6 @@ function applyEdits(source: string, edits: { start: number; end: number; replace
 }
 
 export async function run(partialOpts: Options) {
-  // this makes sure that we don't fight with other versions of embroider currently running on the system
-  process.env.EMBROIDER_WORKING_DIRECTORY = 'node_modules/.template-tag-codemod';
   let opts = optionsWithDefaults(partialOpts);
   await ensureAppSetup();
   await ensurePrebuild(opts);


### PR DESCRIPTION
This was discussed during the office hours and weekly meeting

essentially while developing the template-tag-codemod it was inconvenient to have to wait for the Ember prebuild every time the script was run. But when people are using this in real apps it is usually better that they don't re-use the prebuild, especially if they are likely to be making changes that would change the contents of the prebuild

This PR removes the reuse of the prebuild entirely 👍 