### PR TITLE
fix release of legacy-inspector-support

### DIFF
--- a/packages/legacy-inspector-support/package.json
+++ b/packages/legacy-inspector-support/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "Module that installs globals ember-inspector support",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embroider-build/embroider.git",
+    "directory": "packages/legacy-inspector-support"
+  },
   "exports": {
     "./ember-source-4.12": {
       "default": "./src/ember-source-4.12.js",


### PR DESCRIPTION
a (good?) side-effect of using provenance is that it forces all of our package.jsons to point to the correct github url 🙈 if you don't have this it breaks the release. Seems like something we should add a lint for 🤔 