### PR TITLE
Short circuit the reverseSearchAppTree when possible to reduce time

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1371,9 +1371,14 @@ export class Resolver {
     // really be understood as a request for a module in the containing engine
     if (owningPackage.isV2Addon()) {
       let sections = [owningPackage.meta['app-js'], owningPackage.meta['fastboot-js']];
+      let fromPackageRelativePath = explicitRelative(owningPackage.root, fromFile);
+      if (!fromPackageRelativePath.includes('/_app_/')) {
+        // the inAddonName values always contain /_app_/, so we can exit early without it
+        return;
+      }
+
       for (let section of sections) {
         if (section) {
-          let fromPackageRelativePath = explicitRelative(owningPackage.root, fromFile);
           for (let [inAppName, inAddonName] of Object.entries(section)) {
             if (inAddonName === fromPackageRelativePath) {
               return { owningEngine: this.owningEngine(owningPackage), inAppName };


### PR DESCRIPTION
In a large app with lots of addons, this change dropped time spent in `reverseSearchAppTree` from 2.2s to 600ms.

I think `inAddonName` will always have `/_app_/` as part of it making this change safe.

### Before

<img width="891" alt="Screenshot 2025-03-12 at 9 50 33 AM" src="https://github.com/user-attachments/assets/f1e88f0e-c423-4c42-8520-b67d887b2cdb" />


### After

<img width="894" alt="Screenshot 2025-03-12 at 10 04 54 AM" src="https://github.com/user-attachments/assets/ca8f54d9-b17f-42e4-b3f6-32fa6bf13a1b" />
