### PR TITLE
use a filter for transform in hbs and template-tag plugins instead of early-out return in the transform function

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -24,7 +24,6 @@
     "@babel/core": "^7.22.9",
     "@embroider/macros": "workspace:*",
     "@embroider/reverse-exports": "workspace:*",
-    "@rollup/pluginutils": "^5.1.0",
     "assert-never": "^1.2.1",
     "browserslist": "*",
     "browserslist-to-esbuild": "^2.1.1",

--- a/packages/vite/src/hbs.ts
+++ b/packages/vite/src/hbs.ts
@@ -1,9 +1,6 @@
-import { createFilter } from '@rollup/pluginutils';
 import type { PluginContext } from 'rollup';
 import type { Plugin } from 'vite';
 import { hbsToJS, templateOnlyComponentSource } from '@embroider/core';
-
-const hbsFilter = createFilter('**/*.hbs?([?]*)');
 
 export function hbs(): Plugin {
   return {
@@ -18,11 +15,13 @@ export function hbs(): Plugin {
       }
     },
 
-    transform(code: string, id: string) {
-      if (!hbsFilter(id)) {
-        return null;
-      }
-      return hbsToJS(code);
+    transform: {
+      filter: {
+        id: '**/*.hbs?([?]*)',
+      },
+      handler(code: string) {
+        return hbsToJS(code);
+      },
     },
   };
 }

--- a/packages/vite/src/template-tag.ts
+++ b/packages/vite/src/template-tag.ts
@@ -1,8 +1,5 @@
-import { createFilter } from '@rollup/pluginutils';
 import type { Plugin } from 'vite';
 import { Preprocessor } from 'content-tag';
-
-const gjsFilter = createFilter('**/*.{gjs,gts}?(\\?)*');
 
 export function templateTag(): Plugin {
   let preprocessor = new Preprocessor();
@@ -11,13 +8,15 @@ export function templateTag(): Plugin {
     name: 'embroider-template-tag',
     enforce: 'pre',
 
-    transform(code: string, id: string) {
-      if (!gjsFilter(id)) {
-        return null;
-      }
-      return preprocessor.process(code, {
-        filename: id,
-      });
+    transform: {
+      filter: {
+        id: '**/*.{gjs,gts}?(\\?)*',
+      },
+      handler(code: string, id: string) {
+        return preprocessor.process(code, {
+          filename: id,
+        });
+      },
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,9 +955,6 @@ importers:
       '@embroider/reverse-exports':
         specifier: workspace:*
         version: link:../reverse-exports
-      '@rollup/pluginutils':
-        specifier: ^5.1.0
-        version: 5.3.0(rollup@4.53.3)
       assert-never:
         specifier: ^1.2.1
         version: 1.4.0
@@ -18206,14 +18203,6 @@ snapshots:
       picomatch: 4.0.3
     optionalDependencies:
       rollup: 3.29.5
-
-  '@rollup/pluginutils@5.3.0(rollup@4.53.3)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.53.3
 
   '@rollup/rollup-android-arm-eabi@4.53.3':
     optional: true


### PR DESCRIPTION
This allows rolldown-vite to execute the filter in rustland before passing back to the JS environment. I don't know how much of a performance increase this might have but why not 🤷 

Edit: we also drop a dependency which is nice 😂 