### PR TITLE
simplify gitignore for @embroider/vite

### DIFF
--- a/packages/vite/.gitignore
+++ b/packages/vite/.gitignore
@@ -2,8 +2,4 @@
 /src/**/*.js
 /src/**/*.d.ts
 /src/**/*.map
-/tests/**/*.js
-/tests/**/*.d.ts
-/tests/**/*.map
 /dist/
-!tests/warn-root-url.test.js


### PR DESCRIPTION
we don't build tests inline in this package any more (and shouldn't do so anywhere) 

