### PR TITLE
Major speedup of reverse-exports

### DIFF
--- a/packages/reverse-exports/package.json
+++ b/packages/reverse-exports/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "mem": "^8.0.0",
     "resolve.exports": "^2.0.2"
   }
 }

--- a/packages/reverse-exports/src/index.ts
+++ b/packages/reverse-exports/src/index.ts
@@ -2,7 +2,7 @@ import { posix } from 'path';
 import { exports as resolveExports } from 'resolve.exports';
 import memoize from 'mem';
 
-type PkgJSON = { name: string; exports?: Exports };
+type PkgJSON = { name: string; version: string; exports?: Exports };
 type Exports = string | string[] | { [key: string]: Exports };
 
 /**
@@ -81,7 +81,7 @@ export function _findPathRecursively(
   Returns undefined for a relativePath that is forbidden to be accessed from the
   outside.
 */
-export function externalName(pkg: PkgJSON, relativePath: string): string | undefined {
+function _externalName(pkg: PkgJSON, relativePath: string): string | undefined {
   let { exports } = pkg;
   if (!exports) {
     return posix.join(pkg.name, relativePath);
@@ -111,6 +111,10 @@ export function externalName(pkg: PkgJSON, relativePath: string): string | undef
 
   return posix.join(pkg.name, resolvedPath);
 }
+
+export const externalName = memoize(_externalName, {
+  cacheKey: ([pkg, relativePath]) => `${pkg.name}::${pkg.version}::${relativePath}`,
+});
 
 function regexEscape(input: string): string {
   return input.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');

--- a/packages/reverse-exports/src/index.ts
+++ b/packages/reverse-exports/src/index.ts
@@ -87,7 +87,7 @@ function _externalName(pkg: PkgJSON, relativePath: string): string | undefined {
     return posix.join(pkg.name, relativePath);
   }
 
-  const maybeKeyValuePair = _findPathRecursively(exports, candidate => stringToRegex(candidate).test(relativePath));
+  const maybeKeyValuePair = _findPathRecursively(exports, candidate => _matches(candidate, relativePath));
 
   if (!maybeKeyValuePair) {
     return undefined;
@@ -116,20 +116,19 @@ export const externalName = memoize(_externalName, {
   cacheKey: ([pkg, relativePath]) => `${pkg.name}::${pkg.version}::${relativePath}`,
 });
 
-function regexEscape(input: string): string {
+function _regexEscape(input: string): string {
   return input.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }
+const regexEscape = memoize(_regexEscape);
 
-export function _stringToRegex(input: string): RegExp {
-  let wildCardIndex = input.indexOf('*');
+export function _matches(candidate: string, relativePath: string): boolean {
+  let wildCardIndex = candidate.indexOf('*');
 
   if (~wildCardIndex) {
     return new RegExp(
-      `^${regexEscape(input.substring(0, wildCardIndex))}.*${regexEscape(input.substring(wildCardIndex + 1))}$`
-    );
+      `^${regexEscape(candidate.substring(0, wildCardIndex))}.*${regexEscape(candidate.substring(wildCardIndex + 1))}$`
+    ).test(relativePath);
   } else {
-    return new RegExp(`^${regexEscape(input)}$`);
+    return candidate === relativePath;
   }
 }
-
-const stringToRegex = memoize(_stringToRegex);

--- a/packages/reverse-exports/src/index.ts
+++ b/packages/reverse-exports/src/index.ts
@@ -115,15 +115,16 @@ export function externalName(pkg: PkgJSON, relativePath: string): string | undef
   return posix.join(pkg.name, resolvedPath);
 }
 
+function regexEscape(input: string): string {
+  return input.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 export function _prepareStringForRegex(input: string): string {
-  let result = input
-    .split('*')
-    .map(substr => substr.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&'))
-    .join('.*');
+  let wildCardIndex = input.indexOf('*');
 
-  if (result.endsWith('/')) {
-    result += '.*';
+  if (~wildCardIndex) {
+    return `^${regexEscape(input.substring(0, wildCardIndex))}.*${regexEscape(input.substring(wildCardIndex + 1))}$`;
+  } else {
+    return `^${regexEscape(input)}$`;
   }
-
-  return `^${result}$`;
 }

--- a/packages/reverse-exports/src/index.ts
+++ b/packages/reverse-exports/src/index.ts
@@ -1,5 +1,6 @@
 import { posix } from 'path';
 import { exports as resolveExports } from 'resolve.exports';
+import memoize from 'mem';
 
 type PkgJSON = { name: string; exports?: Exports };
 type Exports = string | string[] | { [key: string]: Exports };
@@ -86,7 +87,7 @@ export function externalName(pkg: PkgJSON, relativePath: string): string | undef
     return posix.join(pkg.name, relativePath);
   }
 
-  const maybeKeyValuePair = _findPathRecursively(exports, candidate => _stringToRegex(candidate).test(relativePath));
+  const maybeKeyValuePair = _findPathRecursively(exports, candidate => stringToRegex(candidate).test(relativePath));
 
   if (!maybeKeyValuePair) {
     return undefined;
@@ -126,3 +127,5 @@ export function _stringToRegex(input: string): RegExp {
     return new RegExp(`^${regexEscape(input)}$`);
   }
 }
+
+const stringToRegex = memoize(_stringToRegex);

--- a/packages/reverse-exports/src/index.ts
+++ b/packages/reverse-exports/src/index.ts
@@ -86,11 +86,7 @@ export function externalName(pkg: PkgJSON, relativePath: string): string | undef
     return posix.join(pkg.name, relativePath);
   }
 
-  const maybeKeyValuePair = _findPathRecursively(exports, candidate => {
-    const regex = new RegExp(_prepareStringForRegex(candidate));
-
-    return regex.test(relativePath);
-  });
+  const maybeKeyValuePair = _findPathRecursively(exports, candidate => _stringToRegex(candidate).test(relativePath));
 
   if (!maybeKeyValuePair) {
     return undefined;
@@ -119,12 +115,14 @@ function regexEscape(input: string): string {
   return input.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-export function _prepareStringForRegex(input: string): string {
+export function _stringToRegex(input: string): RegExp {
   let wildCardIndex = input.indexOf('*');
 
   if (~wildCardIndex) {
-    return `^${regexEscape(input.substring(0, wildCardIndex))}.*${regexEscape(input.substring(wildCardIndex + 1))}$`;
+    return new RegExp(
+      `^${regexEscape(input.substring(0, wildCardIndex))}.*${regexEscape(input.substring(wildCardIndex + 1))}$`
+    );
   } else {
-    return `^${regexEscape(input)}$`;
+    return new RegExp(`^${regexEscape(input)}$`);
   }
 }

--- a/packages/reverse-exports/tests/reverse-exports.test.ts
+++ b/packages/reverse-exports/tests/reverse-exports.test.ts
@@ -1,4 +1,4 @@
-import { externalName, _findPathRecursively, _stringToRegex } from '../src';
+import { externalName, _findPathRecursively, _matches } from '../src';
 
 describe('reverse exports', function () {
   it('exports is missing', function () {
@@ -287,14 +287,16 @@ describe('_findKeyRecursively', function () {
   });
 });
 
-describe('_stringToRegex', function () {
-  [
-    { input: './foo', expected: '/^\\.\\/foo$/' },
-    { input: './foo.js', expected: '/^\\.\\/foo\\.js$/' },
-    { input: './foo/*.js', expected: '/^\\.\\/foo\\/.*\\.js$/' },
-  ].forEach(({ input, expected }) => {
-    it(input, function () {
-      expect(_stringToRegex(input).toString()).toStrictEqual(expected);
-    });
+describe('_matches', function () {
+  it('matches for non-wildcards entries', function () {
+    expect(_matches('./foo.js', './foo.js')).toBe(true);
+    expect(_matches('./foo.js', './bar.js')).toBe(false);
+  });
+
+  it('matches for wildcards entries', function () {
+    expect(_matches('./foo/*.js', './foo/index.js')).toBe(true);
+    expect(_matches('./foo/*.js', './foo/bar.js')).toBe(true);
+    expect(_matches('./foo/*.js', './foo/bar/index.js')).toBe(true);
+    expect(_matches('./foo/*.js', './bar/index.js')).toBe(false);
   });
 });

--- a/packages/reverse-exports/tests/reverse-exports.test.ts
+++ b/packages/reverse-exports/tests/reverse-exports.test.ts
@@ -1,4 +1,4 @@
-import { externalName, _findPathRecursively, _prepareStringForRegex } from '../src';
+import { externalName, _findPathRecursively, _stringToRegex } from '../src';
 
 describe('reverse exports', function () {
   it('exports is missing', function () {
@@ -277,14 +277,14 @@ describe('_findKeyRecursively', function () {
   });
 });
 
-describe('_prepareStringForRegex', function () {
+describe('_stringToRegex', function () {
   [
-    { input: './foo', expected: '^\\.\\/foo$' },
-    { input: './foo.js', expected: '^\\.\\/foo\\.js$' },
-    { input: './foo/*.js', expected: '^\\.\\/foo\\/.*\\.js$' },
+    { input: './foo', expected: '/^\\.\\/foo$/' },
+    { input: './foo.js', expected: '/^\\.\\/foo\\.js$/' },
+    { input: './foo/*.js', expected: '/^\\.\\/foo\\/.*\\.js$/' },
   ].forEach(({ input, expected }) => {
     it(input, function () {
-      expect(_prepareStringForRegex(input)).toStrictEqual(expected);
+      expect(_stringToRegex(input).toString()).toStrictEqual(expected);
     });
   });
 });

--- a/packages/reverse-exports/tests/reverse-exports.test.ts
+++ b/packages/reverse-exports/tests/reverse-exports.test.ts
@@ -2,7 +2,7 @@ import { externalName, _findPathRecursively, _stringToRegex } from '../src';
 
 describe('reverse exports', function () {
   it('exports is missing', function () {
-    expect(externalName({ name: 'best-addon' }, './dist/_app_/components/face.js')).toBe(
+    expect(externalName({ name: 'best-addon', version: '1.0.0' }, './dist/_app_/components/face.js')).toBe(
       'best-addon/dist/_app_/components/face.js'
     );
   });
@@ -11,6 +11,7 @@ describe('reverse exports', function () {
     const actual = externalName(
       {
         name: 'my-addon',
+        version: '1.0.0',
         exports: './foo.js',
       },
       './foo.js'
@@ -22,6 +23,7 @@ describe('reverse exports', function () {
     const actual = externalName(
       {
         name: 'my-addon',
+        version: '1.1.0',
         exports: {
           '.': './foo.js',
         },
@@ -34,6 +36,7 @@ describe('reverse exports', function () {
   it('subpath exports', function () {
     const packageJson = {
       name: 'my-addon',
+      version: '1.2.0',
       exports: {
         '.': './main.js',
         './sub/path': './secondary.js',
@@ -54,6 +57,7 @@ describe('reverse exports', function () {
   it('alternative exports', function () {
     const packageJson = {
       name: 'my-addon',
+      version: '1.3.0',
       exports: {
         './things/*': ['./good-things/*', './bad-things/*'],
       },
@@ -65,6 +69,7 @@ describe('reverse exports', function () {
   it('conditional exports - simple abbreviated', function () {
     const packageJson = {
       name: 'my-addon',
+      version: '1.4.0',
       exports: {
         import: './index-module.js',
         require: './index-require.cjs',
@@ -79,6 +84,7 @@ describe('reverse exports', function () {
   it('conditional exports - simple non-abbreviated', function () {
     const packageJson = {
       name: 'my-addon',
+      version: '1.5.0',
       exports: {
         '.': {
           import: './index-module.js',
@@ -95,6 +101,7 @@ describe('reverse exports', function () {
   it('conditional subpath exports', function () {
     const packageJson = {
       name: 'my-addon',
+      version: '1.6.0',
       exports: {
         '.': './index.js',
         './feature.js': {
@@ -111,6 +118,7 @@ describe('reverse exports', function () {
   it('nested conditional exports', function () {
     const packageJson = {
       name: 'my-addon',
+      version: '1.7.0',
       exports: {
         node: {
           import: './feature-node.mjs',
@@ -127,6 +135,7 @@ describe('reverse exports', function () {
   it('should return undefined when no exports entry is matching', function () {
     const packageJson = {
       name: 'my-addon',
+      version: '1.8.0',
       exports: {
         node: {
           import: './feature-node.mjs',
@@ -142,6 +151,7 @@ describe('reverse exports', function () {
   it('conditional exports: using a single asterisk as glob for nested path', function () {
     const packageJson = {
       name: 'my-v2-addon',
+      version: '1.9.0',
       exports: {
         '.': './dist/index.js',
         './*': {

--- a/packages/reverse-exports/tests/reverse-exports.test.ts
+++ b/packages/reverse-exports/tests/reverse-exports.test.ts
@@ -37,10 +37,10 @@ describe('reverse exports', function () {
       exports: {
         '.': './main.js',
         './sub/path': './secondary.js',
-        './prefix/': './directory/',
-        './prefix/deep/': './other-directory/',
-        './other-prefix/*': './yet-another/*/*.js',
-        './glob/*': './grod/**/*.js',
+        './prefix/*': './directory/*',
+        './prefix/deep/*': './other-directory/*',
+        './other-prefix/*': './yet-another/*.js',
+        './glob/*': './grod/*.js',
       },
     };
     expect(externalName(packageJson, './main.js')).toBe('my-addon');
@@ -55,7 +55,7 @@ describe('reverse exports', function () {
     const packageJson = {
       name: 'my-addon',
       exports: {
-        './things/': ['./good-things/', './bad-things/'],
+        './things/*': ['./good-things/*', './bad-things/*'],
       },
     };
     expect(externalName(packageJson, './good-things/apple.js')).toBe('my-addon/things/apple.js');
@@ -282,7 +282,6 @@ describe('_prepareStringForRegex', function () {
     { input: './foo', expected: '^\\.\\/foo$' },
     { input: './foo.js', expected: '^\\.\\/foo\\.js$' },
     { input: './foo/*.js', expected: '^\\.\\/foo\\/.*\\.js$' },
-    { input: './foo/', expected: '^\\.\\/foo\\/.*$' },
   ].forEach(({ input, expected }) => {
     it(input, function () {
       expect(_prepareStringForRegex(input)).toStrictEqual(expected);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,6 +645,9 @@ importers:
 
   packages/reverse-exports:
     dependencies:
+      mem:
+        specifier: ^8.0.0
+        version: 8.1.1
       resolve.exports:
         specifier: ^2.0.2
         version: 2.0.3
@@ -3776,7 +3779,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.10(supports-color@8.1.1)
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
   /@babel/plugin-transform-private-methods@7.25.9(@babel/core@7.26.10):


### PR DESCRIPTION
When running Embroider/Vite the first time on one of our larger test-apps, I was seeing unexpectedly long build times for the initial load. Time to first paint was about 5 minutes. Network tab showed some requests like `app.css` taking 4 minutes to complete, but I don't think this was related to that particular request being processed, rather Vite was busy processing all kinds of other things in the background.

I took a [CPU profile](https://vite.dev/guide/troubleshooting.html#performance-bottlenecks) and was able to identify where this is coming from: the `@embroider/reverse-exports` package:

![image](https://github.com/user-attachments/assets/a82ec144-eb6c-415d-9b6e-09702720ebc3)

A few interesting things:
* the `mergeMaps` getter took 220s, not on its own but for the APIs it calls, mostly `externalName` from that package (221s in total)
* the biggest offenders under "Self time" are the utilities in that package, like `_prepareStringForRegex` and some arrow functions, e.g. the matcher that is creating and testing the Regex
* running the  `[/\-\\^$*+?.()|[\]{}]` RegEx replace alone (used in `_prepareStringForRegex`) is taking 15s
* lots of GC (14s)

For context: this is a typical YMMV situation. We were very affected by this performance bottleneck because we were historically using the "index-layout " for components and other modules (e.g. `<FancyButton>` lives in `components/fancy-button/index.ts` but gets imported from `fancy-addon/fancy-button`), which for v2 addons requires each and every index module to have its own package.json exports entry (see https://github.com/embroider-build/addon-blueprint/pull/229). So we have _a lot_! 😅 

This PR is fixing that by optimizing these utility functions that are in the hot path. Best reviewed by commit. The major changes are:
* use memoization: I was able to see these functions being called multiple times with the same args
* avoid using `.split('*')` for processing wildcards, as this creates intermediary arrays that need to get GC'ed
* avoid using RegEx when the exports path has no wildcard. A simple string match is enough.

With these changes, the browser has its first paint after 70s (instead of 300s) and my CPU profile now looks like this:

![image](https://github.com/user-attachments/assets/0d2cfab9-2840-41fc-a970-1d8816e6a981)

The `memoized` function take less than a second, but in return we get `mergeMaps` running in 3.7s (instead of 220s, see above), and no `reverse-exports` calls showing up anywhere. Also much less GC and no RegEx time (in the top of the list).

One more thing to point out. In the [first commit](https://github.com/embroider-build/embroider/pull/2449/commits/f1845336bb77642198384842ac81fa90ae843f65) I was changing the tests a bit, because I think they actually had wrong assumptions about how package.json exports work. I am a bit puzzled that it seems there is actually no detailed spec AFAICT, but the most authoritative resource I know of is the [node.js docs on exports](https://nodejs.org/api/packages.html#package-entry-points). Correct me if I'm wrong, but I don't think any of the following things that we had in tests are actually supported:
* use of multiple `*` wildcards. Node docs and every example I have ever seen only shows a single wildcard, also `resolve.exports` assumes that [here](https://github.com/lukeed/resolve.exports/blob/master/src/utils.ts#L43)
* use of globs like `**/*`
* some assumption that a path ending with a slash would cover deeper paths. Like `'./prefix/deep/': './other-directory/'` would map `my-addon/prefix/deep/foo/bar.js` to `./other-directory/foo/bar.js`. That is not the case, that is what you use wildcards for.