### PR TITLE
mark template-codemod as a stable 1.0.0 release

### DIFF
--- a/packages/template-tag-codemod/package.json
+++ b/packages/template-tag-codemod/package.json
@@ -24,14 +24,6 @@
     "dist/src/**/*.js.map"
   ],
   "scripts": {},
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "prerelease",
-      "minor": "prerelease",
-      "patch": "prerelease"
-    },
-    "semverIncrementTag": "alpha"
-  },
   "dependencies": {
     "@babel/code-frame": "^7.26.2",
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
This is marked as a breaking change because that will kick semver to think that this is a 1.0.0 release 🎉 

I verified this locally: 

```
> semver.inc('0.5.0-alpha.10', 'major')
'1.0.0'
```

We just need to merge this PR and the [Plan release PR](https://github.com/embroider-build/embroider/pull/2376) once it updates and that will then release our 1.0.0 as stable 🎉 