### PR TITLE
Fix dependency-aware macros in dummy apps

### DIFF
--- a/tests/fixtures/macro-sample-addon/addon/app-ember-satisfies.js
+++ b/tests/fixtures/macro-sample-addon/addon/app-ember-satisfies.js
@@ -1,0 +1,8 @@
+import { appEmberSatisfies } from '@embroider/macros';
+
+export default function() {
+  return {
+    aboveTwo: appEmberSatisfies('> 2.0.0'),
+    belowTwo: appEmberSatisfies('< 2.0.0')
+  };
+}

--- a/tests/fixtures/macro-sample-addon/ember-cli-build.js
+++ b/tests/fixtures/macro-sample-addon/ember-cli-build.js
@@ -15,8 +15,5 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return maybeEmbroider(app, {
-    useAddonAppBoot: false,
-    useAddonConfigModule: false,
-  });
+  return app.toTree();
 };

--- a/tests/fixtures/macro-sample-addon/tests/unit/app-ember-satisfies-test.js
+++ b/tests/fixtures/macro-sample-addon/tests/unit/app-ember-satisfies-test.js
@@ -1,0 +1,9 @@
+import { module, test } from 'qunit';
+import appEmberSat from 'macro-sample-addon/app-ember-satisfies';
+
+module('Unit | appEmberSatisfies', function() {
+  test('addon code can use appEmberSatisfies', function(assert) {
+    assert.strictEqual(appEmberSat().aboveTwo, true);
+    assert.strictEqual(appEmberSat().belowTwo, false);
+  })
+});

--- a/tests/scenarios/macro-test.ts
+++ b/tests/scenarios/macro-test.ts
@@ -201,9 +201,6 @@ function dummyAppScenarioSetup(project: Project) {
   let addonFiles = loadFromFixtureData('macro-sample-addon');
   project.name = 'macro-sample-addon';
   project.linkDependency('@embroider/macros', { baseDir: __dirname });
-  project.linkDependency('@embroider/webpack', { baseDir: __dirname });
-  project.linkDependency('@embroider/compat', { baseDir: __dirname });
-  project.linkDependency('@embroider/core', { baseDir: __dirname });
 
   addonFiles['index.js'] = `
   module.exports = {
@@ -275,7 +272,6 @@ dummyAppScenarios
   });
 
 dummyAppScenarios
-  .skip()
   .map('macro-sample-addon-classic', project => {
     dummyAppScenarioSetup(project);
     project.linkDependency('ember-cli-babel', { baseDir: __dirname, resolveName: 'ember-cli-babel-latest' });
@@ -289,8 +285,8 @@ dummyAppScenarios
         addon = await scenario.prepare();
       });
 
-      test(`pnpm test EMBROIDER_TEST_SETUP_FORCE=classic`, async function (assert) {
-        let result = await addon.execute('cross-env EMBROIDER_TEST_SETUP_FORCE=classic pnpm ember test');
+      test(`pnpm test`, async function (assert) {
+        let result = await addon.execute('pnpm ember test');
         assert.equal(result.exitCode, 0, result.output);
       });
     });


### PR DESCRIPTION
This fixes the issue in  https://github.com/embroider-build/embroider/pull/2628.

appEmberSatisfies and dependencySatisfies need to work inside classic dummy apps, and didn't.

There was already a passing skipped test for a classic build of an addon's dummy app that got skipped too agressively when we dropped support for dummy apps. This unskips it and extends it.