### PR TITLE
Update pkg-entry-points dependency version

### DIFF
--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -35,7 +35,7 @@
     "js-string-escape": "^1.0.1",
     "lodash": "^4.17.21",
     "minimatch": "^3.0.4",
-    "pkg-entry-points": "^1.1.0",
+    "pkg-entry-points": "^1.1.1",
     "resolve.exports": "^2.0.2",
     "resolve-package-path": "^4.0.1",
     "semver": "^7.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,7 +758,7 @@ importers:
         specifier: ^3.0.4
         version: 3.1.2
       pkg-entry-points:
-        specifier: ^1.1.0
+        specifier: ^1.1.1
         version: 1.1.1
       resolve-package-path:
         specifier: ^4.0.1


### PR DESCRIPTION
1.1.0 scans all of node_modules.

we should not allow 1.1.0 ever.
