### PR TITLE
App ember satisfies for dummy apps

### DIFF
--- a/packages/macros/src/babel/app-ember-satisfies.ts
+++ b/packages/macros/src/babel/app-ember-satisfies.ts
@@ -9,7 +9,10 @@ const CACHE = new Map<string, string | false>();
 
 function getAppEmberVersion(state: State): string | false {
   let appRoot = state.packageCache.appRoot;
-
+  const DUMMY_APP_PATH = '/tests/dummy';
+  if (appRoot.endsWith(DUMMY_APP_PATH)) {
+    appRoot = appRoot.slice(0, -DUMMY_APP_PATH.length);
+  }
   if (CACHE.has(appRoot)) {
     return CACHE.get(appRoot)!;
   }


### PR DESCRIPTION
dummy apps have no package.json to be read so can't be used

since it's a well known path we strip it to find the real package