### PR TITLE
add a failing test for Component.extend()

### DIFF
--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -180,6 +180,63 @@ tsAppScenarios
         });
       });
 
+      test('basic js backing component', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'app/components/example.hbs': `<button {{on "click" this.clicked}}>Click me</button>`,
+            'app/components/example.js': `
+              import Component from "@ember/component";
+              export default class extends Component {
+
+                clicked() {
+                  alert('i got clicked');
+                }
+              }
+            `,
+          },
+          to: {
+            'app/components/example.gjs': `
+              import Component from "@ember/component";
+              import { on } from "@ember/modifier";
+              export default class extends Component {<template><button {{on "click" this.clicked}}>Click me</button></template>
+                clicked() {
+                  alert('i got clicked');
+                }
+              }
+            `,
+          },
+          via: 'npx template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs',
+        });
+      });
+
+      test('basic js backing component', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'app/components/example.hbs': `<button {{on "click" this.clicked}}>Click me</button>`,
+            'app/components/example.js': `
+              import Component from "@ember/component";
+              export default Component.extend({
+                clicked() {
+                  alert('i got clicked');
+                }
+              })
+            `,
+          },
+          to: {
+            'app/components/example.gjs': `
+              import Component from "@ember/component";
+              import { on } from "@ember/modifier";
+              export default class extends Component {<template><button {{on "click" this.clicked}}>Click me</button></template>
+                clicked() {
+                  alert('i got clicked');
+                }
+              }
+            `,
+          },
+          via: 'npx template-tag-codemod  --renderTests false --routeTemplates false --components ./app/components/example.hbs',
+        });
+      });
+
       test('name collision between original js and added import', async function (assert) {
         await assert.codeMod({
           from: {


### PR DESCRIPTION
testing this out on an old and out of date package threw up another place where people might have issues 🙈 This adds a test for cases where components are exported using `export default Component.extend({})` 

I couldn't find the code in the rest of embroider that handles this 🤔 but I figure we must be handling this somewhere else. Alternatively if we don't want to support this path we could easily add a case that instructs people to update that file to a `export default Class` without the `.extend({})` call, maybe pointing them at a different codemod? 

thoughts?  