### PR TITLE
remove pin on babel-plugin-ember-template-compilation

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -40,7 +40,7 @@
     "@types/yargs": "^17.0.3",
     "assert-never": "^1.1.0",
     "babel-import-util": "^2.0.0",
-    "babel-plugin-ember-template-compilation": "~2.3.0",
+    "babel-plugin-ember-template-compilation": "^2.3.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babylon": "^6.18.0",
     "bind-decorator": "^1.0.11",

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -209,7 +209,7 @@ class TemplateResolver implements ASTPlugin {
       case 'component':
       case 'modifier':
       case 'helper': {
-        let name = this.env.meta.jsutils.bindImport(resolution.specifier, resolution.importedName, parentPath, {
+        let name = this.env.meta.jsutils.bindImport(resolution.specifier, resolution.importedName, parentPath as any, {
           nameHint: resolution.nameHint,
         });
         setter(parentPath.node, this.env.syntax.builders.path(name));

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "@embroider/macros": "^1.18.1",
     "@embroider/shared-internals": "workspace:*",
     "assert-never": "^1.2.1",
-    "babel-plugin-ember-template-compilation": "~2.3.0",
+    "babel-plugin-ember-template-compilation": "^2.3.0",
     "broccoli-node-api": "^1.7.0",
     "broccoli-persistent-filter": "^3.1.2",
     "broccoli-plugin": "^4.0.7",

--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^15.12.2",
     "@types/resolve": "^1.20.0",
     "@types/semver": "^7.3.6",
-    "babel-plugin-ember-template-compilation": "~2.3.0",
+    "babel-plugin-ember-template-compilation": "^2.3.0",
     "code-equality-assertions": "^0.9.0",
     "scenario-tester": "^2.1.2",
     "typescript": "^5.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6286,7 +6286,7 @@ packages:
     engines: {node: '>= 16.0.0'}
     dependencies:
       '@glimmer/interfaces': 0.92.0
-      '@glimmer/syntax': 0.92.0
+      '@glimmer/syntax': 0.92.3
       '@glimmer/util': 0.92.0
       '@glimmer/vm': 0.92.0
       '@glimmer/wire-format': 0.92.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,7 +241,7 @@ importers:
         specifier: ^2.0.0
         version: 2.1.1
       babel-plugin-ember-template-compilation:
-        specifier: ~2.3.0
+        specifier: ^2.3.0
         version: 2.3.0
       babel-plugin-syntax-dynamic-import:
         specifier: ^6.18.0
@@ -419,7 +419,7 @@ importers:
         specifier: ^1.2.1
         version: 1.4.0
       babel-plugin-ember-template-compilation:
-        specifier: ~2.3.0
+        specifier: ^2.3.0
         version: 2.3.0
       broccoli-node-api:
         specifier: ^1.7.0
@@ -616,7 +616,7 @@ importers:
         specifier: ^7.3.6
         version: 7.7.1
       babel-plugin-ember-template-compilation:
-        specifier: ~2.3.0
+        specifier: ^2.3.0
         version: 2.3.0
       code-equality-assertions:
         specifier: ^0.9.0
@@ -1709,7 +1709,7 @@ importers:
         specifier: ^7.3.6
         version: 7.7.1
       babel-plugin-ember-template-compilation:
-        specifier: ~2.3.0
+        specifier: ^2.3.0
         version: 2.3.0
       bootstrap:
         specifier: ^4.3.1

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -56,7 +56,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.170",
     "@types/semver": "^7.3.6",
-    "babel-plugin-ember-template-compilation": "~2.3.0",
+    "babel-plugin-ember-template-compilation": "^2.3.0",
     "bootstrap": "^4.3.1",
     "broccoli-funnel": "^3.0.5",
     "broccoli-merge-trees": "^3.0.2",


### PR DESCRIPTION
The pin was added in https://github.com/embroider-build/embroider/pull/2426 which was intended to be a type-only change but it limits anyone upgrading to babel-plugin-ember-template-compilation 2.4.0 when using Embroider@v3, and this was the version that we made it legal to use things like `Array` in your templates.

Without this change people can't get https://github.com/emberjs/babel-plugin-ember-template-compilation/releases/tag/v2.4.0-babel-plugin-ember-template-compilation and thus can't use https://rfcs.emberjs.com/id/1070-default-globals-for-strict-mode/ in Embroider@v3 applications

Note: I added the `any` type to the one places where the types didn't match and I reasoned that this was a simple change to unblock a legacy support branch 👍 Sure it would be nice to track down the difference but the blast radius is likely not worth the effort