### PR TITLE
Chore: Upgrade jsdom

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -57,7 +57,7 @@
     "fast-sourcemap-concat": "^2.1.1",
     "fs-extra": "^9.1.0",
     "fs-tree-diff": "^2.0.1",
-    "jsdom": "^25.0.0",
+    "jsdom": "^26.1.0",
     "lodash": "^4.17.21",
     "pkg-up": "^3.1.0",
     "resolve": "^1.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,8 +298,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       jsdom:
-        specifier: ^25.0.0
-        version: 25.0.1(supports-color@8.1.1)
+        specifier: ^26.1.0
+        version: 26.1.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1136,7 +1136,7 @@ importers:
         version: 3.28.6(babel-core@6.26.3)(encoding@0.1.13)(handlebars@4.7.8)(underscore@1.13.7)
       ember-cli-dependency-checker:
         specifier: ^3.1.0
-        version: 3.3.3(ember-cli@3.28.6(encoding@0.1.13))
+        version: 3.3.3(ember-cli@3.28.6)
       ember-cli-htmlbars:
         specifier: ^6.0.0
         version: 6.3.0
@@ -10059,6 +10059,15 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -21664,7 +21673,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.3(ember-cli@3.28.6(encoding@0.1.13)):
+  ember-cli-dependency-checker@3.3.3(ember-cli@3.28.6):
     dependencies:
       chalk: 2.4.2
       ember-cli: 3.28.6(babel-core@6.26.3)(encoding@0.1.13)(handlebars@4.7.8)(underscore@1.13.7)
@@ -27516,6 +27525,33 @@ snapshots:
       nwsapi: 2.2.21
       parse5: 7.3.0
       rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.21
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 5.1.2


### PR DESCRIPTION
In https://github.com/jsdom/jsdom/releases/tag/26.1.0, jsdom removes the form-data dependency, which resolves a vulnerability https://github.com/hashicorp/terraform-enterprise/security/code-scanning/1455

