### PR TITLE
Add "merge-history" subcommand to codemod

### DIFF
--- a/packages/template-tag-codemod/README.md
+++ b/packages/template-tag-codemod/README.md
@@ -9,6 +9,8 @@ This codemod converts all usage of non-strict handlebars in an Ember app to the 
 4. Start with clean source control. We're going to mutate all your files. Use git to give you control over what changed.
 5. Run the codemod via `npx @embroider/template-tag-codemod YOUR_OPTIONS_HERE`
 6. Use `prettier` to apply nice formatting to the results.
+7. Commit your results.
+8. *Optional but recommended:* use the `merge-history` command to adjust Git history so that your GJS files inherit correctly from *both* the JS and HBS files they were created from. See below.
 
 
 ## Important Options
@@ -123,6 +125,19 @@ Pass `--defaultFormat gts` instead if you prefer to produce typescript. Also see
 4. Upgrade @ember/test-helpers to >= 5.0.1 (because you may need [this feature](https://github.com/emberjs/ember-test-helpers/pull/1527/)).
 
 5. If you're planning to use `--nativeRouteTemplates false` to support Ember < 6.3.0, make sure you have installed the `ember-route-template` addon.
+
+## merge-history
+
+The `merge-history` command takes a branch where the codemod has already been applied and produces a new branch with the same contents, except that the Git history has been adjusted so that your GJS files inherit correctly from *both* the JS and HBS files that they replaced. Example:
+
+```sh
+npx @embroider/template-tag-codemod merge-history --help`
+npx @embroider/template-tag-codemod merge-history main your-codemodded-branch --outputBranch better-codemodded-branch`
+git push -u origin better-codemodded-branch
+```
+
+The command also produces a [.git-blame-ignore-revs file](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view), which is supported by default by GitHub to let you see past the codemod formatting. 
+
 
 # Known Compatibility Issues
 

--- a/packages/template-tag-codemod/src/cli.ts
+++ b/packages/template-tag-codemod/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import yargs from 'yargs/yargs';
 import { type Options, optionsWithDefaults, run } from './index.js';
+import type { MergeHistoryOptions } from './merge-history.js';
 
 yargs(process.argv.slice(2))
   .scriptName('template-tag-codemod')
@@ -91,6 +92,36 @@ yargs(process.argv.slice(2))
       // broccoli-babel-transpiler which leak worker processes and will
       // otherwise prevent exit.🤮
       process.exit(0);
+    }
+  )
+  .command(
+    'merge-history <beforeCommit> <afterCommit>',
+    'Merge the histories of your hbs and js files into your new gjs files',
+    y =>
+      y
+        .positional('beforeCommit', {
+          type: 'string',
+          description: 'A git commit-ish identifying the commit before you ran the template-tag-codemod',
+        })
+        .positional('afterCommit', {
+          type: 'string',
+          description: `A git commit-ish identifying the commit after you ran the template-tag-codemod`,
+        })
+        .option('outputBranch', {
+          type: 'string',
+          default: 'template-tag-codemod',
+          description:
+            'The name of the branch this command will create for you, containing the merged history from "beforeCommit" and "afterCommmit"',
+        })
+        .option('allowOverwrite', {
+          type: 'boolean',
+          default: false,
+          description: 'Destructively replace the existing outputBranch',
+        }),
+
+    async argv => {
+      let { mergeHistory } = await import('./merge-history.js');
+      await mergeHistory(argv as MergeHistoryOptions);
     }
   )
   .strict()

--- a/packages/template-tag-codemod/src/merge-history.ts
+++ b/packages/template-tag-codemod/src/merge-history.ts
@@ -101,6 +101,7 @@ function applyMoves(workDir: string, changedFiles: string[], sourceExtensions: s
       let sourceFilename = filename.replace(newExtension, sourceExtension);
       if (changedFiles.includes(sourceFilename)) {
         execSync(`git mv ${sourceFilename} ${filename}`, { cwd: workDir });
+        console.log(`renamed ${sourceFilename} -> ${filename}`);
       }
     }
   }
@@ -125,6 +126,7 @@ function concatenateMerge(workDir: string, jsRenameCommit: string, hbsRenameComm
       gitShow(jsRenameCommit, filename) + '\n' + gitShow(hbsRenameCommit, filename)
     );
     execSync(`git add ${filename}`, { cwd: workDir });
+    console.log(`resolved merge conflict in ${filename}`);
   }
 }
 
@@ -132,6 +134,7 @@ function applyCodemod(workDir: string, changedFiles: string[], endpoints: Endpoi
   for (let filename of newFiles(changedFiles)) {
     writeFileSync(resolve(workDir, filename), gitShow(endpoints.afterSha, filename));
     execSync(`git add ${filename}`, { cwd: workDir });
+    console.log(`applied codemod output to ${filename}`);
   }
 }
 

--- a/packages/template-tag-codemod/src/merge-history.ts
+++ b/packages/template-tag-codemod/src/merge-history.ts
@@ -1,0 +1,173 @@
+import { execSync as _execSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+export interface MergeHistoryOptions {
+  beforeCommit: string;
+  afterCommit: string;
+  outputBranch: string;
+  allowOverwrite: boolean;
+}
+
+function execSync(cmd: string, opts?: { cwd?: string }) {
+  return _execSync(cmd, { encoding: 'utf8', stdio: 'pipe', ...opts });
+}
+
+function revParse(name: string, opts?: { cwd?: string }) {
+  try {
+    let output = execSync(`git rev-parse --revs-only ${name} --`, opts);
+    return output.trim();
+  } catch (err) {
+    if (!/bad revision/.test(err.stderr)) {
+      throw err;
+    }
+    return null;
+  }
+}
+
+function head(opts?: { cwd?: string }): string {
+  let sha = revParse('HEAD', opts);
+  if (!sha) {
+    throw new Error(`bug: could not rev-parse HEAD`);
+  }
+  return sha;
+}
+
+interface Endpoints {
+  beforeSha: string;
+  afterSha: string;
+}
+
+function resolveEndpoints(opts: MergeHistoryOptions): Endpoints {
+  let beforeSha = revParse(opts.beforeCommit);
+  if (!beforeSha) {
+    console.error(`Cannot locate a commit named "${opts.beforeCommit}"`);
+    process.exit(-1);
+  }
+  let afterSha = revParse(opts.afterCommit);
+  if (!afterSha) {
+    console.error(`Cannot locate a commit named "${opts.afterCommit}"`);
+    process.exit(-1);
+  }
+  return { beforeSha, afterSha };
+}
+
+function setupWorkDir(opts: MergeHistoryOptions, endpoints: Endpoints): string {
+  let workDir = resolve(tmpdir(), 'template-tag-codemod-history');
+  if (existsSync(workDir)) {
+    rmSync(workDir, { recursive: true });
+    execSync(`git worktree prune`);
+  }
+
+  if (revParse(opts.outputBranch)) {
+    if (opts.allowOverwrite) {
+      execSync(`git branch -D ${opts.outputBranch}`);
+    } else {
+      console.error(
+        `Output branch "${opts.outputBranch}" already exists. If you really want to overwrite it, pass --allowOverwite`
+      );
+      process.exit(-1);
+    }
+  }
+
+  execSync(`git worktree add ${workDir} ${endpoints.beforeSha}`);
+  return workDir;
+}
+
+function listFiles(endpoints: Endpoints): string[] {
+  return execSync(`git diff-tree -r --name-only ${endpoints.beforeSha} ${endpoints.afterSha}`)
+    .split('\n')
+    .filter(Boolean);
+}
+
+function gitShow(commitIsh: string, filename: string): string {
+  return execSync(`git show ${commitIsh}:${filename}`);
+}
+
+const newExtension = /\.g[jt]s$/;
+
+function* newFiles(changedFiles: string[]) {
+  for (let filename of changedFiles) {
+    if (newExtension.test(filename)) {
+      yield filename;
+    }
+  }
+}
+
+function applyMoves(workDir: string, changedFiles: string[], sourceExtensions: string[]) {
+  for (let filename of newFiles(changedFiles)) {
+    for (let sourceExtension of sourceExtensions) {
+      let sourceFilename = filename.replace(newExtension, sourceExtension);
+      if (changedFiles.includes(sourceFilename)) {
+        execSync(`git mv ${sourceFilename} ${filename}`, { cwd: workDir });
+      }
+    }
+  }
+}
+
+function expectMergeConflicts(cb: () => void) {
+  try {
+    cb();
+  } catch (err) {
+    if (!/Merge conflict/.test(err.output)) throw err;
+  }
+}
+
+function listConflicts(opts?: { cwd: string }) {
+  return execSync(`git diff --name-only --diff-filter=U --relative`, opts).split('\n').filter(Boolean);
+}
+
+function concatenateMerge(workDir: string, jsRenameCommit: string, hbsRenameCommit: string) {
+  for (let filename of listConflicts({ cwd: workDir })) {
+    writeFileSync(
+      resolve(workDir, filename),
+      gitShow(jsRenameCommit, filename) + '\n' + gitShow(hbsRenameCommit, filename)
+    );
+    execSync(`git add ${filename}`, { cwd: workDir });
+  }
+}
+
+function applyCodemod(workDir: string, changedFiles: string[], endpoints: Endpoints) {
+  for (let filename of newFiles(changedFiles)) {
+    writeFileSync(resolve(workDir, filename), gitShow(endpoints.afterSha, filename));
+    execSync(`git add ${filename}`, { cwd: workDir });
+  }
+}
+
+function addBlameIgnoreFile(workDir: string, codemodCommit: string) {
+  let ignoreRevsFile = resolve(workDir, '.git-blame-ignore-revs');
+  if (existsSync(ignoreRevsFile)) {
+    writeFileSync(ignoreRevsFile, readFileSync(ignoreRevsFile, 'utf8') + '\n' + codemodCommit + '\n');
+  } else {
+    writeFileSync(ignoreRevsFile, codemodCommit + '\n');
+  }
+  execSync(`git add .git-blame-ignore-revs`, { cwd: workDir });
+  execSync(`git commit --no-verify -m "add codemod to ignore-revs"`, { cwd: workDir });
+}
+
+export async function mergeHistory(opts: MergeHistoryOptions): Promise<void> {
+  let endpoints = resolveEndpoints(opts);
+  let workDir = setupWorkDir(opts, endpoints);
+  let changedFiles = listFiles(endpoints);
+  applyMoves(workDir, changedFiles, ['.js', '.ts']);
+  execSync(`git commit --no-verify -m "renamed JS/TS to GJS/GTS"`, { cwd: workDir });
+  let jsRenameCommit = head({ cwd: workDir });
+  execSync(`git reset --hard ${endpoints.beforeSha}`, { cwd: workDir });
+  applyMoves(workDir, changedFiles, ['.hbs']);
+  execSync(`git commit --no-verify -m "renamed HBS to GJS/GTS"`, { cwd: workDir });
+  let hbsRenameCommit = head({ cwd: workDir });
+  expectMergeConflicts(() => {
+    execSync(`git merge ${jsRenameCommit}`, { cwd: workDir });
+  });
+  concatenateMerge(workDir, jsRenameCommit, hbsRenameCommit);
+  execSync(`git commit --no-verify -m "combined JS and HBS"`, { cwd: workDir });
+  applyCodemod(workDir, changedFiles, endpoints);
+  execSync(`git commit --no-verify -m "applied codemod"`, { cwd: workDir });
+  let codemodCommit = head({ cwd: workDir });
+  addBlameIgnoreFile(workDir, codemodCommit);
+  execSync(`git checkout -b ${opts.outputBranch}`, { cwd: workDir });
+  rmSync(workDir, { recursive: true });
+  execSync(`git worktree prune`);
+  console.log(`Successfully created branch ${opts.outputBranch}`);
+}


### PR DESCRIPTION
Based on ideas from both @void-mAlex's https://github.com/embroider-build/embroider/pull/2361 and @davidtaylorhq's https://gist.github.com/davidtaylorhq/484505beccd5eeac1166bd75002b3e5a

This one does all the work in a git ~subtree~ worktree, so it doesn't actually touch your checked out code at all. The only visible change should be the creation of its outputBranch.

