### PR TITLE
fix(ts-app-template): use scripts for a Vite app

### DIFF
--- a/tests/ts-app-template/.env.development
+++ b/tests/ts-app-template/.env.development
@@ -1,0 +1,8 @@
+# This file is committed to git and should not contain any secrets.
+# 
+# Vite recommends using .env.local or .env.[mode].local if you need to manage secrets
+# SEE: https://vite.dev/guide/env-and-mode.html#env-files for more information.
+
+
+# Default NODE_ENV with vite build --mode=test is production
+NODE_ENV=development

--- a/tests/ts-app-template/.gitignore
+++ b/tests/ts-app-template/.gitignore
@@ -7,6 +7,7 @@
 
 # misc
 /.env*
+!.env.development
 /.pnp*
 /.eslintcache
 /coverage/

--- a/tests/ts-app-template/package.json
+++ b/tests/ts-app-template/package.json
@@ -15,7 +15,7 @@
     "./*": "./app/*"
   },
   "scripts": {
-    "build": "ember build --environment=production",
+    "build": "vite build",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:css": "stylelint \"**/*.css\"",
     "lint:css:fix": "concurrently \"npm:lint:css -- --fix\"",
@@ -24,9 +24,9 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "start": "ember serve",
-    "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
-    "test:ember": "ember test"
+    "start": "vite",
+    "test": "vite build --mode test && ember test --path dist",
+    "test:ember": "vite build --mode test && ember test --path dist"
   },
   "devDependencies": {
     "@babel/core": "^7.22.20",

--- a/tests/ts-app-template/package.json
+++ b/tests/ts-app-template/package.json
@@ -15,7 +15,7 @@
     "./*": "./app/*"
   },
   "scripts": {
-    "build": "ember build --environment=production",
+    "build": "vite build",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:css": "stylelint \"**/*.css\"",
     "lint:css:fix": "concurrently \"npm:lint:css -- --fix\"",
@@ -24,9 +24,9 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "start": "ember serve",
-    "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
-    "test:ember": "ember test"
+    "start": "vite",
+    "test": "vite build --mode development && ember test --path dist",
+    "test:ember": "vite build --mode development && ember test --path dist"
   },
   "devDependencies": {
     "@babel/core": "^7.22.20",


### PR DESCRIPTION
**Context**: `ts-app-template` is the template of a TypeScript Ember app building with Vite for the scenario tester. However, the scripts in the `package.json` correspond to a classic app, so when you output a scenario to do some manual testing, the scripts don't work out of the box.

**This PR**: Changes the scripts in `ts-app-template` to correspond to an Embroider+Vite app. 