### PR TITLE
Add Vite support for Ember 4.12

### DIFF
--- a/tests/scenarios/scenarios.ts
+++ b/tests/scenarios/scenarios.ts
@@ -24,7 +24,7 @@ async function lts_4_8(project: Project) {
 async function lts_4_12(project: Project) {
   project.linkDevDependency('ember-source', { baseDir: __dirname, resolveName: 'ember-source-4.12' });
   project.linkDevDependency('ember-cli', { baseDir: __dirname, resolveName: 'ember-cli-4.12' });
-  project.linkDevDependency('ember-data', { baseDir: __dirname, resolveName: 'ember-data-4.12' });
+  project.linkDevDependency('ember-data', { baseDir: __dirname, resolveName: 'ember-data-5.3' });
 }
 
 async function lts_5_4(project: Project) {

--- a/tests/scenarios/scenarios.ts
+++ b/tests/scenarios/scenarios.ts
@@ -113,7 +113,6 @@ export function fullSupportMatrix(scenarios: Scenarios) {
       .skip('lts_3_28')
       .skip('lts_4_4')
       .skip('lts_4_8')
-      .skip('lts_4_12')
   );
 }
 


### PR DESCRIPTION
You can see that this works here https://github.com/mainmatter/ember-vite-codemod/pull/53

Edit: ember-data@4.12 has issues so I don't think we can support it. I tried ember-data@4.13-alpha but it also has issues so we can update the 4.x test to use 4.13 once we iron out those problems 👍 