### PR TITLE
Fix issue when your library has no prior app-js entry in package.json

### DIFF
--- a/packages/addon-dev/src/rollup-app-reexports.ts
+++ b/packages/addon-dev/src/rollup-app-reexports.ts
@@ -46,7 +46,7 @@ export default function appReexports(opts: {
           });
         }
       }
-      let originalAppJS = pkg['ember-addon']?.['app-js'];
+      let originalAppJS = pkg['ember-addon']?.['app-js'] ?? {};
 
       let hasChanges = !!symmetricDifference(
         Object.keys(originalAppJS),


### PR DESCRIPTION
Found this while adding tests to the new v2 addon blueprint over here: https://github.com/ember-cli/ember-addon-blueprint/pull/23

Error looks like this:
```
https://rollupjs.org/troubleshooting/#warning-sourcemap-is-likely-to-be-incorrect
Plugins that transform code (such as "keep-assets") should generate accompanying sourcemaps.
[!] (plugin app-reexports) TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.generateBundle (/tmp/v2-addon-blueprint--zNksTg/my-addon/node_modules/.pnpm/@embroider+addon-dev@8.0.0_rollup@4.39.0/node_modules/@embroider/addon-dev/src/rollup-app-reexports.ts:52:16)
    at /tmp/v2-addon-blueprint--zNksTg/my-addon/node_modules/.pnpm/rollup@4.39.0/node_modules/rollup/dist/shared/rollup.js:3368:40
```