### PR TITLE
Fix merge-history commands (remove `)

### DIFF
--- a/packages/template-tag-codemod/README.md
+++ b/packages/template-tag-codemod/README.md
@@ -135,8 +135,8 @@ Pass `--defaultFormat gts` instead if you prefer to produce typescript. Also see
 The `merge-history` command takes a branch where the codemod has already been applied and produces a new branch with the same contents, except that the Git history has been adjusted so that your GJS files inherit correctly from *both* the JS and HBS files that they replaced. Example:
 
 ```sh
-npx @embroider/template-tag-codemod merge-history --help`
-npx @embroider/template-tag-codemod merge-history main your-codemodded-branch --outputBranch better-codemodded-branch`
+npx @embroider/template-tag-codemod merge-history --help
+npx @embroider/template-tag-codemod merge-history main your-codemodded-branch --outputBranch better-codemodded-branch
 git push -u origin better-codemodded-branch
 ```
 


### PR DESCRIPTION
Before:
![grafik](https://github.com/user-attachments/assets/04ec5933-9f6b-46c0-bb25-c55645cda744)


After:
![grafik](https://github.com/user-attachments/assets/48e3914d-c68e-4114-9023-235090bf9b4e)