### PR TITLE
widen the ember-cli-babel dependency range for macros

### DIFF
--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -33,7 +33,7 @@
     "@embroider/shared-internals": "workspace:*",
     "assert-never": "^1.2.1",
     "babel-import-util": "^3.0.1",
-    "ember-cli-babel": "^7.26.6",
+    "ember-cli-babel": "^7.26.6 || ^8.3.1",
     "find-up": "^5.0.0",
     "lodash": "^4.17.21",
     "resolve": "^1.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,7 +598,7 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       ember-cli-babel:
-        specifier: ^7.26.6
+        specifier: ^7.26.6 || ^8.3.1
         version: 7.26.11
       find-up:
         specifier: ^5.0.0
@@ -7827,6 +7827,12 @@ packages:
 
   ember-cli-babel@8.2.0:
     resolution: {integrity: sha512-8H4+jQElCDo6tA7CamksE66NqBXWs7VNpS3a738L9pZCjg2kXIX4zoyHzkORUqCtr0Au7YsCnrlAMi1v2ALo7A==}
+    engines: {node: 16.* || 18.* || >= 20}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+
+  ember-cli-babel@8.3.1:
+    resolution: {integrity: sha512-Pxm5JP0jQ6fCBlXuh1BFmhrg2/5YXjhf16JI/n8ReOR6Nl+fEbudMpdO69LlqZRsMmTgdjCRmfSxMh26Wsw/rw==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
       '@babel/core': ^7.12.0
@@ -16456,7 +16462,7 @@ snapshots:
       broccoli-funnel: 3.0.8
       dom-element-descriptors: 0.5.1
       ember-auto-import: 2.12.0(@glint/template@1.7.3)(webpack@5.103.0)
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-htmlbars: 6.3.0
       ember-source: 3.26.2(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -16474,7 +16480,7 @@ snapshots:
       broccoli-funnel: 3.0.8
       dom-element-descriptors: 0.5.1
       ember-auto-import: 2.12.0(@glint/template@1.7.3)(webpack@5.103.0)
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-htmlbars: 6.3.0
       ember-source: 4.6.0(@babel/core@7.28.5)(@glint/template@1.7.3)(webpack@5.103.0)
     transitivePeerDependencies:
@@ -16492,7 +16498,7 @@ snapshots:
       broccoli-funnel: 3.0.8
       dom-element-descriptors: 0.5.1
       ember-auto-import: 2.12.0(@glint/template@1.7.3)(webpack@5.103.0)
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-htmlbars: 6.3.0
       ember-source: 5.3.0(@babel/core@7.28.5)(@glimmer/component@1.1.2(@babel/core@7.28.5))(@glint/template@1.7.3)(rsvp@4.8.5)(webpack@5.103.0)
     transitivePeerDependencies:
@@ -22200,6 +22206,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-cli-babel@8.3.1(@babel/core@7.28.5):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
+      '@babel/runtime': 7.12.18
+      amd-name-resolver: 1.3.1
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.5)
+      babel-plugin-ember-data-packages-polyfill: 0.1.2
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-module-resolver: 5.0.0
+      broccoli-babel-transpiler: 8.0.2(@babel/core@7.28.5)
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-source: 3.0.1
+      calculate-cache-key-for-tree: 2.0.0
+      clone: 2.1.2
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-cli-version-checker: 5.1.2
+      ensure-posix-path: 1.1.1
+      resolve-package-path: 4.0.3
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   ember-cli-build-config-editor@0.5.1:
     dependencies:
       recast: 0.12.9
@@ -24943,7 +24982,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
       ember-auto-import: 2.12.0(@glint/template@1.7.3)(webpack@5.103.0(esbuild@0.25.12))
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
@@ -24993,7 +25032,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
       ember-auto-import: 2.12.0(@glint/template@1.7.3)(webpack@5.103.0)
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
@@ -25043,7 +25082,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
       ember-auto-import: 2.12.0(@glint/template@1.7.3)(webpack@5.103.0(esbuild@0.25.12))
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
@@ -25257,7 +25296,7 @@ snapshots:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
@@ -25304,7 +25343,7 @@ snapshots:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
@@ -25353,7 +25392,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
       ember-auto-import: 2.12.0(@glint/template@1.7.3)(webpack@5.103.0(esbuild@0.25.12))
-      ember-cli-babel: 8.2.0(@babel/core@7.28.5)
+      ember-cli-babel: 8.3.1(@babel/core@7.28.5)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0


### PR DESCRIPTION
there is a bug in ember-cli-babel@7 that has a dev dependency marked as a dependency (fixturify-project) with macros requiring ember-cli-babel@7 that means that all the npm deprecations related to dependendencies of fixturify-project are being experienced by new ember apps 🙈 

this allow for new ember-apps to be installed with only the newer ember-cli-babel 👍 