### PR TITLE
Revert "Fix emitFile warning"

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -103,7 +103,6 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
   }
 
   let mode = '';
-  let command = '';
 
   return {
     name: 'embroider-resolver',
@@ -111,7 +110,6 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
 
     configResolved(config) {
       mode = config.mode;
-      command = config.command;
       cacheDir = normalize(config.cacheDir);
     },
 
@@ -170,14 +168,12 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
       }
     },
     async buildEnd() {
-      if (command === 'build') {
-        emitVirtualFile(this, '@embroider/virtual/vendor.js');
-        emitVirtualFile(this, '@embroider/virtual/vendor.css');
+      emitVirtualFile(this, '@embroider/virtual/vendor.js');
+      emitVirtualFile(this, '@embroider/virtual/vendor.css');
 
-        if (mode !== 'production') {
-          emitVirtualFile(this, '@embroider/virtual/test-support.js');
-          emitVirtualFile(this, '@embroider/virtual/test-support.css');
-        }
+      if (mode !== 'production') {
+        emitVirtualFile(this, '@embroider/virtual/test-support.js');
+        emitVirtualFile(this, '@embroider/virtual/test-support.css');
       }
     },
   };


### PR DESCRIPTION
Reverts embroider-build/embroider#2732

This change is not compatible with people using rolldown directly. We discussed this as a viable use case for people using Embroider when discussing moving the Embroider config out of ember-cli-build so I figure is is something that we **want** to support.

It's probably worth adding a smoke test for rolldown directly to the monorepo but for now I thought I would just revert this one PR since it was a cosmetic change that does have functional ramifications 👍 