### PR TITLE
Handle a couple more common use cases in template tag codemod

### DIFF
--- a/packages/template-tag-codemod/src/extract-meta.ts
+++ b/packages/template-tag-codemod/src/extract-meta.ts
@@ -127,13 +127,6 @@ function locatePlugin(_babel: typeof Babel): Babel.PluginObj<{ opts: LocatePlugi
   return {
     visitor: {
       ExportDefaultDeclaration(path, state) {
-        if (path.parentPath.node.type !== 'Program') {
-          // Not at the top level of the program, so likely an export from a
-          // TypeScript module declaration such as a GLint loose-mode Registry
-          // augmentation, rather than the actual default export of the module.
-          return;
-        }
-
         let dec: types.Node = path.node.declaration;
 
         if (dec.type === 'Identifier') {
@@ -164,6 +157,9 @@ function locatePlugin(_babel: typeof Babel): Babel.PluginObj<{ opts: LocatePlugi
               };
               return;
             }
+          case 'TSInterfaceDeclaration':
+            // ignoring type-only export
+            return;
           default:
             state.opts.componentBody = {
               problem: `The default export from this JS file is not something we understand. Found ${dec.type}`,

--- a/packages/template-tag-codemod/src/extract-meta.ts
+++ b/packages/template-tag-codemod/src/extract-meta.ts
@@ -127,6 +127,13 @@ function locatePlugin(_babel: typeof Babel): Babel.PluginObj<{ opts: LocatePlugi
   return {
     visitor: {
       ExportDefaultDeclaration(path, state) {
+        if (path.parentPath.node.type !== 'Program') {
+          // Not at the top level of the program, so likely an export from a
+          // TypeScript module declaration such as a GLint loose-mode Registry
+          // augmentation, rather than the actual default export of the module.
+          return;
+        }
+
         let dec = path.node.declaration;
         switch (dec.type) {
           case 'ClassDeclaration':

--- a/packages/template-tag-codemod/src/extract-meta.ts
+++ b/packages/template-tag-codemod/src/extract-meta.ts
@@ -134,7 +134,19 @@ function locatePlugin(_babel: typeof Babel): Babel.PluginObj<{ opts: LocatePlugi
           return;
         }
 
-        let dec = path.node.declaration;
+        let dec: types.Node = path.node.declaration;
+
+        if (dec.type === 'Identifier') {
+          // This is an export of an identifier, not the value, e.g.
+          // `class Foo {}; export default Foo;`. So find the
+          // underlying declaration
+          let binding = path.scope.getBinding(dec.name);
+          if (!binding) {
+            throw new Error(`bug: unable to get binding for identifier: ${dec.name}`);
+          }
+          dec = binding.path.node;
+        }
+
         switch (dec.type) {
           case 'ClassDeclaration':
           case 'ClassExpression':

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -268,6 +268,37 @@ tsAppScenarios
         });
       });
 
+      test('js backing component with separate export statement', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'app/components/example.hbs': `<button {{on "click" this.clicked}}>Click me</button>`,
+            'app/components/example.js': `
+              import Component from "@ember/component";
+              class Foo extends Component {
+
+                clicked() {
+                  alert('i got clicked');
+                }
+              }
+              export default Foo;
+            `,
+          },
+          to: {
+            'app/components/example.gjs': `
+              import Component from "@ember/component";
+              import { on } from "@ember/modifier";
+              class Foo extends Component {<template><button {{on "click" this.clicked}}>Click me</button></template>
+                clicked() {
+                  alert('i got clicked');
+                }
+              }
+              export default Foo;
+            `,
+          },
+          via: 'npx template-tag-codemod --reusePrebuild  --renderTests false --routeTemplates false --components ./app/components/example.hbs',
+        });
+      });
+
       test('loose-mode registry augmentation', async function (assert) {
         await assert.codeMod({
           from: {

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -268,6 +268,58 @@ tsAppScenarios
         });
       });
 
+      test('loose-mode registry augmentation', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'app/components/example.hbs': `Hello world`,
+            'app/components/example.ts': `
+              import Component from '@glimmer/component';
+
+              interface FooSignature {
+                Args: {
+                  value?: string;
+                };
+              }
+
+              export default class Foo extends Component<FooSignature> {
+                get value() {
+                  return this.args.value ?? '';
+                }
+              }
+
+              declare module '@glint/environment-ember-loose/registry' {
+                export default interface Registry {
+                  Foo: typeof Foo;
+                }
+              }
+            `,
+          },
+          to: {
+            'app/components/example.gts': `
+              import Component from '@glimmer/component';
+
+              interface FooSignature {
+                Args: {
+                  value?: string;
+                };
+              }
+
+              export default class Foo extends Component<FooSignature> {<template>Hello world</template>
+                get value() {
+                  return this.args.value ?? '';
+                }
+              }
+
+              declare module '@glint/environment-ember-loose/registry' {
+                export default interface Registry {
+                  Foo: typeof Foo;
+                }
+              }            `,
+          },
+          via: 'npx template-tag-codemod --reusePrebuild  --renderTests false --routeTemplates false --components ./app/components/example.hbs',
+        });
+      });
+
       test('name collision between original js and added import', async function (assert) {
         await assert.codeMod({
           from: {


### PR DESCRIPTION
This allows the template tag codemod to handle a couple more common formats for `.js`/`.ts` component files.