### PR TITLE
fix(template-tag-codemod): this becomes controller on component invokation

### DIFF
--- a/packages/template-tag-codemod/src/replace-this-transform.ts
+++ b/packages/template-tag-codemod/src/replace-this-transform.ts
@@ -5,6 +5,12 @@ export function replaceThisTransform(replacement: string): ASTPluginBuilder {
     return {
       name: 'template-tag-codemod-route-template',
       visitor: {
+        ElementNode(node) {
+          if (node.path.type === 'PathExpression' && node.path.head.type === 'ThisHead') {
+            node.path = builders.path([replacement, ...node.path.tail].join('.'));
+            return node;
+          }
+        },
         PathExpression(node) {
           if (node.head.type === 'ThisHead') {
             return builders.path([replacement, ...node.tail].join('.'));

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -566,12 +566,18 @@ tsAppScenarios
       test('route template rewrite this to @controller', async function (assert) {
         await assert.codeMod({
           from: {
-            'app/templates/example.hbs': `<div>{{t this.message}}</div>`,
+            'app/templates/example.hbs': `
+              <div>{{t this.message}}</div>
+              <this.greetingBoxComponent />
+            `,
           },
           to: {
             'app/templates/example.gjs': `
               import t from "../helpers/t.js";
-              <template><div>{{t @controller.message}}</div></template>
+              <template>
+                <div>{{t @controller.message}}</div>
+                <@controller.greetingBoxComponent />
+              </template>
             `,
           },
           via: `node ${templateTagPath} --reusePrebuild  --renderTests false --routeTemplates ./app/templates/example.hbs --components false`,


### PR DESCRIPTION
**Context**: While working with template-tag-codemod to convert a codebase to template tags, I came across a case where the controller has a getter returning a component class. In the template, `this.theComponent` was correctly replaced in conditional blocks, but not on the invocation.

**This PR**: In the plugin that transforms `this` into `@controller`, adds a handler for `ElementNode` so it catches and transforms an expression like `<this.myComponent>`.