### PR TITLE
Fix issue occuring when some consumers of @embroider/macros specify extensions for macros' content via require/import

### DIFF
--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": "./src/index.js",
     "./babel": "./src/babel.js",
-    "./src/*": "./src/*.js"
+    "./src/*": "./src/*.js",
+    "./src/*.js": "./src/*.js"
   },
   "files": [
     "src/**/*.js",


### PR DESCRIPTION
Due to: https://github.com/emberjs/data/blob/main/packages/build-config/src/index.ts#L65

Context: https://discord.com/channels/480462759797063690/568935504288940056/1357473589061881997

Caused by: https://github.com/embroider-build/embroider/pull/2249/files#diff-8acb338dc45f894eea12861ef90e17ca526242613d070b515ef2448b8361407dR17 (a change intending to be completely non-breaking and backwards compatible)

afaict, no other exports patterns are needed:
![image](https://github.com/user-attachments/assets/4cd278cd-1af3-40c1-930f-7580e378b197)
