### PR TITLE
Document adding app reexports to package.json#exports

### DIFF
--- a/docs/v2-faq.md
+++ b/docs/v2-faq.md
@@ -5,19 +5,19 @@
 <!-- toc -->
 
 - [Authoring](#authoring)
-  - [How can I use template tag components?](#how-can-i-use-template-tag-components)
-  - [How do I import my addon's own modules?](#how-do-i-import-my-addons-own-modules)
-  - [How can I lazy-load my addon's code?](#how-can-i-lazy-load-my-addons-code)
-  - [How can I write code depending on the context of the app or its dependencies?](#how-can-i-write-code-depending-on-the-context-of-the-app-or-its-dependencies)
+  * [How can I use template tag components?](#how-can-i-use-template-tag-components)
+  * [How do I import my addon's own modules?](#how-do-i-import-my-addons-own-modules)
+  * [How can I lazy-load my addon's code?](#how-can-i-lazy-load-my-addons-code)
+  * [How can I write code depending on the context of the app or its dependencies?](#how-can-i-write-code-depending-on-the-context-of-the-app-or-its-dependencies)
 - [Asset handling](#asset-handling)
-  - [How can I ship CSS with my addon?](#how-can-i-ship-css-with-my-addon)
-  - [How can I ship other static assets with my addon?](#how-can-i-ship-other-static-assets-with-my-addon)
-  - [How can I "push" static assets into the app?](#how-can-i-push-static-assets-into-the-app)
+  * [How can I ship CSS with my addon?](#how-can-i-ship-css-with-my-addon)
+  * [How can I ship other static assets with my addon?](#how-can-i-ship-other-static-assets-with-my-addon)
+  * [How can I "push" static assets into the app?](#how-can-i-push-static-assets-into-the-app)
 - [Build setup](#build-setup)
-  - [Why do v2 addons need a build step?](#why-do-v2-addons-need-a-build-step)
-  - [How can I integrate with the app's build?](#how-can-i-integrate-with-the-apps-build)
-  - [How can I define the public exports of my addon?](#how-can-i-define-the-public-exports-of-my-addon)
-  - [How can I provide route templates with my v2 addon?](#how-can-i-provide-route-templates-with-my-v2-addon)
+  * [Why do v2 addons need a build step?](#why-do-v2-addons-need-a-build-step)
+  * [How can I integrate with the app's build?](#how-can-i-integrate-with-the-apps-build)
+  * [How can I define the public exports of my addon?](#how-can-i-define-the-public-exports-of-my-addon)
+  * [How can I provide route templates with my v2 addon?](#how-can-i-provide-route-templates-with-my-v2-addon)
 
 <!-- tocstop -->
 

--- a/docs/v2-faq.md
+++ b/docs/v2-faq.md
@@ -5,19 +5,19 @@
 <!-- toc -->
 
 - [Authoring](#authoring)
-  * [How can I use template tag components?](#how-can-i-use-template-tag-components)
-  * [How do I import my addon's own modules?](#how-do-i-import-my-addons-own-modules)
-  * [How can I lazy-load my addon's code?](#how-can-i-lazy-load-my-addons-code)
-  * [How can I write code depending on the context of the app or its dependencies?](#how-can-i-write-code-depending-on-the-context-of-the-app-or-its-dependencies)
+  - [How can I use template tag components?](#how-can-i-use-template-tag-components)
+  - [How do I import my addon's own modules?](#how-do-i-import-my-addons-own-modules)
+  - [How can I lazy-load my addon's code?](#how-can-i-lazy-load-my-addons-code)
+  - [How can I write code depending on the context of the app or its dependencies?](#how-can-i-write-code-depending-on-the-context-of-the-app-or-its-dependencies)
 - [Asset handling](#asset-handling)
-  * [How can I ship CSS with my addon?](#how-can-i-ship-css-with-my-addon)
-  * [How can I ship other static assets with my addon?](#how-can-i-ship-other-static-assets-with-my-addon)
-  * [How can I "push" static assets into the app?](#how-can-i-push-static-assets-into-the-app)
+  - [How can I ship CSS with my addon?](#how-can-i-ship-css-with-my-addon)
+  - [How can I ship other static assets with my addon?](#how-can-i-ship-other-static-assets-with-my-addon)
+  - [How can I "push" static assets into the app?](#how-can-i-push-static-assets-into-the-app)
 - [Build setup](#build-setup)
-  * [Why do v2 addons need a build step?](#why-do-v2-addons-need-a-build-step)
-  * [How can I integrate with the app's build?](#how-can-i-integrate-with-the-apps-build)
-  * [How can I define the public exports of my addon?](#how-can-i-define-the-public-exports-of-my-addon)
-  * [How can I provide route templates with my v2 addon?](#how-can-i-provide-route-templates-with-my-v2-addon)
+  - [Why do v2 addons need a build step?](#why-do-v2-addons-need-a-build-step)
+  - [How can I integrate with the app's build?](#how-can-i-integrate-with-the-apps-build)
+  - [How can I define the public exports of my addon?](#how-can-i-define-the-public-exports-of-my-addon)
+  - [How can I provide route templates with my v2 addon?](#how-can-i-provide-route-templates-with-my-v2-addon)
 
 <!-- tocstop -->
 
@@ -187,7 +187,14 @@ For example, when your addon exposes a few components at the root level of `src/
 
 ```js
 // rollup.config.mjs
-addon.publicEntrypoints('index.js', 'components/*.js'),
+addon.publicEntrypoints(['index.js', 'components/*.js']),
+```
+
+If you also want those same components to be reexported into the traditional "app" tree, your `addon.appReexports()` could look like this:
+
+```js
+// rollup.config.mjs
+addon.appReexports(['components/*.js']);
 ```
 
 Additionally, there is a feature supported in node.js and modern bundlers to define an `exports` key in your `package.json` with a mapping of export paths to the actual files on disk, that lets you further tweak or constrain your public exports. This is explained in more detail here:
@@ -197,6 +204,7 @@ Additionally, there is a feature supported in node.js and modern bundlers to def
 When using `package.json#exports` make sure that:
 - the `addon.publicEntrypoints(...)` plugin in `rollup.config.mjs` includes _at least_ whatever is defined in `package.json#exports`
 - the modules that `addon.appReexports(...)` exposes must have overlap with the `package.json#exports` so that the app-tree merging may import from the addon
+- if you are reexporting modules into the "app" tree, the built reexports must also be added in `package.json#exports`. In most cases, adding `"./_app_/*": "./dist/_app_/*.js"` to `package.json#exports` will be sufficient
 
 ### How can I provide route templates with my v2 addon?
 


### PR DESCRIPTION
Added explicit documentation for ensuring apps can find `addon.appReexports()` stuff in `./dist/_app_/` when an addon is reexporting modules into the app tree. I ran into this when customizing my addon's `publicEntrypoints` and it wasn't obvious that I also needed to add the `_app_` stuff to `package.json#exports`. See the discord discussion here for additional context: https://discord.com/channels/480462759797063690/491905849405472769/1359599871379636511 

Also added what looked like some missing array brackets on line 190.