### PR TITLE
Make publicAssets() support multiple folders

### DIFF
--- a/packages/addon-dev/README.md
+++ b/packages/addon-dev/README.md
@@ -18,9 +18,11 @@ For a guide on porting a V1 addon to V2, see https://github.com/embroider-build/
 2. Copy the `./sample-rollup.config.js` in this repo to your own `rollup.config.js`.
 3. Copy the `./sample-babel.config.json` in this repo to your own `babel.config.json`.
 
-### addon.publicAssets(path <required>, options)
+### addon.publicAssets(path <required>, options) *or* addon.publicAssets(pathsAndOptions <required>)
 
 A rollup plugin to expose a folder of assets. `path` is a required to define which folder to expose. `options.include` is a glob pattern passed to `walkSync.include` to pick files. `options.exlude` is a glob pattern passed to `walkSync.ignore` to exclude files. `options.namespace` is the namespace to expose files, defaults to the package name + the path that you provided e.g. if you call `addon.publicAssets('public')` in a v2 addon named `super-addon` then your namespace will default to `super-addon/public`.
+
+To specify multiple folders, pass a `pathsAndOptions` array, where each entry includes a `path` and `options`.
 
 ### addon.keepAssets(patterns: string[], exports?: 'default' | '*')
 

--- a/packages/addon-dev/src/rollup.ts
+++ b/packages/addon-dev/src/rollup.ts
@@ -5,10 +5,7 @@ import { default as appReexports } from './rollup-app-reexports';
 import { default as keepAssets } from './rollup-keep-assets';
 import { default as declarations } from './rollup-declarations';
 import { default as dependencies } from './rollup-addon-dependencies';
-import {
-  default as publicAssets,
-  type PublicAssetsOptions,
-} from './rollup-public-assets';
+import { default as publicAssets } from './rollup-public-assets';
 import { default as clean } from './rollup-incremental-plugin';
 import type { Plugin } from 'rollup';
 
@@ -107,8 +104,8 @@ export class Addon {
     return dependencies();
   }
 
-  publicAssets(path: string, opts?: PublicAssetsOptions) {
-    return publicAssets(path, opts);
+  publicAssets(...args: Parameters<typeof publicAssets>) {
+    return publicAssets(...args);
   }
 
   declarations(path: string, command?: string) {


### PR DESCRIPTION
Extend the publicAssets() rollup plugin to be able to accept multiple paths + options. Note that this preserves backwards compatibility with the existing single-path usage.