### PR TITLE
build config-meta-loader into dist folder

### DIFF
--- a/packages/config-meta-loader/.gitignore
+++ b/packages/config-meta-loader/.gitignore
@@ -6,3 +6,4 @@
 /*/tests/**/*.d.ts
 /*/tests/**/*.map
 *.tsbuildinfo
+/dist/

--- a/packages/config-meta-loader/package.json
+++ b/packages/config-meta-loader/package.json
@@ -11,11 +11,9 @@
   },
   "license": "MIT",
   "author": "Marine Dunstetter",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "files": [
-    "src/**/*.js",
-    "src/**/*.d.ts",
-    "src/**/*.js.map"
+    "dist"
   ],
   "scripts": {},
   "release-plan": {

--- a/packages/config-meta-loader/tsconfig.json
+++ b/packages/config-meta-loader/tsconfig.json
@@ -4,6 +4,8 @@
   ],
   "compilerOptions": {
     "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
     "target": "es2019",
     "module": "ESNext",
     "declaration": true,


### PR DESCRIPTION
This is a tiny change to the config-meta-loader package's tsconfig that just builds into a dist folder so the build artefacts don't pollute the `src` folder 👍 