### PR TITLE
fix: handle Embroider macro helpers in template tag codemod

### DIFF
--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -120,6 +120,33 @@ function builtInKeywords(emberVersion: string): Record<string, BuiltIn | undefin
       importableHelper: ['uniqueId', '@ember/helper'],
     };
   }
+
+  // Template macro helpers from @embroider/macros.
+  //
+  // In app builds these helpers are normally handled by @embroider/macros'
+  // template transforms. The template-tag codemod needs to recognize them
+  // explicitly while generating scoped .gjs/.gts output, otherwise the
+  // resolver can produce unresolvable @embroider/virtual/helpers/* imports.
+  //
+  // Some of these names are real JS exports from @embroider/macros and need
+  // explicit imports in generated .gjs/.gts output:
+  //   macroCondition, dependencySatisfies
+  //
+  // Others are template-only macro helper names that are not JS exports.
+  // These must be treated as known keywords to suppress virtual imports,
+  // without generating import statements:
+  //   macroGetOwnConfig
+  const embroiderTemplateMacroHelpers: Record<string, BuiltIn> = {
+    dependencySatisfies: {
+      importableHelper: ['dependencySatisfies', '@embroider/macros'],
+    },
+    macroCondition: {
+      importableHelper: ['macroCondition', '@embroider/macros'],
+    },
+    macroGetOwnConfig: {},
+  };
+  Object.assign(builtInKeywords, embroiderTemplateMacroHelpers);
+
   return builtInKeywords;
 }
 

--- a/packages/compat/src/resolver-transform.ts
+++ b/packages/compat/src/resolver-transform.ts
@@ -128,22 +128,18 @@ function builtInKeywords(emberVersion: string): Record<string, BuiltIn | undefin
   // explicitly while generating scoped .gjs/.gts output, otherwise the
   // resolver can produce unresolvable @embroider/virtual/helpers/* imports.
   //
-  // Some of these names are real JS exports from @embroider/macros and need
-  // explicit imports in generated .gjs/.gts output:
-  //   macroCondition, dependencySatisfies
-  //
-  // Others are template-only macro helper names that are not JS exports.
-  // These must be treated as known keywords to suppress virtual imports,
-  // without generating import statements:
-  //   macroGetOwnConfig
+  // Treat these as legacy template macro keywords, not as importable JS
+  // helpers. Some related JS macros are importable from @embroider/macros,
+  // but template macro usage should not cause the codemod to generate those
+  // imports.
   const embroiderTemplateMacroHelpers: Record<string, BuiltIn> = {
-    dependencySatisfies: {
-      importableHelper: ['dependencySatisfies', '@embroider/macros'],
-    },
-    macroCondition: {
-      importableHelper: ['macroCondition', '@embroider/macros'],
-    },
     macroGetOwnConfig: {},
+    macroGetConfig: {},
+    macroCondition: {},
+    macroDependencySatisfies: {},
+    macroAppEmberSatisfies: {},
+    macroMaybeAttrs: {},
+    macroFailBuild: {},
   };
   Object.assign(builtInKeywords, embroiderTemplateMacroHelpers);
 

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -513,7 +513,6 @@ tsAppScenarios
           to: {
             'app/components/own-config-example.gjs': `
               import Component from '@glimmer/component';
-              import { macroCondition } from "@embroider/macros";
               export default class OwnConfigExample extends Component {<template>{{#if (macroCondition (macroGetOwnConfig "increment-twice"))}}Hello{{/if}}</template>}
             `,
           },
@@ -521,10 +520,10 @@ tsAppScenarios
         });
       });
 
-      test('component template using macroCondition with dependencySatisfies', async function (assert) {
+      test('component template using macroCondition with macroDependencySatisfies', async function (assert) {
         await assert.codeMod({
           from: {
-            'app/components/dependency-example.hbs': `{{#if (macroCondition (dependencySatisfies "some-package" "*"))}}Hello{{/if}}`,
+            'app/components/dependency-example.hbs': `{{#if (macroCondition (macroDependencySatisfies "some-package" "*"))}}Hello{{/if}}`,
             'app/components/dependency-example.js': `
               import Component from '@glimmer/component';
 
@@ -534,8 +533,7 @@ tsAppScenarios
           to: {
             'app/components/dependency-example.gjs': `
               import Component from '@glimmer/component';
-              import { macroCondition, dependencySatisfies } from "@embroider/macros";
-              export default class DependencyExample extends Component {<template>{{#if (macroCondition (dependencySatisfies "some-package" "*"))}}Hello{{/if}}</template>}
+              export default class DependencyExample extends Component {<template>{{#if (macroCondition (macroDependencySatisfies "some-package" "*"))}}Hello{{/if}}</template>}
             `,
           },
           via: `node ${templateTagPath} --reusePrebuild  --renderTests false --routeTemplates false --components ./app/components/dependency-example.hbs`,

--- a/tests/scenarios/template-tag-codemod-test.ts
+++ b/tests/scenarios/template-tag-codemod-test.ts
@@ -500,6 +500,48 @@ tsAppScenarios
         });
       });
 
+      test('component template using macroCondition with macroGetOwnConfig', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'app/components/own-config-example.hbs': `{{#if (macroCondition (macroGetOwnConfig "increment-twice"))}}Hello{{/if}}`,
+            'app/components/own-config-example.js': `
+              import Component from '@glimmer/component';
+
+              export default class OwnConfigExample extends Component {}
+            `,
+          },
+          to: {
+            'app/components/own-config-example.gjs': `
+              import Component from '@glimmer/component';
+              import { macroCondition } from "@embroider/macros";
+              export default class OwnConfigExample extends Component {<template>{{#if (macroCondition (macroGetOwnConfig "increment-twice"))}}Hello{{/if}}</template>}
+            `,
+          },
+          via: `node ${templateTagPath} --reusePrebuild  --renderTests false --routeTemplates false --components ./app/components/own-config-example.hbs`,
+        });
+      });
+
+      test('component template using macroCondition with dependencySatisfies', async function (assert) {
+        await assert.codeMod({
+          from: {
+            'app/components/dependency-example.hbs': `{{#if (macroCondition (dependencySatisfies "some-package" "*"))}}Hello{{/if}}`,
+            'app/components/dependency-example.js': `
+              import Component from '@glimmer/component';
+
+              export default class DependencyExample extends Component {}
+            `,
+          },
+          to: {
+            'app/components/dependency-example.gjs': `
+              import Component from '@glimmer/component';
+              import { macroCondition, dependencySatisfies } from "@embroider/macros";
+              export default class DependencyExample extends Component {<template>{{#if (macroCondition (dependencySatisfies "some-package" "*"))}}Hello{{/if}}</template>}
+            `,
+          },
+          via: `node ${templateTagPath} --reusePrebuild  --renderTests false --routeTemplates false --components ./app/components/dependency-example.hbs`,
+        });
+      });
+
       test('basic route template - native js', async function (assert) {
         await assert.codeMod({
           from: {


### PR DESCRIPTION
Fixes #2671.

The template-tag codemod failed when migrating colocated component templates that use `@embroider/macros` template helpers. In the repro, `macroCondition` with `macroGetOwnConfig` caused the resolver to produce an unresolvable `@embroider/virtual/helpers/macroCondition` import from the backing component JS file.

This adds explicit handling for known template macro helpers:
- `macroCondition` and `dependencySatisfies` are imported from `@embroider/macros` in generated `.gjs/.gts`.
- `macroGetOwnConfig` is treated as a known template-only macro helper without generating an import.

A regression test covers the repro shape, and another covers the related `dependencySatisfies` case.