### PR TITLE
fix gitignore for switching between stable and main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ tests/scenarios/output/
 *.swp
 
 /tsconfig.tsbuildinfo
+
+# build artefacts on main branch
+packages/template-tag-codemod/dist/
+packages/config-meta-loader/dist/
+tests/scenarios/dist/

--- a/packages/vite/.gitignore
+++ b/packages/vite/.gitignore
@@ -5,3 +5,4 @@
 /tests/**/*.js
 /tests/**/*.d.ts
 /tests/**/*.map
+/dist/


### PR DESCRIPTION
This is purely to make our lives better while working on the embroider repo 😂 

Essentially when you run a build on the `main` branch and then switch to stable there are a bunch of build artefacts that are seen as new files. This PR updates the `.gitignore` file to ignore files that are currently being ignored on main 👍 