### PR TITLE
new Macro: `appEmberSatisfies(range)`

### DIFF
--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.5",
+    "@babel/plugin-transform-class-properties": "^7.27.1",
     "@babel/plugin-transform-modules-amd": "^7.19.6",
     "@babel/traverse": "^7.14.5",
     "@embroider/core": "workspace:*",

--- a/packages/macros/src/babel/app-ember-satisfies.ts
+++ b/packages/macros/src/babel/app-ember-satisfies.ts
@@ -14,7 +14,7 @@ export default function appEmberSatisfies(path: NodePath<t.CallExpression>, stat
   const [range] = path.node.arguments;
   if (range.type !== 'StringLiteral') {
     throw error(
-      assertArray(path.get('arguments'))[1],
+      assertArray(path.get('arguments'))[0],
       `the only argument to appEmberSatisfies must be a string literal`
     );
   }

--- a/packages/macros/src/babel/app-ember-satisfies.ts
+++ b/packages/macros/src/babel/app-ember-satisfies.ts
@@ -9,7 +9,7 @@ const packageName = 'ember-source';
 
 export default function appEmberSatisfies(path: NodePath<t.CallExpression>, state: State): boolean {
   if (path.node.arguments.length !== 1) {
-    throw error(path, `dependencySatisfies takes exactly one argument, you passed ${path.node.arguments.length}`);
+    throw error(path, `appEmberSatisfies takes exactly one argument, you passed ${path.node.arguments.length}`);
   }
   const [range] = path.node.arguments;
   if (range.type !== 'StringLiteral') {

--- a/packages/macros/src/babel/app-ember-satisfies.ts
+++ b/packages/macros/src/babel/app-ember-satisfies.ts
@@ -1,0 +1,40 @@
+import type { NodePath } from '@babel/traverse';
+import type { types as t } from '@babel/core';
+import type State from './state';
+import { satisfies } from 'semver';
+import error from './error';
+import { assertArray } from './evaluate-json';
+
+const packageName = 'ember-source';
+
+export default function appEmberSatisfies(path: NodePath<t.CallExpression>, state: State): boolean {
+  if (path.node.arguments.length !== 1) {
+    throw error(path, `dependencySatisfies takes exactly one argument, you passed ${path.node.arguments.length}`);
+  }
+  const [range] = path.node.arguments;
+  if (range.type !== 'StringLiteral') {
+    throw error(
+      assertArray(path.get('arguments'))[1],
+      `the second argument to dependencySatisfies must be a string literal`
+    );
+  }
+  try {
+    let root = state.packageCache.get(state.packageCache.appRoot);
+
+    if (!root?.hasDependency(packageName)) {
+      return false;
+    }
+
+    let resolvedInfo = state.packageCache.resolve(packageName, root);
+    let version = resolvedInfo.version;
+
+    return satisfies(version, range.value, {
+      includePrerelease: true,
+    });
+  } catch (err) {
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      throw err;
+    }
+    return false;
+  }
+}

--- a/packages/macros/src/babel/app-ember-satisfies.ts
+++ b/packages/macros/src/babel/app-ember-satisfies.ts
@@ -1,11 +1,72 @@
 import type { NodePath } from '@babel/traverse';
 import type { types as t } from '@babel/core';
 import type State from './state';
-import { satisfies } from 'semver';
+import { satisfies, coerce } from 'semver';
 import error from './error';
 import { assertArray } from './evaluate-json';
+import { pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
+import findUp from 'find-up';
+
 
 const packageName = 'ember-source';
+const CACHE = new Map<string, string | false>();
+/**
+ * NOTE: Since there will only ever be one app ember version, we can cache the result of looking it up.
+ *       (partly to save disk i/o)
+ */
+function getAppEmberVersion(state: State): string | false {
+  let appRoot = state.packageCache.appRoot;
+
+  if (CACHE.has(appRoot)) {
+    return CACHE.get(appRoot)!;
+  }
+
+  let root = state.packageCache.get(appRoot);
+
+  if (!root?.hasDependency(packageName)) {
+    CACHE.set(appRoot, false);
+    return false;
+  }
+
+  /**
+   * This version can, and often is a range (^6.4.0), 
+   * and using a range for the first parameter of satisfies will cause a failure to always occur.
+   * So we must resolve the actual version on disk.
+  */
+  let resolvedInfo = state.packageCache.resolve(packageName, root);
+  let version = resolvedInfo.version;
+  /**
+   * But, if the version is "clean", we can avoid a disk hit 
+   * (which is helpful for corporate machines which intercept every disk i/o behavior)
+   */
+  let cleanedVersion = String(coerce(version, { includePrerelease: true }));
+
+  /**
+   * these are the same, so we don't need to ask the disk what was installed
+   */
+  if (cleanedVersion === version) {
+    CACHE.set(appRoot, version);
+    return version;
+  }
+
+  const appURL = pathToFileURL(appRoot);
+  const require = createRequire(appURL);
+  const emberSourceEntry = require.resolve(packageName, {
+    paths: [appRoot],
+  });
+  const emberSourceManifestPath = findUp.sync('package.json', { cwd: dirname(emberSourceEntry) });
+
+  if (!emberSourceManifestPath) {
+    throw new Error(`We resolved an ember-source package, but could not find its package.json`);
+  }
+  const emberSourceManifest = require(emberSourceManifestPath);
+
+
+  CACHE.set(appRoot, emberSourceManifest.version);
+  return emberSourceManifest.version;
+}
 
 export default function appEmberSatisfies(path: NodePath<t.CallExpression>, state: State): boolean {
   if (path.node.arguments.length !== 1) {
@@ -19,16 +80,14 @@ export default function appEmberSatisfies(path: NodePath<t.CallExpression>, stat
     );
   }
   try {
-    let root = state.packageCache.get(state.packageCache.appRoot);
 
-    if (!root?.hasDependency(packageName)) {
+    let appEmberVersion = getAppEmberVersion(state);
+
+    if (!appEmberVersion) {
       return false;
     }
 
-    let resolvedInfo = state.packageCache.resolve(packageName, root);
-    let version = resolvedInfo.version;
-
-    return satisfies(version, range.value, {
+    return satisfies(appEmberVersion, range.value, {
       includePrerelease: true,
     });
   } catch (err) {

--- a/packages/macros/src/babel/app-ember-satisfies.ts
+++ b/packages/macros/src/babel/app-ember-satisfies.ts
@@ -15,7 +15,7 @@ export default function appEmberSatisfies(path: NodePath<t.CallExpression>, stat
   if (range.type !== 'StringLiteral') {
     throw error(
       assertArray(path.get('arguments'))[1],
-      `the second argument to dependencySatisfies must be a string literal`
+      `the only argument to appEmberSatisfies must be a string literal`
     );
   }
   try {

--- a/packages/macros/src/babel/app-ember-satisfies.ts
+++ b/packages/macros/src/babel/app-ember-satisfies.ts
@@ -9,7 +9,6 @@ import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import findUp from 'find-up';
 
-
 const packageName = 'ember-source';
 const CACHE = new Map<string, string | false>();
 /**
@@ -31,14 +30,14 @@ function getAppEmberVersion(state: State): string | false {
   }
 
   /**
-   * This version can, and often is a range (^6.4.0), 
+   * This version can, and often is a range (^6.4.0),
    * and using a range for the first parameter of satisfies will cause a failure to always occur.
    * So we must resolve the actual version on disk.
-  */
+   */
   let resolvedInfo = state.packageCache.resolve(packageName, root);
   let version = resolvedInfo.version;
   /**
-   * But, if the version is "clean", we can avoid a disk hit 
+   * But, if the version is "clean", we can avoid a disk hit
    * (which is helpful for corporate machines which intercept every disk i/o behavior)
    */
   let cleanedVersion = String(coerce(version, { includePrerelease: true }));
@@ -63,7 +62,6 @@ function getAppEmberVersion(state: State): string | false {
   }
   const emberSourceManifest = require(emberSourceManifestPath);
 
-
   CACHE.set(appRoot, emberSourceManifest.version);
   return emberSourceManifest.version;
 }
@@ -80,7 +78,6 @@ export default function appEmberSatisfies(path: NodePath<t.CallExpression>, stat
     );
   }
   try {
-
     let appEmberVersion = getAppEmberVersion(state);
 
     if (!appEmberVersion) {

--- a/packages/macros/src/babel/evaluate-json.ts
+++ b/packages/macros/src/babel/evaluate-json.ts
@@ -412,8 +412,8 @@ export class Evaluator {
         let maybeFastbootProperty = maybeFastbootMemberExpression.isMemberExpression()
           ? maybeFastbootMemberExpression.get('property')
           : maybeFastbootMemberExpression.isOptionalMemberExpression()
-            ? maybeFastbootMemberExpression.get('property')
-            : assertNever(maybeFastbootMemberExpression);
+          ? maybeFastbootMemberExpression.get('property')
+          : assertNever(maybeFastbootMemberExpression);
 
         if (maybeFastbootProperty.isIdentifier() && maybeFastbootProperty.node.name === 'fastboot') {
           return {
@@ -435,7 +435,7 @@ export class Evaluator {
         confident: true,
         value: Boolean(
           this.state.opts.appPackageRoot &&
-          this.state.opts.isDevelopingPackageRoots.includes(this.state.opts.appPackageRoot)
+            this.state.opts.isDevelopingPackageRoots.includes(this.state.opts.appPackageRoot)
         ),
         hasRuntimeImplementation: false,
       };

--- a/packages/macros/src/babel/evaluate-json.ts
+++ b/packages/macros/src/babel/evaluate-json.ts
@@ -3,6 +3,7 @@ import type * as Babel from '@babel/core';
 import type { types as t } from '@babel/core';
 import type State from './state';
 import dependencySatisfies from './dependency-satisfies';
+import appEmberSatisfies from './app-ember-satisfies';
 import moduleExists from './module-exists';
 import getConfig from './get-config';
 import assertNever from 'assert-never';
@@ -385,6 +386,9 @@ export class Evaluator {
       return { confident: false };
     }
     let callee = path.get('callee');
+    if (callee.referencesImport('@embroider/macros', 'appEmberSatisfies')) {
+      return { confident: true, value: appEmberSatisfies(path, this.state), hasRuntimeImplementation: false };
+    }
     if (callee.referencesImport('@embroider/macros', 'dependencySatisfies')) {
       return { confident: true, value: dependencySatisfies(path, this.state), hasRuntimeImplementation: false };
     }
@@ -408,8 +412,8 @@ export class Evaluator {
         let maybeFastbootProperty = maybeFastbootMemberExpression.isMemberExpression()
           ? maybeFastbootMemberExpression.get('property')
           : maybeFastbootMemberExpression.isOptionalMemberExpression()
-          ? maybeFastbootMemberExpression.get('property')
-          : assertNever(maybeFastbootMemberExpression);
+            ? maybeFastbootMemberExpression.get('property')
+            : assertNever(maybeFastbootMemberExpression);
 
         if (maybeFastbootProperty.isIdentifier() && maybeFastbootProperty.node.name === 'fastboot') {
           return {
@@ -431,7 +435,7 @@ export class Evaluator {
         confident: true,
         value: Boolean(
           this.state.opts.appPackageRoot &&
-            this.state.opts.isDevelopingPackageRoots.includes(this.state.opts.appPackageRoot)
+          this.state.opts.isDevelopingPackageRoots.includes(this.state.opts.appPackageRoot)
         ),
         hasRuntimeImplementation: false,
       };

--- a/packages/macros/src/babel/macros-babel-plugin.ts
+++ b/packages/macros/src/babel/macros-babel-plugin.ts
@@ -198,6 +198,7 @@ export default function main(context: typeof Babel): unknown {
     ReferencedIdentifier(path: NodePath<t.Identifier>, state: State) {
       for (let candidate of [
         'dependencySatisfies',
+        'appEmberSatisfies',
         'moduleExists',
         'getConfig',
         'getOwnConfig',

--- a/packages/macros/src/glimmer/app-ember-satisfies.ts
+++ b/packages/macros/src/glimmer/app-ember-satisfies.ts
@@ -1,0 +1,35 @@
+import { satisfies } from 'semver';
+import type { RewrittenPackageCache } from '@embroider/shared-internals';
+
+const packageName = 'ember-source';
+
+export default function appEmberSatisfies(node: any, packageCache: RewrittenPackageCache) {
+  if (node.params.length !== 1) {
+    throw new Error(`macroAppEmberSatisfies requires only one argument, you passed ${node.params.length}`);
+  }
+
+  if (!node.params.every((p: any) => p.type === 'StringLiteral')) {
+    throw new Error(`all arguments to macroAppEmberSatisfies must be string literals`);
+  }
+
+  let root = packageCache.get(packageCache.appRoot);
+  let range = node.params[0].value;
+
+  if (!root?.hasDependency(packageName)) {
+    return false;
+  }
+
+  let pkg;
+  try {
+    pkg = packageCache.resolve(packageName, root);
+  } catch (err) {
+    // it's not an error if we can't resolve it, we just don't satisfy it.
+  }
+
+  if (pkg) {
+    return satisfies(pkg.version, range, {
+      includePrerelease: true,
+    });
+  }
+  return false;
+}

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -147,9 +147,7 @@ export function makeFirstTransform(opts: FirstTransformParams) {
             );
           }
           if (node.path.original === 'macroAppEmberSatisfies') {
-            return env.syntax.builders.mustache(
-              literal(appEmberSatisfies(node, packageCache), env.syntax.builders)
-            );
+            return env.syntax.builders.mustache(literal(appEmberSatisfies(node, packageCache), env.syntax.builders));
           }
         },
       },

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -146,6 +146,11 @@ export function makeFirstTransform(opts: FirstTransformParams) {
               literal(dependencySatisfies(node, opts.packageRoot, moduleName, packageCache), env.syntax.builders)
             );
           }
+          if (node.path.original === 'macroAppEmberSatisfies') {
+            return env.syntax.builders.mustache(
+              literal(appEmberSatisfies(node, packageCache), env.syntax.builders)
+            );
+          }
         },
       },
     };

--- a/packages/macros/src/glimmer/ast-transform.ts
+++ b/packages/macros/src/glimmer/ast-transform.ts
@@ -1,5 +1,6 @@
 import literal from './literal';
 import getConfig from './get-config';
+import appEmberSatisfies from './app-ember-satisfies';
 import dependencySatisfies from './dependency-satisfies';
 import { maybeAttrs } from './macro-maybe-attrs';
 import {
@@ -99,6 +100,15 @@ export function makeFirstTransform(opts: FirstTransformParams) {
               dependencySatisfies(node, opts.packageRoot, moduleName, packageCache),
               env.syntax.builders
             );
+            // If this is a macro expression by itself, then turn it into a macroCondition for the second pass to prune.
+            // Otherwise assume it's being composed with another macro and evaluate it as a literal
+            if (walker.parent.node.path.original === 'if') {
+              return env.syntax.builders.sexpr('macroCondition', [staticValue]);
+            }
+            return staticValue;
+          }
+          if (node.path.original === 'macroAppEmberSatisfies') {
+            const staticValue = literal(appEmberSatisfies(node, packageCache), env.syntax.builders);
             // If this is a macro expression by itself, then turn it into a macroCondition for the second pass to prune.
             // Otherwise assume it's being composed with another macro and evaluate it as a literal
             if (walker.parent.node.path.original === 'if') {

--- a/packages/macros/src/index.ts
+++ b/packages/macros/src/index.ts
@@ -20,6 +20,10 @@ export function dependencySatisfies(packageName: string, semverRange: string): b
   throw new Oops(packageName, semverRange);
 }
 
+export function appEmberSatisfies(semverRange: string): boolean {
+  throw new Oops(semverRange);
+}
+
 export function macroCondition(predicate: boolean): boolean {
   throw new Oops(predicate);
 }
@@ -91,6 +95,10 @@ export interface EmbroiderMacrosRegistry {
   macroDependencySatisfies: HelperLike<{
     Args: { Positional: Parameters<typeof dependencySatisfies> };
     Return: ReturnType<typeof dependencySatisfies>;
+  }>;
+  macroAppEmberSatisfies: HelperLike<{
+    Args: { Positional: Parameters<typeof appEmberSatisfies> };
+    Return: ReturnType<typeof appEmberSatisfies>;
   }>;
   macroMaybeAttrs: HelperLike<{
     Args: { Positional: [predicate: boolean, ...bareAttrs: unknown[]] };

--- a/packages/macros/tests/babel/app-ember-satisfies.test.ts
+++ b/packages/macros/tests/babel/app-ember-satisfies.test.ts
@@ -3,11 +3,12 @@ import { Project } from 'scenario-tester';
 import { join, dirname } from 'node:path';
 import { buildMacros } from '../../src/babel';
 
-
 const ROOT = process.cwd();
 
 export function baseV2Addon() {
-  return Project.fromDir(dirname(require.resolve('../../../../tests/v2-addon-template/package.json')), { linkDeps: true });
+  return Project.fromDir(dirname(require.resolve('../../../../tests/v2-addon-template/package.json')), {
+    linkDeps: true,
+  });
 }
 
 export function fakeEmber(version: string) {
@@ -18,7 +19,6 @@ export function fakeEmber(version: string) {
 
   return project;
 }
-
 
 describe(`appEmberSatisfies`, function () {
   let project: Project;

--- a/packages/macros/tests/babel/app-ember-satisfies.test.ts
+++ b/packages/macros/tests/babel/app-ember-satisfies.test.ts
@@ -63,7 +63,6 @@ describe(`appEmberSatisfies`, function () {
         project.addDependency(fakeEmber('4.12.0'));
         project.pkg.dependencies ||= {};
         project.pkg.dependencies['ember-source'] = '^4.11.0';
-        project.write();
 
         let code = transform(`
       import { appEmberSatisfies } from '@embroider/macros';

--- a/packages/macros/tests/babel/app-ember-satisfies.test.ts
+++ b/packages/macros/tests/babel/app-ember-satisfies.test.ts
@@ -34,7 +34,7 @@ describe(`appEmberSatisfies`, function () {
 
     createTests(transform) {
       test('is satisfied', () => {
-        project.addDependency('ember-source', '>= 4.11.0');
+        project.addDependency('ember-source', '4.11.0');
         let code = transform(`
       import { appEmberSatisfies } from '@embroider/macros';
       export default function() {
@@ -79,7 +79,7 @@ describe(`appEmberSatisfies`, function () {
         let code = transform(`
       import { appEmberSatisfies } from '@embroider/macros';
       export default function() {
-        return appEmberSatisfies('not-a-real-dep', '*');
+        return appEmberSatisfies('*');
       }
       `);
         expect(code).not.toMatch(/appEmberSatisfies/);
@@ -122,7 +122,7 @@ describe(`appEmberSatisfies`, function () {
           let range = '*';
           appEmberSatisfies(range);
         `);
-        }).toThrow(/the first argument to appEmberSatisfies must be a string literal/);
+        }).toThrow(/the only argument to appEmberSatisfies must be a string literal/);
       });
 
       test('it considers prereleases (otherwise within the range) as allowed', () => {
@@ -136,25 +136,6 @@ describe(`appEmberSatisfies`, function () {
         `
         );
         expect(runDefault(code)).toBe(true);
-      });
-
-      test('monorepo resolutions resolve correctly', () => {
-        project.addDependency('ember-source', '1.2.3');
-        let code = transform(`
-        import { appEmberSatisfies } from '@embroider/macros';
-
-        export default function() {
-          return {
-            // specified in dependencies
-            util: appEmberSatisfies('*'),
-
-            // not specified as any kind of dep
-            webpack: appEmberSatisfies('*'),
-          }
-        }
-      `);
-
-        expect(runDefault(code)).toEqual({ util: true, webpack: false });
       });
     },
   });

--- a/packages/macros/tests/babel/app-ember-satisfies.test.ts
+++ b/packages/macros/tests/babel/app-ember-satisfies.test.ts
@@ -1,0 +1,161 @@
+import { allBabelVersions, runDefault } from '@embroider/test-support';
+import { Project } from 'scenario-tester';
+import { join } from 'path';
+import { buildMacros } from '../../src/babel';
+
+const ROOT = process.cwd();
+
+describe(`appEmberSatisfies`, function () {
+  let project: Project;
+
+  beforeEach(() => {
+    project = new Project('test-app');
+  });
+
+  afterEach(() => {
+    project?.dispose();
+    process.chdir(ROOT);
+  });
+
+  allBabelVersions({
+    includePresetsTests: true,
+    babelConfig() {
+      project.write();
+
+      let config = buildMacros({
+        dir: project.baseDir,
+      });
+
+      return {
+        filename: join(project.baseDir, 'sample.js'),
+        plugins: config.babelMacros,
+      };
+    },
+
+    createTests(transform) {
+      test('is satisfied', () => {
+        project.addDependency('ember-source', '>= 4.11.0');
+        let code = transform(`
+      import { appEmberSatisfies } from '@embroider/macros';
+      export default function() {
+        return appEmberSatisfies('^4.11.0');
+      }
+      `);
+        expect(runDefault(code)).toBe(true);
+      });
+
+      test('is not satisfied', () => {
+        project.addDependency('ember-source', '2.9.0');
+        let code = transform(`
+      import { appEmberSatisfies } from '@embroider/macros';
+      export default function() {
+        return appEmberSatisfies('^10.0.0');
+      }
+      `);
+        expect(runDefault(code)).toBe(false);
+      });
+
+      test('is not present', () => {
+        let code = transform(`
+      import { appEmberSatisfies } from '@embroider/macros';
+      export default function() {
+        return appEmberSatisfies('^10.0.0');
+      }
+      `);
+        expect(runDefault(code)).toBe(false);
+      });
+
+      test('import gets removed', () => {
+        let code = transform(`
+      import { appEmberSatisfies } from '@embroider/macros';
+      export default function() {
+        return appEmberSatisfies('1');
+      }
+      `);
+        expect(code).not.toMatch(/appEmberSatisfies/);
+      });
+
+      test('entire import statement gets removed', () => {
+        let code = transform(`
+      import { appEmberSatisfies } from '@embroider/macros';
+      export default function() {
+        return appEmberSatisfies('not-a-real-dep', '*');
+      }
+      `);
+        expect(code).not.toMatch(/appEmberSatisfies/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+      });
+
+      test('unused import gets removed', () => {
+        let code = transform(`
+      import { appEmberSatisfies } from '@embroider/macros';
+      export default function() {
+        return 1;
+      }
+      `);
+        expect(code).not.toMatch(/appEmberSatisfies/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+      });
+
+      test('non call error', () => {
+        expect(() => {
+          transform(`
+          import { appEmberSatisfies } from '@embroider/macros';
+          let x = appEmberSatisfies;
+        `);
+        }).toThrow(/You can only use appEmberSatisfies as a function call/);
+      });
+
+      test('args length error', () => {
+        expect(() => {
+          transform(`
+          import { appEmberSatisfies } from '@embroider/macros';
+          appEmberSatisfies('foo', 'bar', 'baz');
+        `);
+        }).toThrow(/appEmberSatisfies takes exactly one argument, you passed 3/);
+      });
+
+      test('non literal arg error', () => {
+        expect(() => {
+          transform(`
+          import { appEmberSatisfies } from '@embroider/macros';
+          let range = '*';
+          appEmberSatisfies(range);
+        `);
+        }).toThrow(/the first argument to appEmberSatisfies must be a string literal/);
+      });
+
+      test('it considers prereleases (otherwise within the range) as allowed', () => {
+        project.addDependency('ember-source', '1.1.0-beta.1');
+        let code = transform(
+          `
+          import { appEmberSatisfies } from '@embroider/macros';
+          export default function() {
+            return appEmberSatisfies('^1.0.0');
+          }
+        `
+        );
+        expect(runDefault(code)).toBe(true);
+      });
+
+      test('monorepo resolutions resolve correctly', () => {
+        project.addDependency('ember-source', '1.2.3');
+        let code = transform(`
+        import { appEmberSatisfies } from '@embroider/macros';
+
+        export default function() {
+          return {
+            // specified in dependencies
+            util: appEmberSatisfies('*'),
+
+            // not specified as any kind of dep
+            webpack: appEmberSatisfies('*'),
+          }
+        }
+      `);
+
+        expect(runDefault(code)).toEqual({ util: true, webpack: false });
+      });
+    },
+  });
+});

--- a/packages/macros/tests/glimmer/app-ember-satisfies.test.ts
+++ b/packages/macros/tests/glimmer/app-ember-satisfies.test.ts
@@ -1,0 +1,66 @@
+import type { TemplateTransformOptions } from './helpers';
+import { Project, templateTests } from './helpers';
+import { join } from 'path';
+
+describe('dependency satisfies', () => {
+  let project: Project;
+  let filename: string;
+
+  beforeAll(async () => {
+    project = new Project('app');
+    project.addDependency('ember-source', '2.9.1');
+    project.addDependency('foo', '1.1.0-beta.1');
+    await project.write();
+    filename = join(project.baseDir, 'sample.js');
+  });
+
+  afterAll(() => {
+    project?.dispose();
+  });
+
+  templateTests((transform: (code: string, options?: TemplateTransformOptions) => Promise<string>) => {
+    test('in content position', async () => {
+      let result = await transform(`{{macroAppEmberSatisfies '^2.8.0'}}`, { filename });
+      expect(result).toEqual('{{true}}');
+    });
+
+    test('in subexpression position', async () => {
+      let result = await transform(`<Foo @a={{macroAppEmberSatisfies '^2.8.0'}} />`, { filename });
+      expect(result).toMatch(/@a=\{\{true\}\}/);
+    });
+
+    test('in branch', async () => {
+      let result = await transform(`{{#if (macroAppEmberSatisfies '^2.8.0')}}red{{else}}blue{{/if}}`, {
+        filename,
+      });
+      expect(result).toEqual('red');
+    });
+
+    test('emits false for out-of-range package', async () => {
+      let result = await transform(`{{macroAppEmberSatisfies '^10.0.0'}}`, { filename });
+      expect(result).toEqual('{{false}}');
+    });
+
+    test('emits false for missing package', async () => {
+      let result = await transform(`{{macroAppEmberSatisfies '^10.0.0'}}`, { filename });
+      expect(result).toEqual('{{false}}');
+    });
+
+    test('args length error', async () => {
+      await expect(async () => {
+        await transform(`{{macroAppEmberSatisfies 'not-a-real-dep' 'another'}}`, { filename });
+      }).rejects.toThrow(/macroAppEmberSatisfies requires one argument, you passed 2/);
+    });
+
+    test('non literal arg error', async () => {
+      await expect(async () => {
+        await transform(`{{macroAppEmberSatisfies someDep }}`, { filename });
+      }).rejects.toThrow(/all arguments to macroAppEmberSatisfies must be string literals/);
+    });
+
+    test('it considers prereleases (otherwise within the range) as allowed', async () => {
+      let result = await transform(`{{macroAppEmberSatisfies '^1.0.0'}}`, { filename });
+      expect(result).toEqual('{{true}}');
+    });
+  });
+});

--- a/packages/macros/tests/glimmer/app-ember-satisfies.test.ts
+++ b/packages/macros/tests/glimmer/app-ember-satisfies.test.ts
@@ -16,7 +16,7 @@ describe('app ember dependency satisfies (prerelease)', () => {
     project?.dispose();
   });
 
-  templateTests((originalTransform) => {
+  templateTests(originalTransform => {
     function transform(text: string): Promise<string> {
       return originalTransform(text, { filename, appRoot: project.baseDir });
     }
@@ -43,7 +43,7 @@ describe('app ember dependency satisfies (released)', () => {
     project?.dispose();
   });
 
-  templateTests((originalTransform) => {
+  templateTests(originalTransform => {
     function transform(text: string): Promise<string> {
       return originalTransform(text, { filename, appRoot: project.baseDir });
     }

--- a/packages/macros/tests/glimmer/app-ember-satisfies.test.ts
+++ b/packages/macros/tests/glimmer/app-ember-satisfies.test.ts
@@ -1,14 +1,40 @@
 import { Project, templateTests } from './helpers';
 import { join } from 'path';
 
-describe('dependency satisfies', () => {
+describe('app ember dependency satisfies (prerelease)', () => {
+  let project: Project;
+  let filename: string;
+
+  beforeAll(async () => {
+    project = new Project('app');
+    project.addDependency('ember-source', '1.2.0-beta.1');
+    await project.write();
+    filename = join(project.baseDir, 'sample.js');
+  });
+
+  afterAll(() => {
+    project?.dispose();
+  });
+
+  templateTests((originalTransform) => {
+    function transform(text: string): Promise<string> {
+      return originalTransform(text, { filename, appRoot: project.baseDir });
+    }
+
+    test('it considers prereleases (otherwise within the range) as allowed', async () => {
+      let result = await transform(`{{macroAppEmberSatisfies '^1.0.0'}}`);
+      expect(result).toEqual('{{true}}');
+    });
+  });
+});
+
+describe('app ember dependency satisfies (released)', () => {
   let project: Project;
   let filename: string;
 
   beforeAll(async () => {
     project = new Project('app');
     project.addDependency('ember-source', '2.9.1');
-    project.addDependency('foo', '1.1.0-beta.1');
     await project.write();
     filename = join(project.baseDir, 'sample.js');
   });
@@ -50,18 +76,13 @@ describe('dependency satisfies', () => {
     test('args length error', async () => {
       await expect(async () => {
         await transform(`{{macroAppEmberSatisfies 'not-a-real-dep' 'another'}}`);
-      }).rejects.toThrow(/macroAppEmberSatisfies requires one argument, you passed 2/);
+      }).rejects.toThrow(/macroAppEmberSatisfies requires only one argument, you passed 2/);
     });
 
     test('non literal arg error', async () => {
       await expect(async () => {
         await transform(`{{macroAppEmberSatisfies someDep }}`);
       }).rejects.toThrow(/all arguments to macroAppEmberSatisfies must be string literals/);
-    });
-
-    test('it considers prereleases (otherwise within the range) as allowed', async () => {
-      let result = await transform(`{{macroAppEmberSatisfies '^1.0.0'}}`);
-      expect(result).toEqual('{{true}}');
     });
   });
 });

--- a/packages/macros/tests/glimmer/dependency-satisfies.test.ts
+++ b/packages/macros/tests/glimmer/dependency-satisfies.test.ts
@@ -1,4 +1,3 @@
-import type { TemplateTransformOptions } from './helpers';
 import { Project, templateTests } from './helpers';
 import { join } from 'path';
 
@@ -18,7 +17,7 @@ describe('dependency satisfies', () => {
     project?.dispose();
   });
 
-  templateTests((transform: (code: string, options?: TemplateTransformOptions) => Promise<string>) => {
+  templateTests((transform) => {
     test('in content position', async () => {
       let result = await transform(`{{macroDependencySatisfies 'qunit' '^2.8.0'}}`, { filename });
       expect(result).toEqual('{{true}}');

--- a/packages/macros/tests/glimmer/dependency-satisfies.test.ts
+++ b/packages/macros/tests/glimmer/dependency-satisfies.test.ts
@@ -17,7 +17,7 @@ describe('dependency satisfies', () => {
     project?.dispose();
   });
 
-  templateTests((transform) => {
+  templateTests(transform => {
     test('in content position', async () => {
       let result = await transform(`{{macroDependencySatisfies 'qunit' '^2.8.0'}}`, { filename });
       expect(result).toEqual('{{true}}');

--- a/packages/macros/tests/glimmer/fail-build.test.ts
+++ b/packages/macros/tests/glimmer/fail-build.test.ts
@@ -2,9 +2,15 @@ import { templateTests } from './helpers';
 import type { MacrosConfig } from '../../src/node';
 
 describe(`macroFailBuild`, function () {
-  templateTests(function (transform: (code: string) => Promise<string>, config: MacrosConfig) {
-    config.setOwnConfig(__filename, { failureMessage: 'I said so' });
-    config.finalize();
+  templateTests(function (originalTransform) {
+    function configure(config: MacrosConfig) {
+      config.setOwnConfig(__filename, { failureMessage: 'I said so' });
+      config.finalize();
+    }
+
+    async function transform(text: string): Promise<string> {
+      return originalTransform(text, { configure });
+    }
 
     test('it can fail the build, content position', async () => {
       await expect(async () => {

--- a/packages/macros/tests/glimmer/get-config.test.ts
+++ b/packages/macros/tests/glimmer/get-config.test.ts
@@ -1,22 +1,28 @@
+import { MacrosConfig } from '../../src/node';
 import { templateTests } from './helpers';
-import type { MacrosConfig } from '../../src/node';
 
 describe(`macroGetConfig`, function () {
-  templateTests(function (transform: (code: string) => Promise<string>, config: MacrosConfig) {
-    config.setOwnConfig(__filename, {
-      mode: 'amazing',
-      count: 42,
-      inner: {
-        items: [{ name: 'Arthur', awesome: true }],
-        description: null,
-      },
-    });
+  templateTests(function (originalTransform) {
+    function configure(config: MacrosConfig) {
+      config.setOwnConfig(__filename, {
+        mode: 'amazing',
+        count: 42,
+        inner: {
+          items: [{ name: 'Arthur', awesome: true }],
+          description: null,
+        },
+      });
 
-    config.setConfig(__filename, 'scenario-tester', {
-      color: 'orange',
-    });
+      config.setConfig(__filename, 'scenario-tester', {
+        color: 'orange',
+      });
 
-    config.finalize();
+      config.finalize();
+    }
+
+    async function transform(text: string): Promise<string> {
+      return originalTransform(text, { configure });
+    }
 
     test('macroGetOwnConfig in content position', async function () {
       let code = await transform(`{{macroGetOwnConfig "mode"}}`);

--- a/packages/macros/tests/glimmer/get-config.test.ts
+++ b/packages/macros/tests/glimmer/get-config.test.ts
@@ -1,4 +1,4 @@
-import { MacrosConfig } from '../../src/node';
+import type { MacrosConfig } from '../../src/node';
 import { templateTests } from './helpers';
 
 describe(`macroGetConfig`, function () {

--- a/packages/macros/tests/glimmer/helpers.ts
+++ b/packages/macros/tests/glimmer/helpers.ts
@@ -10,10 +10,11 @@ const compilerPath = emberTemplateCompiler().path;
 
 export { Project };
 
-type CreateTests = (transform: (templateContents: string, options?: TemplateTransformOptions) => Promise<string>) => void;
+type CreateTests = (
+  transform: (templateContents: string, options?: TemplateTransformOptions) => Promise<string>
+) => void;
 
 export interface TemplateTransformOptions {
-
   /**
    * The path to the source we are transforming
    */
@@ -26,7 +27,7 @@ export interface TemplateTransformOptions {
 
   /**
    * Allow further customization of the macros config before finalization and invocation of the transform callback.
-   * 
+   *
    * If this option is passed you must call `config.finalize()` yourself in this callback.
    */
   configure?: (config: MacrosConfig) => void;
@@ -91,7 +92,6 @@ export function templateTests(createTests: CreateTests) {
     );
     return hbs ?? `no hbs found`;
   };
-
 
   createTests(transform);
 }

--- a/packages/macros/tests/glimmer/macro-condition.test.ts
+++ b/packages/macros/tests/glimmer/macro-condition.test.ts
@@ -1,6 +1,5 @@
 import { Project } from 'scenario-tester';
 import { join } from 'path';
-import type { TemplateTransformOptions } from './helpers';
 import { templateTests } from './helpers';
 
 describe(`macroCondition`, function () {
@@ -10,7 +9,7 @@ describe(`macroCondition`, function () {
     project?.dispose();
   });
 
-  templateTests(function (transform: (code: string, opts?: TemplateTransformOptions) => Promise<string>) {
+  templateTests(function (transform) {
     test('leaves regular if-block untouched', async function () {
       let code = await transform(`{{#if this.error}}red{{else}}blue{{/if}}`);
       expect(code).toEqual(`{{#if this.error}}red{{else}}blue{{/if}}`);

--- a/packages/macros/tests/runtime.test.ts
+++ b/packages/macros/tests/runtime.test.ts
@@ -1,4 +1,5 @@
 import {
+  appEmberSatisfies,
   dependencySatisfies,
   macroCondition,
   each,
@@ -16,6 +17,11 @@ describe(`type-only exports`, function () {
   test('dependencySatisfies exists', function () {
     expect(dependencySatisfies).toBeDefined();
     expect(dependencySatisfies).toThrow(ERROR_REGEX);
+  });
+
+  test('appEmberSatisfies exists', function () {
+    expect(appEmberSatisfies).toBeDefined();
+    expect(appEmberSatisfies).toThrow(ERROR_REGEX);
   });
 
   test('macroCondition exists', function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,7 +602,16 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.14.5
+<<<<<<< HEAD
         version: 7.28.4
+||||||| parent of be9e9c48 (Fix issues with macroCondition tests trying to use a babel plugin that was not declared in the package.json)
+        version: 7.28.0
+=======
+        version: 7.28.0
+      '@babel/plugin-transform-class-properties':
+        specifier: ^7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+>>>>>>> be9e9c48 (Fix issues with macroCondition tests trying to use a babel plugin that was not declared in the package.json)
       '@babel/plugin-transform-modules-amd':
         specifier: ^7.19.6
         version: 7.27.1(@babel/core@7.28.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,16 +602,10 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.14.5
-<<<<<<< HEAD
         version: 7.28.4
-||||||| parent of be9e9c48 (Fix issues with macroCondition tests trying to use a babel plugin that was not declared in the package.json)
-        version: 7.28.0
-=======
-        version: 7.28.0
       '@babel/plugin-transform-class-properties':
         specifier: ^7.27.1
-        version: 7.27.1(@babel/core@7.28.0)
->>>>>>> be9e9c48 (Fix issues with macroCondition tests trying to use a babel plugin that was not declared in the package.json)
+        version: 7.27.1(@babel/core@7.28.4)
       '@babel/plugin-transform-modules-amd':
         specifier: ^7.19.6
         version: 7.27.1(@babel/core@7.28.4)


### PR DESCRIPTION
Why?:
- while trying to implement:
  https://github.com/tracked-tools/tracked-built-ins/pull/440
  I ran in to an issue where `dependencySatisfies` was always returning false (because the peerDep was not declared). We _can't_ declare the peerDep because then we force all consumers of `tracked-built-ins` to _forward_ the peer. We've already learned that we can't successfully manage a fully correct package.json-declared dep graph. It's been best to just _not_ declare peers, and rely on the resolve algo, as well as the assumption that the host app _must_ provide ember-source. 