### PR TITLE
Fix emitFile warning

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -103,6 +103,7 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
   }
 
   let mode = '';
+  let command = '';
 
   return {
     name: 'embroider-resolver',
@@ -110,6 +111,7 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
 
     configResolved(config) {
       mode = config.mode;
+      command = config.command;
       cacheDir = normalize(config.cacheDir);
     },
 
@@ -168,12 +170,14 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
       }
     },
     async buildEnd() {
-      emitVirtualFile(this, '@embroider/virtual/vendor.js');
-      emitVirtualFile(this, '@embroider/virtual/vendor.css');
+      if (command === 'build') {
+        emitVirtualFile(this, '@embroider/virtual/vendor.js');
+        emitVirtualFile(this, '@embroider/virtual/vendor.css');
 
-      if (mode !== 'production') {
-        emitVirtualFile(this, '@embroider/virtual/test-support.js');
-        emitVirtualFile(this, '@embroider/virtual/test-support.css');
+        if (mode !== 'production') {
+          emitVirtualFile(this, '@embroider/virtual/test-support.js');
+          emitVirtualFile(this, '@embroider/virtual/test-support.css');
+        }
       }
     },
   };


### PR DESCRIPTION
When the vite dev server decides to restart itself, we cause `emitFile` warnings, since that API doesn't work in `vite dev`.

This guards it so it's only called in `vite build`.