### PR TITLE
Babel import util updates

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -41,7 +41,7 @@
     "@embroider/macros": "workspace:*",
     "@types/babel__code-frame": "^7.0.2",
     "assert-never": "^1.1.0",
-    "babel-import-util": "^2.0.0",
+    "babel-import-util": "^3.0.1",
     "babel-plugin-debug-macros": "^1.0.2",
     "babel-plugin-ember-template-compilation": "^2.3.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",

--- a/packages/compat/src/babel-plugin-adjust-imports.ts
+++ b/packages/compat/src/babel-plugin-adjust-imports.ts
@@ -36,7 +36,6 @@ type InternalConfig = {
 };
 
 export default function main(babel: typeof Babel) {
-  let t = babel.types;
   let cached: InternalConfig | undefined;
   function getConfig(appRoot: string) {
     if (cached) {
@@ -56,7 +55,7 @@ export default function main(babel: typeof Babel) {
     visitor: {
       Program: {
         enter(path: NodePath<t.Program>, state: State) {
-          addExtraImports(t, path, getConfig(state.opts.appRoot));
+          addExtraImports(babel, path, getConfig(state.opts.appRoot));
         },
       },
     },
@@ -67,19 +66,19 @@ export default function main(babel: typeof Babel) {
   return join(__dirname, '..');
 };
 
-function addExtraImports(t: BabelTypes, path: NodePath<t.Program>, config: InternalConfig) {
+function addExtraImports(babel: typeof Babel, path: NodePath<t.Program>, config: InternalConfig) {
   let filename: string = cleanUrl((path.hub as any).file.opts.filename);
   let entry = config.extraImports[filename];
-  let adder = new ImportUtil(t, path);
+  let adder = new ImportUtil(babel, path);
   if (entry) {
-    applyRules(t, path, entry, adder, config, filename);
+    applyRules(babel.types, path, entry, adder, config, filename);
   }
 
   let componentName = config.loader.resolver.reverseComponentLookup(filename);
   if (componentName) {
     let rules = config.componentExtraImports[componentName];
     if (rules) {
-      applyRules(t, path, rules, adder, config, filename);
+      applyRules(babel.types, path, rules, adder, config, filename);
     }
   }
 }

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@embroider/shared-internals": "workspace:*",
     "assert-never": "^1.2.1",
-    "babel-import-util": "^2.0.0",
+    "babel-import-util": "^3.0.1",
     "ember-cli-babel": "^7.26.6",
     "find-up": "^5.0.0",
     "lodash": "^4.17.21",

--- a/packages/macros/src/babel/macros-babel-plugin.ts
+++ b/packages/macros/src/babel/macros-babel-plugin.ts
@@ -19,7 +19,7 @@ export default function main(context: typeof Babel): unknown {
   let visitor = {
     Program: {
       enter(path: NodePath<t.Program>, state: State) {
-        initState(t, path, state);
+        initState(context, path, state);
       },
       exit(_: NodePath<t.Program>, state: State) {
         // @embroider/macros itself has no runtime behaviors and should always be removed

--- a/packages/macros/src/babel/state.ts
+++ b/packages/macros/src/babel/state.ts
@@ -47,7 +47,7 @@ export default interface State {
   };
 }
 
-export function initState(t: typeof Babel.types, path: NodePath<Babel.types.Program>, state: State) {
+export function initState(t: typeof Babel, path: NodePath<Babel.types.Program>, state: State) {
   state.importUtil = new ImportUtil(t, path);
   state.jobs = [];
   state.removed = new Set();

--- a/packages/macros/tests/babel/eval.test.ts
+++ b/packages/macros/tests/babel/eval.test.ts
@@ -371,7 +371,7 @@ function testRuntime(babelContext: typeof Babel) {
   let visitor = {
     Program: {
       enter(path: NodePath<t.Program>, state: State) {
-        initState(t, path, state);
+        initState(babelContext, path, state);
       },
     },
     VariableDeclarator: {

--- a/packages/macros/tests/babel/import-sync.test.ts
+++ b/packages/macros/tests/babel/import-sync.test.ts
@@ -11,8 +11,8 @@ describe('importSync', function () {
       import { importSync } from '@embroider/macros';
       importSync('foo');
       `);
-      expect(code).toMatch(/import \* as _importSync\d from "foo"/);
-      expect(code).toMatch(/esc\(_importSync\d\);/);
+      expect(code).toMatch(/import \* as _importSync\d* from "foo"/);
+      expect(code).toMatch(/esc\(_importSync\d*\);/);
       expect(code).not.toMatch(/window/);
     });
     test('importSync leaves existing binding for require alone', () => {
@@ -22,7 +22,7 @@ describe('importSync', function () {
       importSync('foo');
       require('x');
       `);
-      expect(code).toMatch(/import \* as _importSync\d from "foo"/);
+      expect(code).toMatch(/import \* as _importSync\d* from "foo"/);
       expect(code).toMatch(/import require from 'require'/);
       expect(code).toMatch(/require\(['"]x['"]\)/);
     });
@@ -31,7 +31,7 @@ describe('importSync', function () {
       import { importSync as i } from '@embroider/macros';
       i('foo');
       `);
-      expect(code).toMatch(/import \* as _i\d from "foo"/);
+      expect(code).toMatch(/import \* as _i\d* from "foo"/);
       expect(code).not.toMatch(/window/);
     });
     test('import of importSync itself gets removed', () => {
@@ -51,7 +51,7 @@ describe('importSync', function () {
       import { importSync, getOwnConfig } from '@embroider/macros';
       importSync(getOwnConfig().target);
       `);
-      expect(code).toMatch(/import \* as _importSync\d from "my-plugin"/);
+      expect(code).toMatch(/import \* as _importSync\d* from "my-plugin"/);
     });
     test('importSync accepts template argument with dynamic part', () => {
       let code = transform(`
@@ -61,20 +61,20 @@ describe('importSync', function () {
       }
       `);
       expect(code).toEqual(`import esc from "../../src/addon/es-compat2";
-import * as _importSync0 from "../../README";
-import * as _importSync20 from "../../jest.config";
-import * as _importSync30 from "../../node_modules";
-import * as _importSync40 from "../../package";
-import * as _importSync50 from "../../src";
-import * as _importSync60 from "../../tests";
+import * as _importSync20 from "../../README";
+import * as _importSync40 from "../../jest.config";
+import * as _importSync60 from "../../node_modules";
+import * as _importSync80 from "../../package";
+import * as _importSync100 from "../../src";
+import * as _importSync120 from "../../tests";
 function getFile(file) {
   return {
-    "README": esc(_importSync0),
-    "jest.config": esc(_importSync20),
-    "node_modules": esc(_importSync30),
-    "package": esc(_importSync40),
-    "src": esc(_importSync50),
-    "tests": esc(_importSync60)
+    "README": esc(_importSync20),
+    "jest.config": esc(_importSync40),
+    "node_modules": esc(_importSync60),
+    "package": esc(_importSync80),
+    "src": esc(_importSync100),
+    "tests": esc(_importSync120)
   }[file].default;
 }`);
     });

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -35,7 +35,7 @@
     "semverIncrementTag": "alpha"
   },
   "dependencies": {
-    "babel-import-util": "^2.0.0",
+    "babel-import-util": "^3.0.1",
     "debug": "^4.3.2",
     "ember-rfc176-data": "^0.3.17",
     "fs-extra": "^9.1.0",

--- a/packages/shared-internals/src/template-colocation-plugin.ts
+++ b/packages/shared-internals/src/template-colocation-plugin.ts
@@ -64,7 +64,7 @@ export default function main(babel: typeof Babel) {
     visitor: {
       Program: {
         enter(path: NodePath<t.Program>, state: State) {
-          state.adder = new ImportUtil(t, path);
+          state.adder = new ImportUtil(babel, path);
           let filename = cleanUrl((path.hub as any).file.opts.filename);
 
           if (state.opts.packageGuard) {

--- a/packages/template-tag-codemod/package.json
+++ b/packages/template-tag-codemod/package.json
@@ -44,7 +44,7 @@
     "@humanwhocodes/module-importer": "^1.0.1",
     "@types/babel__core": "^7.20.5",
     "@types/yargs": "^17.0.3",
-    "babel-import-util": "^3.0.0",
+    "babel-import-util": "^3.0.1",
     "babel-plugin-ember-template-compilation": "^2.3.0",
     "broccoli": "^3.5.2",
     "chalk": "^5.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: ^1.1.0
         version: 1.4.0
       babel-import-util:
-        specifier: ^2.0.0
-        version: 2.1.1
+        specifier: ^3.0.1
+        version: 3.0.1
       babel-plugin-debug-macros:
         specifier: ^1.0.2
         version: 1.0.2(@babel/core@7.26.9)
@@ -570,8 +570,8 @@ importers:
         specifier: ^1.2.1
         version: 1.4.0
       babel-import-util:
-        specifier: ^2.0.0
-        version: 2.1.1
+        specifier: ^3.0.1
+        version: 3.0.1
       ember-cli-babel:
         specifier: ^7.26.6
         version: 7.26.11
@@ -728,8 +728,8 @@ importers:
   packages/shared-internals:
     dependencies:
       babel-import-util:
-        specifier: ^2.0.0
-        version: 2.1.1
+        specifier: ^3.0.1
+        version: 3.0.1
       debug:
         specifier: ^4.3.2
         version: 4.4.0(supports-color@8.1.1)
@@ -849,8 +849,8 @@ importers:
         specifier: ^17.0.3
         version: 17.0.33
       babel-import-util:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       babel-plugin-ember-template-compilation:
         specifier: ^2.3.0
         version: 2.3.0
@@ -10407,8 +10407,8 @@ packages:
     resolution: {integrity: sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==}
     engines: {node: '>= 12.*'}
 
-  /babel-import-util@3.0.0:
-    resolution: {integrity: sha512-4YNPkuVsxAW5lnSTa6cn4Wk49RX6GAB6vX+M6LqEtN0YePqoFczv1/x0EyLK/o+4E1j9jEuYj5Su7IEPab5JHQ==}
+  /babel-import-util@3.0.1:
+    resolution: {integrity: sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==}
     engines: {node: '>= 12.*'}
 
   /babel-jest@29.7.0(@babel/core@7.26.9):
@@ -10535,7 +10535,7 @@ packages:
     engines: {node: '>= 12.*'}
     dependencies:
       '@glimmer/syntax': 0.84.3
-      babel-import-util: 3.0.0
+      babel-import-util: 3.0.1
 
   /babel-plugin-filter-imports@4.0.0:
     resolution: {integrity: sha512-jDLlxI8QnfKd7PtieH6pl4tZJzymzfCDCPGdTq/grgbiYAikwDPp/oL0IlFJn0HQjLpcLkyYhPKkUVneRESw5w==}
@@ -13114,7 +13114,7 @@ packages:
     resolution: {integrity: sha512-jo8c1ss9yFPudHuYYcrJ9jpkDZIoi+lOGvt+Uyp9B+dz32i50icRMx9Bfa8hEt7TnX1FyKWKkjV+cUdT/ep2kA==}
     dependencies:
       '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.9)
-      babel-import-util: 3.0.0
+      babel-import-util: 3.0.1
     transitivePeerDependencies:
       - '@babel/core'
     dev: true

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -99,8 +99,8 @@ Scenarios.fromProject(() => new Project())
                   ['babel-plugin-ember-template-compilation', {
                     targetFormat: 'hbs',
                     transforms: [
+                      ...(${JSON.stringify(extraOpts?.astPlugins ?? [])}),
                       ...templateCompatSupport(),
-                      ...(${JSON.stringify(extraOpts?.astPlugins ?? [])})
                     ],
                     enableLegacyModules: [
                       'ember-cli-htmlbars'
@@ -1269,11 +1269,11 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import MyAddonThing_ from "@embroider/virtual/components/my-addon$thing";
-          export default precompileTemplate("<MyAddonThing_ />", {
+          import Thing_ from "@embroider/virtual/components/my-addon@thing";
+          export default precompileTemplate("<Thing_ />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              MyAddonThing_
+              Thing_
             })
           });
       `);
@@ -1293,11 +1293,30 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import myAddonThing_ from "@embroider/virtual/helpers/my-addon$thing";
-          export default precompileTemplate("{{(myAddonThing_)}}", {
+          import thing_ from "@embroider/virtual/helpers/my-addon@thing";
+          export default precompileTemplate("{{(thing_)}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              myAddonThing_
+              thing_
+            })
+          });
+      `);
+      });
+
+      test('helper containing $', async function () {
+        givenFiles({
+          'templates/application.hbs': `{{ ($helper) }}`,
+        });
+        await configure({
+          staticInvokables: true,
+        });
+        expectTranspiled('templates/application.hbs').equalsCode(`
+          import { precompileTemplate } from "@ember/template-compilation";
+          import $helper_ from "@embroider/virtual/helpers/$helper";
+          export default precompileTemplate("{{($helper_)}}", {
+            moduleName: "my-app/templates/application.hbs",
+            scope: () => ({
+              $helper_
             })
           });
       `);

--- a/tests/scenarios/compat-resolver-test.ts
+++ b/tests/scenarios/compat-resolver-test.ts
@@ -160,11 +160,11 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('./templates/application.hbs').equalsCode(`
             import { precompileTemplate } from "@ember/template-compilation";
-            import helloWorld_ from "@embroider/virtual/components/hello-world";
-            export default precompileTemplate("{{helloWorld_}}", {
+            import helloWorld from "@embroider/virtual/components/hello-world";
+            export default precompileTemplate("{{helloWorld}}", {
               moduleName: "my-app/templates/application.hbs",
               scope: () => ({
-                helloWorld_
+                helloWorld
               }),
             });
         `);
@@ -179,11 +179,11 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('templates/application.hbs').equalsCode(`
             import { precompileTemplate } from "@ember/template-compilation";
-            import helloWorld_ from "@embroider/virtual/ambiguous/hello-world";
-            export default precompileTemplate("{{helloWorld_ arg=1}}", {
+            import helloWorld from "@embroider/virtual/ambiguous/hello-world";
+            export default precompileTemplate("{{helloWorld arg=1}}", {
               moduleName: "my-app/templates/application.hbs",
               scope: () => ({
-                helloWorld_
+                helloWorld
               }),
             });
         `);
@@ -198,11 +198,11 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('templates/application.hbs').equalsCode(`
             import { precompileTemplate } from "@ember/template-compilation";
-            import helloWorld_ from "@embroider/virtual/ambiguous/hello-world";
-            export default precompileTemplate("{{helloWorld_ arg=1}}", {
+            import helloWorld from "@embroider/virtual/ambiguous/hello-world";
+            export default precompileTemplate("{{helloWorld arg=1}}", {
               moduleName: "my-app/templates/application.hbs",
               scope: () => ({
-                helloWorld_
+                helloWorld
               }),
             });
         `);
@@ -215,11 +215,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
             import { precompileTemplate } from "@ember/template-compilation";
-            import somethingHelloWorld_ from "@embroider/virtual/ambiguous/something/hello-world";
-            export default precompileTemplate("{{somethingHelloWorld_}}", {
+            import somethingHelloWorld from "@embroider/virtual/ambiguous/something/hello-world";
+            export default precompileTemplate("{{somethingHelloWorld}}", {
               moduleName: "my-app/templates/application.hbs",
               scope: () => ({
-                somethingHelloWorld_,
+                somethingHelloWorld,
               }),
             });
         `);
@@ -232,11 +232,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import HelloWorld_ from "@embroider/virtual/components/hello-world";
-          export default precompileTemplate("<HelloWorld_ /><HelloWorld_ />", {
+          import HelloWorld from "@embroider/virtual/components/hello-world";
+          export default precompileTemplate("<HelloWorld /><HelloWorld />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              HelloWorld_
+              HelloWorld
             })
           });
         `);
@@ -251,11 +251,11 @@ Scenarios.fromProject(() => new Project())
         });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import Thing_ from "@embroider/virtual/components/thing";
-          export default precompileTemplate("<Thing_ @foo={{1}} />", {
+          import Thing from "@embroider/virtual/components/thing";
+          export default precompileTemplate("<Thing @foo={{1}} />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              Thing_
+              Thing
             })
           });
         `);
@@ -268,11 +268,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/components/hello-world";
-          export default precompileTemplate("{{#helloWorld_}} {{/helloWorld_}}", {
+          import helloWorld from "@embroider/virtual/components/hello-world";
+          export default precompileTemplate("{{#helloWorld}} {{/helloWorld}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_
+              helloWorld
             })
           });
         `);
@@ -285,11 +285,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import HelloWorld_ from "@embroider/virtual/components/hello-world";
-          export default precompileTemplate("<HelloWorld_ />", {
+          import HelloWorld from "@embroider/virtual/components/hello-world";
+          export default precompileTemplate("<HelloWorld />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              HelloWorld_
+              HelloWorld
             })
           });
         `);
@@ -302,11 +302,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import HelloWorld_ from "@embroider/virtual/components/hello/world";
-          export default precompileTemplate("<HelloWorld_ />", {
+          import HelloWorld from "@embroider/virtual/components/hello/world";
+          export default precompileTemplate("<HelloWorld />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              HelloWorld_
+              HelloWorld
             })
           });
         `);
@@ -319,11 +319,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import HelloWorld_ from "@embroider/virtual/components/hello-world";
-          export default precompileTemplate("<HelloWorld_></HelloWorld_>", {
+          import HelloWorld from "@embroider/virtual/components/hello-world";
+          export default precompileTemplate("<HelloWorld></HelloWorld>", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              HelloWorld_
+              HelloWorld
             })
           });
         `);
@@ -513,15 +513,15 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import HelloWorld_ from "@embroider/virtual/components/hello-world";
-          import firstTarget_ from "@embroider/virtual/components/first-target";
-          import secondTarget_ from "@embroider/virtual/components/second-target";
-          export default precompileTemplate("<HelloWorld_ @iAmAComponent={{firstTarget_}} /><HelloWorld_ @iAmAComponent={{secondTarget_}} />", {
+          import HelloWorld from "@embroider/virtual/components/hello-world";
+          import firstTarget from "@embroider/virtual/components/first-target";
+          import secondTarget from "@embroider/virtual/components/second-target";
+          export default precompileTemplate("<HelloWorld @iAmAComponent={{firstTarget}} /><HelloWorld @iAmAComponent={{secondTarget}} />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              HelloWorld_,
-              firstTarget_,
-              secondTarget_,
+              HelloWorld,
+              firstTarget,
+              secondTarget,
             }),
           });
         `);
@@ -546,15 +546,15 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/components/hello-world";
-          import firstTarget_ from "@embroider/virtual/components/first-target";
-          import secondTarget_ from "@embroider/virtual/components/second-target";
-          export default precompileTemplate("{{#helloWorld_ iAmAComponent=firstTarget_}}{{/helloWorld_}}{{#helloWorld_ iAmAComponent=secondTarget_}}{{/helloWorld_}}", {
+          import helloWorld from "@embroider/virtual/components/hello-world";
+          import firstTarget from "@embroider/virtual/components/first-target";
+          import secondTarget from "@embroider/virtual/components/second-target";
+          export default precompileTemplate("{{#helloWorld iAmAComponent=firstTarget}}{{/helloWorld}}{{#helloWorld iAmAComponent=secondTarget}}{{/helloWorld}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_,
-              firstTarget_,
-              secondTarget_,
+              helloWorld,
+              firstTarget,
+              secondTarget,
             }),
           });
         `);
@@ -579,15 +579,15 @@ Scenarios.fromProject(() => new Project())
 
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/ambiguous/hello-world";
-          import firstTarget_ from "@embroider/virtual/components/first-target";
-          import secondTarget_ from "@embroider/virtual/components/second-target";
-          export default precompileTemplate("{{helloWorld_ iAmAComponent=firstTarget_}}{{helloWorld_ iAmAComponent=secondTarget_}}", {
+          import helloWorld from "@embroider/virtual/ambiguous/hello-world";
+          import firstTarget from "@embroider/virtual/components/first-target";
+          import secondTarget from "@embroider/virtual/components/second-target";
+          export default precompileTemplate("{{helloWorld iAmAComponent=firstTarget}}{{helloWorld iAmAComponent=secondTarget}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_,
-              firstTarget_,
-              secondTarget_,
+              helloWorld,
+              firstTarget,
+              secondTarget,
             }),
           });
         `);
@@ -669,13 +669,13 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import Stuff_ from "@embroider/virtual/components/stuff"
-          import myHelper_ from "@embroider/virtual/helpers/myHelper";
-          export default precompileTemplate("<Stuff_ @value={{myHelper_ 1}} />", {
+          import Stuff from "@embroider/virtual/components/stuff"
+          import myHelper from "@embroider/virtual/helpers/myHelper";
+          export default precompileTemplate("<Stuff @value={{myHelper 1}} />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              Stuff_,
-              myHelper_,
+              Stuff,
+              myHelper,
             }),
           });
         `);
@@ -688,11 +688,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import myHelper_ from "@embroider/virtual/helpers/myHelper";
-          export default precompileTemplate("<div class={{myHelper_ 1}} />", {
+          import myHelper from "@embroider/virtual/helpers/myHelper";
+          export default precompileTemplate("<div class={{myHelper 1}} />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-               myHelper_,
+               myHelper,
             }),
           });
         `);
@@ -754,11 +754,11 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import myHelper_ from "@embroider/virtual/helpers/myHelper";
-          export default precompileTemplate("{{myHelper_}}", {
+          import myHelper from "@embroider/virtual/helpers/myHelper";
+          export default precompileTemplate("{{myHelper}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-               myHelper_,
+               myHelper,
             }),
           });
         `);
@@ -797,11 +797,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/components/hello-world";
-          export default precompileTemplate("{{component helloWorld_}}", {
+          import helloWorld from "@embroider/virtual/components/hello-world";
+          export default precompileTemplate("{{component helloWorld}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_
+              helloWorld
             })
           });
         `);
@@ -814,11 +814,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/helpers/hello-world";
-          export default precompileTemplate("{{helper helloWorld_}}", {
+          import helloWorld from "@embroider/virtual/helpers/hello-world";
+          export default precompileTemplate("{{helper helloWorld}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_
+              helloWorld
             })
           });
         `);
@@ -831,11 +831,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/components/hello-world";
-          export default precompileTemplate("{{#component helloWorld_}}{{/component}}", {
+          import helloWorld from "@embroider/virtual/components/hello-world";
+          export default precompileTemplate("{{#component helloWorld}}{{/component}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_
+              helloWorld
             })
           });
         `);
@@ -848,11 +848,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/components/hello-world";
-          export default precompileTemplate("{{(component helloWorld_)}}", {
+          import helloWorld from "@embroider/virtual/components/hello-world";
+          export default precompileTemplate("{{(component helloWorld)}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_
+              helloWorld
             })
           });
         `);
@@ -865,11 +865,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/helpers/hello-world";
-          export default precompileTemplate("{{(helper helloWorld_)}}", {
+          import helloWorld from "@embroider/virtual/helpers/hello-world";
+          export default precompileTemplate("{{(helper helloWorld)}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_
+              helloWorld
             })
           });
         `);
@@ -888,11 +888,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/helpers/hello-world";
-          export default precompileTemplate("\\n            {{#let (helper helloWorld_ name=\\"World\\") as |hello|}}\\n              {{#let (helper hello name=\\"Tomster\\") as |helloTomster|}}\\n                {{helloTomster name=\\"Zoey\\"}}\\n              {{/let}}\\n            {{/let}}\\n          ", {
+          import helloWorld from "@embroider/virtual/helpers/hello-world";
+          export default precompileTemplate("\\n            {{#let (helper helloWorld name=\\"World\\") as |hello|}}\\n              {{#let (helper hello name=\\"Tomster\\") as |helloTomster|}}\\n                {{helloTomster name=\\"Zoey\\"}}\\n              {{/let}}\\n            {{/let}}\\n          ", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_,
+              helloWorld,
             }),
           });
         `);
@@ -905,11 +905,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import helloWorld_ from "@embroider/virtual/modifiers/hello-world";
-          export default precompileTemplate("<div {{(modifier helloWorld_)}} />", {
+          import helloWorld from "@embroider/virtual/modifiers/hello-world";
+          export default precompileTemplate("<div {{(modifier helloWorld)}} />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              helloWorld_
+              helloWorld
             })
           });
         `);
@@ -935,11 +935,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import scrollTop_ from "@embroider/virtual/modifiers/scroll-top";
-          export default precompileTemplate("<div {{scrollTop_}} />", {
+          import scrollTop from "@embroider/virtual/modifiers/scroll-top";
+          export default precompileTemplate("<div {{scrollTop}} />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              scrollTop_
+              scrollTop
             })
           });
         `);
@@ -952,11 +952,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import scrollTop_ from "@embroider/virtual/modifiers/scroll-top";
-          export default precompileTemplate("<div {{scrollTop_ @scrollTopPos}} />", {
+          import scrollTop from "@embroider/virtual/modifiers/scroll-top";
+          export default precompileTemplate("<div {{scrollTop @scrollTopPos}} />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              scrollTop_
+              scrollTop
             })
           });
         `);
@@ -969,13 +969,13 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import Thing_ from "@embroider/virtual/components/thing";
-          import scrollTop_ from "@embroider/virtual/modifiers/scroll-top";
-          export default precompileTemplate("<Thing_ {{scrollTop_ @scrollTopPos}} />", {
+          import Thing from "@embroider/virtual/components/thing";
+          import scrollTop from "@embroider/virtual/modifiers/scroll-top";
+          export default precompileTemplate("<Thing {{scrollTop @scrollTopPos}} />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              Thing_,
-              scrollTop_
+              Thing,
+              scrollTop
             })
           });
         `);
@@ -988,13 +988,13 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import Thing_ from "@embroider/virtual/components/thing";
-          import scrollTop_ from "@embroider/virtual/modifiers/scroll-top";
-          export default precompileTemplate("<Thing_ as |f|><f.Input {{scrollTop_ @scrollTopPos}} /></Thing_>", {
+          import Thing from "@embroider/virtual/components/thing";
+          import scrollTop from "@embroider/virtual/modifiers/scroll-top";
+          export default precompileTemplate("<Thing as |f|><f.Input {{scrollTop @scrollTopPos}} /></Thing>", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              Thing_,
-              scrollTop_
+              Thing,
+              scrollTop
             })
           });
         `);
@@ -1020,11 +1020,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import Form_ from "@embroider/virtual/components/form";
-          export default precompileTemplate("<Form_ as |f|> <input {{f.auto-focus}} /></Form_>", {
+          import Form from "@embroider/virtual/components/form";
+          export default precompileTemplate("<Form as |f|> <input {{f.auto-focus}} /></Form>", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              Form_,
+              Form,
             }),
           });
         `);
@@ -1041,11 +1041,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import addListener_ from "@embroider/virtual/modifiers/add-listener";
-          export default precompileTemplate("{{#let (modifier addListener_) as |addListener|}}\\n          {{#let (modifier addListener \\"click\\") as |addClickListener|}}\\n            <button {{addClickListener this.handleClick}}>Test</button>\\n          {{/let}}\\n        {{/let}}", {
+          import addListener from "@embroider/virtual/modifiers/add-listener";
+          export default precompileTemplate("{{#let (modifier addListener) as |addListener|}}\\n          {{#let (modifier addListener \\"click\\") as |addClickListener|}}\\n            <button {{addClickListener this.handleClick}}>Test</button>\\n          {{/let}}\\n        {{/let}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              addListener_
+              addListener
             })
           });
         `);
@@ -1269,11 +1269,11 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import Thing_ from "@embroider/virtual/components/my-addon@thing";
-          export default precompileTemplate("<Thing_ />", {
+          import Thing from "@embroider/virtual/components/my-addon@thing";
+          export default precompileTemplate("<Thing />", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              Thing_
+              Thing
             })
           });
       `);
@@ -1312,11 +1312,11 @@ Scenarios.fromProject(() => new Project())
         });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import $helper_ from "@embroider/virtual/helpers/$helper";
-          export default precompileTemplate("{{($helper_)}}", {
+          import $helper from "@embroider/virtual/helpers/$helper";
+          export default precompileTemplate("{{($helper)}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              $helper_
+              $helper
             })
           });
       `);
@@ -1349,11 +1349,11 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import ensureSafeComponent_ from "@embroider/virtual/helpers/ensure-safe-component";
-          export default precompileTemplate("{{component (ensureSafeComponent_ this.which)}}", {
+          import ensureSafeComponent from "@embroider/virtual/helpers/ensure-safe-component";
+          export default precompileTemplate("{{component (ensureSafeComponent this.which)}}", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              ensureSafeComponent_,
+              ensureSafeComponent,
             }),
           });
         `);
@@ -1540,13 +1540,13 @@ Scenarios.fromProject(() => new Project())
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
         import capitalize_ from "@embroider/virtual/helpers/capitalize";
-        import Form_ from "@embroider/virtual/components/form";
+        import Form from "@embroider/virtual/components/form";
         import validate_ from "@embroider/virtual/modifiers/validate";
-        export default precompileTemplate("\\n          {{#each things as |capitalize|}} {{(capitalize)}} {{/each}} {{(capitalize_)}}\\n          <Form_ as |validate|><input {{validate}} /></Form_> <input {{validate_}} />\\n          ", {
+        export default precompileTemplate("\\n          {{#each things as |capitalize|}} {{(capitalize)}} {{/each}} {{(capitalize_)}}\\n          <Form as |validate|><input {{validate}} /></Form> <input {{validate_}} />\\n          ", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
             capitalize_,
-            Form_,
+            Form,
             validate_
           })
         });
@@ -1588,11 +1588,11 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/components/form-builder";
-        export default precompileTemplate("{{#formBuilder_ as |field|}}{{component field}}{{/formBuilder_}}", {
+        import formBuilder from "@embroider/virtual/components/form-builder";
+        export default precompileTemplate("{{#formBuilder as |field|}}{{component field}}{{/formBuilder}}", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            formBuilder_
+            formBuilder
           })
         });
       `);
@@ -1618,11 +1618,11 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/components/form-builder";
-        export default precompileTemplate("{{#formBuilder_ as |other field|}}{{component field}}{{/formBuilder_}}", {
+        import formBuilder from "@embroider/virtual/components/form-builder";
+        export default precompileTemplate("{{#formBuilder as |other field|}}{{component field}}{{/formBuilder}}", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            formBuilder_
+            formBuilder
           })
         });
       `);
@@ -1648,11 +1648,11 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/components/form-builder";
-        export default precompileTemplate("{{#formBuilder_ as |f|}}{{component f.field}}{{/formBuilder_}}", {
+        import formBuilder from "@embroider/virtual/components/form-builder";
+        export default precompileTemplate("{{#formBuilder as |f|}}{{component f.field}}{{/formBuilder}}", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            formBuilder_
+            formBuilder
           })
         });
       `);
@@ -1678,11 +1678,11 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import FormBuilder_ from "@embroider/virtual/components/form-builder";
-        export default precompileTemplate("<FormBuilder_ as |field|>{{component field}}</FormBuilder_>", {
+        import FormBuilder from "@embroider/virtual/components/form-builder";
+        export default precompileTemplate("<FormBuilder as |field|>{{component field}}</FormBuilder>", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            FormBuilder_
+            FormBuilder
           })
         });
       `);
@@ -1708,13 +1708,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/ambiguous/form-builder";
-        import fancyTitle_ from "@embroider/virtual/components/fancy-title";
-        export default precompileTemplate("{{formBuilder_ title=fancyTitle_}}", {
+        import formBuilder from "@embroider/virtual/ambiguous/form-builder";
+        import fancyTitle from "@embroider/virtual/components/fancy-title";
+        export default precompileTemplate("{{formBuilder title=fancyTitle}}", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            formBuilder_,
-            fancyTitle_
+            formBuilder,
+            fancyTitle
           })
         });
       `);
@@ -1740,13 +1740,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/components/form-builder";
-        import fancyTitle_ from "@embroider/virtual/components/fancy-title";
-        export default precompileTemplate("{{#formBuilder_ title=fancyTitle_}}{{/formBuilder_}}", {
+        import formBuilder from "@embroider/virtual/components/form-builder";
+        import fancyTitle from "@embroider/virtual/components/fancy-title";
+        export default precompileTemplate("{{#formBuilder title=fancyTitle}}{{/formBuilder}}", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            formBuilder_,
-            fancyTitle_
+            formBuilder,
+            fancyTitle
           })
         });
       `);
@@ -1772,13 +1772,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import FormBuilder_ from "@embroider/virtual/components/form-builder";
-        import fancyTitle_ from "@embroider/virtual/components/fancy-title";
-        export default precompileTemplate("<FormBuilder_ @title={{fancyTitle_}}></FormBuilder_>", {
+        import FormBuilder from "@embroider/virtual/components/form-builder";
+        import fancyTitle from "@embroider/virtual/components/fancy-title";
+        export default precompileTemplate("<FormBuilder @title={{fancyTitle}}></FormBuilder>", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            FormBuilder_,
-            fancyTitle_
+            FormBuilder,
+            fancyTitle
           })
         });
       `);
@@ -1804,13 +1804,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/ambiguous/form-builder";
-        import fancyTitle_ from "@embroider/virtual/components/fancy-title";
-        export default precompileTemplate("{{formBuilder_ title=fancyTitle_}}", {
+        import formBuilder from "@embroider/virtual/ambiguous/form-builder";
+        import fancyTitle from "@embroider/virtual/components/fancy-title";
+        export default precompileTemplate("{{formBuilder title=fancyTitle}}", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            formBuilder_,
-            fancyTitle_
+            formBuilder,
+            fancyTitle
           })
         });
       `);
@@ -1836,13 +1836,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/ambiguous/form-builder";
-        import fancyTitle_ from "@embroider/virtual/components/fancy-title";
-        export default precompileTemplate("{{formBuilder_ title=(component fancyTitle_)}}", {
+        import formBuilder from "@embroider/virtual/ambiguous/form-builder";
+        import fancyTitle from "@embroider/virtual/components/fancy-title";
+        export default precompileTemplate("{{formBuilder title=(component fancyTitle)}}", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            formBuilder_,
-            fancyTitle_
+            formBuilder,
+            fancyTitle
           })
         });
       `);
@@ -1868,13 +1868,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('templates/application.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import FormBuilder_ from "@embroider/virtual/components/form-builder";
-        import fancyTitle_ from "@embroider/virtual/components/fancy-title";
-        export default precompileTemplate("<FormBuilder_ @title={{component fancyTitle_}} />", {
+        import FormBuilder from "@embroider/virtual/components/form-builder";
+        import fancyTitle from "@embroider/virtual/components/fancy-title";
+        export default precompileTemplate("<FormBuilder @title={{component fancyTitle}} />", {
           moduleName: "my-app/templates/application.hbs",
           scope: () => ({
-            FormBuilder_,
-            fancyTitle_
+            FormBuilder,
+            fancyTitle
           })
         });
       `);
@@ -1925,13 +1925,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('components/form-builder.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import FormBuilder_ from "@embroider/virtual/components/form-builder";
-        import fancyNavbar_ from "@embroider/virtual/components/fancy-navbar";
-        export default precompileTemplate("\\n        <FormBuilder_ @navbar={{component fancyNavbar_}} as |bar|>\\n          {{component bar}}\\n        </FormBuilder_>", {
+        import FormBuilder from "@embroider/virtual/components/form-builder";
+        import fancyNavbar from "@embroider/virtual/components/fancy-navbar";
+        export default precompileTemplate("\\n        <FormBuilder @navbar={{component fancyNavbar}} as |bar|>\\n          {{component bar}}\\n        </FormBuilder>", {
           moduleName: "my-app/components/form-builder.hbs",
           scope: () => ({
-            FormBuilder_,
-            fancyNavbar_
+            FormBuilder,
+            fancyNavbar
           })
         });
       `);
@@ -1958,13 +1958,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('components/form-builder.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/components/form-builder";
-        import fancyNavbar_ from "@embroider/virtual/components/fancy-navbar";
-        export default precompileTemplate("\\n        {{#formBuilder_ navbar=(component fancyNavbar_) as |bar|}}\\n          {{component bar}}\\n        {{/formBuilder_}}", {
+        import formBuilder from "@embroider/virtual/components/form-builder";
+        import fancyNavbar from "@embroider/virtual/components/fancy-navbar";
+        export default precompileTemplate("\\n        {{#formBuilder navbar=(component fancyNavbar) as |bar|}}\\n          {{component bar}}\\n        {{/formBuilder}}", {
           moduleName: "my-app/components/form-builder.hbs",
           scope: () => ({
-            formBuilder_,
-            fancyNavbar_
+            formBuilder,
+            fancyNavbar
           })
         });
       `);
@@ -1991,13 +1991,13 @@ Scenarios.fromProject(() => new Project())
         );
         expectTranspiled('components/form-builder.hbs').equalsCode(`
         import { precompileTemplate } from "@ember/template-compilation";
-        import formBuilder_ from "@embroider/virtual/components/form-builder";
-        import fancyNavbar_ from "@embroider/virtual/components/fancy-navbar";
-        export default precompileTemplate("\\n        {{#formBuilder_ navbar=(component fancyNavbar_) as |f|}}\\n          {{component f.bar}}\\n        {{/formBuilder_}}", {
+        import formBuilder from "@embroider/virtual/components/form-builder";
+        import fancyNavbar from "@embroider/virtual/components/fancy-navbar";
+        export default precompileTemplate("\\n        {{#formBuilder navbar=(component fancyNavbar) as |f|}}\\n          {{component f.bar}}\\n        {{/formBuilder}}", {
           moduleName: "my-app/components/form-builder.hbs",
           scope: () => ({
-            formBuilder_,
-            fancyNavbar_
+            formBuilder,
+            fancyNavbar
           })
         });
       `);
@@ -2023,7 +2023,7 @@ Scenarios.fromProject(() => new Project())
           }
         );
         expectTranspiled('components/form-builder.hbs').failsToTransform(
-          `argument "navbar" to component "FormBuilder_" is treated as a component, but the value you're passing is dynamic: this.unknown`
+          `argument "navbar" to component "FormBuilder" is treated as a component, but the value you're passing is dynamic: this.unknown`
         );
       });
 
@@ -2168,12 +2168,12 @@ Scenarios.fromProject(() => new Project())
         await configure({ staticInvokables: true });
         expectTranspiled('templates/application.hbs').equalsCode(`
           import { precompileTemplate } from "@ember/template-compilation";
-          import Example_ from "@embroider/virtual/components/example";
+          import Example from "@embroider/virtual/components/example";
           import title_ from "@embroider/virtual/helpers/title";
-          export default precompileTemplate("<Example_ @arg={{(title_)}} as |title|>{{(title)}}</Example_>", {
+          export default precompileTemplate("<Example @arg={{(title_)}} as |title|>{{(title)}}</Example>", {
             moduleName: "my-app/templates/application.hbs",
             scope: () => ({
-              Example_,
+              Example,
               title_
             })
           });


### PR DESCRIPTION
- Some of the compat resolver tests were not really doing the right thing, which was revealed when dependencies changed. 
- Upgraded babel-import-utility so we're using the same version consistently throughout the monorepo. It brings some improved naming.