### PR TITLE
Don't let keepAssets plugin corrupt source maps

### DIFF
--- a/packages/addon-dev/src/rollup-keep-assets.ts
+++ b/packages/addon-dev/src/rollup-keep-assets.ts
@@ -39,6 +39,7 @@ export default function keepAssets({
           },
         };
       }
+      return null;
     },
 
     transform(code: string, id: string) {
@@ -64,20 +65,24 @@ export default function keepAssets({
           return `${marker}("${ref}")`;
         }
       }
+      return null;
     },
     renderChunk(code, chunk) {
-      const { getName, imports } = nameTracker(code, exports);
+      if (code.includes(marker)) {
+        const { getName, imports } = nameTracker(code, exports);
 
-      code = code.replace(
-        new RegExp(`${marker}\\("([^"]+)"\\)`, 'g'),
-        (_x, ref) => {
-          let assetFileName = this.getFileName(ref);
-          let relativeName =
-            './' + relative(dirname(chunk.fileName), assetFileName);
-          return getName(relativeName) ?? '';
-        }
-      );
-      return imports() + code;
+        code = code.replace(
+          new RegExp(`${marker}\\("([^"]+)"\\)`, 'g'),
+          (_x, ref) => {
+            let assetFileName = this.getFileName(ref);
+            let relativeName =
+              './' + relative(dirname(chunk.fileName), assetFileName);
+            return getName(relativeName) ?? '';
+          }
+        );
+        return imports() + code;
+      }
+      return null;
     },
   };
 }


### PR DESCRIPTION
This fixes an issue where v2 addon source maps are broken, and the follow shows up in the output when building:

```
(!) Broken sourcemap
https://rollupjs.org/troubleshooting/#warning-sourcemap-is-likely-to-be-incorrect
Plugins that transform code (such as "keep-assets") should generate accompanying sourcemaps.
```

I believe the root cause is that `renderChunk` is returning a string in all cases, even when it's not actually modifying the code, which causes rollup to [lose the sourcemaps](https://github.com/rollup/rollup/blob/04766253a50e40a1695a9bb405e90879188e97ea/src/utils/renderChunks.ts#L124-L138) for that chunk. As you can see from that code snippet, returning `null` from the hook is way to prevent this from happening.

Relatedly, rollup appears to have some confusing hook types. Most hooks are typed to return their value, or [NullValue](https://github.com/rollup/rollup/blob/04766253a50e40a1695a9bb405e90879188e97ea/src/rollup/types.d.ts#L339-L367), and [NullValue](https://github.com/rollup/rollup/blob/04766253a50e40a1695a9bb405e90879188e97ea/src/rollup/types.d.ts#L22) includes `undefined`, so the types say that these hooks can return `undefined`. However, at runtime [only null](https://github.com/rollup/rollup/blob/04766253a50e40a1695a9bb405e90879188e97ea/src/utils/PluginDriver.ts#L162) is treated as a non-result (in addition to the specific `renderChunk` hook result behavior described above), so these hooks should return `null` when not doing any work.

So, the fix here is to make `renderChunk` detect when it's not handling the content, and update all the hooks to return `null` instead of `undefined` when not handling the content, which may not be directly related to the bug I was seeing, but will likely prevent other unintended oddities/side-effects.