### PR TITLE
move most of the implementation of staticInvokables to core

### DIFF
--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -118,10 +118,7 @@ const defaults = Object.assign(coreWithDefaults(), {
   allowUnsafeDynamicComponents: false,
 });
 
-export type CompatOptionsType = Required<
-  Omit<Options, 'staticHelpers' | 'staticModifiers' | 'staticComponents' | 'staticInvokables'>
-> &
-  Pick<Options, 'staticHelpers' | 'staticModifiers' | 'staticComponents' | 'staticInvokables'>;
+export type CompatOptionsType = Required<Omit<Options, 'staticInvokables'>> & Pick<Options, 'staticInvokables'>;
 
 export function optionsWithDefaults(options?: Options): CompatOptionsType {
   if (!options?.staticEmberSource) {

--- a/packages/compat/src/options.ts
+++ b/packages/compat/src/options.ts
@@ -139,7 +139,12 @@ export function optionsWithDefaults(options?: Options): CompatOptionsType {
     );
   }
 
-  return Object.assign({}, defaults, options);
+  return Object.assign({}, defaults, {
+    ...options,
+    staticComponents: options?.staticInvokables ?? options?.staticComponents ?? defaults.staticComponents,
+    staticHelpers: options?.staticInvokables ?? options?.staticHelpers ?? defaults.staticHelpers,
+    staticModifiers: options?.staticInvokables ?? options?.staticModifiers ?? defaults.staticModifiers,
+  });
 }
 
 // These are recommended configurations for addons to test themselves under. By

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -152,17 +152,47 @@ export default interface Options {
       };
 }
 
-export type CoreOptionsType = Required<
-  Omit<Options, 'staticHelpers' | 'staticModifiers' | 'staticComponents' | 'staticInvokables'>
-> &
-  Pick<Options, 'staticHelpers' | 'staticModifiers' | 'staticComponents' | 'staticInvokables'>;
+export type CoreOptionsType = Required<Omit<Options, 'staticInvokables'>> & Pick<Options, 'staticInvokables'>;
 
 export function optionsWithDefaults(options?: Options): CoreOptionsType {
+  let staticComponents, staticHelpers, staticModifiers;
+  // staticInvokables always wins when configured
+  if (typeof options?.staticInvokables !== 'undefined') {
+    if (
+      typeof options.staticComponents !== 'undefined' ||
+      typeof options.staticHelpers !== 'undefined' ||
+      typeof options.staticModifiers !== 'undefined'
+    ) {
+      throw new Error(
+        'You cannot set `staticHelpers`, `staticComponents`, or `staticModifiers` if you have set `staticInvokables`. Delete these configs to continue.'
+      );
+    }
+    staticComponents = staticHelpers = staticModifiers = options.staticInvokables;
+  } else {
+    if (typeof options?.staticComponents !== 'undefined') {
+      console.error(`Setting 'staticComponents' is deprecated. Use 'staticInvokables' instead`);
+      staticComponents = options.staticComponents;
+    }
+
+    if (typeof options?.staticHelpers !== 'undefined') {
+      console.error(`Setting 'staticHelpers' is deprecated. Use 'staticInvokables' instead`);
+      staticHelpers = options.staticHelpers;
+    }
+
+    if (typeof options?.staticModifiers !== 'undefined') {
+      console.error(`Setting 'staticModifiers' is deprecated. Use 'staticInvokables' instead`);
+      staticModifiers = options.staticModifiers;
+    }
+  }
+
   let defaults = {
     splitAtRoutes: [],
     staticAppPaths: [],
     skipBabel: [],
     pluginHints: [],
+    staticHelpers: staticHelpers ?? false,
+    staticModifiers: staticModifiers ?? false,
+    staticComponents: staticComponents ?? false,
     amdCompatibility: 'cjs' as const,
   };
   if (options) {


### PR DESCRIPTION
I didn't realise in #2210 what the implications of version drift would be splitting the deprecation and the default across two packages. This fixes that slight mess that I created 🙈 this effectively reverts the changes to `@embroider/compat` that provides any hint of the deprecation and handles it all in `@embroider/core`. This means that you won't get strange errors any more when you have a miss-match of versions 👍 

Edit: I moved all the cases where it would throw an error to core so they are now contained in one package but I still needed to accomidate the functionality in compat because of the implementation of `optionsWithDefaults()`. I also bumped the minimum peer version of compat->core so that should help with the version skew 👍 