### PR TITLE
Narrow gjsFilter to not include files that happen to have .gjs in their file name

### DIFF
--- a/packages/vite/src/template-tag.ts
+++ b/packages/vite/src/template-tag.ts
@@ -2,7 +2,14 @@ import { createFilter } from '@rollup/pluginutils';
 import type { Plugin } from 'vite';
 import { Preprocessor } from 'content-tag';
 
-const gjsFilter = createFilter('**/*.{gjs,gts}?(\\?)*');
+const gjsPathFilter = createFilter('**/*.{gjs,gts}');
+
+export function gjsFilter(id: string): boolean {
+  // Vite ids can contain a query string. We intentionally ignore it so that
+  // `app/foo.gjs.js?pretend.gjs` doesn't count as a .gjs file.
+  let [path] = id.split('?');
+  return gjsPathFilter(path);
+}
 
 export function templateTag(): Plugin {
   let preprocessor = new Preprocessor();

--- a/packages/vite/tests/filters.test.js
+++ b/packages/vite/tests/filters.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { gjsFilter } from '../src/template-tag';
+
+
+const betterExpect = expect.soft;
+
+describe('template-tag', () => {
+  const expect = betterExpect;
+
+  describe.each([{ ext: 'gjs' }, { ext: 'gts'}])('gjsFilter: $ext', ({ ext}) => {
+    it('matches', () => {
+      expect(gjsFilter(`foo.${ext}`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.${ext}`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.${ext}`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.gjs.${ext}`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.gts.${ext}`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.js.${ext}`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.ts.${ext}`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.${ext}?t=123`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.${ext}?f=foo.gjs`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.${ext}.${ext}?f=foo.gjs`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.gjs.${ext}?f=foo.gjs`)).toBeTruthy();
+      expect(gjsFilter(`app/foo.gts.${ext}?f=foo.gjs`)).toBeTruthy();
+      expect(gjsFilter(`app/gjs/foo.${ext}`)).toBeTruthy();
+      expect(gjsFilter(`app/gts/foo.${ext}`)).toBeTruthy();
+    })
+
+    it('non-matches', () => {
+      expect(gjsFilter(`app/foo.${ext}.js`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.js?pretend.gjs`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.md`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.md?foo.gjs`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.md?from=foo.gjs`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.md?from=foo.gjs`)).toBeFalsy();
+      expect(gjsFilter(`app/foo/${ext}`)).toBeFalsy();
+      expect(gjsFilter(`app/foo/${ext}.js`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.gjs.ts`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.gts.ts`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.gjs.ts?x=gjs.${ext}`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.gts.ts?x=gts.${ext}`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.gjs.ts?x=foo.gjs.${ext}`)).toBeFalsy();
+      expect(gjsFilter(`app/foo.${ext}.gts.ts?x=foo.gts.${ext}`)).toBeFalsy();
+    });
+  });
+});
+
+
+


### PR DESCRIPTION
Refactor gjsFilter to support additional patterns for matching files.

Resolves: https://github.com/embroider-build/embroider/issues/2663


Testing here: https://stackblitz.com/edit/stackblitz-starters-un5txv2g?description=Starter%20project%20for%20Node.js,%20a%20JavaScript%20runtime%20built%20on%20Chrome%27s%20V8%20JavaScript%20engine&file=index.js,package.json&title=node.new%20Starter



Fixing filters like this, or at least getting more specific about them will likely be a requirement for our super optimized only rolldown support :muscle: soooooooon (tho, I haven't tested this with rolldown -- I ran in to issues while trying to make a plugin that complies gjs.md to gjs


Without this fix you get errors like:
```
10:05:37 PM [vite] Internal server error: Parse Error at /home/nvp/Development/NullVoxPopuli/kolay-2/docs-app/src/templates/usage/testing.gjs.md:3:9: 3:13
  Plugin: embroider-template-tag
  File: /home/nvp/Development/NullVoxPopuli/kolay-2/docs-app/src/templates/usage/testing.gjs.md
      at wasm://wasm/004647c2:wasm-function[2619]:0xdce1a
      at wasm://wasm/004647c2:wasm-function[239]:0x6c367
      at wasm://wasm/004647c2:wasm-function[1611]:0xc12f1
      at Preprocessor.process (/home/nvp/Development/NullVoxPopuli/kolay-2/node_modules/.pnpm/content-tag@4.1.0/node_modules/content-tag/pkg/node/content_tag.cjs:297:26)
```

I have a [patch of this in action here](https://github.com/universal-ember/kolay/pull/264)