### PR TITLE
Fix `@embroider/virtual` emits under Vite's `experimental.bundleMode`

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -170,7 +170,7 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
       }
     },
     async buildEnd() {
-      if (command === 'build') {
+      if (command !== 'dev') {
         emitVirtualFile(this, '@embroider/virtual/vendor.js');
         emitVirtualFile(this, '@embroider/virtual/vendor.css');
 


### PR DESCRIPTION
In Vite 8's `experimental.bundleMode: true` configuration, the command is returned as `"serve"`. We need to emit these vendor/test-support files in that mode.

This also fixes things for people using the plugin directly in rolldown/rollup. In that situation, the command variable is `undefined`.

Followup to ae47e7af87d0e903c6e9c36ebe989416c44ccc16