### PR TITLE
Runtime `@embroider/macros`

### DIFF
--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -17,11 +17,11 @@
 */
 
 export function dependencySatisfies(packageName: string, semverRange: string): boolean {
-  throw new Oops(packageName, semverRange);
+  return Boolean(packageName && semverRange);
 }
 
 export function macroCondition(predicate: boolean): boolean {
-  throw new Oops(predicate);
+  return predicate;
 }
 
 export function each<T>(array: T[]): T[] {
@@ -48,11 +48,11 @@ export function getGlobalConfig<T>(): T {
 }
 
 export function isDevelopingApp(): boolean {
-  throw new Oops();
+  return true;
 }
 
 export function isTesting(): boolean {
-  throw new Oops();
+  return true;
 }
 
 export function failBuild(message: string): void {


### PR DESCRIPTION
This is what is blocking use of jsbin, or otherwise avoiding babel while being able to use macros-using dependencies (rolldown, esm.sh, etc)

In `ember-repl`, I defined my own minimal copy of `@embroider/macros` (and am not actually using `@embroider/macros`). This is what I ended up using:
```ts
  '@embroider/macros': () => ({
    // passthrough, we are not doing dead-code-elimination
    macroCondition: (x: boolean) => x,
    // I *could* actually implement this
    dependencySatisfies: () => true,
    isDevelopingApp: () => true,
    // Trying to use warp-drive in a REPL environment may be impossible, since they
    // encourage choosing your own adventure without a buildless recommended path.
    // The use of nested configs (specifically env) is also problematic for 
    // "falling back to false" as what all other macros-using libraries use.
    // Even with this config, I have not successfully been able to use warp-drive 
    // in any of my REPL-based projects.
    getGlobalConfig: () => ({
      WarpDrive: {
        debug: false,
        env: {
          DEBUG: false,
          TESTING: false,
          PRODUCTION: true,
        },
        activeLogging: false,
        compatWith: '99.0',
        features: {},
        deprecations: {},
        polyfillUUID: false,
        includeDataAdapter: false,
      },
    }),
    // Private
    // eslint-disable-next-line
    // @ts-ignore
    importSync: (x: string) => window[Symbol.for('__repl-sdk__compiler__')].resolves[x],
    moduleExists: () => false,
  })
```