### PR TITLE
Protect against the compat build running multiple times in parallel

### DIFF
--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -53,12 +53,11 @@ export function emberBuild(command: string, mode: string, resolvableExtensions: 
   });
 }
 
-let buildPromise: Promise<void> | undefined;
-
 export function compatPrebuild(): Plugin {
   let viteCommand: string | undefined;
   let viteMode: string | undefined;
   let resolvableExtensions: string[] | undefined;
+  let buildPromise: Promise<void> | undefined;
 
   return {
     name: 'embroider-builder',


### PR DESCRIPTION
when vite is invoked, `options` can be called multiple times.


This change prevents us calling `emberBuild` multiple times in those situations.

We use the `options` hook here because it's the earliest hook available to us, and we need the compat build stuff to happen before everything else.