### PR TITLE
Fix rollup incremental plugin

### DIFF
--- a/packages/addon-dev/src/rollup-incremental-plugin.ts
+++ b/packages/addon-dev/src/rollup-incremental-plugin.ts
@@ -23,7 +23,7 @@ export default function incremental(): Plugin {
   function initGeneratedFiles(outDir: string) {
     if (existsSync(outDir)) {
       const files = walkSync(outDir, {
-        globs: ['*/**'],
+        globs: ['**/*'],
         directories: false,
       });
       for (const file of files) {


### PR DESCRIPTION
When performing a rebuild (not a watch mode initiated rebuild, but a build when the `dist` folder already exists from a previous build), the incremental plugin was not correctly enumerating the existing files due to a typo in the glob, and was only deleting stale files in subdirectories, and not in the root directory. Because chunk files include their hash, this meant that over time the number of files at the root of `dist/` could grow unboundedly -- one of my addon repos had over 700 of them!

So, write a test for this behavior and fix the regex.