### PR TITLE
Add splitAtRoutes config to ember() vite plugin

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ export { todo, unsupported, warn, debug, expectWarning, throwOnWarnings } from '
 export { Resolver } from './module-resolver';
 export { ModuleRequest, type Resolution, type RequestAdapter, type RequestAdapterCreate } from './module-request';
 export type { Options as ResolverOptions } from './module-resolver-options';
-export { ResolverLoader } from './resolver-loader';
+export { ResolverLoader, type ResolverLoaderOverrides } from './resolver-loader';
 export { virtualContent, type VirtualResponse } from './virtual-content';
 export type { Engine } from './app-files';
 

--- a/packages/core/src/resolver-loader.ts
+++ b/packages/core/src/resolver-loader.ts
@@ -8,12 +8,18 @@ import { watch as fsWatch } from 'fs';
 
 type SplitRouteConfigType = { type: 'string'; value: string } | { type: 'regex'; value: string };
 
+export interface ResolverLoaderOverrides {
+  splitAtRoutes?: (RegExp | string)[];
+}
+
 export class ResolverLoader {
   #resolver: Resolver | undefined;
   #configFile: string;
   #watcher: FSWatcher | undefined;
+  #overrides: ResolverLoaderOverrides;
 
-  constructor(readonly appRoot: string, watch = false) {
+  constructor(readonly appRoot: string, watch = false, overrides?: ResolverLoaderOverrides) {
+    this.#overrides = overrides ?? {};
     this.#configFile = join(locateEmbroiderWorkingDir(this.appRoot), 'resolver.json');
     if (watch) {
       this.#watcher = fsWatch(this.#configFile, { persistent: false }, () => {
@@ -46,7 +52,10 @@ export class ResolverLoader {
 
         config = rawConfig;
       } else {
-        config = buildResolverOptions({});
+        config = buildResolverOptions({ splitAtRoutes: this.#overrides.splitAtRoutes });
+      }
+      if (this.#overrides.splitAtRoutes) {
+        config.splitAtRoutes = this.#overrides.splitAtRoutes;
       }
       this.#resolver = new Resolver(config);
     }

--- a/packages/vite/src/ember.ts
+++ b/packages/vite/src/ember.ts
@@ -28,11 +28,22 @@ export function ember(params?: {
    * `defaultRolldownSharedPlugins`.
    */
   rolldownSharedPlugins?: string[];
+
+  /**
+   * Enables per-route code splitting. Any route names that match these patterns
+   * will be split out of the initial app payload. If you use this, you must
+   * also add @embroider/router to your app.
+   *
+   * This is especially useful for minimal apps that don't have an
+   * ember-cli-build.js where splitAtRoutes would traditionally be configured.
+   */
+  splitAtRoutes?: (RegExp | string)[];
 }) {
+  let overrides = params?.splitAtRoutes ? { splitAtRoutes: params.splitAtRoutes } : undefined;
   return [
     warnRootUrl(),
     templateTag(),
-    resolver(),
+    resolver({ overrides }),
     {
       name: 'vite-plugin-ember-config',
       async config(config: UserConfig, env: ConfigEnv) {
@@ -60,7 +71,8 @@ export function ember(params?: {
 
         const emberRollupPlugins = sharedRolldownPlugins(
           params?.rolldownSharedPlugins ?? defaultRolldownSharedPlugins,
-          config.plugins
+          config.plugins,
+          overrides
         );
 
         if (hasRolldown(this, config)) {
@@ -225,7 +237,8 @@ function findPlugin(plugins: UserConfig['plugins'], name: string): Plugin | unde
 
 function sharedRolldownPlugins<T extends { name: string }>(
   sharedPluginNames: string[],
-  plugins: UserConfig['plugins']
+  plugins: UserConfig['plugins'],
+  overrides?: { splitAtRoutes?: (RegExp | string)[] }
 ): NonNullable<UserConfig['plugins']> {
   return sharedPluginNames
     .map(name => {
@@ -233,7 +246,7 @@ function sharedRolldownPlugins<T extends { name: string }>(
       if (matched) {
         if (name === 'embroider-resolver') {
           // special case. Needs different config.
-          return resolver({ rolldown: true });
+          return resolver({ rolldown: true, overrides });
         }
         return matched;
       }

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -1,5 +1,5 @@
 import { type Plugin, type ViteDevServer, normalizePath } from 'vite';
-import core, { ModuleRequest, type Package, type Resolver } from '@embroider/core';
+import core, { ModuleRequest, type Package, type Resolver, type ResolverLoaderOverrides } from '@embroider/core';
 const { virtualContent, ResolverLoader, explicitRelative, cleanUrl, tmpdir } = core;
 import { type ResponseMeta, RollupRequestAdapter } from './request.js';
 import { assertNever } from 'assert-never';
@@ -17,8 +17,8 @@ const { ensureSymlinkSync, writeFileSync, renameSync } = fs;
 
 const debug = makeDebug('embroider:vite');
 
-export function resolver(params?: { rolldown?: boolean }): Plugin {
-  const resolverLoader = new ResolverLoader(process.cwd());
+export function resolver(params?: { rolldown?: boolean; overrides?: ResolverLoaderOverrides }): Plugin {
+  const resolverLoader = new ResolverLoader(process.cwd(), false, params?.overrides);
   let server: ViteDevServer;
   const virtualDeps: Map<string, string[]> = new Map();
   const notViteDeps = new Set<string>();

--- a/tests/scenarios/vite-split-route-config-test.ts
+++ b/tests/scenarios/vite-split-route-config-test.ts
@@ -1,5 +1,6 @@
-import { minimalAppScenarios } from './scenarios';
+import { appScenarios, renameApp } from './scenarios';
 import { throwOnWarnings } from '@embroider/core';
+import merge from 'lodash/merge';
 import { setupAuditTest } from '@embroider/test-support/audit-assertions';
 import QUnit from 'qunit';
 import CommandWatcher from './helpers/command-watcher';
@@ -8,245 +9,103 @@ import fetch from 'node-fetch';
 const { module: Qmodule, test } = QUnit;
 
 /**
- * Tests that splitAtRoutes can be configured via the ember() vite plugin,
- * without needing an ember-cli-build.js. Uses the minimal app template.
+ * Tests that splitAtRoutes can be configured via the ember() vite plugin
+ * rather than in ember-cli-build.js. The ember-cli-build.js is nulled out
+ * to a bare minimum compat build with no splitAtRoutes config.
  */
-minimalAppScenarios
-  .only('canary')
-  .map('vite-splitAtRoutes', app => {
-    app.linkDevDependency('@embroider/test-support', { baseDir: __dirname });
+let splitScenarios = appScenarios.map('vite-splitAtRoutes', app => {
+  renameApp(app, 'my-app');
+  merge(app.files, {
+    'ember-cli-build.js': `
+      'use strict';
+      const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+      const { maybeEmbroider } = require('@embroider/test-setup');
+      module.exports = function (defaults) {
+        let app = new EmberApp(defaults, {});
+        return maybeEmbroider(app);
+      };
+    `,
+    'vite.config.mjs': `
+      import { defineConfig } from "vite";
+      import { extensions, classicEmberSupport, ember } from "@embroider/vite";
+      import { babel } from "@rollup/plugin-babel";
 
-    app.mergeFiles({
-      'vite.config.mjs': `
-        import { defineConfig } from 'vite';
-        import { extensions, ember } from '@embroider/vite';
-        import { babel } from '@rollup/plugin-babel';
+      export default defineConfig({
+        plugins: [
+          classicEmberSupport(),
+          ember({
+            splitAtRoutes: ['people'],
+          }),
+          babel({
+            babelHelpers: "runtime",
+            extensions,
+          }),
+        ],
+      });
+    `,
+    app: {
+      components: {
+        'all-people.gjs': `<template><div>All people</div></template>`,
+        'one-person.gjs': `
+          import capitalize from 'my-app/helpers/capitalize';
+          <template><div>{{capitalize @person.name}}</div></template>
+        `,
+        'unused.gjs': `<template><div>unused</div></template>`,
+      },
+      helpers: {
+        'capitalize.js': 'export default function(){}',
+      },
+      modifiers: {
+        'auto-focus.js': 'export default function(){}',
+      },
+      'router.js': `import EmberRouter from '@embroider/router';
+      import config from 'my-app/config/environment';
 
-        export default defineConfig({
-          plugins: [
-            ember({
-              splitAtRoutes: ['people'],
-            }),
-            babel({
-              babelHelpers: 'runtime',
-              extensions,
-            }),
-          ],
-        });
+      export default class Router extends EmberRouter {
+        location = config.locationType;
+        rootURL = config.rootURL;
+      }
+
+      Router.map(function () {
+        this.route('people');
+      });
       `,
-      src: {
-        'app.js': `
-          import Application from '@ember/application';
-          import Resolver from 'ember-resolver';
-          import config from '#config';
-          import compatModules from '@embroider/virtual/compat-modules';
-
-          export default class App extends Application {
-            modulePrefix = config.modulePrefix;
-            Resolver = Resolver.withModules(compatModules);
-          }
-        `,
-        'router.js': `
-          import EmberRouter from '@embroider/router';
-          import config from '#config';
-
-          export default class Router extends EmberRouter {
-            location = config.locationType;
-            rootURL = config.rootURL;
-          }
-
-          Router.map(function () {
-            this.route('people');
-          });
-        `,
-        components: {
-          'all-people.gjs': `<template><div>All people</div></template>`,
-          'one-person.gjs': `
-            import capitalize from '../helpers/capitalize.js';
-            <template><div>{{capitalize @person.name}}</div></template>
+      templates: {
+        'index.gjs': `<template><div>Index</div></template>`,
+        'people.gjs': `<template><h1>People</h1>{{outlet}}</template>`,
+        people: {
+          'index.gjs': `
+            import AllPeople from 'my-app/components/all-people';
+            <template><AllPeople /></template>
           `,
-          'unused.gjs': `<template><div>unused</div></template>`,
-        },
-        helpers: {
-          'capitalize.js': 'export default function(){}',
-        },
-        modifiers: {
-          'auto-focus.js': 'export default function(){}',
-        },
-        templates: {
-          'application.gjs': `<template>{{outlet}}</template>`,
-          'index.gjs': `<template><div>Index</div></template>`,
-          'people.gjs': `<template><h1>People</h1>{{outlet}}</template>`,
-          people: {
-            'index.gjs': `
-              import AllPeople from '../../components/all-people.gjs';
-              <template><AllPeople /></template>
-            `,
-            'show.gjs': `
-              import OnePerson from '../../components/one-person.gjs';
-              <template><OnePerson /></template>
-            `,
-            'edit.gjs': `
-              import autoFocus from '../../modifiers/auto-focus.js';
-              <template><input {{autoFocus}} /></template>
-            `,
-          },
-        },
-        routes: {
-          'index.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
-          'people.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
-          people: {
-            'show.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
-          },
-        },
-        controllers: {
-          'index.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
-          'people.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
-          people: {
-            'show.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
-          },
+          'show.gjs': `
+            import OnePerson from 'my-app/components/one-person';
+            <template><OnePerson /></template>
+          `,
+          'edit.gjs': `
+            import autoFocus from 'my-app/modifiers/auto-focus';
+            <template><input {{autoFocus}} /></template>
+          `,
         },
       },
-    });
-  })
-  .forEachScenario(scenario => {
-    Qmodule(scenario.name, function (hooks) {
-      throwOnWarnings(hooks);
-
-      let server: CommandWatcher;
-      let appURL: string;
-
-      hooks.before(async () => {
-        let app = await scenario.prepare();
-        server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
-        [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
-      });
-
-      hooks.after(async () => {
-        await server?.shutdown();
-      });
-
-      let expectAudit = setupAuditTest(hooks, () => ({
-        appURL,
-        startingFrom: ['index.html'],
-        fetch: fetch as unknown as typeof globalThis.fetch,
-      }));
-
-      test('has non-split controllers in main entrypoint', function () {
-        checkContents(expectAudit, contents => {
-          if (!contents.includes('controllers/index')) {
-            throw new Error(`controllers/index should be found in entrypoint:\n---\n${contents}`);
-          }
-        });
-      });
-
-      test('has non-split route templates in main entrypoint', function () {
-        checkContents(expectAudit, contents => {
-          if (!contents.includes('templates/index')) {
-            throw new Error(`templates/index should be found in entrypoint:\n---\n${contents}`);
-          }
-        });
-      });
-
-      test('has non-split routes in main entrypoint', function () {
-        checkContents(expectAudit, contents => {
-          if (!contents.includes('routes/index')) {
-            throw new Error(`routes/index should be found in entrypoint:\n---\n${contents}`);
-          }
-        });
-      });
-
-      test('does not have split controllers in main entrypoint', function () {
-        checkContents(expectAudit, contents => {
-          for (let t of ['controllers/people', 'controllers/people/show']) {
-            if (contents.includes(t)) {
-              throw new Error(`${t} should not be found in entrypoint`);
-            }
-          }
-        });
-      });
-
-      test('does not have split route templates in main entrypoint', function () {
-        checkContents(expectAudit, contents => {
-          for (let t of ['templates/people', 'templates/people/index', 'templates/people/show']) {
-            if (contents.includes(t)) {
-              throw new Error(`${t} should not be found in entrypoint`);
-            }
-          }
-        });
-      });
-
-      test('does not have split routes in main entrypoint', function () {
-        checkContents(expectAudit, contents => {
-          for (let t of ['routes/people', 'routes/people/show']) {
-            if (contents.includes(t)) {
-              throw new Error(`${t} should not be found in entrypoint`);
-            }
-          }
-        });
-      });
-
-      test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        checkContents(expectAudit, contents => {
-          if (!/import\(".*-embroider-route-entrypoint\.js:route=people/.test(contents)) {
-            throw new Error(
-              `Entrypoint should contain a dynamic import for the people route entrypoint:\n---\n${contents}`
-            );
-          }
-        });
-      });
-
-      test('has split controllers in route entrypoint', function () {
-        checkContents(
-          expectAudit,
-          contents => {
-            for (let t of ['controllers/people', 'controllers/people/show']) {
-              if (!contents.includes(t)) {
-                throw new Error(`${t} should be found in route entrypoint:\n---\n${contents}`);
-              }
-            }
-          },
-          /\/-embroider-route-entrypoint\.js:route=people/
-        );
-      });
-
-      test('has split route templates in route entrypoint', function () {
-        checkContents(
-          expectAudit,
-          contents => {
-            for (let t of ['templates/people', 'templates/people/index', 'templates/people/show']) {
-              if (!contents.includes(t)) {
-                throw new Error(`${t} should be found in route entrypoint:\n---\n${contents}`);
-              }
-            }
-          },
-          /\/-embroider-route-entrypoint\.js:route=people/
-        );
-      });
-
-      test('has split routes in route entrypoint', function () {
-        checkContents(
-          expectAudit,
-          contents => {
-            for (let t of ['routes/people', 'routes/people/show']) {
-              if (!contents.includes(t)) {
-                throw new Error(`${t} should be found in route entrypoint:\n---\n${contents}`);
-              }
-            }
-          },
-          /\/-embroider-route-entrypoint\.js:route=people/
-        );
-      });
-
-      test('has no issues', function () {
-        expectAudit.hasNoFindings();
-      });
-
-      test('does not include unused component', function () {
-        expectAudit.module('./src/components/unused.gjs').doesNotExist();
-      });
-    });
+      controllers: {
+        'index.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
+        'people.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
+        people: {
+          'show.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
+        },
+      },
+      routes: {
+        'index.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
+        'people.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
+        people: {
+          'show.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
+        },
+      },
+    },
   });
+  app.linkDependency('@ember/string', { baseDir: __dirname });
+});
 
 function checkContents(
   expectAudit: ReturnType<typeof setupAuditTest>,
@@ -257,9 +116,9 @@ function checkContents(
     .module('./index.html')
     .resolves(/\/index.html.*/) // in-html app-boot script
     .toModule()
-    .resolves(/\/app\.js.*/)
+    .resolves(/\/app\/app\.js.*/)
     .toModule()
-    .resolves(/.*\/-embroider-entrypoint\.js/);
+    .resolves(/.*\/-embroider-entrypoint.js/);
 
   if (entrypointFile) {
     resolved = resolved.toModule().resolves(entrypointFile);
@@ -269,3 +128,149 @@ function checkContents(
     return true;
   });
 }
+
+function notInEntrypointFunction(expectAudit: ReturnType<typeof setupAuditTest>) {
+  return function (text: string[] | string, entrypointFile?: string | RegExp) {
+    checkContents(
+      expectAudit,
+      contents => {
+        if (Array.isArray(text)) {
+          text.forEach(t => {
+            if (contents.includes(t)) {
+              throw new Error(`${t} should not be found in entrypoint`);
+            }
+          });
+        } else {
+          if (contents.includes(text)) {
+            throw new Error(`${text} should not be found in entrypoint`);
+          }
+        }
+      },
+      entrypointFile
+    );
+  };
+}
+
+function inEntrypointFunction(expectAudit: ReturnType<typeof setupAuditTest>) {
+  return function (text: string[] | string | RegExp, entrypointFile?: string | RegExp) {
+    checkContents(
+      expectAudit,
+      contents => {
+        if (Array.isArray(text)) {
+          text.forEach(t => {
+            if (!contents.includes(t)) {
+              throw new Error(`${t} should be found in entrypoint:
+---
+${contents}`);
+            }
+          });
+        } else if (text instanceof RegExp) {
+          if (!text.test(contents)) {
+            throw new Error(`Entrypoint should match ${text}`);
+          }
+        } else {
+          if (!contents.includes(text)) {
+            throw new Error(`${text} should be found in entrypoint`);
+          }
+        }
+      },
+      entrypointFile
+    );
+  };
+}
+
+splitScenarios.forEachScenario(scenario => {
+  Qmodule(scenario.name, function (hooks) {
+    throwOnWarnings(hooks);
+
+    let server: CommandWatcher;
+    let appURL: string;
+
+    hooks.before(async () => {
+      let app = await scenario.prepare();
+      server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+      [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+    });
+
+    hooks.after(async () => {
+      await server?.shutdown();
+    });
+
+    let expectAudit = setupAuditTest(hooks, () => ({
+      appURL,
+      startingFrom: ['index.html'],
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    }));
+    let notInEntrypoint = notInEntrypointFunction(expectAudit);
+    let inEntrypoint = inEntrypointFunction(expectAudit);
+
+    test('has non-split controllers in main entrypoint', function () {
+      inEntrypoint('controllers/index');
+    });
+
+    test('has non-split route templates in main entrypoint', function () {
+      inEntrypoint('templates/index');
+    });
+
+    test('has non-split routes in main entrypoint', function () {
+      inEntrypoint('routes/index');
+    });
+
+    test('does not have split controllers in main entrypoint', function () {
+      notInEntrypoint(['controllers/people', 'controllers/people/show']);
+    });
+
+    test('does not have split route templates in main entrypoint', function () {
+      notInEntrypoint(['templates/people', 'templates/people/index', 'templates/people/show']);
+    });
+
+    test('does not have split routes in main entrypoint', function () {
+      notInEntrypoint(['routes/people', 'routes/people/show']);
+    });
+
+    test('dynamically imports the route entrypoint from the main entrypoint', function () {
+      inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
+    });
+
+    test('has split controllers in route entrypoint', function () {
+      inEntrypoint(
+        ['app/controllers/people', 'app/controllers/people/show'],
+        /\/app\/-embroider-route-entrypoint.js:route=people/
+      );
+    });
+
+    test('has split route templates in route entrypoint', function () {
+      inEntrypoint(
+        ['app/templates/people', 'app/templates/people/index', 'app/templates/people/show'],
+        /\/app\/-embroider-route-entrypoint.js:route=people/
+      );
+    });
+
+    test('has split routes in route entrypoint', function () {
+      inEntrypoint(
+        ['app/routes/people', 'app/routes/people/show'],
+        /\/app\/-embroider-route-entrypoint.js:route=people/
+      );
+    });
+
+    test('has no components in route entrypoint', function () {
+      notInEntrypoint(['all-people', 'unused'], /\/app\/-embroider-route-entrypoint.js:route=people/);
+    });
+
+    test('has no helpers in route entrypoint', function () {
+      notInEntrypoint('capitalize', /\/app\/-embroider-route-entrypoint.js:route=people/);
+    });
+
+    test('has no modifiers in route entrypoint', function () {
+      notInEntrypoint('auto-focus', /\/app\/-embroider-route-entrypoint.js:route=people/);
+    });
+
+    test('has no issues', function () {
+      expectAudit.hasNoFindings();
+    });
+
+    test('does not include unused component', function () {
+      expectAudit.module('./app/components/unused.gjs').doesNotExist();
+    });
+  });
+});

--- a/tests/scenarios/vite-split-route-config-test.ts
+++ b/tests/scenarios/vite-split-route-config-test.ts
@@ -1,0 +1,288 @@
+import { appScenarios, renameApp } from './scenarios';
+import { throwOnWarnings } from '@embroider/core';
+import merge from 'lodash/merge';
+import { setupAuditTest } from '@embroider/test-support/audit-assertions';
+import QUnit from 'qunit';
+import CommandWatcher from './helpers/command-watcher';
+import fetch from 'node-fetch';
+
+const { module: Qmodule, test } = QUnit;
+
+let splitScenarios = appScenarios.map('vite-splitAtRoutes', app => {
+  renameApp(app, 'my-app');
+  merge(app.files, {
+    'ember-cli-build.js': `
+      'use strict';
+
+      const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+      const { maybeEmbroider } = require('@embroider/test-setup');
+
+      module.exports = function (defaults) {
+        let app = new EmberApp(defaults, {});
+        return maybeEmbroider(app, {
+          staticInvokables: true,
+        });
+      };
+    `,
+    'vite.config.mjs': `
+      import { defineConfig } from "vite";
+      import { extensions, classicEmberSupport, ember } from "@embroider/vite";
+      import { babel } from "@rollup/plugin-babel";
+
+      export default defineConfig({
+        plugins: [
+          classicEmberSupport(),
+          ember({
+            splitAtRoutes: ['people'],
+          }),
+          babel({
+            babelHelpers: "runtime",
+            extensions,
+          }),
+        ],
+      });
+    `,
+    app: {
+      components: {
+        'welcome.hbs': '',
+        'all-people.js': 'export default class {}',
+        'one-person.hbs': '{{capitalize @person.name}}',
+        'unused.hbs': '',
+      },
+      helpers: {
+        'capitalize.js': 'export default function(){}',
+      },
+      modifiers: {
+        'auto-focus.js': 'export default function(){}',
+      },
+      'router.js': `import EmberRouter from '@embroider/router';
+      import config from 'my-app/config/environment';
+
+      export default class Router extends EmberRouter {
+        location = config.locationType;
+        rootURL = config.rootURL;
+      }
+
+      Router.map(function () {
+        this.route('people');
+      });
+      `,
+      templates: {
+        'index.hbs': '<Welcome/>',
+        'people.hbs': '<h1>People</h1>{{outlet}}',
+        people: {
+          'index.hbs': '<AllPeople/>',
+          'show.hbs': '<OnePerson/>',
+          'edit.hbs': '<input {{auto-focus}} />',
+        },
+      },
+      controllers: {
+        'index.js': `import Controller from '@ember/controller'; export default class Thingy extends Controller {}`,
+        'people.js': `import Controller from '@ember/controller'; export default class Thingy extends Controller {}`,
+        people: {
+          'show.js': `import Controller from '@ember/controller'; export default class Thingy extends Controller {}`,
+        },
+      },
+      routes: {
+        'index.js': `import Route from '@ember/routing/route';export default class ThingyRoute extends Route {}`,
+        'people.js': `import Route from '@ember/routing/route';export default class ThingyRoute extends Route {}`,
+        people: {
+          'show.js': `import Route from '@ember/routing/route';export default class ThingyRoute extends Route {}`,
+        },
+      },
+    },
+  });
+  app.linkDependency('@ember/string', { baseDir: __dirname });
+});
+
+function checkContents(
+  expectAudit: ReturnType<typeof setupAuditTest>,
+  fn: (contents: string) => void,
+  entrypointFile?: string | RegExp
+) {
+  let resolved = expectAudit
+    .module('./index.html')
+    .resolves(/\/index.html.*/) // in-html app-boot script
+    .toModule()
+    .resolves(/\/app\/app\.js.*/)
+    .toModule()
+    .resolves(/.*\/-embroider-entrypoint.js/);
+
+  if (entrypointFile) {
+    resolved = resolved.toModule().resolves(entrypointFile);
+  }
+  resolved.toModule().withContents(contents => {
+    fn(contents);
+    return true;
+  });
+}
+
+function notInEntrypoint(expectAudit: ReturnType<typeof setupAuditTest>) {
+  return function (text: string[] | string, entrypointFile?: string | RegExp) {
+    checkContents(
+      expectAudit,
+      contents => {
+        if (Array.isArray(text)) {
+          text.forEach(t => {
+            if (contents.includes(t)) {
+              throw new Error(`${t} should not be found in entrypoint`);
+            }
+          });
+        } else {
+          if (contents.includes(text)) {
+            throw new Error(`${text} should not be found in entrypoint`);
+          }
+        }
+      },
+      entrypointFile
+    );
+  };
+}
+
+function inEntrypoint(expectAudit: ReturnType<typeof setupAuditTest>) {
+  return function (text: string[] | string | RegExp, entrypointFile?: string | RegExp) {
+    checkContents(
+      expectAudit,
+      contents => {
+        if (Array.isArray(text)) {
+          text.forEach(t => {
+            if (!contents.includes(t)) {
+              throw new Error(`${t} should be found in entrypoint:
+---
+${contents}`);
+            }
+          });
+        } else if (text instanceof RegExp) {
+          if (!text.test(contents)) {
+            throw new Error(`Entrypoint should match ${text}`);
+          }
+        } else {
+          if (!contents.includes(text)) {
+            throw new Error(`${text} should be found in entrypoint`);
+          }
+        }
+      },
+      entrypointFile
+    );
+  };
+}
+
+splitScenarios.forEachScenario(scenario => {
+  Qmodule(scenario.name, function (hooks) {
+    throwOnWarnings(hooks);
+
+    let server: CommandWatcher;
+    let appURL: string;
+
+    hooks.before(async () => {
+      let app = await scenario.prepare();
+      server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+      [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+    });
+
+    hooks.after(async () => {
+      await server?.shutdown();
+    });
+
+    let expectAudit = setupAuditTest(hooks, () => ({
+      appURL,
+      startingFrom: ['index.html'],
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    }));
+    let assertNotInEntrypoint = notInEntrypoint(expectAudit);
+    let assertInEntrypoint = inEntrypoint(expectAudit);
+
+    test('has no components in main entrypoint', function () {
+      assertNotInEntrypoint(['all-people', 'welcome', 'unused']);
+    });
+
+    test('has no helpers in main entrypoint', function () {
+      assertNotInEntrypoint('capitalize');
+    });
+
+    test('has no modifiers in main entrypoint', function () {
+      assertNotInEntrypoint('auto-focus');
+    });
+
+    test('has non-split controllers in main entrypoint', function () {
+      assertInEntrypoint('controllers/index');
+    });
+
+    test('has non-split route templates in main entrypoint', function () {
+      assertInEntrypoint('templates/index');
+    });
+
+    test('has non-split routes in main entrypoint', function () {
+      assertInEntrypoint('routes/index');
+    });
+
+    test('does not have split controllers in main entrypoint', function () {
+      assertNotInEntrypoint(['controllers/people', 'controllers/people/show']);
+    });
+
+    test('does not have split route templates in main entrypoint', function () {
+      assertNotInEntrypoint(['templates/people', 'templates/people/index', 'templates/people/show']);
+    });
+
+    test('does not have split routes in main entrypoint', function () {
+      assertNotInEntrypoint(['routes/people', 'routes/people/show']);
+    });
+
+    test('dynamically imports the route entrypoint from the main entrypoint', function () {
+      assertInEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
+    });
+
+    test('has split controllers in route entrypoint', function () {
+      assertInEntrypoint(
+        ['app/controllers/people', 'app/controllers/people/show'],
+        /\/app\/-embroider-route-entrypoint.js:route=people/
+      );
+    });
+
+    test('has split route templates in route entrypoint', function () {
+      assertInEntrypoint(
+        ['app/templates/people', 'app/templates/people/index', 'app/templates/people/show'],
+        /\/app\/-embroider-route-entrypoint.js:route=people/
+      );
+    });
+
+    test('has split routes in route entrypoint', function () {
+      assertInEntrypoint(
+        ['app/routes/people', 'app/routes/people/show'],
+        /\/app\/-embroider-route-entrypoint.js:route=people/
+      );
+    });
+
+    test('has no components in route entrypoint', function () {
+      assertNotInEntrypoint(['all-people', 'welcome', 'unused'], /\/app\/-embroider-route-entrypoint.js:route=people/);
+    });
+
+    test('has no helpers in route entrypoint', function () {
+      assertNotInEntrypoint('capitalize', /\/app\/-embroider-route-entrypoint.js:route=people/);
+    });
+
+    test('has no modifiers in route entrypoint', function () {
+      assertNotInEntrypoint('auto-focus', /\/app\/-embroider-route-entrypoint.js:route=people/);
+    });
+
+    test('has no issues', function () {
+      expectAudit.hasNoFindings();
+    });
+
+    test('helper is consumed only from the template that uses it', function () {
+      expectAudit.module('./app/helpers/capitalize.js').hasConsumers(['./app/components/one-person.hbs']);
+    });
+
+    test('component is consumed only from the template that uses it', function () {
+      expectAudit.module('./app/components/one-person.js').hasConsumers(['./app/templates/people/show.hbs']);
+    });
+
+    test('modifier is consumed only from the template that uses it', function () {
+      expectAudit.module('./app/modifiers/auto-focus.js').hasConsumers(['./app/templates/people/edit.hbs']);
+    });
+
+    test('does not include unused component', function () {
+      expectAudit.module('./app/components/unused.hbs').doesNotExist();
+    });
+  });
+});

--- a/tests/scenarios/vite-split-route-config-test.ts
+++ b/tests/scenarios/vite-split-route-config-test.ts
@@ -19,12 +19,11 @@ minimalAppScenarios
     app.mergeFiles({
       'vite.config.mjs': `
         import { defineConfig } from 'vite';
-        import { extensions, ember, hbs } from '@embroider/vite';
+        import { extensions, ember } from '@embroider/vite';
         import { babel } from '@rollup/plugin-babel';
 
         export default defineConfig({
           plugins: [
-            hbs(),
             ember({
               splitAtRoutes: ['people'],
             }),

--- a/tests/scenarios/vite-split-route-config-test.ts
+++ b/tests/scenarios/vite-split-route-config-test.ts
@@ -1,6 +1,5 @@
-import { appScenarios, renameApp } from './scenarios';
+import { minimalAppScenarios } from './scenarios';
 import { throwOnWarnings } from '@embroider/core';
-import merge from 'lodash/merge';
 import { setupAuditTest } from '@embroider/test-support/audit-assertions';
 import QUnit from 'qunit';
 import CommandWatcher from './helpers/command-watcher';
@@ -8,92 +7,247 @@ import fetch from 'node-fetch';
 
 const { module: Qmodule, test } = QUnit;
 
-let splitScenarios = appScenarios.map('vite-splitAtRoutes', app => {
-  renameApp(app, 'my-app');
-  merge(app.files, {
-    'ember-cli-build.js': `
-      'use strict';
+/**
+ * Tests that splitAtRoutes can be configured via the ember() vite plugin,
+ * without needing an ember-cli-build.js. Uses the minimal app template.
+ */
+minimalAppScenarios
+  .only('canary')
+  .map('vite-splitAtRoutes', app => {
+    app.linkDevDependency('@embroider/test-support', { baseDir: __dirname });
 
-      const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-      const { maybeEmbroider } = require('@embroider/test-setup');
+    app.mergeFiles({
+      'vite.config.mjs': `
+        import { defineConfig } from 'vite';
+        import { extensions, ember, hbs } from '@embroider/vite';
+        import { babel } from '@rollup/plugin-babel';
 
-      module.exports = function (defaults) {
-        let app = new EmberApp(defaults, {});
-        return maybeEmbroider(app, {
-          staticInvokables: true,
+        export default defineConfig({
+          plugins: [
+            hbs(),
+            ember({
+              splitAtRoutes: ['people'],
+            }),
+            babel({
+              babelHelpers: 'runtime',
+              extensions,
+            }),
+          ],
         });
-      };
-    `,
-    'vite.config.mjs': `
-      import { defineConfig } from "vite";
-      import { extensions, classicEmberSupport, ember } from "@embroider/vite";
-      import { babel } from "@rollup/plugin-babel";
-
-      export default defineConfig({
-        plugins: [
-          classicEmberSupport(),
-          ember({
-            splitAtRoutes: ['people'],
-          }),
-          babel({
-            babelHelpers: "runtime",
-            extensions,
-          }),
-        ],
-      });
-    `,
-    app: {
-      components: {
-        'welcome.hbs': '',
-        'all-people.js': 'export default class {}',
-        'one-person.hbs': '{{capitalize @person.name}}',
-        'unused.hbs': '',
-      },
-      helpers: {
-        'capitalize.js': 'export default function(){}',
-      },
-      modifiers: {
-        'auto-focus.js': 'export default function(){}',
-      },
-      'router.js': `import EmberRouter from '@embroider/router';
-      import config from 'my-app/config/environment';
-
-      export default class Router extends EmberRouter {
-        location = config.locationType;
-        rootURL = config.rootURL;
-      }
-
-      Router.map(function () {
-        this.route('people');
-      });
       `,
-      templates: {
-        'index.hbs': '<Welcome/>',
-        'people.hbs': '<h1>People</h1>{{outlet}}',
-        people: {
-          'index.hbs': '<AllPeople/>',
-          'show.hbs': '<OnePerson/>',
-          'edit.hbs': '<input {{auto-focus}} />',
+      src: {
+        'app.js': `
+          import Application from '@ember/application';
+          import Resolver from 'ember-resolver';
+          import config from '#config';
+          import compatModules from '@embroider/virtual/compat-modules';
+
+          export default class App extends Application {
+            modulePrefix = config.modulePrefix;
+            Resolver = Resolver.withModules(compatModules);
+          }
+        `,
+        'router.js': `
+          import EmberRouter from '@embroider/router';
+          import config from '#config';
+
+          export default class Router extends EmberRouter {
+            location = config.locationType;
+            rootURL = config.rootURL;
+          }
+
+          Router.map(function () {
+            this.route('people');
+          });
+        `,
+        components: {
+          'all-people.gjs': `<template><div>All people</div></template>`,
+          'one-person.gjs': `
+            import capitalize from '../helpers/capitalize.js';
+            <template><div>{{capitalize @person.name}}</div></template>
+          `,
+          'unused.gjs': `<template><div>unused</div></template>`,
+        },
+        helpers: {
+          'capitalize.js': 'export default function(){}',
+        },
+        modifiers: {
+          'auto-focus.js': 'export default function(){}',
+        },
+        templates: {
+          'application.gjs': `<template>{{outlet}}</template>`,
+          'index.gjs': `<template><div>Index</div></template>`,
+          'people.gjs': `<template><h1>People</h1>{{outlet}}</template>`,
+          people: {
+            'index.gjs': `
+              import AllPeople from '../../components/all-people.gjs';
+              <template><AllPeople /></template>
+            `,
+            'show.gjs': `
+              import OnePerson from '../../components/one-person.gjs';
+              <template><OnePerson /></template>
+            `,
+            'edit.gjs': `
+              import autoFocus from '../../modifiers/auto-focus.js';
+              <template><input {{autoFocus}} /></template>
+            `,
+          },
+        },
+        routes: {
+          'index.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
+          'people.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
+          people: {
+            'show.js': `import Route from '@ember/routing/route'; export default class extends Route {}`,
+          },
+        },
+        controllers: {
+          'index.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
+          'people.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
+          people: {
+            'show.js': `import Controller from '@ember/controller'; export default class extends Controller {}`,
+          },
         },
       },
-      controllers: {
-        'index.js': `import Controller from '@ember/controller'; export default class Thingy extends Controller {}`,
-        'people.js': `import Controller from '@ember/controller'; export default class Thingy extends Controller {}`,
-        people: {
-          'show.js': `import Controller from '@ember/controller'; export default class Thingy extends Controller {}`,
-        },
-      },
-      routes: {
-        'index.js': `import Route from '@ember/routing/route';export default class ThingyRoute extends Route {}`,
-        'people.js': `import Route from '@ember/routing/route';export default class ThingyRoute extends Route {}`,
-        people: {
-          'show.js': `import Route from '@ember/routing/route';export default class ThingyRoute extends Route {}`,
-        },
-      },
-    },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      throwOnWarnings(hooks);
+
+      let server: CommandWatcher;
+      let appURL: string;
+
+      hooks.before(async () => {
+        let app = await scenario.prepare();
+        server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
+        [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+      });
+
+      hooks.after(async () => {
+        await server?.shutdown();
+      });
+
+      let expectAudit = setupAuditTest(hooks, () => ({
+        appURL,
+        startingFrom: ['index.html'],
+        fetch: fetch as unknown as typeof globalThis.fetch,
+      }));
+
+      test('has non-split controllers in main entrypoint', function () {
+        checkContents(expectAudit, contents => {
+          if (!contents.includes('controllers/index')) {
+            throw new Error(`controllers/index should be found in entrypoint:\n---\n${contents}`);
+          }
+        });
+      });
+
+      test('has non-split route templates in main entrypoint', function () {
+        checkContents(expectAudit, contents => {
+          if (!contents.includes('templates/index')) {
+            throw new Error(`templates/index should be found in entrypoint:\n---\n${contents}`);
+          }
+        });
+      });
+
+      test('has non-split routes in main entrypoint', function () {
+        checkContents(expectAudit, contents => {
+          if (!contents.includes('routes/index')) {
+            throw new Error(`routes/index should be found in entrypoint:\n---\n${contents}`);
+          }
+        });
+      });
+
+      test('does not have split controllers in main entrypoint', function () {
+        checkContents(expectAudit, contents => {
+          for (let t of ['controllers/people', 'controllers/people/show']) {
+            if (contents.includes(t)) {
+              throw new Error(`${t} should not be found in entrypoint`);
+            }
+          }
+        });
+      });
+
+      test('does not have split route templates in main entrypoint', function () {
+        checkContents(expectAudit, contents => {
+          for (let t of ['templates/people', 'templates/people/index', 'templates/people/show']) {
+            if (contents.includes(t)) {
+              throw new Error(`${t} should not be found in entrypoint`);
+            }
+          }
+        });
+      });
+
+      test('does not have split routes in main entrypoint', function () {
+        checkContents(expectAudit, contents => {
+          for (let t of ['routes/people', 'routes/people/show']) {
+            if (contents.includes(t)) {
+              throw new Error(`${t} should not be found in entrypoint`);
+            }
+          }
+        });
+      });
+
+      test('dynamically imports the route entrypoint from the main entrypoint', function () {
+        checkContents(expectAudit, contents => {
+          if (!/import\(".*-embroider-route-entrypoint\.js:route=people/.test(contents)) {
+            throw new Error(
+              `Entrypoint should contain a dynamic import for the people route entrypoint:\n---\n${contents}`
+            );
+          }
+        });
+      });
+
+      test('has split controllers in route entrypoint', function () {
+        checkContents(
+          expectAudit,
+          contents => {
+            for (let t of ['controllers/people', 'controllers/people/show']) {
+              if (!contents.includes(t)) {
+                throw new Error(`${t} should be found in route entrypoint:\n---\n${contents}`);
+              }
+            }
+          },
+          /\/-embroider-route-entrypoint\.js:route=people/
+        );
+      });
+
+      test('has split route templates in route entrypoint', function () {
+        checkContents(
+          expectAudit,
+          contents => {
+            for (let t of ['templates/people', 'templates/people/index', 'templates/people/show']) {
+              if (!contents.includes(t)) {
+                throw new Error(`${t} should be found in route entrypoint:\n---\n${contents}`);
+              }
+            }
+          },
+          /\/-embroider-route-entrypoint\.js:route=people/
+        );
+      });
+
+      test('has split routes in route entrypoint', function () {
+        checkContents(
+          expectAudit,
+          contents => {
+            for (let t of ['routes/people', 'routes/people/show']) {
+              if (!contents.includes(t)) {
+                throw new Error(`${t} should be found in route entrypoint:\n---\n${contents}`);
+              }
+            }
+          },
+          /\/-embroider-route-entrypoint\.js:route=people/
+        );
+      });
+
+      test('has no issues', function () {
+        expectAudit.hasNoFindings();
+      });
+
+      test('does not include unused component', function () {
+        expectAudit.module('./src/components/unused.gjs').doesNotExist();
+      });
+    });
   });
-  app.linkDependency('@ember/string', { baseDir: __dirname });
-});
 
 function checkContents(
   expectAudit: ReturnType<typeof setupAuditTest>,
@@ -104,9 +258,9 @@ function checkContents(
     .module('./index.html')
     .resolves(/\/index.html.*/) // in-html app-boot script
     .toModule()
-    .resolves(/\/app\/app\.js.*/)
+    .resolves(/\/app\.js.*/)
     .toModule()
-    .resolves(/.*\/-embroider-entrypoint.js/);
+    .resolves(/.*\/-embroider-entrypoint\.js/);
 
   if (entrypointFile) {
     resolved = resolved.toModule().resolves(entrypointFile);
@@ -116,173 +270,3 @@ function checkContents(
     return true;
   });
 }
-
-function notInEntrypoint(expectAudit: ReturnType<typeof setupAuditTest>) {
-  return function (text: string[] | string, entrypointFile?: string | RegExp) {
-    checkContents(
-      expectAudit,
-      contents => {
-        if (Array.isArray(text)) {
-          text.forEach(t => {
-            if (contents.includes(t)) {
-              throw new Error(`${t} should not be found in entrypoint`);
-            }
-          });
-        } else {
-          if (contents.includes(text)) {
-            throw new Error(`${text} should not be found in entrypoint`);
-          }
-        }
-      },
-      entrypointFile
-    );
-  };
-}
-
-function inEntrypoint(expectAudit: ReturnType<typeof setupAuditTest>) {
-  return function (text: string[] | string | RegExp, entrypointFile?: string | RegExp) {
-    checkContents(
-      expectAudit,
-      contents => {
-        if (Array.isArray(text)) {
-          text.forEach(t => {
-            if (!contents.includes(t)) {
-              throw new Error(`${t} should be found in entrypoint:
----
-${contents}`);
-            }
-          });
-        } else if (text instanceof RegExp) {
-          if (!text.test(contents)) {
-            throw new Error(`Entrypoint should match ${text}`);
-          }
-        } else {
-          if (!contents.includes(text)) {
-            throw new Error(`${text} should be found in entrypoint`);
-          }
-        }
-      },
-      entrypointFile
-    );
-  };
-}
-
-splitScenarios.forEachScenario(scenario => {
-  Qmodule(scenario.name, function (hooks) {
-    throwOnWarnings(hooks);
-
-    let server: CommandWatcher;
-    let appURL: string;
-
-    hooks.before(async () => {
-      let app = await scenario.prepare();
-      server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
-      [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
-    });
-
-    hooks.after(async () => {
-      await server?.shutdown();
-    });
-
-    let expectAudit = setupAuditTest(hooks, () => ({
-      appURL,
-      startingFrom: ['index.html'],
-      fetch: fetch as unknown as typeof globalThis.fetch,
-    }));
-    let assertNotInEntrypoint = notInEntrypoint(expectAudit);
-    let assertInEntrypoint = inEntrypoint(expectAudit);
-
-    test('has no components in main entrypoint', function () {
-      assertNotInEntrypoint(['all-people', 'welcome', 'unused']);
-    });
-
-    test('has no helpers in main entrypoint', function () {
-      assertNotInEntrypoint('capitalize');
-    });
-
-    test('has no modifiers in main entrypoint', function () {
-      assertNotInEntrypoint('auto-focus');
-    });
-
-    test('has non-split controllers in main entrypoint', function () {
-      assertInEntrypoint('controllers/index');
-    });
-
-    test('has non-split route templates in main entrypoint', function () {
-      assertInEntrypoint('templates/index');
-    });
-
-    test('has non-split routes in main entrypoint', function () {
-      assertInEntrypoint('routes/index');
-    });
-
-    test('does not have split controllers in main entrypoint', function () {
-      assertNotInEntrypoint(['controllers/people', 'controllers/people/show']);
-    });
-
-    test('does not have split route templates in main entrypoint', function () {
-      assertNotInEntrypoint(['templates/people', 'templates/people/index', 'templates/people/show']);
-    });
-
-    test('does not have split routes in main entrypoint', function () {
-      assertNotInEntrypoint(['routes/people', 'routes/people/show']);
-    });
-
-    test('dynamically imports the route entrypoint from the main entrypoint', function () {
-      assertInEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
-    });
-
-    test('has split controllers in route entrypoint', function () {
-      assertInEntrypoint(
-        ['app/controllers/people', 'app/controllers/people/show'],
-        /\/app\/-embroider-route-entrypoint.js:route=people/
-      );
-    });
-
-    test('has split route templates in route entrypoint', function () {
-      assertInEntrypoint(
-        ['app/templates/people', 'app/templates/people/index', 'app/templates/people/show'],
-        /\/app\/-embroider-route-entrypoint.js:route=people/
-      );
-    });
-
-    test('has split routes in route entrypoint', function () {
-      assertInEntrypoint(
-        ['app/routes/people', 'app/routes/people/show'],
-        /\/app\/-embroider-route-entrypoint.js:route=people/
-      );
-    });
-
-    test('has no components in route entrypoint', function () {
-      assertNotInEntrypoint(['all-people', 'welcome', 'unused'], /\/app\/-embroider-route-entrypoint.js:route=people/);
-    });
-
-    test('has no helpers in route entrypoint', function () {
-      assertNotInEntrypoint('capitalize', /\/app\/-embroider-route-entrypoint.js:route=people/);
-    });
-
-    test('has no modifiers in route entrypoint', function () {
-      assertNotInEntrypoint('auto-focus', /\/app\/-embroider-route-entrypoint.js:route=people/);
-    });
-
-    test('has no issues', function () {
-      expectAudit.hasNoFindings();
-    });
-
-    test('helper is consumed only from the template that uses it', function () {
-      expectAudit.module('./app/helpers/capitalize.js').hasConsumers(['./app/components/one-person.hbs']);
-    });
-
-    test('component is consumed only from the template that uses it', function () {
-      expectAudit.module('./app/components/one-person.js').hasConsumers(['./app/templates/people/show.hbs']);
-    });
-
-    test('modifier is consumed only from the template that uses it', function () {
-      expectAudit.module('./app/modifiers/auto-focus.js').hasConsumers(['./app/templates/people/edit.hbs']);
-    });
-
-    test('does not include unused component', function () {
-      expectAudit.module('./app/components/unused.hbs').doesNotExist();
-    });
-  });
-});


### PR DESCRIPTION
## Summary

- Adds a `splitAtRoutes` option to the `ember()` vite plugin, enabling per-route code splitting for apps that don't have an `ember-cli-build.js` (minimal apps)
- Threads the config through `resolver()` → `ResolverLoader` via a new `ResolverLoaderOverrides` interface in `@embroider/core`
- When `splitAtRoutes` is provided via the vite plugin, it overrides/supplements any config from `resolver.json`

### Usage

```js
// vite.config.mjs
import { ember } from '@embroider/vite';

export default defineConfig({
  plugins: [
    ember({
      splitAtRoutes: ['people', /^admin/],
    }),
  ],
});
```

## Test plan

- [ ] New `vite-split-route-config-test` scenario validates route splitting configured entirely via the vite plugin (no `splitAtRoutes` in `ember-cli-build.js`)
- [ ] Existing `compat-route-split-test` scenarios continue passing (the `ember-cli-build.js` path is unaffected)
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)