### PR TITLE
Disabling the gzip reporting, even on small projects showed a 12% speedup in build time.

### DIFF
--- a/packages/vite/src/ember.ts
+++ b/packages/vite/src/ember.ts
@@ -108,6 +108,10 @@ export function ember(params?: {
           config.build = {};
         }
 
+        if (!('reportCompressedSize' in config.build)) {
+          config.build.reportCompressedSize = false;
+        }
+
         if (!config.build.rollupOptions) {
           config.build.rollupOptions = {};
         }


### PR DESCRIPTION
no behavioral difference.

this only affects output reporting after a build