### PR TITLE
Handle name collisions when using `--addNameToTemplateOnly`

### DIFF
--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -206,6 +206,20 @@ tsAppScenarios
         });
       });
 
+      test('adding named const to a template-only component with a name collision', async function (assert) {
+        await assert.codeMod({
+          from: { 'app/components/example.hbs': '<Nested::Example />' },
+          to: {
+            'app/components/example.gjs': `
+              import Example from "./nested/example.js";
+              const Example0 = <template><Example /></template>;
+              export default Example0;
+            `,
+          },
+          via: 'npx template-tag-codemod --addNameToTemplateOnly --reusePrebuild --renderTests false --routeTemplates false --components ./app/components/example.hbs',
+        });
+      });
+
       test('basic js backing component', async function (assert) {
         await assert.codeMod({
           from: {


### PR DESCRIPTION
A follow-up to #2348 that fixes cases where a template name would clash with one of the import names.

@mansona, let me know if you think it would be better to use JSUtils from https://github.com/emberjs/babel-plugin-ember-template-compilation (and know how 😉)