### PR TITLE
Vite build should resolve ember-cli from working dir

### DIFF
--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -11,7 +11,7 @@ export function emberBuild(command: string, mode: string, resolvableExtensions: 
     EMBROIDER_PREBUILD: 'true',
   };
 
-  let emberCLIMain = require.resolve('ember-cli');
+  let emberCLIMain = require.resolve('ember-cli', { paths: [process.cwd()] });
   if (!emberCLIMain) {
     throw new Error('Could not resolve ember-cli');
   }


### PR DESCRIPTION
ember-cli is not a dep or peerDep of @embroider/vite so it's wrong to try to resolve it directly.