### PR TITLE
reset addon-shim to have the same version as stable

### DIFF
--- a/packages/addon-shim/package.json
+++ b/packages/addon-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embroider/addon-shim",
-  "version": "2.0.0-alpha.2",
+  "version": "1.9.0",
   "description": "Make v2 addons work in non-Embroider apps.",
   "keywords": [],
   "main": "./src/index.js",


### PR DESCRIPTION
we noticed that we were about to release a 2.x of the @embroider/addon-shim but it's totally not necessary (and would be very disruptive).

This PR fixes that and resets it to what is currently defined on the stable branch, and we can tag this PR depending on what we would like it to be released as 👍 