### PR TITLE
tolerate negation before macroCondition

### DIFF
--- a/packages/macros/src/babel/macro-condition.ts
+++ b/packages/macros/src/babel/macro-condition.ts
@@ -4,27 +4,36 @@ import type { types as t } from '@babel/core';
 import error from './error';
 import type State from './state';
 
-export type MacroConditionPath = NodePath<t.IfStatement | t.ConditionalExpression> & {
-  get(test: 'test'): NodePath<t.CallExpression> & { get(callee: 'callee'): NodePath<t.Identifier> };
-};
+export interface MacroCondition {
+  parity: boolean;
+  conditional: NodePath<t.IfStatement | t.ConditionalExpression>;
+  callExpression: NodePath<t.CallExpression>;
+}
 
-export function isMacroConditionPath(
+export function identifyMacroConditionPath(
   path: NodePath<t.IfStatement | t.ConditionalExpression>
-): path is MacroConditionPath {
+): MacroCondition | false {
+  let parity = true;
   let test = path.get('test');
+
+  if (test.isUnaryExpression() && test.node.operator === '!') {
+    parity = false;
+    test = test.get('argument');
+  }
+
   if (test.isCallExpression()) {
     let callee = test.get('callee');
     if (callee.referencesImport('@embroider/macros', 'macroCondition')) {
-      return true;
+      return { parity, conditional: path, callExpression: test };
     }
   }
   return false;
 }
 
-export default function macroCondition(conditionalPath: MacroConditionPath, state: State) {
-  let args = conditionalPath.get('test').get('arguments');
+export default function macroCondition(macro: MacroCondition, state: State) {
+  let args = macro.callExpression.get('arguments');
   if (args.length !== 1) {
-    throw error(conditionalPath, `macroCondition accepts exactly one argument, you passed ${args.length}`);
+    throw error(macro.conditional, `macroCondition accepts exactly one argument, you passed ${args.length}`);
   }
 
   let [predicatePath] = args;
@@ -33,18 +42,19 @@ export default function macroCondition(conditionalPath: MacroConditionPath, stat
     throw error(args[0], `the first argument to macroCondition must be statically known`);
   }
 
-  let consequent = conditionalPath.get('consequent');
-  let alternate = conditionalPath.get('alternate');
+  let consequent = macro.conditional.get('consequent');
+  let alternate = macro.conditional.get('alternate');
 
   if (state.opts.mode === 'run-time' && predicate.hasRuntimeImplementation !== false) {
-    let callee = conditionalPath.get('test').get('callee');
+    let callee = macro.conditional.get('test').get('callee');
     callee.replaceWith(state.importUtil.import(callee, state.pathToOurAddon('runtime'), 'macroCondition'));
   } else {
-    let [kept, removed] = predicate.value ? [consequent.node, alternate.node] : [alternate.node, consequent.node];
+    let [kept, removed] =
+      predicate.value === macro.parity ? [consequent.node, alternate.node] : [alternate.node, consequent.node];
     if (kept) {
-      conditionalPath.replaceWith(kept);
+      macro.conditional.replaceWith(kept);
     } else {
-      conditionalPath.remove();
+      macro.conditional.remove();
     }
     if (removed) {
       state.removed.add(removed);

--- a/packages/macros/src/babel/macros-babel-plugin.ts
+++ b/packages/macros/src/babel/macros-babel-plugin.ts
@@ -4,7 +4,7 @@ import type State from './state';
 import { initState } from './state';
 import type { Mode as GetConfigMode } from './get-config';
 import { inlineRuntimeConfig, insertConfig } from './get-config';
-import macroCondition, { isMacroConditionPath } from './macro-condition';
+import macroCondition, { identifyMacroConditionPath } from './macro-condition';
 import { isEachPath, insertEach } from './each';
 
 import error from './error';
@@ -31,9 +31,10 @@ export default function main(context: typeof Babel): unknown {
     },
     'IfStatement|ConditionalExpression': {
       enter(path: NodePath<t.IfStatement | t.ConditionalExpression>, state: State) {
-        if (isMacroConditionPath(path)) {
-          state.calledIdentifiers.add(path.get('test').get('callee').node);
-          macroCondition(path, state);
+        let found = identifyMacroConditionPath(path);
+        if (found) {
+          state.calledIdentifiers.add(found.callExpression.get('callee').node);
+          macroCondition(found, state);
         }
       },
     },

--- a/packages/macros/tests/babel/macro-condition.test.ts
+++ b/packages/macros/tests/babel/macro-condition.test.ts
@@ -386,6 +386,23 @@ describe('macroCondition', function () {
         expect(code).not.toMatch(/alpha/);
       });
 
+      // adding this because some other babel plugins can introduce this as part
+      // of their "optimization".
+      test('tolerates negation between IfStatement and macroCondition CallExpression', () => {
+        let code = transform(`
+      import { macroCondition, getConfig } from '@embroider/macros';
+      export default function() {
+        if (!macroCondition(getConfig('qunit').items[0]["approved"])) {
+          return 'alpha';
+        } else {
+          return 'beta';
+        }
+      }
+      `);
+        expect(run(code, { filename })).toBe('beta');
+        expect(code).not.toMatch(/alpha/);
+      });
+
       if (transform.babelMajorVersion === 7) {
         buildTimeTest('can be used as class field initializer', () => {
           let code = transform(`


### PR DESCRIPTION
Other plugins can rewrite `if (macroCondition(...))` to `if (!macroCondition(...))` before we get a chance to handle it. This allows that syntax.