### PR TITLE
Propagate other plugin's custom metadata

### DIFF
--- a/packages/vite/src/request.ts
+++ b/packages/vite/src/request.ts
@@ -49,7 +49,7 @@ export class RollupRequestAdapter implements RequestAdapter<Resolution<ResolveId
 
       return {
         initialState: { specifier: cleanSource, fromFile, meta: custom?.embroider?.meta },
-        adapter: new RollupRequestAdapter(context, queryParams, importerQueryParams),
+        adapter: new RollupRequestAdapter(context, queryParams, importerQueryParams, custom),
       };
     }
   };
@@ -57,7 +57,8 @@ export class RollupRequestAdapter implements RequestAdapter<Resolution<ResolveId
   private constructor(
     private context: PluginContext,
     private queryParams: string,
-    private importerQueryParams: string
+    private importerQueryParams: string,
+    private custom: Record<string, unknown> | undefined
   ) {}
 
   get debugType() {
@@ -106,6 +107,7 @@ export class RollupRequestAdapter implements RequestAdapter<Resolution<ResolveId
       {
         skipSelf: true,
         custom: {
+          ...this.custom,
           embroider: {
             enableCustomResolver: false,
             meta: request.meta,


### PR DESCRIPTION
This silences the warning:

> [plugin commonjs--resolver] It appears a plugin has implemented a "resolveId" hook that uses "this.resolve" without forwarding the third "options" parameter of "resolveId". This is problematic as it can lead to wrong module resolutions especially for the node-resolve plugin and in certain cases cause early exit errors for the commonjs plugin.
In rare cases, this warning can appear if the same file is both imported and required from the same mixed ES/CommonJS module, in which case it can be ignored.