### PR TITLE
esbuild backchannel fix

### DIFF
--- a/packages/vite/src/backchannel.ts
+++ b/packages/vite/src/backchannel.ts
@@ -1,0 +1,66 @@
+import makeDebug from 'debug';
+
+const debug = makeDebug('embroider:vite-esbuild-backchannel');
+
+export class BackChannel {
+  #state = new Map<string, InternalStatus>();
+
+  constructor() {
+    /*
+      This is an unfortunate necessity. During depscan, vite deliberately hides
+      information from esbuild. Specifically, it treats "not found" and "this is an
+      external dependency" as both "external: true". But we really care about the
+      difference, since we have fallback behaviors for the "not found" case. Using
+      this global state, our rollup resolver plugin can observe what vite is
+      actually doing and communicate that knowledge outward to our esbuild resolver
+      plugin.
+   */
+    (globalThis as any).__embroider_vite_resolver_channel__ = this;
+  }
+
+  requestStatus(specifier: string, fromFile: string): void {
+    let id = stateKey(specifier, fromFile);
+    if (!this.#state.has(id)) {
+      debug('requestStatus(%s, %s) pending', specifier, fromFile);
+      this.#state.set(stateKey(specifier, fromFile), { type: 'pending' });
+    } else {
+      debug('requestStatus(%s, %s) exists', specifier, fromFile);
+    }
+  }
+
+  writeStatus(specifier: string, fromFile: string, status: FinalStatus): void {
+    let id = stateKey(specifier, fromFile);
+    if (this.#state.get(id)?.type === 'pending') {
+      debug('writeStatus(%s, %s) = %s', specifier, fromFile, status.type);
+      this.#state.set(id, status);
+    } else {
+      debug('writeStatus(%s, %s) not pending', specifier, fromFile, status.type);
+    }
+  }
+
+  readStatus(specifier: string, fromFile: string): Status {
+    let id = stateKey(specifier, fromFile);
+    let found = this.#state.get(id);
+    debug('readStatus(%s, %s) = %s', specifier, fromFile, found?.type);
+    if (!found) {
+      throw new Error(`bug in BackChannel: readStatus before requestStatus`);
+    }
+    if (found.type === 'pending') {
+      return { type: 'indeterminate' };
+    }
+    return found;
+  }
+}
+
+export function writeStatus(specifier: string, fromFile: string, status: FinalStatus): void {
+  let channel = (globalThis as any).__embroider_vite_resolver_channel__ as BackChannel | undefined;
+  channel?.writeStatus(specifier, fromFile, status);
+}
+
+function stateKey(specifier: string, fromFile: string): string {
+  return `${specifier}\0${fromFile}`;
+}
+
+export type FinalStatus = { type: 'not_found' } | { type: 'found'; filename: string };
+export type Status = FinalStatus | { type: 'indeterminate' };
+type InternalStatus = { type: 'pending' } | FinalStatus;

--- a/packages/vite/src/esbuild-request.ts
+++ b/packages/vite/src/esbuild-request.ts
@@ -11,6 +11,8 @@ import type {
   VirtualResponse,
 } from '@embroider/core';
 import { externalName } from '@embroider/reverse-exports';
+import type { BackChannel } from './backchannel.js';
+import { assertNever } from 'assert-never';
 
 export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolveResult, OnResolveResult>> {
   static create({
@@ -21,14 +23,16 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
     path,
     importer,
     pluginData,
+    backChannel,
   }: {
     packageCache: PackageCache;
-    phase: 'bundling' | 'other';
+    phase: 'bundling' | 'scanning' | 'other';
     build: PluginBuild;
     kind: ImportKind;
     path: string;
     importer: string | undefined;
     pluginData: Record<string, any> | undefined;
+    backChannel: BackChannel | undefined;
   }) {
     if (!(pluginData?.embroider?.enableCustomResolver ?? true)) {
       return;
@@ -46,16 +50,17 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
           fromFile,
           meta: pluginData?.embroider?.meta,
         },
-        adapter: new EsBuildRequestAdapter(packageCache, phase, build, kind),
+        adapter: new EsBuildRequestAdapter(packageCache, phase, build, kind, backChannel),
       };
     }
   }
 
   private constructor(
     private packageCache: PackageCache,
-    private phase: 'bundling' | 'other',
+    private phase: 'bundling' | 'scanning' | 'other',
     private context: PluginBuild,
-    private kind: ImportKind
+    private kind: ImportKind,
+    private backChannel: BackChannel | undefined
   ) {}
 
   get debugType() {
@@ -88,7 +93,9 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
   async resolve(
     request: ModuleRequest<Resolution<OnResolveResult, OnResolveResult>>
   ): Promise<Resolution<OnResolveResult, OnResolveResult>> {
-    requestStatus(request.specifier);
+    if (this.backChannel) {
+      this.backChannel.requestStatus(request.specifier, request.fromFile);
+    }
 
     let result = await this.context.resolve(request.specifier, {
       importer: request.fromFile,
@@ -102,107 +109,79 @@ export class EsBuildRequestAdapter implements RequestAdapter<Resolution<OnResolv
       },
     });
 
-    let status = readStatus(request.specifier);
-
-    if (result.errors.length > 0 || status.type === 'not_found') {
+    if (result.errors.length > 0) {
       return { type: 'not_found', err: result };
-    } else {
-      if (this.phase === 'bundling') {
-        // we need to ensure that we don't traverse back into the app while
-        // doing dependency pre-bundling. There are multiple ways an addon can
-        // resolve things from the app, due to the existince of both app-js
-        // (modules in addons that are logically part of the app's namespace)
-        // and non-strict handlebars (which resolves
-        // components/helpers/modifiers against the app's global pool).
-        let pkg = this.packageCache.ownerOfFile(result.path);
-        if (
-          pkg?.root === this.packageCache.appRoot &&
-          // vite provides node built-in polyfills under a custom namespace and we dont
-          // want to interrupt that. We'd prefer they get bundled in the dep optimizer normally,
-          // rather than getting deferred to the app build (which also works, but means they didn't
-          // get pre-optimized).
-          (result.namespace === 'file' || result.namespace.startsWith('embroider-'))
-        ) {
-          let externalizedName = request.specifier;
-          if (!packageName(externalizedName)) {
-            // the request was a relative path. This won't remain valid once
-            // it has been bundled into vite/deps. But we know it targets the
-            // app, so we can always convert it into a non-relative import
-            // from the app's namespace
-            //
-            // IMPORTANT: whenever an addon resolves a relative path to the
-            // app, it does so because our code in the core resolver has
-            // rewritten the request to be relative to the app's root. So here
-            // we will only ever encounter relative paths that are already
-            // relative to the app's root directory.
-            externalizedName = externalName(pkg.packageJSON, externalizedName) || externalizedName;
-          }
-          return {
-            type: 'found',
-            filename: externalizedName,
-            virtual: false,
-            result: {
-              path: externalizedName,
-              external: true,
-            },
-          };
-        }
-      }
-
-      let filename: string;
-      if (status.type === 'found' && result.external) {
-        // when we know that the file was really found, but vite has
-        // externalized it, report the true filename that was found, not the
-        // externalized request path.
-        filename = status.filename;
-      } else {
-        filename = result.path;
-      }
-
-      return {
-        type: 'found',
-        filename,
-        result,
-        virtual: false,
-      };
     }
+
+    let filename = result.path;
+
+    if (this.backChannel) {
+      let status = this.backChannel.readStatus(request.specifier, request.fromFile);
+      switch (status.type) {
+        case 'not_found':
+          return { type: 'not_found', err: result };
+        case 'found':
+          if (result.external) {
+            // when we know that the file was really found, but vite has
+            // externalized it, report the true filename that was found, not the
+            // externalized request path.
+            filename = status.filename;
+          }
+          break;
+        case 'indeterminate':
+          break;
+        default:
+          throw assertNever(status);
+      }
+    }
+
+    if (this.phase === 'bundling') {
+      // we need to ensure that we don't traverse back into the app while
+      // doing dependency pre-bundling. There are multiple ways an addon can
+      // resolve things from the app, due to the existince of both app-js
+      // (modules in addons that are logically part of the app's namespace)
+      // and non-strict handlebars (which resolves
+      // components/helpers/modifiers against the app's global pool).
+      let pkg = this.packageCache.ownerOfFile(result.path);
+      if (
+        pkg?.root === this.packageCache.appRoot &&
+        // vite provides node built-in polyfills under a custom namespace and we dont
+        // want to interrupt that. We'd prefer they get bundled in the dep optimizer normally,
+        // rather than getting deferred to the app build (which also works, but means they didn't
+        // get pre-optimized).
+        (result.namespace === 'file' || result.namespace.startsWith('embroider-'))
+      ) {
+        let externalizedName = request.specifier;
+        if (!packageName(externalizedName)) {
+          // the request was a relative path. This won't remain valid once
+          // it has been bundled into vite/deps. But we know it targets the
+          // app, so we can always convert it into a non-relative import
+          // from the app's namespace
+          //
+          // IMPORTANT: whenever an addon resolves a relative path to the
+          // app, it does so because our code in the core resolver has
+          // rewritten the request to be relative to the app's root. So here
+          // we will only ever encounter relative paths that are already
+          // relative to the app's root directory.
+          externalizedName = externalName(pkg.packageJSON, externalizedName) || externalizedName;
+        }
+        return {
+          type: 'found',
+          filename: externalizedName,
+          virtual: false,
+          result: {
+            path: externalizedName,
+            external: true,
+          },
+        };
+      }
+    }
+
+    return {
+      type: 'found',
+      filename,
+      result,
+      virtual: false,
+    };
   }
 }
-
-/*
-  This is an unfortunate necessity. During depscan, vite deliberately hides
-  information from esbuild. Specifically, it treats "not found" and "this is an
-  external dependency" as both "external: true". But we really care about the
-  difference, since we have fallback behaviors for the "not found" case. Using
-  this global state, our rollup resolver plugin can observe what vite is
-  actually doing and communicate that knowledge outward to our esbuild resolver
-  plugin.
- */
-function sharedGlobalState() {
-  let channel = (globalThis as any).__embroider_vite_resolver_channel__ as undefined | Map<string, InternalStatus>;
-  if (!channel) {
-    channel = new Map();
-    (globalThis as any).__embroider_vite_resolver_channel__ = channel;
-  }
-  return channel;
-}
-
-function requestStatus(id: string): void {
-  sharedGlobalState().set(id, { type: 'pending' });
-}
-
-export function writeStatus(id: string, status: InternalStatus): void {
-  let channel = sharedGlobalState();
-  if (channel.get(id)?.type === 'pending') {
-    channel.set(id, status);
-  }
-}
-
-function readStatus(id: string): InternalStatus {
-  let channel = sharedGlobalState();
-  let result = channel.get(id) ?? { type: 'pending' };
-  channel.delete(id);
-  return result;
-}
-
-type InternalStatus = { type: 'pending' } | { type: 'not_found' } | { type: 'found'; filename: string };

--- a/packages/vite/src/esbuild-resolver.ts
+++ b/packages/vite/src/esbuild-resolver.ts
@@ -9,6 +9,7 @@ import { assertNever } from 'assert-never';
 import { hbsToJS } from '@embroider/core';
 import { Preprocessor } from 'content-tag';
 import { extname } from 'path';
+import { BackChannel } from './backchannel.js';
 
 export function esBuildResolver(): EsBuildPlugin {
   let resolverLoader = new ResolverLoader(process.cwd());
@@ -56,6 +57,16 @@ export function esBuildResolver(): EsBuildPlugin {
     setup(build) {
       const phase = detectPhase(build);
 
+      let backChannel: BackChannel | undefined;
+      if (phase === 'scanning') {
+        // this is created here because of the lifetime it should have. When we
+        // catch vite lying to esbuild about missing deps actually being
+        // "external", we need to remember that fact for the remainder of the
+        // depscan, because if esbuild asks again it will hit a cache and we
+        // won't get to observe it again.
+        backChannel = new BackChannel();
+      }
+
       // Embroider Resolver
       build.onResolve({ filter: /./ }, async ({ path, importer, pluginData, kind }) => {
         let request = ModuleRequest.create(EsBuildRequestAdapter.create, {
@@ -66,6 +77,7 @@ export function esBuildResolver(): EsBuildPlugin {
           path,
           importer,
           pluginData,
+          backChannel,
         });
         if (!request) {
           return null;
@@ -130,10 +142,12 @@ export function esBuildResolver(): EsBuildPlugin {
   };
 }
 
-function detectPhase(build: PluginBuild): 'bundling' | 'other' {
+function detectPhase(build: PluginBuild): 'bundling' | 'scanning' | 'other' {
   let plugins = (build.initialOptions.plugins ?? []).map(p => p.name);
   if (plugins.includes('vite:dep-pre-bundle')) {
     return 'bundling';
+  } else if (plugins.includes('vite:dep-scan')) {
+    return 'scanning';
   } else {
     return 'other';
   }

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -5,7 +5,7 @@ import { type ResponseMeta, RollupRequestAdapter } from './request.js';
 import { assertNever } from 'assert-never';
 import makeDebug from 'debug';
 import { join, resolve } from 'path';
-import { writeStatus } from './esbuild-request.js';
+import { writeStatus } from './backchannel.js';
 import type { PluginContext, ResolveIdResult } from 'rollup';
 import { externalName } from '@embroider/reverse-exports';
 import fs from 'fs-extra';
@@ -179,7 +179,7 @@ async function observeDepScan(context: PluginContext, source: string, importer: 
     ...options,
     skipSelf: true,
   });
-  writeStatus(source, result ? { type: 'found', filename: result.id } : { type: 'not_found' });
+  writeStatus(source, importer ?? '', result ? { type: 'found', filename: result.id } : { type: 'not_found' });
   return result;
 }
 

--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -144,6 +144,17 @@ function buildViteInternalsTest(testNonColocatedTemplates: boolean, app: Project
             message = "delta";
          }
         `,
+        'multi-loose-example': {
+          'targeted.gjs': `
+            <template>hi</template>
+          `,
+          'first.hbs': `
+            <MultiLooseExample::Targeted />
+          `,
+          'second.hbs': `
+            <MultiLooseExample::Targeted />
+          `,
+        },
       },
       templates: {
         'application.hbs': `
@@ -240,6 +251,21 @@ function buildViteInternalsTest(testNonColocatedTemplates: boolean, app: Project
                 assert.strictEqual(globalThis.appLibTwoLoaded, 1, 'app lib two loaded once');
               });
             });
+          `,
+          'multi-loose-test.gjs': `
+            import { module, test } from 'qunit';
+            import { setupRenderingTest } from 'ts-app-template/tests/helpers';
+            import { render } from '@ember/test-helpers';
+            import First from 'ts-app-template/components/multi-loose-example/first';
+            import Second from 'ts-app-template/components/multi-loose-example/second';
+
+            module('Integration | multi-loose-example', function (hooks) {
+              setupRenderingTest(hooks);
+              test('Two different loose mode components that both target the same gjs component both work', async function (assert) {
+                await render(<template><div class="here"><First /><Second /></div></template>);
+                assert.dom('.here').hasText('hi hi');
+              })
+            })
           `,
         },
       },


### PR DESCRIPTION
This is a small change to the existing hack we use to detect `not_found` resolutions within Vite's depscan mode.

Previously it had no memory, and we expected to be able to intercept every resolution. But it turns out esbuild will sometimes cache results so that we cannot observe subsequent resolutions. So we need to remember the results for the lifetime of the depscan.

The included test is one of the cases that would fail. The symptom of the failure is that you spuriously get the `Components with separately resolved templates were removed at Ember 6.0` error, because we check whether a separately resolved template exists, and the correct answer is "not_found" but vite lies to esbuild and says "Yup, it's an external". The first time that happens our hack detected it correctly, but the second time esbuild didn't bother to ask Vite again, so we go with esbuild's answer which incorrectly claims the file exists.