### PR TITLE
fix: ensure minify can be disabled

### DIFF
--- a/packages/vite/src/ember.ts
+++ b/packages/vite/src/ember.ts
@@ -107,7 +107,7 @@ function minification(config: UserConfig, mode: string) {
    */
   config.build ||= {};
 
-  if (config.build.minify === undefined) {
+  if (config.build.minify === undefined || config.build.minify === true) {
     config.build.minify = 'terser';
   }
 

--- a/packages/vite/src/ember.ts
+++ b/packages/vite/src/ember.ts
@@ -107,7 +107,7 @@ function minification(config: UserConfig, mode: string) {
    */
   config.build ||= {};
 
-  if (!config.build.minify) {
+  if (config.build.minify === undefined) {
     config.build.minify = 'terser';
   }
 


### PR DESCRIPTION
Allows for users to disable `minify` whenever they wish. Currently if you set it to `false`, embroider/vite will turn it back on again.