### PR TITLE
don't break SSR with legacy-inspector-support

### DIFF
--- a/packages/legacy-inspector-support/src/common-implementation.js
+++ b/packages/legacy-inspector-support/src/common-implementation.js
@@ -9,5 +9,8 @@ export default function setupGlobal(app, importCallback) {
     loadCompatInspector: importCallback,
   });
 
-  window.dispatchEvent(new Event('Ember'));
+  // Only dispatch an event if window.dispatchEvent is available i.e. we are not in SSR mode
+  if (globalThis.dispatchEvent) {
+    globalThis.dispatchEvent(new Event('Ember'));
+  }
 }


### PR DESCRIPTION
- update `window` reference to `globalThis` since we're a module
- only call `globalThis.dispatchEvent` if the function is available

I have tested this with a patch locally on an SSR'd Ember app 👍 