### PR TITLE
upgrade release-plan

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -15,75 +15,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  is-this-a-release:
-    name: "Is this a release?"
+  should-run-release-plan-prepare:
+    name: Should we run release-plan prepare?
     runs-on: ubuntu-latest
     outputs:
-      command: ${{ steps.check-release.outputs.command }}
-
+      should-prepare: ${{ steps.should-prepare.outputs.should-prepare }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: release-plan/actions/should-prepare-release@v1
         with:
-          fetch-depth: 2
           ref: 'main'
-      # This will only cause the `is-this-a-release` job to have a "command" of `release`
-      # when the .release-plan.json file was changed on the last commit.
-      - id: check-release
-        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+        id: should-prepare
 
   create-prepare-release-pr:
     name: Create Prepare Release PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: is-this-a-release
+    needs: should-run-release-plan-prepare
     permissions:
       contents: write
       issues: read
       pull-requests: write
-    # only run on push event or workflow dispatch if plan wasn't updated (don't create a release plan when we're releasing)
-    # only run on labeled event if the PR has already been merged
-    if: ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.is-this-a-release.outputs.command != 'release') || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
-
+    if: needs.should-run-release-plan-prepare.outputs.should-prepare == 'true'
     steps:
-      - uses: actions/checkout@v4
-        # We need to download lots of history so that
-        # github-changelog can discover what's changed since the last release
+      - uses: release-plan/actions/prepare@v1
+        name: Run release-plan prepare
         with:
-          fetch-depth: 0
           ref: 'main'
-      - uses: ./.github/actions/setup
-        with:
-          use_pinned_node: true
-
-      - name: "Generate Explanation and Prep Changelogs"
-        id: explanation
-        run: |
-          set +e
-          pnpm release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
-
-          if [ $? -ne 0 ]; then
-            release_plan_output=$(cat release-plan-stderr.txt)
-          else
-            release_plan_output=$(jq .description .release-plan.json -r)
-            rm release-plan-stderr.txt
-
-            if [ $(jq '.solution | length' .release-plan.json) -eq 1 ]; then
-              new_version=$(jq -r '.solution[].newVersion' .release-plan.json)
-              echo "new_version=v$new_version" >> $GITHUB_OUTPUT
-            fi
-          fi
-            echo 'text<<EOF' >> $GITHUB_OUTPUT
-          echo "$release_plan_output" >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+        id: explanation
 
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
+        name: Create Prepare Release PR
         with:
-          commit-message: "Prepare Release ${{ steps.explanation.outputs.new_version}} using 'release-plan'"
+          commit-message: "Prepare Release ${{ steps.explanation.outputs.new-version}} using 'release-plan'"
           labels: "internal"
+          sign-commits: true
           branch: release-preview
-          title: Prepare Release ${{ steps.explanation.outputs.new_version }}
+          title: Prepare Release ${{ steps.explanation.outputs.new-version }}
           body: |
             This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,21 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
       id-token: write
       attestations: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
         with:
-          use_pinned_node: "true"
-      - uses: actions/setup-node@v4
-        with:
-          # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+      - run: npm install -g npm@latest # ensure that the globally installed npm is new enough to support OIDC
+      - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
         run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.2.1",
     "prettier": "^2.3.1",
-    "release-plan": "^0.16.0",
+    "release-plan": "^0.17.4",
     "typescript": "^5.5.2"
   },
   "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
@@ -50,11 +50,11 @@
   },
   "pnpm": {
     "overrides": {
+      "@embroider/addon-shim": "workspace:*",
       "@types/eslint": "^8.37.0",
       "babel-plugin-module-resolver@5.0.1": "5.0.0",
       "browserslist": "^4.14.0",
-      "graceful-fs": "^4.0.0",
-      "@embroider/addon-shim": "workspace:*"
+      "graceful-fs": "^4.0.0"
     }
   },
   "changelog": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^2.3.1
         version: 2.8.8
       release-plan:
-        specifier: ^0.16.0
-        version: 0.16.0
+        specifier: ^0.17.4
+        version: 0.17.4
       typescript:
         specifier: ^5.5.2
         version: 5.9.3
@@ -9238,8 +9238,8 @@ packages:
     resolution: {integrity: sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==}
     engines: {node: '>= 4.0'}
 
-  github-changelog@2.1.2:
-    resolution: {integrity: sha512-psDEGxwD5fWDLOW+BOORg1JgZOnbCuMhNLevsD/nP7QVXEVExUGnXBP6MmrFm0hAao9LgBLSBKfcNzGuwecRDA==}
+  github-changelog@2.1.4:
+    resolution: {integrity: sha512-mZQF/YC9OR8XMGpYlLQqG66RiKwlaQZ7rXTZug28oOYkzOXd0acszuvYHVzPlYmns1aDDSwQkbzFxNOYpWhmig==}
     engines: {node: 18.* || 20.* || >= 22}
     hasBin: true
 
@@ -11954,8 +11954,8 @@ packages:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
     engines: {node: '>= 0.10'}
 
-  release-plan@0.16.0:
-    resolution: {integrity: sha512-S2hrXACiy39LenrdvPAhSY7PcitS4A4fAxlzoPgYyCiS2OU6Ed+cUKvN4h9/uRyZ/B3AMGywZUIPtIhCUIjTng==}
+  release-plan@0.17.4:
+    resolution: {integrity: sha512-CK+RrsvP6JXysgFuqUoOvprAT95J5x8usHzAQh3M1RMQqFScnAyfY6lb1LBsjqW/HUsvLjkLfSp8dJseRHEpEw==}
     hasBin: true
 
   remote-git-tags@3.0.0:
@@ -12847,6 +12847,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
@@ -26986,7 +26987,7 @@ snapshots:
 
   git-repo-info@2.1.1: {}
 
-  github-changelog@2.1.2:
+  github-changelog@2.1.4:
     dependencies:
       '@manypkg/get-packages': 2.2.2
       chalk: 4.1.2
@@ -30119,7 +30120,7 @@ snapshots:
 
   relateurl@0.2.7: {}
 
-  release-plan@0.16.0:
+  release-plan@0.17.4:
     dependencies:
       '@manypkg/get-packages': 2.2.2
       '@npmcli/package-json': 6.2.0
@@ -30129,7 +30130,7 @@ snapshots:
       cli-highlight: 2.1.11
       execa: 9.6.1
       fs-extra: 11.3.2
-      github-changelog: 2.1.2
+      github-changelog: 2.1.4
       js-yaml: 4.1.1
       latest-version: 9.0.0
       parse-github-repo-url: 1.4.1


### PR DESCRIPTION
This updates the release-plan package and also the github CI jobs to use our new shared actions

One thing to note with this PR: the new actions assume OIDC support 🤔 this means that we would need to configure OIDC for each of  the packages in the monorepo. 

Here is a checklist that we should do before we merge: 

- [x] @embroider/config-meta-loader
- [x] @embroider/reverse-exports
- [x] @embroider/util
- [x] @embroider/core
- [x] @embroider/addon-dev
- [x] @embroider/babel-loader-9
- [x] @embroider/hbs-loader
- [x] @embroider/shared-internals
- [x] @embroider/addon-shim
- [x] @embroider/broccoli-side-watch
- [x] @embroider/macros
- [x] @embroider/compat
- [x] @embroider/legacy-inspector-support
- [x] @embroider/router
- [x] @embroider/vite
- [x] @embroider/template-tag-codemod

That's a lot of packages 🙈 

Edit: turns out I had enough permissions to setup OIDC for each of these so I have now already done it all 👍 