### PR TITLE
POC: Provide explicit overloads for the specific uses of importSync mentioned in deprecation guides

### DIFF
--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -49,6 +49,8 @@
     "@types/babel__generator": "^7.6.2",
     "@types/babel__template": "^7.4.0",
     "@types/babel__traverse": "^7.18.5",
+    "@types/ember__application": "^4.0.0",
+    "@types/ember__owner": "^4.0.0",
     "@types/lodash": "^4.14.170",
     "@types/node": "^22.9.3",
     "@types/resolve": "^1.20.0",

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -31,6 +31,16 @@ export function each<T>(array: T[]): T[] {
 // We would prefer to write:
 //   export function importSync<T extends string>(specifier: T): typeof import(T) {
 // but TS doesn't seem to support that at present.
+//
+// Though, we should at least provide explicit overloads for the specific uses of importSync
+// that are mentioned in official guides, such as deprecation guides.
+// See e.g. https://deprecations.emberjs.com/id/deprecate-import-get-owner-from-ember
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+export function importSync(specifier: '@ember/owner'): typeof import('@ember/owner');
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+export function importSync(specifier: '@ember/application'): typeof import('@ember/application');
+
 export function importSync(specifier: string): unknown {
   throw new Oops(specifier);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,10 +95,10 @@ importers:
         version: 1.5.2(typescript@5.9.2)
       '@glint/environment-ember-loose':
         specifier: ^1.5.0
-        version: 1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
+        version: 1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
       '@glint/environment-ember-template-imports':
         specifier: ^1.5.0
-        version: 1.5.2(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)
+        version: 1.5.2(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))
       '@glint/template':
         specifier: ^1.5.0
         version: 1.5.2
@@ -621,6 +621,12 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.18.5
         version: 7.28.0
+      '@types/ember__application':
+        specifier: ^4.0.0
+        version: 4.0.11(@babel/core@7.28.0)
+      '@types/ember__owner':
+        specifier: ^4.0.0
+        version: 4.0.9
       '@types/lodash':
         specifier: ^4.14.170
         version: 4.17.20
@@ -1774,7 +1780,7 @@ importers:
         version: 7.28.2
       '@ember/legacy-built-in-components':
         specifier: ^0.4.1
-        version: 0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/string':
         specifier: ^3.0.0
         version: 3.1.1
@@ -1840,7 +1846,7 @@ importers:
         version: 3.0.0
       ember-bootstrap:
         specifier: ^5.0.0
-        version: 5.1.1(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+        version: 5.1.1(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       ember-cli-3.28:
         specifier: npm:ember-cli@~3.28.0
         version: ember-cli@3.28.6(babel-core@6.26.3)(encoding@0.1.13)(handlebars@4.7.8)(underscore@1.13.7)
@@ -1864,31 +1870,31 @@ importers:
         version: ember-cli@6.7.0-beta.1(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7)
       ember-cli-fastboot:
         specifier: ^4.1.1
-        version: 4.1.5(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 4.1.5(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-latest:
         specifier: npm:ember-cli@latest
         version: ember-cli@6.6.0(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7)
       ember-data:
         specifier: ~3.28.0
-        version: 3.28.13(@babel/core@7.28.0)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.28.13(@babel/core@7.28.0)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-data-4.12:
         specifier: npm:ember-data@~4.12.0
-        version: ember-data@4.12.8(@babel/core@7.28.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+        version: ember-data@4.12.8(@babel/core@7.28.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       ember-data-4.4:
         specifier: npm:ember-data@~4.4.0
-        version: ember-data@4.4.3(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+        version: ember-data@4.4.3(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       ember-data-4.8:
         specifier: npm:ember-data@~4.8.0
-        version: ember-data@4.8.8(@babel/core@7.28.0)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+        version: ember-data@4.8.8(@babel/core@7.28.0)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       ember-data-5.3:
         specifier: npm:ember-data@~5.3.13
-        version: ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)
+        version: ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)
       ember-data-latest:
         specifier: npm:ember-data@~5.5.0
-        version: ember-data@5.5.0(@ember/string@3.1.1)(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)
+        version: ember-data@5.5.0(@ember/string@3.1.1)(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)
       ember-engines:
         specifier: ^0.8.23
-        version: 0.8.23(@ember/legacy-built-in-components@0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 0.8.23(@ember/legacy-built-in-components@0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-inline-svg:
         specifier: ^0.2.1
         version: 0.2.1(@babel/core@7.28.0)
@@ -1897,10 +1903,10 @@ importers:
         version: 4.2.2(@babel/core@7.28.0)
       ember-page-title:
         specifier: ^8.2.3
-        version: 8.2.4(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 8.2.4(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-qunit-6:
         specifier: npm:ember-qunit@^6.0.0
-        version: ember-qunit@6.2.0(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)(webpack@5.101.0)
+        version: ember-qunit@6.2.0(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)(webpack@5.101.0)
       ember-source-3.28:
         specifier: npm:ember-source@~3.28.11
         version: ember-source@3.28.12(@babel/core@7.28.0)
@@ -1927,7 +1933,7 @@ importers:
         version: ember-source@6.7.0-beta.1(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-canary:
         specifier: npm:ember-source@alpha
-        version: ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-latest:
         specifier: npm:ember-source@latest
         version: ember-source@6.6.0(@glimmer/component@2.0.0)(rsvp@4.8.5)
@@ -1936,7 +1942,7 @@ importers:
         version: 4.3.0
       ember-test-helpers-2:
         specifier: npm:@ember/test-helpers@^2.0.0
-        version: '@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))'
+        version: '@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))'
       ember-truth-helpers:
         specifier: ^3.0.0
         version: 3.1.1
@@ -2041,7 +2047,7 @@ importers:
         version: 1.1.2
       '@glint/environment-ember-loose':
         specifier: ^1.1.0
-        version: 1.5.2(@glimmer/component@1.1.2(@babel/core@7.28.0))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
+        version: 1.5.2(@glimmer/component@1.1.2(@babel/core@7.28.0))(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
       '@glint/template':
         specifier: ^1.1.0
         version: 1.5.2
@@ -2209,7 +2215,7 @@ importers:
         version: 1.1.2
       '@glint/environment-ember-loose':
         specifier: ^1.1.0
-        version: 1.5.2(@glimmer/component@1.1.2(@babel/core@7.28.0))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
+        version: 1.5.2(@glimmer/component@1.1.2(@babel/core@7.28.0))(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
       '@glint/template':
         specifier: ^1.1.0
         version: 1.5.2
@@ -4054,6 +4060,10 @@ packages:
     resolution: {integrity: sha512-SrWiaKM3AND2FQ732wtjAKol7XhCnRqit3tJShG4X0mT27Jb3zuhTI2dkfYVVMTJ23pjT/+0y+s/uGaBSirnBg==}
     engines: {node: '>= 18.0.0'}
 
+  '@glimmer/compiler@0.94.11':
+    resolution: {integrity: sha512-t9eyLZIFsiwAib8Zyfu67yBep5Vn2bd5DScIE2hharPE/OKKI7cpQYi6BzQhSGYEBVU82ITd/2TLvJ1K8eIahA==}
+    engines: {node: '>= 18.0.0'}
+
   '@glimmer/component@1.1.2':
     resolution: {integrity: sha512-XyAsEEa4kWOPy+gIdMjJ8XlzA3qrGH55ZDv6nA16ibalCR17k74BI0CztxuRds+Rm6CtbUVgheCVlcCULuqD7A==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -4155,6 +4165,9 @@ packages:
   '@glimmer/manager@0.92.4':
     resolution: {integrity: sha512-YMoarZT/+Ft2YSd+Wuu5McVsdP9y6jeAdVQGYFpno3NlL3TXYbl7ELtK7OGxFLjzQE01BdiUZZRvcY+a/s9+CQ==}
 
+  '@glimmer/manager@0.94.10':
+    resolution: {integrity: sha512-Hqi92t6vtVg4nSRGWTvCJ+0Vg3iF1tiTG9RLzuUtZac7DIAzuQAxjhGbtu82miT+liCqU+MFmB3nkfNH0Zz74g==}
+
   '@glimmer/manager@0.94.9':
     resolution: {integrity: sha512-AQT90eSRbgx6O4VnyRgR+y3SqKChPrpZs5stENa0UnqOSbt7dF6XdqAmllfznKFpLlKmJSV7JaVpCarVTR/JQQ==}
 
@@ -4170,6 +4183,9 @@ packages:
   '@glimmer/node@0.92.4':
     resolution: {integrity: sha512-a5GME7HQJZFJPQDdSetQI6jjKXXQi0Vdr3WuUrYwhienVTV5LG0uClbFE2yYWC7TX97YDHpRrNk1CC258rujkQ==}
 
+  '@glimmer/node@0.94.10':
+    resolution: {integrity: sha512-8kw6K+RoKhjfprMO059M7x5yRZRK7WGLzD2056/G+65wV7gnJVDuh4qQirekaagjtskz6OdRBVWrSmrbICWtzQ==}
+
   '@glimmer/node@0.94.9':
     resolution: {integrity: sha512-X90Xyru/TNi/ocq27ttT4zlMGK931J+pGL0eDYEkUX2fJYHd9Wm1idAB7MLJYIJarv/kuoxteiGThGIYkeNVaQ==}
 
@@ -4184,6 +4200,9 @@ packages:
 
   '@glimmer/opcode-compiler@0.92.4':
     resolution: {integrity: sha512-WnZSBwxNqW/PPD/zfxEg6BVR5tHwTm8fp76piix8BNCQ6CuzVn6HUJ5SlvBsOwyoRCmzt/pkKmBJn+I675KG4w==}
+
+  '@glimmer/opcode-compiler@0.94.10':
+    resolution: {integrity: sha512-KYsaODjkgtpUzMR1chyI0IRcvo4ewnjW8Dy+5833+OIG7rx6INl7HvKtooLzjHv+uJOZ74fd/s/0XfaY6eNEww==}
 
   '@glimmer/opcode-compiler@0.94.9':
     resolution: {integrity: sha512-LlBniSmtBoIlkxzPKHyOw4Nj946Cczelo8RAnqoG/egkHuk4hoO/7ycSgNpPvV3G14BA4Fpy5ExBffx6iuRxQQ==}
@@ -4215,6 +4234,9 @@ packages:
   '@glimmer/program@0.92.4':
     resolution: {integrity: sha512-fkquujQ11lsGCWl/+XpZW2E7bjHj/g6/Ht292A7pSoANBD8Bz/gPYiPM+XuMwes9MApEsTEMjV4EXlyk2/Cirg==}
 
+  '@glimmer/program@0.94.10':
+    resolution: {integrity: sha512-a5rpsvBwrcAn0boV4ONy+dHr8tWSTvLAPTR1T1KxF0OBHRVciCAfBPRFemVO6Q3H117At9ifn3uoevtQ6H0M+Q==}
+
   '@glimmer/program@0.94.9':
     resolution: {integrity: sha512-KA3TXYL2iDdR92pPnB/sw1tgIC7B40l2P60iD1sqkYbyxAbrUPHSToA1ycmK4DwmxDOT3Hz9dvpceoCMbh0xjA==}
 
@@ -4236,6 +4258,9 @@ packages:
   '@glimmer/reference@0.94.8':
     resolution: {integrity: sha512-FPoXBRMXJupO9nAq/Vw3EY/FCY3xbd+VALqZupyu6ds9vjNiKAkD9+ujIjYa1f+d/ez2ONhy8QjEFoBsyW2flA==}
 
+  '@glimmer/reference@0.94.9':
+    resolution: {integrity: sha512-qlgTYxgEOpgxuyb13u2qwqhibpfktlk08F+nfwuNxtuhodsItBi3YxjFMPrVP0zOjTnhUObR8OYtMsD5WFOddA==}
+
   '@glimmer/runtime@0.84.2':
     resolution: {integrity: sha512-mUefYwq8l4df61iWYsRKVYQUqAeCgeZ3fuYNRNbvKDudnT9bQXayJLqr6ZxwTVaDoeKjg+7lMjkDSDSvqoxfsA==}
 
@@ -4250,6 +4275,9 @@ packages:
 
   '@glimmer/runtime@0.94.10':
     resolution: {integrity: sha512-eRe9TmP02ESVXJn2ZOOEm/Hm/Ro7X0kRvZsU8OVtXOqWU8JxeKMwjCEiLbJBQKbYfycRy1u8jZ2wuH0qM/d3EQ==}
+
+  '@glimmer/runtime@0.94.11':
+    resolution: {integrity: sha512-96PqfxnkEW8k8dMydDmaXgijD7yvtIfjMkHoJ7ljUmE1icZ7jj6f+UIZ0LThpXMzkKaBe1xEapjr91Ldsvmqbg==}
 
   '@glimmer/syntax@0.65.4':
     resolution: {integrity: sha512-y+/C3e8w96efk3a/Z5If9o4ztKJwrr8RtDpbhV2J8X+DUsn5ic2N3IIdlThbt/Zn6tkP1K3dY6uaFUx3pGTvVQ==}
@@ -4268,6 +4296,9 @@ packages:
 
   '@glimmer/syntax@0.94.9':
     resolution: {integrity: sha512-OBw8DqMzKO4LX4kJBhwfTUqtpbd7O9amQXNTfb1aS7pufio5Vu5Qi6mRTfdFj6RyJ//aSI/l0kxWt6beYW0Apg==}
+
+  '@glimmer/syntax@0.95.0':
+    resolution: {integrity: sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==}
 
   '@glimmer/tracking@1.1.2':
     resolution: {integrity: sha512-cyV32zsHh+CnftuRX84ALZpd2rpbDrhLhJnTXn9W//QpqdRZ5rdMsxSY9fOsj0CKEc706tmEU299oNnDc0d7tA==}
@@ -4314,6 +4345,9 @@ packages:
   '@glimmer/validator@0.94.8':
     resolution: {integrity: sha512-vTP6hAcrxE5/0dG2w+tHSteXxgWmkBwMzu5ZTxMg+EkqthWl8B5r5skLiviQ6SdKAOBJGhzf6tF4ltHo5y83hQ==}
 
+  '@glimmer/validator@0.95.0':
+    resolution: {integrity: sha512-xF3K5voKeRqhONztfMHDd2wHDYD6UUI9pFPd+RMGtW6DXYv31G0zUm2pGsOwQ9dyNeE6khaXy7e3FtNjDrSmvQ==}
+
   '@glimmer/vm-babel-plugins@0.77.5':
     resolution: {integrity: sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==}
 
@@ -4339,6 +4373,10 @@ packages:
 
   '@glimmer/vm-babel-plugins@0.93.4':
     resolution: {integrity: sha512-+MjT+U/MsP7O32rXTYlvcmuiKtwI/PflokpVIW0M9wrkfFrsqgdhLQKvA+tNNxFW9LQ55zbhOtJweFNblHOvxg==}
+    engines: {node: '>=18.18.0'}
+
+  '@glimmer/vm-babel-plugins@0.93.5':
+    resolution: {integrity: sha512-xwVRgDjuadOB9qV1jyTKBrUgE/cpmixD/wIYnFf4+hNJRD39urteKRPw98xJSAt7Bw/6y5B8zsgwFS18Nknlrg==}
     engines: {node: '>=18.18.0'}
 
   '@glimmer/vm@0.84.2':
@@ -4436,6 +4474,10 @@ packages:
 
   '@handlebars/parser@2.0.0':
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
+
+  '@handlebars/parser@2.2.1':
+    resolution: {integrity: sha512-D76vKOZFEGA9v6g0rZTYTQDUXNopCblW1Zeas3EEVrbdeh8gWrCEO9/goocKmcgtqAwv1Md76p58UQp7HeFTEw==}
+    engines: {node: ^18 || ^20 || ^22 || >=24}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -5156,6 +5198,60 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/ember@4.0.11':
+    resolution: {integrity: sha512-v7VIex0YILK8fP87LkIfzeeYKNnu74+xwf6U56v6MUDDGfSs9q/6NCxiUfwkxD+z5nQiUcwvfKVokX8qzZFRLw==}
+
+  '@types/ember__application@4.0.11':
+    resolution: {integrity: sha512-U1S7XW0V70nTWbFckWoraJbYGBJK69muP/CsPFLeAuUYHfkkDiwh1SfqgAUN9aHtrEJM5SuSYVYp2YsTI2yLuA==}
+
+  '@types/ember__array@4.0.10':
+    resolution: {integrity: sha512-UrhDbopLI3jB0MqV14y8yji2IuPNmeDrtT1PRYJL4CThLHrRkfeYyFvxqvrxWxn0wXKjbbjfH1gOe7BU57QrLQ==}
+
+  '@types/ember__component@4.0.22':
+    resolution: {integrity: sha512-m72EtmBN/RxOChXqRsyOg4RR5+AiB4LQ8s1CEKNYAfvANt18m4hjqxtA7QZYLTq2ZjEVJGpdMsrdDuONWjwRSQ==}
+
+  '@types/ember__controller@4.0.12':
+    resolution: {integrity: sha512-80rdnSC0UJBqoUX5/vkQcM2xkRdTPTvY0dPXEfY5cC5OZITbcSeRo5qa7ZGhgNBfH6XYyh55Lo/b811LwU3N9w==}
+
+  '@types/ember__debug@4.0.8':
+    resolution: {integrity: sha512-9wF7STmDHDsUxSjyCq2lpMq/03QOPkBQMGJnV8yOBnVZxB6f+FJH/kxaCprdMkUe7iwAPNEC2zrFFx1tzH75Kg==}
+
+  '@types/ember__engine@4.0.11':
+    resolution: {integrity: sha512-ryR4Q1Xm3kQ3Ap58w10CxV3+vb3hs1cJqi7UZ5IlSdLRql7AbpS6hIjxSQ3EQ4zadeeJ6/D8JJcSwqR7eX3PFA==}
+
+  '@types/ember__error@4.0.6':
+    resolution: {integrity: sha512-vYrLaGGjHkN14K89Vm8yqB2mkpJQefE5w7QJkkgYyV+smzns1vKlPbvuFevRtoeYNn4u4yY0JyF7HceNkm3H0Q==}
+
+  '@types/ember__object@4.0.12':
+    resolution: {integrity: sha512-ZEpikPjZ02m1QCBiTPTayMJwVwF4UBlHlGDoScRB3IP/SUS1O5mmn1/CnSQDxzzF3ctfmhNuTZzVBBc1Y8OC1A==}
+
+  '@types/ember__owner@4.0.9':
+    resolution: {integrity: sha512-iyBda4aUIjBmeiKTKmPow/EJO7xWn8m85CnQTOCqQzTWJyJpgfObbXSHahOHXOfMm279Oa5NlbmS/EontB+XiQ==}
+
+  '@types/ember__polyfills@4.0.6':
+    resolution: {integrity: sha512-hbds3Qv+oVm/QKIaY1E6atvrCoJTH/MPSl4swOhX6P0RiMB2fOfFCrFSD1mP1KrU1LqpHJ2Rzs7XLe53SWVzgw==}
+
+  '@types/ember__routing@4.0.22':
+    resolution: {integrity: sha512-qLk9Vd2GMxdlGmX9xbzg4Farths+AQGzYDH901Wo2Nsre+Cwv1Tk1rbCiay2V3ICYZYufytdWT6V++DISF3nvw==}
+
+  '@types/ember__runloop@4.0.10':
+    resolution: {integrity: sha512-9MZfOJBXuUP7RqLjovmzy1yY2xKTxVpqHMapqy6QJ8mjAekRmq9IJ+ni2zJ5CWftyb3Lqu3Eks05CL7fnbhcJA==}
+
+  '@types/ember__service@4.0.9':
+    resolution: {integrity: sha512-DrepocL/4hH5YxbDWbxEKMDcAchBPSGGa4g+LEINW1Po81RmSdKw5GZV4UO0mvRWgkdu3EbWUxbTzB4gmbDSeQ==}
+
+  '@types/ember__string@3.0.15':
+    resolution: {integrity: sha512-SxoaweAJUJKSIt82clIwpi/Fm0IfeisozLnXthnBp/hE2JyVcnOb1wMIbw0CCfzercmyWG1njV45VBqy8SrLDQ==}
+
+  '@types/ember__template@4.0.7':
+    resolution: {integrity: sha512-jv4hhG+8d1zdma+jhbCdJ3Ak7C22YNatGyWWvB3N9zbXq358AAPXaJoyNY8QTDbD/RIR9P6yoRk4u9vLbF6zfA==}
+
+  '@types/ember__test@4.0.6':
+    resolution: {integrity: sha512-Nswm/epfTepXknT8scZvWyyop1aqJcZcyzY4THGHFcXvYQQfA9rgmgrx6vo9vCJmYHh3jm0TTAIAIfoCvGaX5g==}
+
+  '@types/ember__utils@4.0.7':
+    resolution: {integrity: sha512-qQPBeWRyIPigKnZ68POlkqI5e6XA78Q4G3xHo687wQTcEtfoL/iZyPC4hn70mdijcZq8Hjch2Y3E5yhsEMzK+g==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -7946,8 +8042,8 @@ packages:
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
 
-  ember-source@6.8.0-alpha.2:
-    resolution: {integrity: sha512-1qENLFfF9vI6xguXBh6MYGsQGktkjbIKrJXd937POfcwii6s309hA5FRu04mA4/zpDvGaebBnwGbZRQ681co9w==}
+  ember-source@6.8.0-alpha.4:
+    resolution: {integrity: sha512-SuUm97vgCfRnVAyPRQt+Kk4veHZ7D9DQw07PciyGBLmDeJgPuTmvmUYtkA4rJQN91bL7X+REL+PFxkvgrCzXSA==}
     engines: {node: '>= 18.*'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
@@ -11250,6 +11346,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:
@@ -14642,15 +14739,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/adapter@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))':
+  '@ember-data/adapter@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -14671,27 +14768,27 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/adapter@4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(webpack@5.101.0)':
+  '@ember-data/adapter@4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(webpack@5.101.0)':
     dependencies:
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  '@ember-data/adapter@5.3.13(1cb068e4cdf195d7484be05bead75e79)':
+  '@ember-data/adapter@5.3.13(f79f680031eb84d417963b73eb78207f)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.13(9143dc8d740020cca93344469531bdeb)
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/legacy-compat': 5.3.13(f12a434a34830d31eb3954af23c52d77)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
@@ -14699,16 +14796,16 @@ snapshots:
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/adapter@5.5.0(af903faa4850b72b124e7311a18e9fdc)':
+  '@ember-data/adapter@5.5.0(a465452427001a8e4b7eb743f47bb8b8)':
     dependencies:
-      '@ember-data/legacy-compat': 5.5.0(afc55c401b70604f1a249051fa4abd27)
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/legacy-compat': 5.5.0(855ca77b89e368196263f3571545284f)
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
@@ -14716,7 +14813,7 @@ snapshots:
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -14758,7 +14855,7 @@ snapshots:
   '@ember-data/debug@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(webpack@5.101.0)':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
@@ -14797,30 +14894,30 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/debug@5.3.13(2fcca3d418937ea139bb2d403f632c2a)':
+  '@ember-data/debug@5.3.13(b4e00bef4ee904d17149939c2cce4649)':
     dependencies:
-      '@ember-data/model': 5.3.13(e90ae7c768bea556b41910ffd6eea7c5)
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/model': 5.3.13(189578edb9a2ba73d1a34a4b52a3d814)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/debug@5.5.0(d15746374d9b3ed10d7e0cdc22652e95)':
+  '@ember-data/debug@5.5.0(4eb0df899d6188f2adc15ee0c73ef098)':
     dependencies:
-      '@ember-data/model': 5.5.0(e3579d8366593afc8ec289d2f1844cff)
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/model': 5.5.0(47f9e5bab338a153fd33863cdf3e6db1)
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -14828,7 +14925,7 @@ snapshots:
   '@ember-data/graph@4.12.8(@ember-data/store@4.12.8)(@glint/template@1.5.2)':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-cli-babel: 7.26.11
@@ -14836,20 +14933,20 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember-data/graph@5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))':
+  '@ember-data/graph@5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))':
     dependencies:
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
@@ -14861,7 +14958,7 @@ snapshots:
     dependencies:
       '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.5.2)
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-cli-babel: 7.26.11
@@ -14869,11 +14966,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@5.3.13(1aaa9a7aa03bc9ee25d36ac2cff4592c)':
+  '@ember-data/json-api@5.3.13(52f4db880c578edbf75fab0d7a8d6c83)':
     dependencies:
-      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
@@ -14883,11 +14980,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@5.5.0(2e49a201e350068aaa5a0c1a46335656)':
+  '@ember-data/json-api@5.5.0(3a249b2a4422677ffcfb116f5304533b)':
     dependencies:
-      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
@@ -14910,36 +15007,36 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@5.3.13(9143dc8d740020cca93344469531bdeb)':
+  '@ember-data/legacy-compat@5.3.13(f12a434a34830d31eb3954af23c52d77)':
     dependencies:
       '@ember-data/request': 5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/json-api': 5.3.13(1aaa9a7aa03bc9ee25d36ac2cff4592c)
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/json-api': 5.3.13(52f4db880c578edbf75fab0d7a8d6c83)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@5.5.0(afc55c401b70604f1a249051fa4abd27)':
+  '@ember-data/legacy-compat@5.5.0(855ca77b89e368196263f3571545284f)':
     dependencies:
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
-      '@ember-data/json-api': 5.5.0(2e49a201e350068aaa5a0c1a46335656)
+      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
+      '@ember-data/json-api': 5.5.0(3a249b2a4422677ffcfb116f5304533b)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -14962,20 +15059,20 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/model@4.12.8(@babel/core@7.28.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember-data/model@4.12.8(@babel/core@7.28.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember-data/tracking': 4.12.8(@glint/template@1.5.2)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       inflection: 2.0.1
     optionalDependencies:
       '@ember-data/debug': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(webpack@5.101.0)
@@ -15008,22 +15105,22 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/model@4.8.8(@babel/core@7.28.0)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)':
+  '@ember-data/model@4.8.8(@babel/core@7.28.0)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)':
     dependencies:
       '@ember-data/canary-features': 4.8.8(@glint/template@1.5.2)
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       '@ember-data/tracking': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
       ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       inflection: 1.13.4
     optionalDependencies:
       '@ember-data/record-data': 4.8.8(@ember-data/store@4.8.8)(@glint/template@1.5.2)(webpack@5.101.0)
@@ -15034,43 +15131,43 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/model@5.3.13(e90ae7c768bea556b41910ffd6eea7c5)':
+  '@ember-data/model@5.3.13(189578edb9a2ba73d1a34a4b52a3d814)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.13(9143dc8d740020cca93344469531bdeb)
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/tracking': 5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/legacy-compat': 5.3.13(f12a434a34830d31eb3954af23c52d77)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/tracking': 5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       inflection: 3.0.2
     optionalDependencies:
-      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/json-api': 5.3.13(1aaa9a7aa03bc9ee25d36ac2cff4592c)
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/json-api': 5.3.13(52f4db880c578edbf75fab0d7a8d6c83)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@5.5.0(e3579d8366593afc8ec289d2f1844cff)':
+  '@ember-data/model@5.5.0(47f9e5bab338a153fd33863cdf3e6db1)':
     dependencies:
-      '@ember-data/legacy-compat': 5.5.0(afc55c401b70604f1a249051fa4abd27)
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/legacy-compat': 5.5.0(855ca77b89e368196263f3571545284f)
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       inflection: 3.0.2
     optionalDependencies:
-      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
-      '@ember-data/json-api': 5.5.0(2e49a201e350068aaa5a0c1a46335656)
+      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
+      '@ember-data/json-api': 5.5.0(3a249b2a4422677ffcfb116f5304533b)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -15237,7 +15334,7 @@ snapshots:
     dependencies:
       '@ember-data/canary-features': 4.8.8(@glint/template@1.5.2)
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
@@ -15247,20 +15344,20 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
       '@ember/string': 3.1.1
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))':
+  '@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))':
     dependencies:
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
@@ -15268,7 +15365,7 @@ snapshots:
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
     optionalDependencies:
       '@ember/string': 3.1.1
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -15316,15 +15413,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/serializer@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))':
+  '@ember-data/serializer@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -15343,26 +15440,26 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/serializer@4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(webpack@5.101.0)':
+  '@ember-data/serializer@4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(webpack@5.101.0)':
     dependencies:
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.5.2)
-      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  '@ember-data/serializer@5.3.13(1cb068e4cdf195d7484be05bead75e79)':
+  '@ember-data/serializer@5.3.13(f79f680031eb84d417963b73eb78207f)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.13(9143dc8d740020cca93344469531bdeb)
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/legacy-compat': 5.3.13(f12a434a34830d31eb3954af23c52d77)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
@@ -15370,16 +15467,16 @@ snapshots:
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/serializer@5.5.0(af903faa4850b72b124e7311a18e9fdc)':
+  '@ember-data/serializer@5.5.0(a465452427001a8e4b7eb743f47bb8b8)':
     dependencies:
-      '@ember-data/legacy-compat': 5.5.0(afc55c401b70604f1a249051fa4abd27)
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/legacy-compat': 5.5.0(855ca77b89e368196263f3571545284f)
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
@@ -15387,7 +15484,7 @@ snapshots:
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -15406,20 +15503,20 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/store@4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember-data/store@4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.5.2)
       '@ember-data/tracking': 4.12.8(@glint/template@1.5.2)
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       '@glimmer/tracking': 1.1.2
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel: 7.26.11
     optionalDependencies:
       '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.5.2)
       '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.5.2)
       '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)
-      '@ember-data/model': 4.12.8(@babel/core@7.28.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/model': 4.12.8(@babel/core@7.28.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -15443,7 +15540,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/store@4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)':
+  '@ember-data/store@4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)':
     dependencies:
       '@ember-data/canary-features': 4.8.8(@glint/template@1.5.2)
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.5.2)
@@ -15452,10 +15549,10 @@ snapshots:
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel: 7.26.11
     optionalDependencies:
-      '@ember-data/model': 4.8.8(@babel/core@7.28.0)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+      '@ember-data/model': 4.8.8(@babel/core@7.28.0)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       '@ember-data/record-data': 4.8.8(@ember-data/store@4.8.8)(@glint/template@1.5.2)(webpack@5.101.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -15464,29 +15561,29 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@ember-data/request': 5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/tracking': 5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/tracking': 5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
     optionalDependencies:
-      '@ember-data/tracking': 5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      '@ember-data/tracking': 5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -15507,22 +15604,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -15603,13 +15700,13 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember/legacy-built-in-components@0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember/legacy-built-in-components@0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-typescript: 4.2.1
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -15638,12 +15735,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/render-modifiers@2.1.0(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember/render-modifiers@2.1.0(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.0)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
       '@glint/template': 1.5.2
     transitivePeerDependencies:
@@ -15656,17 +15753,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
-      '@embroider/util': 1.13.3(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@embroider/util': 1.13.3(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-destroyable-polyfill: 2.0.3(@babel/core@7.28.0)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/environment-ember-loose'
@@ -15854,14 +15951,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/util@1.13.3(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@embroider/util@1.13.3(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@glint/environment-ember-loose': 1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
+      '@glint/environment-ember-loose': 1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
       '@glint/template': 1.5.2
     transitivePeerDependencies:
       - supports-color
@@ -16096,6 +16193,13 @@ snapshots:
       '@glimmer/util': 0.94.8
       '@glimmer/wire-format': 0.94.8
 
+  '@glimmer/compiler@0.94.11':
+    dependencies:
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/syntax': 0.95.0
+      '@glimmer/util': 0.94.8
+      '@glimmer/wire-format': 0.94.8
+
   '@glimmer/component@1.1.2(@babel/core@7.28.0)':
     dependencies:
       '@glimmer/di': 0.1.11
@@ -16288,6 +16392,16 @@ snapshots:
       '@glimmer/validator': 0.92.3
       '@glimmer/vm': 0.92.3
 
+  '@glimmer/manager@0.94.10':
+    dependencies:
+      '@glimmer/destroyable': 0.94.8
+      '@glimmer/global-context': 0.93.4
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/reference': 0.94.9
+      '@glimmer/util': 0.94.8
+      '@glimmer/validator': 0.95.0
+      '@glimmer/vm': 0.94.8
+
   '@glimmer/manager@0.94.9':
     dependencies:
       '@glimmer/destroyable': 0.94.8
@@ -16326,6 +16440,13 @@ snapshots:
       '@glimmer/interfaces': 0.92.3
       '@glimmer/runtime': 0.92.4
       '@glimmer/util': 0.92.3
+      '@simple-dom/document': 1.4.0
+
+  '@glimmer/node@0.94.10':
+    dependencies:
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/runtime': 0.94.11
+      '@glimmer/util': 0.94.8
       '@simple-dom/document': 1.4.0
 
   '@glimmer/node@0.94.9':
@@ -16380,6 +16501,15 @@ snapshots:
       '@glimmer/util': 0.92.3
       '@glimmer/vm': 0.92.3
       '@glimmer/wire-format': 0.92.3
+
+  '@glimmer/opcode-compiler@0.94.10':
+    dependencies:
+      '@glimmer/encoder': 0.93.8
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/manager': 0.94.10
+      '@glimmer/util': 0.94.8
+      '@glimmer/vm': 0.94.8
+      '@glimmer/wire-format': 0.94.8
 
   '@glimmer/opcode-compiler@0.94.9':
     dependencies:
@@ -16448,6 +16578,15 @@ snapshots:
       '@glimmer/vm': 0.92.3
       '@glimmer/wire-format': 0.92.3
 
+  '@glimmer/program@0.94.10':
+    dependencies:
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/manager': 0.94.10
+      '@glimmer/opcode-compiler': 0.94.10
+      '@glimmer/util': 0.94.8
+      '@glimmer/vm': 0.94.8
+      '@glimmer/wire-format': 0.94.8
+
   '@glimmer/program@0.94.9':
     dependencies:
       '@glimmer/interfaces': 0.94.6
@@ -16503,6 +16642,13 @@ snapshots:
       '@glimmer/interfaces': 0.94.6
       '@glimmer/util': 0.94.8
       '@glimmer/validator': 0.94.8
+
+  '@glimmer/reference@0.94.9':
+    dependencies:
+      '@glimmer/global-context': 0.93.4
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/util': 0.94.8
+      '@glimmer/validator': 0.95.0
 
   '@glimmer/runtime@0.84.2':
     dependencies:
@@ -16579,6 +16725,19 @@ snapshots:
       '@glimmer/validator': 0.94.8
       '@glimmer/vm': 0.94.8
 
+  '@glimmer/runtime@0.94.11':
+    dependencies:
+      '@glimmer/destroyable': 0.94.8
+      '@glimmer/global-context': 0.93.4
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/manager': 0.94.10
+      '@glimmer/owner': 0.93.4
+      '@glimmer/program': 0.94.10
+      '@glimmer/reference': 0.94.9
+      '@glimmer/util': 0.94.8
+      '@glimmer/validator': 0.95.0
+      '@glimmer/vm': 0.94.8
+
   '@glimmer/syntax@0.65.4':
     dependencies:
       '@glimmer/interfaces': 0.65.4
@@ -16622,6 +16781,14 @@ snapshots:
       '@glimmer/util': 0.94.8
       '@glimmer/wire-format': 0.94.8
       '@handlebars/parser': 2.0.0
+      simple-html-tokenizer: 0.5.11
+
+  '@glimmer/syntax@0.95.0':
+    dependencies:
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/util': 0.94.8
+      '@glimmer/wire-format': 0.94.8
+      '@handlebars/parser': 2.2.1
       simple-html-tokenizer: 0.5.11
 
   '@glimmer/tracking@1.1.2':
@@ -16699,6 +16866,11 @@ snapshots:
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
 
+  '@glimmer/validator@0.95.0':
+    dependencies:
+      '@glimmer/global-context': 0.93.4
+      '@glimmer/interfaces': 0.94.6
+
   '@glimmer/vm-babel-plugins@0.77.5(@babel/core@7.28.0)':
     dependencies:
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
@@ -16742,6 +16914,12 @@ snapshots:
       - '@babel/core'
 
   '@glimmer/vm-babel-plugins@0.93.4(@babel/core@7.28.0)':
+    dependencies:
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+
+  '@glimmer/vm-babel-plugins@0.93.5(@babel/core@7.28.0)':
     dependencies:
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
     transitivePeerDependencies:
@@ -16810,27 +16988,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.28.0))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))':
+  '@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.28.0))(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.28.0)
       '@glint/template': 1.5.2
     optionalDependencies:
+      '@types/ember__array': 4.0.10(@babel/core@7.28.0)
+      '@types/ember__component': 4.0.22(@babel/core@7.28.0)
+      '@types/ember__controller': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__routing': 4.0.22(@babel/core@7.28.0)
       ember-cli-htmlbars: 6.3.0
       ember-modifier: 4.2.2(@babel/core@7.28.0)
 
-  '@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))':
+  '@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))':
     dependencies:
       '@glimmer/component': 2.0.0
       '@glint/template': 1.5.2
     optionalDependencies:
+      '@types/ember__array': 4.0.10(@babel/core@7.28.0)
+      '@types/ember__component': 4.0.22(@babel/core@7.28.0)
+      '@types/ember__controller': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__routing': 4.0.22(@babel/core@7.28.0)
       ember-cli-htmlbars: 6.3.0
       ember-modifier: 4.2.2(@babel/core@7.28.0)
 
-  '@glint/environment-ember-template-imports@1.5.2(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)':
+  '@glint/environment-ember-template-imports@1.5.2(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))':
     dependencies:
-      '@glint/environment-ember-loose': 1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
+      '@glint/environment-ember-loose': 1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0))
       '@glint/template': 1.5.2
       content-tag: 2.0.3
+    optionalDependencies:
+      '@types/ember__component': 4.0.22(@babel/core@7.28.0)
+      '@types/ember__routing': 4.0.22(@babel/core@7.28.0)
 
   '@glint/template@1.5.2': {}
 
@@ -16839,6 +17030,8 @@ snapshots:
   '@handlebars/parser@1.1.0': {}
 
   '@handlebars/parser@2.0.0': {}
+
+  '@handlebars/parser@2.2.1': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -17774,6 +17967,130 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/ember@4.0.11(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember__application': 4.0.11(@babel/core@7.28.0)
+      '@types/ember__array': 4.0.10(@babel/core@7.28.0)
+      '@types/ember__component': 4.0.22(@babel/core@7.28.0)
+      '@types/ember__controller': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__debug': 4.0.8
+      '@types/ember__engine': 4.0.11(@babel/core@7.28.0)
+      '@types/ember__error': 4.0.6
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__polyfills': 4.0.6
+      '@types/ember__routing': 4.0.22(@babel/core@7.28.0)
+      '@types/ember__runloop': 4.0.10(@babel/core@7.28.0)
+      '@types/ember__service': 4.0.9
+      '@types/ember__string': 3.0.15
+      '@types/ember__template': 4.0.7
+      '@types/ember__test': 4.0.6(@babel/core@7.28.0)
+      '@types/ember__utils': 4.0.7(@babel/core@7.28.0)
+      '@types/rsvp': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__application@4.0.11(@babel/core@7.28.0)':
+    dependencies:
+      '@glimmer/component': 1.1.2(@babel/core@7.28.0)
+      '@types/ember': 4.0.11(@babel/core@7.28.0)
+      '@types/ember__engine': 4.0.11(@babel/core@7.28.0)
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__owner': 4.0.9
+      '@types/ember__routing': 4.0.22(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__array@4.0.10(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember': 4.0.11(@babel/core@7.28.0)
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__component@4.0.22(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember': 4.0.11(@babel/core@7.28.0)
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__controller@4.0.12(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__debug@4.0.8':
+    dependencies:
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__owner': 4.0.9
+
+  '@types/ember__engine@4.0.11(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__owner': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__error@4.0.6': {}
+
+  '@types/ember__object@4.0.12(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember': 4.0.11(@babel/core@7.28.0)
+      '@types/rsvp': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__owner@4.0.9': {}
+
+  '@types/ember__polyfills@4.0.6': {}
+
+  '@types/ember__routing@4.0.22(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember': 4.0.11(@babel/core@7.28.0)
+      '@types/ember__controller': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+      '@types/ember__service': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__runloop@4.0.10(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember': 4.0.11(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__service@4.0.9':
+    dependencies:
+      '@types/ember__object': 4.0.12(@babel/core@7.28.0)
+
+  '@types/ember__string@3.0.15': {}
+
+  '@types/ember__template@4.0.7': {}
+
+  '@types/ember__test@4.0.6(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember__application': 4.0.11(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@types/ember__utils@4.0.7(@babel/core@7.28.0)':
+    dependencies:
+      '@types/ember': 4.0.11(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.12
@@ -18148,16 +18465,16 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/ember@5.5.0(073121996238d9f230d2ec285e662a84)':
+  '@warp-drive/ember@5.5.0(c70f36d90c1cb0a305a439443c36602a)':
     dependencies:
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -20806,11 +21123,11 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-bootstrap@5.1.1(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0):
+  ember-bootstrap@5.1.1(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0):
     dependencies:
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember/render-modifiers': 2.1.0(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/macros': 1.16.13(@glint/template@1.5.2)
-      '@embroider/util': 1.13.3(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@embroider/util': 1.13.3(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@glimmer/component': 1.1.2(@babel/core@7.28.0)
       '@glimmer/tracking': 1.1.2
       broccoli-debug: 0.6.5
@@ -20824,15 +21141,15 @@ snapshots:
       ember-cli-version-checker: 5.1.2
       ember-concurrency: 2.3.7(@babel/core@7.28.0)
       ember-decorators: 6.1.1
-      ember-element-helper: 0.6.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      ember-focus-trap: 1.1.1(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-element-helper: 0.6.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-focus-trap: 1.1.1(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-in-element-polyfill: 1.0.1
       ember-named-blocks-polyfill: 0.2.5
       ember-on-helper: 0.1.0
       ember-popper-modifier: 2.0.1(@babel/core@7.28.0)(@glint/template@1.5.2)(webpack@5.101.0)
       ember-ref-bucket: 4.1.0(@babel/core@7.28.0)
       ember-render-helpers: 0.2.1
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-style-modifier: 0.8.0(@babel/core@7.28.0)
       findup-sync: 5.0.0
       fs-extra: 10.1.0
@@ -20867,7 +21184,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@glimmer/tracking': 1.1.2
@@ -20875,7 +21192,7 @@ snapshots:
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.28.0)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -21042,7 +21359,7 @@ snapshots:
       resolve: 1.22.10
       semver: 5.7.2
 
-  ember-cli-fastboot@4.1.5(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-cli-fastboot@4.1.5(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       broccoli-concat: 4.2.5
       broccoli-file-creator: 2.1.1
@@ -21054,7 +21371,7 @@ snapshots:
       ember-cli-lodash-subset: 2.0.1
       ember-cli-preprocess-registry: 3.3.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       fastboot: 4.1.5
       fastboot-express-middleware: 4.1.2
       fastboot-transform: 0.1.3
@@ -22762,7 +23079,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-data@3.28.13(@babel/core@7.28.0)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-data@3.28.13(@babel/core@7.28.0)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@ember-data/adapter': 3.28.13(@babel/core@7.28.0)
       '@ember-data/debug': 3.28.13(@babel/core@7.28.0)
@@ -22777,24 +23094,24 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 4.2.1
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@babel/core'
       - ember-source
       - supports-color
 
-  ember-data@4.12.8(@babel/core@7.28.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0):
+  ember-data@4.12.8(@babel/core@7.28.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0):
     dependencies:
-      '@ember-data/adapter': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/adapter': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
       '@ember-data/debug': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(webpack@5.101.0)
       '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.5.2)
       '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.5.2)
       '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)
-      '@ember-data/model': 4.12.8(@babel/core@7.28.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/model': 4.12.8(@babel/core@7.28.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.5.2)
       '@ember-data/request': 4.12.8(@glint/template@1.5.2)
-      '@ember-data/serializer': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/serializer': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/store': 4.12.8(@babel/core@7.28.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.5.2))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember-data/tracking': 4.12.8(@glint/template@1.5.2)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
@@ -22803,7 +23120,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
       ember-cli-babel: 7.26.11
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/tracking'
@@ -22812,7 +23129,7 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-data@4.4.3(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0):
+  ember-data@4.4.3(@babel/core@7.28.0)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0):
     dependencies:
       '@ember-data/adapter': 4.4.3(@babel/core@7.28.0)(@glint/template@1.5.2)(webpack@5.101.0)
       '@ember-data/debug': 4.4.3(@babel/core@7.28.0)(@glint/template@1.5.2)(webpack@5.101.0)
@@ -22828,7 +23145,7 @@ snapshots:
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.3.0
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -22836,15 +23153,15 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-data@4.8.8(@babel/core@7.28.0)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0):
+  ember-data@4.8.8(@babel/core@7.28.0)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0):
     dependencies:
-      '@ember-data/adapter': 4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(webpack@5.101.0)
+      '@ember-data/adapter': 4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(webpack@5.101.0)
       '@ember-data/debug': 4.8.8(@ember/string@3.1.1)(@glint/template@1.5.2)(webpack@5.101.0)
-      '@ember-data/model': 4.8.8(@babel/core@7.28.0)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+      '@ember-data/model': 4.8.8(@babel/core@7.28.0)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.5.2)
       '@ember-data/record-data': 4.8.8(@ember-data/store@4.8.8)(@glint/template@1.5.2)(webpack@5.101.0)
-      '@ember-data/serializer': 4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(webpack@5.101.0)
-      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
+      '@ember-data/serializer': 4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(webpack@5.101.0)
+      '@ember-data/store': 4.8.8(@babel/core@7.28.0)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.101.0)
       '@ember-data/tracking': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
@@ -22853,7 +23170,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
       ember-cli-babel: 7.26.11
-      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-inflector: 4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/tracking'
@@ -22862,26 +23179,26 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1):
+  ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1):
     dependencies:
-      '@ember-data/adapter': 5.3.13(1cb068e4cdf195d7484be05bead75e79)
-      '@ember-data/debug': 5.3.13(2fcca3d418937ea139bb2d403f632c2a)
-      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/json-api': 5.3.13(1aaa9a7aa03bc9ee25d36ac2cff4592c)
-      '@ember-data/legacy-compat': 5.3.13(9143dc8d740020cca93344469531bdeb)
-      '@ember-data/model': 5.3.13(e90ae7c768bea556b41910ffd6eea7c5)
+      '@ember-data/adapter': 5.3.13(f79f680031eb84d417963b73eb78207f)
+      '@ember-data/debug': 5.3.13(b4e00bef4ee904d17149939c2cce4649)
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/json-api': 5.3.13(52f4db880c578edbf75fab0d7a8d6c83)
+      '@ember-data/legacy-compat': 5.3.13(f12a434a34830d31eb3954af23c52d77)
+      '@ember-data/model': 5.3.13(189578edb9a2ba73d1a34a4b52a3d814)
       '@ember-data/request': 5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/serializer': 5.3.13(1cb068e4cdf195d7484be05bead75e79)
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/tracking': 5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/serializer': 5.3.13(f79f680031eb84d417963b73eb78207f)
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2)))(@ember-data/tracking@5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/tracking': 5.3.13(@glint/template@1.5.2)(@warp-drive/core-types@0.0.3(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.5.2)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.5.2)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@ember/test-helpers': 2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember/test-helpers': 2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/test-waiters': 3.1.0
       qunit: 2.24.1
     transitivePeerDependencies:
@@ -22890,27 +23207,27 @@ snapshots:
       - ember-inflector
       - supports-color
 
-  ember-data@5.5.0(@ember/string@3.1.1)(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1):
+  ember-data@5.5.0(@ember/string@3.1.1)(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1):
     dependencies:
-      '@ember-data/adapter': 5.5.0(af903faa4850b72b124e7311a18e9fdc)
-      '@ember-data/debug': 5.5.0(d15746374d9b3ed10d7e0cdc22652e95)
-      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
-      '@ember-data/json-api': 5.5.0(2e49a201e350068aaa5a0c1a46335656)
-      '@ember-data/legacy-compat': 5.5.0(afc55c401b70604f1a249051fa4abd27)
-      '@ember-data/model': 5.5.0(e3579d8366593afc8ec289d2f1844cff)
+      '@ember-data/adapter': 5.5.0(a465452427001a8e4b7eb743f47bb8b8)
+      '@ember-data/debug': 5.5.0(4eb0df899d6188f2adc15ee0c73ef098)
+      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
+      '@ember-data/json-api': 5.5.0(3a249b2a4422677ffcfb116f5304533b)
+      '@ember-data/legacy-compat': 5.5.0(855ca77b89e368196263f3571545284f)
+      '@ember-data/model': 5.5.0(47f9e5bab338a153fd33863cdf3e6db1)
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))
-      '@ember-data/serializer': 5.5.0(af903faa4850b72b124e7311a18e9fdc)
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember-data/tracking': 5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+      '@ember-data/serializer': 5.5.0(a465452427001a8e4b7eb743f47bb8b8)
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember/string@3.1.1)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2)))(@ember-data/tracking@5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember-data/tracking': 5.5.0(@glint/template@1.5.2)(@warp-drive/core-types@5.5.0(@glint/template@1.5.2))(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.5.2)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.5.2)
-      '@warp-drive/ember': 5.5.0(073121996238d9f230d2ec285e662a84)
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      '@warp-drive/ember': 5.5.0(c70f36d90c1cb0a305a439443c36602a)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@ember/test-helpers': 2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember/test-helpers': 2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/test-waiters': 3.1.0
       qunit: 2.24.1
     transitivePeerDependencies:
@@ -22939,12 +23256,12 @@ snapshots:
 
   ember-disable-prototype-extensions@1.1.3: {}
 
-  ember-element-helper@0.6.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-element-helper@0.6.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
-      '@embroider/util': 1.13.3(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@embroider/util': 1.13.3(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@glint/environment-ember-loose'
       - '@glint/template'
@@ -22976,9 +23293,9 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
-      '@ember/legacy-built-in-components': 0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember/legacy-built-in-components': 0.4.2(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/macros': 1.18.1(@glint/template@1.5.2)
       amd-name-resolver: 1.3.1
       babel-plugin-compact-reexports: 1.1.0
@@ -22996,7 +23313,7 @@ snapshots:
       ember-cli-preprocess-registry: 3.3.0
       ember-cli-string-utils: 1.1.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       lodash: 4.17.21
     transitivePeerDependencies:
       - '@glint/template'
@@ -23019,10 +23336,10 @@ snapshots:
 
   ember-export-application-global@2.0.1: {}
 
-  ember-focus-trap@1.1.1(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-focus-trap@1.1.1(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@embroider/addon-shim': 1.10.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       focus-trap: 6.9.4
     transitivePeerDependencies:
       - supports-color
@@ -23036,10 +23353,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-inflector@4.0.3(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-inflector@4.0.3(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -23153,11 +23470,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-page-title@8.2.4(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-page-title@8.2.4(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@embroider/addon-shim': 1.10.0
       '@simple-dom/document': 1.4.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -23174,16 +23491,16 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-qunit@6.2.0(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)(webpack@5.101.0):
+  ember-qunit@6.2.0(@ember/test-helpers@2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)(webpack@5.101.0):
     dependencies:
-      '@ember/test-helpers': 2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember/test-helpers': 2.9.6(@babel/core@7.28.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.5.2)(@types/ember__array@4.0.10(@babel/core@7.28.0))(@types/ember__component@4.0.22(@babel/core@7.28.0))(@types/ember__controller@4.0.12(@babel/core@7.28.0))(@types/ember__object@4.0.12(@babel/core@7.28.0))(@types/ember__routing@4.0.22(@babel/core@7.28.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.28.0)))(@glint/template@1.5.2)(ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5))
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.1.0
-      ember-source: 6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       qunit: 2.24.1
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -23991,28 +24308,28 @@ snapshots:
       - rsvp
       - supports-color
 
-  ember-source@6.8.0-alpha.2(@glimmer/component@2.0.0)(rsvp@4.8.5):
+  ember-source@6.8.0-alpha.4(@glimmer/component@2.0.0)(rsvp@4.8.5):
     dependencies:
       '@babel/core': 7.28.0
       '@ember/edition-utils': 1.2.0
       '@embroider/addon-shim': 1.10.0
-      '@glimmer/compiler': 0.94.10
+      '@glimmer/compiler': 0.94.11
       '@glimmer/component': 2.0.0
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
-      '@glimmer/manager': 0.94.9
-      '@glimmer/node': 0.94.9
-      '@glimmer/opcode-compiler': 0.94.9
+      '@glimmer/manager': 0.94.10
+      '@glimmer/node': 0.94.10
+      '@glimmer/opcode-compiler': 0.94.10
       '@glimmer/owner': 0.93.4
-      '@glimmer/program': 0.94.9
-      '@glimmer/reference': 0.94.8
-      '@glimmer/runtime': 0.94.10
-      '@glimmer/syntax': 0.94.9
+      '@glimmer/program': 0.94.10
+      '@glimmer/reference': 0.94.9
+      '@glimmer/runtime': 0.94.11
+      '@glimmer/syntax': 0.95.0
       '@glimmer/util': 0.94.8
-      '@glimmer/validator': 0.94.8
+      '@glimmer/validator': 0.95.0
       '@glimmer/vm': 0.94.8
-      '@glimmer/vm-babel-plugins': 0.93.4(@babel/core@7.28.0)
+      '@glimmer/vm-babel-plugins': 0.93.5(@babel/core@7.28.0)
       '@simple-dom/interface': 1.4.0
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1


### PR DESCRIPTION
Provide explicit overloads or the specific uses of [importSync mentioned in deprecation guides.](https://deprecations.emberjs.com/id/deprecate-import-get-owner-from-ember)

This would make every addon that aims for both supporting ember-source < 4.11 and ember-source >= 7.0 avoid the type gymnastics seen in e.g. https://github.com/NullVoxPopuli/ember-resources/blob/main/ember-resources/src/ember-compat.ts and https://github.com/nickschot/ember-mobile-menu/pull/1256/commits/ccc21e1b3cb897445ee204620d504e5e887a2456

If we are also willing/able to change the [compat example in the deprecation guides](https://deprecations.emberjs.com/id/deprecate-import-get-owner-from-ember/) to use assignment of getOwner through ternaries, there would be no typescript gymnastics needed at all, as the javascript and typescript solution would be exactly the same:

```js
import {
  macroCondition,
  dependencySatisfies,
  importSync
} from '@embroider/macros';

const getOwner = macroCondition(dependencySatisfies('ember-source', '>= 4.11'))
  ? importSync('@ember/owner').getOwner
  : importSync('@ember/application').getOwner; 
 ```