### PR TITLE
Avoid crashing the rollup watchmode build when glint hits a syntax error

### DIFF
--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -12,6 +12,7 @@ export default function rollupDeclarationsPlugin(declarationsDir: string) {
         await execa('glint', ['--declaration'], {
           stdio: 'inherit',
           preferLocal: true,
+          reject: false
         });
 
         await fixDeclarationsInMatchingFiles(declarationsDir);

--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -1,18 +1,21 @@
+import type { Plugin } from 'rollup';
 import execa from 'execa';
 import walkSync from 'walk-sync';
 import { readFile, writeFile } from 'fs/promises';
 
-export default function rollupDeclarationsPlugin(declarationsDir: string) {
+export default function rollupDeclarationsPlugin(
+  declarationsDir: string
+): Plugin {
   let glintPromise: Promise<void>;
 
   return {
     name: 'glint-dts',
-    buildStart: () => {
+    buildStart() {
       const runGlint = async () => {
         await execa('glint', ['--declaration'], {
           stdio: 'inherit',
           preferLocal: true,
-          reject: false
+          reject: this.meta.watchMode,
         });
 
         await fixDeclarationsInMatchingFiles(declarationsDir);


### PR DESCRIPTION
As described in the issue, you don't want the build watching script to completely exit when it hits a syntax error. This means you have to restart `pnpm start` once you've fixed the error, which is annoying.



fixes #2341 