### PR TITLE
Fix loading route in @embroider/router

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -144,13 +144,14 @@ if (macroCondition(getGlobalConfig<GlobalConfig>()['@embroider/core']?.active ??
     }
 
     private _handlerResolver(this: this & Internals, original: (name: string) => unknown) {
-      let handler = (async (name: string) => {
+      let handler = ((name: string) => {
         const bundle = this.lazyRoute(name) ?? this.lazyEngine(name);
         this.seenByRoute.add(name);
         if (bundle) {
-          await this.registerBundle(bundle);
+          return this.registerBundle(bundle).then(() => original(name));
+        } else {
+          return original(name);
         }
-        return original(name);
       }) as GetRoute;
       handler.isEmbroiderRouterHandler = true;
       return handler;


### PR DESCRIPTION
Fixes #2496

The hook we're overriding is allowed to return a promise, but it turns out the ember router makes assumptions so that returning a promise doesn't work in all cases. This returns to the behavior we had before 3.0.1 where synchronously available routes are returned synchronously without being wrapped in a promise.