### PR TITLE
Improve template-tag-codemod error reporting

### DIFF
--- a/packages/template-tag-codemod/package.json
+++ b/packages/template-tag-codemod/package.json
@@ -47,6 +47,7 @@
     "babel-import-util": "^3.0.0",
     "babel-plugin-ember-template-compilation": "^2.3.0",
     "broccoli": "^3.5.2",
+    "chalk": "^5.4.1",
     "console-ui": "^3.1.2",
     "ember-cli": "^6.0.1",
     "glob": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,6 +862,9 @@ importers:
       broccoli:
         specifier: ^3.5.2
         version: 3.5.2
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
       console-ui:
         specifier: ^3.1.2
         version: 3.1.2
@@ -12116,7 +12119,6 @@ packages:
   /chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: true
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}


### PR DESCRIPTION
- don't stop at the first problem
- log progress with colors during the run
- report detailed failures at the end

This is the first part of fixing https://github.com/embroider-build/embroider/pull/2322. It creates a general-purpose way for us to report that kind of failure. Next I'll separately implement that specific case.