### PR TITLE
Support `content-for` with single quotes as well

### DIFF
--- a/packages/vite/src/content-for.ts
+++ b/packages/vite/src/content-for.ts
@@ -15,6 +15,7 @@ export function contentFor(): Plugin {
       let contentsForConfig = config[path];
       for (const [contentType, htmlContent] of Object.entries(contentsForConfig)) {
         html = html.replace(`{{content-for "${contentType}"}}`, `${htmlContent}`);
+        html = html.replace(`{{content-for '${contentType}'}}`, `${htmlContent}`);
       }
       return html;
     },

--- a/tests/scenarios/compat-addon-classic-features-test.ts
+++ b/tests/scenarios/compat-addon-classic-features-test.ts
@@ -25,8 +25,12 @@ appScenarios
             switch (type) {
               case 'body':
                 return '<p>Content for body</p>';
+              case 'body-single-quotes':
+                return '<p>Content for body-single-quotes</p>';
               case 'custom':
                 return '<p>Content for custom</p>';
+              case 'custom-single-quotes':
+                return '<p>Content for custom-single-quotes</p>';
               default:
                 return '';
             }
@@ -51,7 +55,7 @@ appScenarios
           });
 
           return maybeEmbroider(app, {
-            availableContentForTypes: ['custom'],
+            availableContentForTypes: ['body-single-quotes', 'custom', 'custom-single-quotes'],
           });
         };
       `,
@@ -73,7 +77,9 @@ appScenarios
             </head>
             <body>
               {{content-for "body"}}
+              {{content-for 'body-single-quotes'}}
               {{content-for "custom"}}
+              {{content-for 'custom-single-quotes'}}
 
               <script src="/@embroider/virtual/vendor.js"></script>
               <script type="module">
@@ -111,11 +117,15 @@ appScenarios
 
         let content = readFileSync(`${app.dir}/dist/index.html`).toString();
         assert.true(content.includes('<p>Content for body</p>'));
+        assert.true(content.includes('<p>Content for body-single-quotes</p>'));
         assert.true(content.includes('<p>Content for custom</p>'));
+        assert.true(content.includes('<p>Content for custom-single-quotes</p>'));
 
         content = readFileSync(`${app.dir}/dist/tests/index.html`).toString();
         assert.true(content.includes('<p>Content for body</p>'));
+        assert.true(!content.includes('<p>Content for body-single-quotes</p>'));
         assert.true(!content.includes('<p>Content for custom</p>'));
+        assert.true(!content.includes('<p>Content for custom-single-quotes</p>'));
       });
 
       test('content-for are replaced: dev mode', async function (assert) {
@@ -125,7 +135,9 @@ appScenarios
           let response = await fetch(`${url}/`);
           let text = await response.text();
           assert.true(text.includes('<p>Content for body</p>'));
+          assert.true(text.includes('<p>Content for body-single-quotes</p>'));
           assert.true(text.includes('<p>Content for custom</p>'));
+          assert.true(text.includes('<p>Content for custom-single-quotes</p>'));
         } finally {
           await server.shutdown();
         }


### PR DESCRIPTION
~~Apparently, for whatever reason, our `index.html` file was using single quotes for `{{content-for}}`.~~
The blueprints (`app` and `addon`) used to use single quotes for these, and it's possible not everyone updated to using double quotes. This isn't flagged or transformed when running the Vite codemod, and you end up with a screen like this:

<img width="2560" height="1440" alt="Screenshot from 2025-11-04 11-55-53" src="https://github.com/user-attachments/assets/c75cbb65-9327-4316-86d3-407126cc83f3" />
