### PR TITLE
fix error on windows build with lazy engines or re-written packages

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -253,7 +253,14 @@ async function maybeCaptureNewOptimizedDep(
     { flush: true }
   );
   renameSync(fromFile + '.tmp', fromFile);
-  ensureSymlinkSync(pkg.root, join(jumpRoot, 'node_modules', pkg.name));
+  try {
+    ensureSymlinkSync(pkg.root, join(jumpRoot, 'node_modules', pkg.name));
+  } catch (error) {
+    //on windows ensureSymlinkSync can throw an EEXIST for invalid reasons
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  }
   let newResult = await context.resolve(target, fromFile);
   if (newResult) {
     if (idFromResult(newResult) === foundFile) {


### PR DESCRIPTION
on windows ensureSymlinkSync would try to recreate the same inode with a different `dev` stat and throw an EEXIST

ignoring this allows the build to continue as we already have a correct symlink