### PR TITLE
fix deployment of addon-shim

### DIFF
--- a/packages/addon-shim/.gitignore
+++ b/packages/addon-shim/.gitignore
@@ -22,6 +22,7 @@
 /npm-debug.log*
 /testem.log
 /yarn-error.log
+/tsconfig.tsbuildinfo
 
 # ember-try
 /.node_modules.ember-try/

--- a/packages/addon-shim/package.json
+++ b/packages/addon-shim/package.json
@@ -15,6 +15,9 @@
     "doc": "doc",
     "test": "tests"
   },
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@embroider/shared-internals": "workspace:^",
     "broccoli-funnel": "^3.0.8",

--- a/packages/addon-shim/tsconfig.json
+++ b/packages/addon-shim/tsconfig.json
@@ -7,7 +7,6 @@
     "composite": true,
     "outDir": "dist",
     "rootDir": "./src",
-    "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "declarationMap": true
   },
 }


### PR DESCRIPTION
in #2604 I fixed the typescript build for this package but I forgot to add the dist folder to the `files` array in package.json 🙈 