### PR TITLE
Update `send` package to fix security vulnerability

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -44,7 +44,7 @@
     "fast-glob": "^3.3.2",
     "fs-extra": "^10.0.0",
     "jsdom": "^25.0.0",
-    "send": "^0.18.0",
+    "send": "^1.2.1",
     "source-map-url": "^0.4.1",
     "terser": "^5.7.0"
   },
@@ -55,7 +55,7 @@
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.12",
     "@types/jsdom": "^16.2.11",
-    "@types/send": "^0.17.4",
+    "@types/send": "^1.2.1",
     "esbuild": "^0.25.0",
     "html-minifier-terser": "^7.2.0",
     "rolldown": "^1.0.0-rc.9",

--- a/packages/vite/src/assets.ts
+++ b/packages/vite/src/assets.ts
@@ -3,7 +3,7 @@ import * as core from '@embroider/core';
 const { ResolverLoader } = core;
 import type { Plugin } from 'vite';
 import * as process from 'process';
-import { join, posix } from 'path';
+import { join, posix, dirname, basename } from 'path';
 import fs from 'fs-extra';
 const { existsSync, readFileSync, lstatSync } = fs;
 import send from 'send';
@@ -50,7 +50,7 @@ export function assets(): Plugin {
           if (originalUrl && originalUrl.length > 1) {
             const assetUrl = findPublicAsset(originalUrl.split('?')[0], resolverLoader.resolver);
             if (assetUrl) {
-              return send(req, assetUrl).pipe(res as unknown as NodeJS.WritableStream);
+              return send(req, basename(assetUrl), { root: dirname(assetUrl) }).pipe(res);
             }
           }
           return next();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,8 +995,8 @@ importers:
         specifier: ^25.0.0
         version: 25.0.1(supports-color@8.1.1)
       send:
-        specifier: ^0.18.0
-        version: 0.18.0
+        specifier: ^1.2.1
+        version: 1.2.1
       source-map-url:
         specifier: ^0.4.1
         version: 0.4.1
@@ -1023,8 +1023,8 @@ importers:
         specifier: ^16.2.11
         version: 16.2.15
       '@types/send':
-        specifier: ^0.17.4
-        version: 0.17.6
+        specifier: ^1.2.1
+        version: 1.2.1
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
@@ -5801,6 +5801,9 @@ packages:
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
@@ -9847,10 +9850,6 @@ packages:
     resolution: {integrity: sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==}
     engines: {node: '>= 0.6'}
 
-  http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -12671,10 +12670,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.18.0:
-    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
-    engines: {node: '>= 0.8.0'}
-
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -12964,10 +12959,6 @@ packages:
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
-
-  statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -19312,7 +19303,7 @@ snapshots:
       '@types/node': 22.19.19
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
-      '@types/send': 0.17.6
+      '@types/send': 1.2.1
 
   '@types/express@4.17.25':
     dependencies:
@@ -19466,6 +19457,10 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
+      '@types/node': 22.19.19
+
+  '@types/send@1.2.1':
+    dependencies:
       '@types/node': 22.19.19
 
   '@types/serve-static@1.15.10':
@@ -27848,14 +27843,6 @@ snapshots:
       setprototypeof: 1.1.0
       statuses: 1.5.0
 
-  http-errors@2.0.0:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      toidentifier: 1.0.1
-
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -31061,24 +31048,6 @@ snapshots:
 
   semver@7.8.0: {}
 
-  send@0.18.0:
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -31464,8 +31433,6 @@ snapshots:
       object-copy: 0.1.0
 
   statuses@1.5.0: {}
-
-  statuses@2.0.1: {}
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
Updating `send` to latest helps to fix a vulnerable in embroider apps with vite (see https://github.com/advisories/GHSA-m6fv-jmcg-4jfg)

Not sure if this change is breaking or not, because there is no node version in package.json defined...
`send` has dropped node < 18 with 1.x (see https://github.com/pillarjs/send/blob/master/HISTORY.md#100--2024-07-25)

<img width="972" height="293" alt="grafik" src="https://github.com/user-attachments/assets/a0e1eb9d-164b-4848-beca-4627f8e843dc" />

As alternative, we can update to 0.19.x

Note: Vite 5 has already required Node.js 18+, so maybe its not breaking (embroider/vite supports `vite >= 5.2.0`