### PR TITLE
Cleanup for #2616

### DIFF
--- a/packages/addon-dev/src/rollup-keep-assets.ts
+++ b/packages/addon-dev/src/rollup-keep-assets.ts
@@ -39,7 +39,6 @@ export default function keepAssets({
           },
         };
       }
-      return null;
     },
 
     transform(code: string, id: string) {
@@ -65,7 +64,6 @@ export default function keepAssets({
           return `${marker}("${ref}")`;
         }
       }
-      return null;
     },
     renderChunk(code, chunk) {
       if (code.includes(marker)) {
@@ -82,7 +80,6 @@ export default function keepAssets({
         );
         return imports() + code;
       }
-      return null;
     },
   };
 }


### PR DESCRIPTION
We don't actually need to return null in those cases -- I mis-read rollup's code and missed that they were doing `==` and `!=` comparisons against `null`, and since `null == undefined`, returning `undefined` works just fine.

So, keep the fix to not always return a string from `renderChunk`, but roll back the `return null` additions.