### PR TITLE
unskip typechecks for ember-source@latest on stable branch

### DIFF
--- a/tests/scenarios/router-test.ts
+++ b/tests/scenarios/router-test.ts
@@ -231,13 +231,10 @@ routerApp.forEachScenario(scenario => {
       app = await scenario.prepare();
     });
 
-    // type checks no longer pass on ember-release
-    if (scenario.name !== 'release-router') {
-      test(`type checks`, async function (assert) {
-        let result = await app.execute('pnpm tsc');
-        assert.equal(result.exitCode, 0, result.output);
-      });
-    }
+    test(`type checks`, async function (assert) {
+      let result = await app.execute('pnpm tsc');
+      assert.equal(result.exitCode, 0, result.output);
+    });
 
     test(`CLASSIC pnpm test:ember`, async function (assert) {
       let result = await app.execute('pnpm test:ember', {

--- a/tests/scenarios/typescript-app-test.ts
+++ b/tests/scenarios/typescript-app-test.ts
@@ -105,13 +105,10 @@ typescriptApp.forEachScenario(scenario => {
       app = await scenario.prepare();
     });
 
-    // type checks no longer pass on ember-release
-    if (scenario.name !== 'release-typescript-app') {
-      test(`check types`, async function (assert) {
-        let result = await app.execute(`pnpm tsc`);
-        assert.equal(result.exitCode, 0, result.output);
-      });
-    }
+    test(`check types`, async function (assert) {
+      let result = await app.execute(`pnpm tsc`);
+      assert.equal(result.exitCode, 0, result.output);
+    });
 
     test(`pnpm ember test safe`, async function (assert) {
       let result = await app.execute(`ember test`, {


### PR DESCRIPTION
I needed to skip a number of tests in https://github.com/embroider-build/embroider/pull/2710 to get CI running again. This PR is unskipping the type checks that started failing on the `release` scenarios.

@NullVoxPopuli had some ideas in this comment thread about how to maybe fix them 🤷 https://github.com/embroider-build/embroider/pull/2710#discussion_r3137913744

I would really need some assistance here because I don't understand what changed or what exactly the type errors are telling me