### PR TITLE
feat(template-tag-codemod): add a skipIgnoreRev option to merge-history

### DIFF
--- a/packages/template-tag-codemod/src/cli.ts
+++ b/packages/template-tag-codemod/src/cli.ts
@@ -118,6 +118,7 @@ program
     'template-tag-codemod'
   )
   .option('--allowOverwrite <value>', 'Destructively replace the existing outputBranch', trueFalseOnly, false)
+  .option('--skipIgnoreRev', `Disables modification of .git-blame-ignore-revs when using merge-history.`, false)
   .action(async (beforeCommit, afterCommit, args) => {
     let { mergeHistory } = await import('./merge-history.js');
     await mergeHistory({ beforeCommit, afterCommit, ...args });

--- a/packages/template-tag-codemod/src/merge-history.ts
+++ b/packages/template-tag-codemod/src/merge-history.ts
@@ -8,6 +8,12 @@ export interface MergeHistoryOptions {
   afterCommit: string;
   outputBranch: string;
   allowOverwrite: boolean;
+  //  when true, .git-blame-ignore-revs won't be modified when using merge-history.
+  // This is only useful if the change on this file causes a problem with your process.
+  // For instance, if your migration to template tags includes a lot of PRs that
+  // conflict with each other, and the platform that hosts your code doesn't manage
+  // automated ways to fix conflicts (e.g. no support for .gitattributes)
+  skipIgnoreRev: boolean;
 }
 
 function execSync(cmd: string, opts?: { cwd?: string }) {
@@ -177,7 +183,9 @@ export async function mergeHistory(opts: MergeHistoryOptions): Promise<void> {
   applyCodemod(workDir, changedFiles, endpoints);
   execSync(`git commit --no-verify -m "applied codemod"`, { cwd: workDir });
   let codemodCommit = head({ cwd: workDir });
-  addBlameIgnoreFile(workDir, codemodCommit);
+  if (!opts.skipIgnoreRev) {
+    addBlameIgnoreFile(workDir, codemodCommit);
+  }
   execSync(`git checkout -b ${opts.outputBranch}`, { cwd: workDir });
   rmSync(workDir, { recursive: true });
   execSync(`git worktree prune`);


### PR DESCRIPTION
**Context**: In template-tag-codemod, using the merge history always creates or edits `.git-blame-ignore-rev`. Even though it's usually something you want, some projects have process constraints that make this feature impractical to work with, and you would like to manage your `.git-blame-ignore-rev` differently.

 **This PR**: Adds a `--skipIgnoreRev` option to the merge-history tool of template-tag-codemod to prevent the creation or edit of `.git-blame-ignore-rev`.