### PR TITLE
provide a resolver for v1 addons running template-tag-codemod

### DIFF
--- a/packages/template-tag-codemod/package.json
+++ b/packages/template-tag-codemod/package.json
@@ -13,7 +13,8 @@
   "author": "Edward Faulkner <edward@eaf4.com>",
   "exports": {
     ".": "./dist/src/index.js",
-    "./default-renaming": "./dist/src/default-renaming.js"
+    "./default-renaming": "./dist/src/default-renaming.js",
+    "./addon-resolver": "./dist/src/addon-resolver.js"
   },
   "bin": {
     "template-tag-codemod": "./dist/src/cli.js"

--- a/packages/template-tag-codemod/src/addon-resolver.ts
+++ b/packages/template-tag-codemod/src/addon-resolver.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+
+// this call changes types based on which optional parameters you pass. The way it
+// is being called here it will always return string[]. I don't know why they didn't
+// fix this in the types upstream 🤔
+const localStuff = fs.readdirSync('./addon/', { recursive: true }) as string[];
+
+const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+
+const availableComponents: string[] = [];
+const availableHelpers: string[] = [];
+const availableModifiers: string[] = [];
+
+const extensionRegex = /\.(hbs|ts|js|gts|gjs)$/;
+
+for (const item of localStuff) {
+  if (!extensionRegex.test(item)) {
+    // probably a directory
+    continue;
+  }
+  if (item.startsWith('components/')) {
+    availableComponents.push(item.replace(/^components\//, '').replace(extensionRegex, ''));
+  }
+  if (item.startsWith('helpers/')) {
+    availableHelpers.push(item.replace(/^helpers\//, '').replace(extensionRegex, ''));
+  }
+
+  if (item.startsWith('modifiers/')) {
+    availableHelpers.push(item.replace(/^modifiers\//, '').replace(extensionRegex, ''));
+  }
+}
+
+function resolveVirtualInvokable(path: string) {
+  let basePath = path.replace('@embroider/virtual/', '');
+  const barePath = basePath.replace(/^(components|helpers|ambiguous|modifiers)\//, '');
+
+  if (basePath.startsWith('components/') && availableComponents.includes(barePath)) {
+    return `${pkg.name}/${basePath}`;
+  }
+
+  if (basePath.startsWith('helpers/') && availableHelpers.includes(barePath)) {
+    return `${pkg.name}/${basePath}`;
+  }
+
+  if (basePath.startsWith('modifiers/') && availableModifiers.includes(barePath)) {
+    return `${pkg.name}/${basePath}`;
+  }
+
+  if (availableComponents.includes(barePath)) {
+    return `${pkg.name}/components/${barePath}`;
+  }
+
+  if (availableHelpers.includes(barePath)) {
+    return `${pkg.name}/helpers/${barePath}`;
+  }
+
+  if (availableModifiers.includes(barePath)) {
+    return `${pkg.name}/modifiers/${barePath}`;
+  }
+}
+
+// I set resolve as any here because we're just passing it through and it doesn't matter to this use case
+export default async function (path: string, filename: string, resolve: any) {
+  let localResolution = resolveVirtualInvokable(path);
+
+  if (localResolution) {
+    return localResolution;
+  }
+
+  await resolve(path, filename);
+}


### PR DESCRIPTION
I've recently pushed a bit further to understand what is necessary to get the template-tag-codemod to work on v1 addons while working with the ember-bootstrap maintainers

This PR adds a basic addon resolver that can be opted into by passing it as a command-line arg to the template tag codemod: 

```
pnpm dlx @embroider/template-tag-codemod convert --components addon/components/**/* --customResolver @embroider/template-tag-codemod/addon-resolver
```

This is not the only thing that is needed to successfully run the template-tag codemod on a v1 addon, I have updated https://github.com/embroider-build/embroider/issues/2563 to list other issues I had after solving the resolver problem




