### PR TITLE
Fix addon-dev's declarations plugin when glint fails

### DIFF
--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -2,6 +2,7 @@ import type { Plugin } from 'rollup';
 import execa from 'execa';
 import walkSync from 'walk-sync';
 import { readFile, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
 
 export default function rollupDeclarationsPlugin(
   declarationsDir: string
@@ -32,6 +33,12 @@ export default function rollupDeclarationsPlugin(
 }
 
 async function fixDeclarationsInMatchingFiles(dir: string) {
+  // can't fix what doesn't exist
+  // (happens when glint errors and doesn't output a ${dir} directory
+  if (existsSync(dir)) {
+    return;
+  }
+  
   const dtsFiles = walkSync(dir, {
     globs: ['**/*.d.ts'],
     directories: false,

--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -39,6 +39,7 @@ export default function rollupDeclarationsPlugin(
         }
 
         await fixDeclarationsInMatchingFiles(declarationsDir);
+        this.info(`\`${escapedCommand}\` succeeded`);
       };
 
       // We just kick off glint here early in the rollup process, without making rollup wait for this to finish, by not returning the promise

--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -39,7 +39,9 @@ export default function rollupDeclarationsPlugin(
         }
 
         await fixDeclarationsInMatchingFiles(declarationsDir);
-        this.info(`\`${escapedCommand}\` succeeded`);
+        if (exitCode === 0) {
+          this.info(`\`${escapedCommand}\` succeeded`);
+        }
       };
 
       // We just kick off glint here early in the rollup process, without making rollup wait for this to finish, by not returning the promise

--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -35,7 +35,7 @@ export default function rollupDeclarationsPlugin(
 async function fixDeclarationsInMatchingFiles(dir: string) {
   // can't fix what doesn't exist
   // (happens when glint errors and doesn't output a ${dir} directory
-  if (existsSync(dir)) {
+  if (!existsSync(dir)) {
     return;
   }
   

--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -16,7 +16,7 @@ export default function rollupDeclarationsPlugin(
         await execa('glint', ['--declaration'], {
           stdio: 'inherit',
           preferLocal: true,
-          reject: this.meta.watchMode,
+          reject: !this.meta.watchMode,
         });
 
         await fixDeclarationsInMatchingFiles(declarationsDir);

--- a/packages/addon-dev/src/rollup-declarations.ts
+++ b/packages/addon-dev/src/rollup-declarations.ts
@@ -13,11 +13,15 @@ export default function rollupDeclarationsPlugin(
     name: 'glint-dts',
     buildStart() {
       const runGlint = async () => {
-        await execa('glint', ['--declaration'], {
+        let { exitCode } = await execa('glint', ['--declaration'], {
           stdio: 'inherit',
           preferLocal: true,
           reject: !this.meta.watchMode,
         });
+
+        if (this.meta.watchMode && exitCode > 0) {
+          this.warn(`Failed to generate declarations`);
+        }
 
         await fixDeclarationsInMatchingFiles(declarationsDir);
       };
@@ -38,7 +42,7 @@ async function fixDeclarationsInMatchingFiles(dir: string) {
   if (!existsSync(dir)) {
     return;
   }
-  
+
   const dtsFiles = walkSync(dir, {
     globs: ['**/*.d.ts'],
     directories: false,


### PR DESCRIPTION
### Successes

![image](https://github.com/user-attachments/assets/11a298c4-ef28-49b1-9924-4e93ce37a9c3)
![image](https://github.com/user-attachments/assets/a242d377-379d-4614-a6f5-912c1672d817)



### Type errors retain color

![image](https://github.com/user-attachments/assets/e48b8ffc-48bc-4741-90f6-6866a15de761)

(and there is a summary at the bottom that reports which plugin errored)


### The downsides, some types of errors are hard to understand:

(this error is from Volar)
#### Watch

![image](https://github.com/user-attachments/assets/40f72f79-989d-4440-90d2-e72c329f1a9b)

#### Build

![image](https://github.com/user-attachments/assets/e3be5dc7-0035-4197-a83e-e500d9082e61)

