### PR TITLE
Terser by default in prod

### DIFF
--- a/packages/vite/src/ember.ts
+++ b/packages/vite/src/ember.ts
@@ -55,6 +55,7 @@ export function ember() {
         if (!config.build) {
           config.build = {};
         }
+
         if (!config.build.rollupOptions) {
           config.build.rollupOptions = {};
         }
@@ -83,6 +84,25 @@ export function ember() {
         // by babel, because we don't want esbuild's decorator implementation.
         if (config.esbuild == null) {
           config.esbuild = false;
+        }
+
+        /**
+         * These settings are only used when mode === production
+         */
+        if (!config.build.minify) {
+          config.build.minify = 'terser';
+        }
+
+        if (config.build.minify === 'terser' && !config.build.terserOptions) {
+          config.build.terserOptions = {
+            module: true,
+            compress: {
+              passes: 3,
+              keep_fargs: false,
+              keep_fnames: false,
+              toplevel: true,
+            },
+          };
         }
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1760,6 +1760,9 @@ importers:
       stylelint-prettier:
         specifier: ^3.0.0
         version: 3.0.0(prettier@2.8.8)(stylelint@15.11.0)
+      terser:
+        specifier: ^5.7.0
+        version: 5.39.0
       tracked-built-ins:
         specifier: ^3.1.1
         version: 3.4.0(@babel/core@7.26.10)
@@ -1835,9 +1838,12 @@ importers:
       qunit-dom:
         specifier: ^3.4.0
         version: 3.4.0
+      terser:
+        specifier: ^5.7.0
+        version: 5.39.0
       vite:
         specifier: ^5.0.9
-        version: 5.4.17
+        version: 5.4.17(terser@5.39.0)
 
   tests/fixtures: {}
 
@@ -2137,7 +2143,7 @@ importers:
         version: 5.8.3
       vite-5:
         specifier: npm:vite@^5.0.0
-        version: /vite@5.4.17
+        version: /vite@5.4.17(terser@5.39.0)
       vite-6:
         specifier: npm:vite@^6.1.0
         version: /vite@6.2.5(terser@5.39.0)
@@ -2306,6 +2312,9 @@ importers:
       stylelint-prettier:
         specifier: ^4.0.2
         version: 4.1.0(prettier@3.5.3)(stylelint@15.11.0)
+      terser:
+        specifier: ^5.7.0
+        version: 5.39.0
       tracked-built-ins:
         specifier: ^3.2.0
         version: 3.4.0(@babel/core@7.26.10)
@@ -26021,7 +26030,7 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /vite@5.4.17:
+  /vite@5.4.17(terser@5.39.0):
     resolution: {integrity: sha512-5+VqZryDj4wgCs55o9Lp+p8GE78TLVg0lasCH5xFZ4jacZjtqZa6JUw9/p0WeAojaOfncSM6v77InkFPGnvPvg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -26055,6 +26064,7 @@ packages:
       esbuild: 0.21.5
       postcss: 8.5.3
       rollup: 4.39.0
+      terser: 5.39.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true

--- a/tests/app-template-minimal/package.json
+++ b/tests/app-template-minimal/package.json
@@ -47,6 +47,7 @@
     "ember-source": "6.3.0-alpha.3",
     "qunit": "^2.19.4",
     "qunit-dom": "^3.4.0",
+    "terser": "^5.7.0",
     "vite": "^5.0.9"
   },
   "engines": {

--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -47,8 +47,8 @@
     "@rollup/plugin-babel": "^5.3.1",
     "babel-plugin-ember-template-compilation": "^2.3.0",
     "concurrently": "^8.2.0",
-    "ember-auto-import": "^2.6.3",
     "decorator-transforms": "^2.0.0",
+    "ember-auto-import": "^2.6.3",
     "ember-cli": "~5.0.0",
     "ember-cli-app-version": "^6.0.0",
     "ember-cli-babel": "^7.26.11",
@@ -77,6 +77,7 @@
     "stylelint": "^15.7.0",
     "stylelint-config-standard": "^33.0.0",
     "stylelint-prettier": "^3.0.0",
+    "terser": "^5.7.0",
     "tracked-built-ins": "^3.1.1",
     "vite": "^6.0.0"
   },

--- a/tests/ts-app-template/package.json
+++ b/tests/ts-app-template/package.json
@@ -82,6 +82,7 @@
     "stylelint": "^15.10.3",
     "stylelint-config-standard": "^34.0.0",
     "stylelint-prettier": "^4.0.2",
+    "terser": "^5.7.0",
     "tracked-built-ins": "^3.2.0",
     "typescript": "^5.4.5",
     "vite": "^6.0.0",


### PR DESCRIPTION
Normally esbuild is used for minification -- but we disabled it.

This PR enables terser, and configures multi-pass mode so that we have proper DCE for our dev tools (assert, etc)


minimal app:
before:
```
✓ 141 modules transformed.
dist/@embroider/virtual/vendor.js       0.02 kB
dist/index.html                         0.41 kB │ gzip:   0.26 kB
dist/@embroider/virtual/vendor.css      0.00 kB │ gzip:   0.02 kB
dist/assets/main-DdpU0Dsm.css           0.03 kB │ gzip:   0.05 kB
dist/assets/main-D0ol2zb2.js        1,140.11 kB │ gzip: 290.61 kB
```

after:
```
✓ 141 modules transformed.
dist/@embroider/virtual/vendor.js     0.02 kB
dist/index.html                       0.41 kB │ gzip:   0.26 kB
dist/@embroider/virtual/vendor.css    0.00 kB │ gzip:   0.02 kB
dist/assets/main-DdpU0Dsm.css         0.03 kB │ gzip:   0.05 kB
dist/assets/main-6NALA_VY.js        493.76 kB │ gzip: 125.89 kB
✓ built in 3.02s
```