### PR TITLE
Remove auto-import from the app-template

### DIFF
--- a/tests/app-template/package.json
+++ b/tests/app-template/package.json
@@ -48,7 +48,6 @@
     "babel-plugin-ember-template-compilation": "^3.0.0",
     "concurrently": "^8.2.0",
     "decorator-transforms": "^2.0.0",
-    "ember-auto-import": "^2.6.3",
     "ember-cli": "~5.0.0",
     "ember-cli-app-version": "^6.0.0",
     "ember-cli-babel": "^7.26.11",


### PR DESCRIPTION
This is the repro that @ef4 asked for in https://github.com/embroider-build/ember-auto-import/pull/659