### PR TITLE
optimize `ownerOfFile` in PackageCache

### DIFF
--- a/packages/shared-internals/src/package-cache.ts
+++ b/packages/shared-internals/src/package-cache.ts
@@ -57,6 +57,7 @@ export default class PackageCache {
 
   private rootCache: Map<string, Package> = new Map();
   private resolutionCache: Map<Package, Map<string, Package | null>> = new Map();
+  private ownerCache: Map<string, Package | undefined> = new Map();
 
   get(packageRoot: string) {
     let root = getCachedRealpath(packageRoot);
@@ -67,6 +68,11 @@ export default class PackageCache {
   }
 
   ownerOfFile(filename: string): Package | undefined {
+    if (this.ownerCache.has(filename)) {
+      return this.ownerCache.get(filename);
+    }
+
+    let result: Package | undefined;
     let candidate = filename;
 
     // first we look through our cached packages for any that are rooted right
@@ -79,10 +85,12 @@ export default class PackageCache {
       }
 
       if (this.rootCache.has(candidate)) {
-        return this.rootCache.get(candidate);
+        result = this.rootCache.get(candidate);
+        break;
       }
       if (getCachedExists(join(candidate, 'package.json'))) {
-        return this.get(candidate);
+        result = this.get(candidate);
+        break;
       }
       let nextCandidate = resolve(candidate, '..');
       if (nextCandidate === candidate) {
@@ -91,6 +99,9 @@ export default class PackageCache {
       }
       candidate = nextCandidate;
     }
+
+    this.ownerCache.set(filename, result);
+    return result;
   }
 
   static shared(identifier: string, appRoot: string) {


### PR DESCRIPTION
Previously, every `ownerOfFile` call walked the directory tree upward from the file - performing `resolve(, "..")` and cache lookups  at each level, until it reached the root of a package. This ran on every `resolveId` call, via `handleRenaming` and other handlers.

Many resolutions share the same `fromFile` (every import in a module resolves from that one file), so the identical walk was being repeated thousands of times in a build.

This commit memoizes the result in a `Map` keyed by filename, so repeated lookups for the same file become a single `map.get()`, with no change in functionality.

In our testing, this provides a 3-5% boost in overall Discourse build times.