### PR TITLE
Support named const exports in template-tag-codemod

### DIFF
--- a/packages/template-tag-codemod/src/cli.ts
+++ b/packages/template-tag-codemod/src/cli.ts
@@ -77,6 +77,11 @@ yargs(process.argv.slice(2))
           type: 'boolean',
           default: optionsWithDefaults().reusePrebuild,
           describe: `Allows you to reuse prebuild between runs of this codemod. While this speeds things up it is not what most people should be doing, use with caution.`,
+        })
+        .option('addNameToTemplateOnly', {
+          type: 'boolean',
+          default: optionsWithDefaults().addNameToTemplateOnly,
+          describe: `Exports template-only components via a named const definition. This can improve import autocompletion in IDEs.`,
         }),
 
     async argv => {

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -87,6 +87,13 @@ export interface Options {
    * the prebuild in any way. Most people should leave this set to its default `false` value
    */
   reusePrebuild?: boolean;
+
+  /**
+   * Exports template-only components via a named const definition.
+   *
+   * This can improve import autocompletion in IDEs like VSCode.
+   */
+  addNameToTemplateOnly?: boolean;
 }
 
 export function optionsWithDefaults(options?: Options): OptionsWithDefaults {
@@ -105,6 +112,7 @@ export function optionsWithDefaults(options?: Options): OptionsWithDefaults {
       templateInsertion: 'beginning',
       renamingRules: '@embroider/template-tag-codemod/default-renaming',
       reusePrebuild: false,
+      addNameToTemplateOnly: false,
     },
     options
   );
@@ -328,6 +336,26 @@ export async function processComponents(opts: OptionsWithDefaults): Promise<Resu
   return results;
 }
 
+// Copied from https://github.com/emberjs/ember-string/blob/16fffa2a565f21c177f9cfa41751ba60b9634863/src/index.ts
+const STRING_CLASSIFY_REGEXP_1 = /^(\-|_)+(.)?/;
+const STRING_CLASSIFY_REGEXP_2 = /(.)(\-|\_|\.|\s)+(.)?/g;
+const STRING_CLASSIFY_REGEXP_3 = /(^|\/|\.)([a-z])/g;
+
+function classify(str: string) {
+  const replace1 = (_match: string, _separator: string, chr: string) => (chr ? `_${chr.toUpperCase()}` : '');
+  const replace2 = (_match: string, initialChar: string, _separator: string, chr: string) =>
+    initialChar + (chr ? chr.toUpperCase() : '');
+  const parts = str.split('/');
+
+  for (let i = 0; i < parts.length; i++) {
+    parts[i] = (parts as any)[i]
+      .replace(STRING_CLASSIFY_REGEXP_1, replace1)
+      .replace(STRING_CLASSIFY_REGEXP_2, replace2);
+  }
+
+  return parts.join('/').replace(STRING_CLASSIFY_REGEXP_3, (match /*, separator, chr */) => match.toUpperCase());
+}
+
 export async function processComponent(
   hbsPath: string,
   jsPath: string | undefined,
@@ -384,10 +412,11 @@ export async function processComponent(
     if (finalTemplates.length !== 1) {
       throw new Error(`bug: should see one templates, not ${finalTemplates.length}`);
     }
+    let componentName = classify(hbsPath.match(/.*\/(.+)\.hbs$/)![1]);
     let newSrc =
       extractImports(ast, path => path !== '@ember/template-compilation') +
       '\n' +
-      hbsOnlyComponent(finalTemplates[0].templateSource, opts);
+      hbsOnlyComponent(finalTemplates[0].templateSource, componentName, opts);
     writeFileSync(hbsPath.replace(/.hbs$/, '.' + opts.defaultFormat), newSrc);
     unlinkSync(hbsPath);
   }
@@ -457,12 +486,16 @@ async function insertComponentTemplate(
   return result!.ast!;
 }
 
-function hbsOnlyComponent(templateSource: string, opts: OptionsWithDefaults): string {
+function hbsOnlyComponent(templateSource: string, componentName: string, opts: OptionsWithDefaults): string {
   let outSource: string[] = [];
   if (opts.defaultFormat === 'gts') {
     outSource.unshift(`import type { TemplateOnlyComponent } from '@ember/component/template-only';`);
     outSource.push(
       `export default <template>${templateSource}</template> satisfies TemplateOnlyComponent<${opts.templateOnlyComponentSignature}>`
+    );
+  } else if (opts.addNameToTemplateOnly) {
+    outSource.push(
+      `const ${componentName} = <template>${templateSource}</template>;\nexport default ${componentName};`
     );
   } else {
     outSource.push(`<template>${templateSource}</template>`);

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -180,6 +180,19 @@ tsAppScenarios
         });
       });
 
+      test('adding named const to a template-only component', async function (assert) {
+        await assert.codeMod({
+          from: { 'app/components/example-foo-bar.hbs': 'Hello world' },
+          to: {
+            'app/components/example-foo-bar.gjs': `
+              const ExampleFooBar = <template>Hello world</template>;
+              export default ExampleFooBar;
+            `,
+          },
+          via: 'npx template-tag-codemod --addNameToTemplateOnly --reusePrebuild --renderTests false --routeTemplates false --components ./app/components/example-foo-bar.hbs',
+        });
+      });
+
       test('basic js backing component', async function (assert) {
         await assert.codeMod({
           from: {


### PR DESCRIPTION
This adds a `--addNameToTemplateOnly` flag to the codemod to optionally make template-only components use named consts:

```gjs
const MyComponent = <template>…</template>;
export default MyComponent;
```

That helps with autocompletion in IDEs.

Ideally, editors/plugins/language server would recognize components that don't have an explicit export/a name, but currently this is an okay workaround.