### PR TITLE
perf: dedupe duplicate addons and avoid array spread

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -37,7 +37,9 @@ export default function buildCompatAddon(originalPackage: Package, v1Cache: V1In
   if (needsSmooshing) {
     let trees = oldPackages.map(pkg => pkg.v2Tree).reverse();
     let smoosher = new SmooshPackageJSON(trees, { annotation: originalPackage.name });
-    return broccoliMergeTrees([...trees, smoosher], { overwrite: true });
+    let finalTrees = trees.slice();
+    finalTrees.push(smoosher);
+    return broccoliMergeTrees(finalTrees, { overwrite: true });
   } else {
     return oldPackages[0].v2Tree;
   }

--- a/packages/compat/src/compat-adapters/ember-source.ts
+++ b/packages/compat/src/compat-adapters/ember-source.ts
@@ -542,7 +542,8 @@ function moveObjectSpecifiersToMetal() {
            * I need to use getAllPRevSiblings and getAllNextSiblings here because I need the siblings
            * to be paths and path.container only holds nodes (for some strange reason).
            */
-          const objectimport = [...path.getAllPrevSiblings(), ...path.getAllNextSiblings()].find(
+          const searchObjects = Array.from(path.getAllPrevSiblings()).concat(Array.from(path.getAllNextSiblings()));
+          const objectimport = searchObjects.find(
             p => p.node.type === 'ImportDeclaration' && p.node.source.value === '@ember/object'
           ) as NodePath<Babel.types.ImportDeclaration>;
 

--- a/packages/compat/src/merges.ts
+++ b/packages/compat/src/merges.ts
@@ -1,12 +1,18 @@
 import mergeWith from 'lodash/mergeWith';
 import uniq from 'lodash/uniq';
 
-export function mergeWithAppend(dest: object, ...srcs: object[]) {
-  return mergeWith(dest, ...srcs, appendArrays);
+export function mergeWithAppend(dest: object, srcs: object[]) {
+  for (const src of srcs) {
+    mergeWith(dest, src, appendArrays);
+  }
+  return dest;
 }
 
-export function mergeWithUniq(dest: object, ...srcs: object[]) {
-  return mergeWith(dest, ...srcs, appendArraysUniq);
+export function mergeWithUniq(dest: object, srcs: object[]) {
+  for (const src of srcs) {
+    mergeWith(dest, src, appendArraysUniq);
+  }
+  return dest;
 }
 
 function appendArrays(objValue: any, srcValue: any) {

--- a/packages/compat/src/module-visitor.ts
+++ b/packages/compat/src/module-visitor.ts
@@ -350,7 +350,7 @@ class ModuleVisitor {
       ...result,
       type: 'parsed',
       resolutions: fromPairs(
-        [...module.resolved].map(([source, target]) => [
+        Array.from(module.resolved).map(([source, target]) => [
           source,
           isResolutionFailure(target) ? null : explicitRelative(this.base, target),
         ])

--- a/packages/compat/src/smoosh-package-json.ts
+++ b/packages/compat/src/smoosh-package-json.ts
@@ -20,7 +20,7 @@ export default class SmooshPackageJSON extends Plugin {
         return JSON.parse(readFileSync(pkgPath, 'utf8'));
       }
     });
-    let pkg = mergeWithUniq({}, ...pkgs);
+    let pkg = mergeWithUniq({}, pkgs);
     writeFileSync(join(this.outputPath, 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
   }
 }

--- a/packages/compat/src/standalone-addon-build.ts
+++ b/packages/compat/src/standalone-addon-build.ts
@@ -8,7 +8,6 @@ import broccoliMergeTrees from 'broccoli-merge-trees';
 import writeFile from 'broccoli-file-creator';
 import type { Node } from 'broccoli-node-api';
 import type CompatApp from './compat-app';
-import { join } from 'path';
 
 export function convertLegacyAddons(compatApp: CompatApp) {
   let packageCache = PackageCache.shared('embroider', compatApp.root);
@@ -45,7 +44,7 @@ ${summarizePeerDepViolations(violations)}
   let index = buildAddonIndex(appPackage, v1Addons);
 
   let interiorTrees: Node[] = [];
-  let exteriorTrees = [...v1Addons].map(pkg => {
+  let exteriorTrees = Array.from(v1Addons).map(pkg => {
     let interior = buildCompatAddon(pkg, instanceCache);
     interiorTrees.push(interior);
     return new Funnel(interior, { destDir: index.packages[pkg.root] });
@@ -57,11 +56,10 @@ ${summarizePeerDepViolations(violations)}
       segments.pop();
     }
     segments.push('moved-package-target.js');
-    return writeFile(join(...segments), '');
+    return writeFile(segments.join('/'), '');
   });
 
-  return broccoliMergeTrees([
-    ...exteriorTrees,
+  let additionalTrees = [
     new Funnel(compatApp.synthesizeStylesPackage(interiorTrees), {
       destDir: '@embroider/synthesized-styles',
     }),
@@ -69,8 +67,11 @@ ${summarizePeerDepViolations(violations)}
       destDir: '@embroider/synthesized-vendor',
     }),
     writeFile('index.json', JSON.stringify(index, null, 2)),
-    ...fakeTargets,
-  ]);
+  ];
+
+  let finalTrees = exteriorTrees.slice().concat(additionalTrees, fakeTargets);
+
+  return broccoliMergeTrees(finalTrees);
 }
 
 function buildAddonIndex(appPackage: Package, packages: Set<Package>): RewrittenPackageIndex {
@@ -83,13 +84,13 @@ function buildAddonIndex(appPackage: Package, packages: Set<Package>): Rewritten
     content.packages[oldPkg.root] = newRoot;
     let nonResolvableDeps = oldPkg.nonResolvableDeps;
     if (nonResolvableDeps) {
-      content.extraResolutions[newRoot] = [...nonResolvableDeps.values()].map(v => v.root);
+      content.extraResolutions[newRoot] = Array.from(nonResolvableDeps.values()).map(v => v.root);
     }
   }
 
   let nonResolvableDeps = appPackage.nonResolvableDeps;
   if (nonResolvableDeps) {
-    let extraRoots = [...nonResolvableDeps.values()].map(v => v.root);
+    let extraRoots = Array.from(nonResolvableDeps.values()).map(v => v.root);
     // the app gets extraResolutions registered against its *original*
     // location
     content.extraResolutions[appPackage.root] = extraRoots;

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -315,10 +315,7 @@ export default class V1Addon {
 
   @Memoize()
   get root(): string {
-    // addonInstance.root gets modified by a customized "main" or
-    // "ember-addon.main" in package.json. We want the real package root here
-    // (the place where package.json lives).
-    return dirname(pkgUpSync({ cwd: this.addonInstance.root })!);
+    return v1AddonRoot(this.addonInstance);
   }
 
   @Memoize()
@@ -1066,6 +1063,15 @@ export default class V1Addon {
     this.buildPackageJSON(built);
     return built;
   }
+}
+
+/**
+ * addonInstance.root gets modified by a customized "main" or
+ * "ember-addon.main" in package.json. We want the real package root here
+ * (the place where package.json lives).
+ */
+export function v1AddonRoot(addonInstance: AddonInstance) {
+  return dirname(pkgUpSync({ cwd: addonInstance.root })!);
 }
 
 export interface V1AddonConstructor {

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -583,14 +583,17 @@ export default class V1Addon {
   // things to the package metadata.
   protected get packageMeta(): Partial<AddonMeta> {
     let built = this.build();
+    const metas = [built.staticMeta];
+    for (const dynamicMeta of built.dynamicMeta) {
+      metas.push(dynamicMeta());
+    }
     return mergeWithAppend(
       {
         version: 2,
         'auto-upgraded': true,
         type: 'addon',
       },
-      built.staticMeta,
-      ...built.dynamicMeta.map(d => d())
+      metas
     );
   }
 

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -3,7 +3,7 @@
 // between the new and old words.
 
 import type { V1AddonConstructor } from './v1-addon';
-import V1Addon from './v1-addon';
+import V1Addon, { v1AddonRoot } from './v1-addon';
 import { pathExistsSync } from 'fs-extra';
 import type { AddonInstance, PackageCache } from '@embroider/core';
 import { getOrCreate } from '@embroider/core';
@@ -13,7 +13,7 @@ export default class V1InstanceCache {
   // maps from package root directories to known V1 instances of that packages.
   // There can be many because a single copy of an addon may be consumed by many
   // other packages and each gets an instance.
-  private addons: Map<string, Set<V1Addon>> = new Map();
+  private addons: Map<string, V1Addon> = new Map();
   private orderIdx: number;
 
   constructor(private app: CompatApp, private packageCache: PackageCache) {
@@ -62,13 +62,17 @@ export default class V1InstanceCache {
     addonInstance.addons.forEach(a => this.addAddon(a));
 
     this.orderIdx += 1;
-    let Klass = this.adapterClass(addonInstance);
-    let v1Addon = new Klass(addonInstance, this.app.options, this.app, this.packageCache, this.orderIdx);
-    let pkgs = getOrCreate(this.addons, v1Addon.root, () => new Set());
-    pkgs.add(v1Addon);
+    const root = v1AddonRoot(addonInstance);
+
+    getOrCreate(this.addons, root, () => {
+      let Klass = this.adapterClass(addonInstance);
+      let v1Addon = new Klass(addonInstance, this.app.options, this.app, this.packageCache, this.orderIdx);
+      return v1Addon;
+    });
   }
 
   getAddons(root: string): V1Addon[] {
-    return Array.from(this.addons.get(root) || []);
+    const addon = this.addons.get(root);
+    return addon ? [addon] : [];
   }
 }

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -13,7 +13,7 @@ export default class V1InstanceCache {
   // maps from package root directories to known V1 instances of that packages.
   // There can be many because a single copy of an addon may be consumed by many
   // other packages and each gets an instance.
-  private addons: Map<string, V1Addon[]> = new Map();
+  private addons: Map<string, Set<V1Addon>> = new Map();
   private orderIdx: number;
 
   constructor(private app: CompatApp, private packageCache: PackageCache) {
@@ -64,11 +64,11 @@ export default class V1InstanceCache {
     this.orderIdx += 1;
     let Klass = this.adapterClass(addonInstance);
     let v1Addon = new Klass(addonInstance, this.app.options, this.app, this.packageCache, this.orderIdx);
-    let pkgs = getOrCreate(this.addons, v1Addon.root, () => []);
-    pkgs.push(v1Addon);
+    let pkgs = getOrCreate(this.addons, v1Addon.root, () => new Set());
+    pkgs.add(v1Addon);
   }
 
   getAddons(root: string): V1Addon[] {
-    return this.addons.get(root) || [];
+    return Array.from(this.addons.get(root) || []);
   }
 }

--- a/packages/core/src/module-resolver-options.ts
+++ b/packages/core/src/module-resolver-options.ts
@@ -98,7 +98,7 @@ function partitionEngines(
     findActiveAddons(current.package, current, extraDeps);
     // ensure addons are applied in the correct order, if set (via @embroider/compat/v1-addon)
     current.addons = new Map(
-      [...current.addons].sort(([a], [b]) => {
+      Array.from(current.addons).sort(([a], [b]) => {
         return (a.meta['order-index'] || 0) - (b.meta['order-index'] || 0);
       })
     );

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -298,7 +298,7 @@ export function splitRoute(
   }
 
   if (ownFiles.length > 0) {
-    addLazyBundle([...ownNames], ownFiles);
+    addLazyBundle(Array.from(ownNames), ownFiles);
   }
 }
 

--- a/packages/core/src/virtual-vendor-styles.ts
+++ b/packages/core/src/virtual-vendor-styles.ts
@@ -83,7 +83,9 @@ function impliedAddonVendorStyles(engine: Engine): string[] {
     let styles = getAddonImplicitStyles(addon);
 
     if (styles.length) {
-      result = [...styles, ...result];
+      const newResult = styles.slice().concat(result);
+
+      result = newResult;
     }
   }
   return result;

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -64,7 +64,7 @@ function gatherAddonCacheKey(project: any): string {
     gatherAddonCacheKeyWorker(addon, memo);
   });
 
-  cacheKey = [...memo].join('|');
+  cacheKey = Array.from(memo).join('|');
   addonCacheKey.set(project, cacheKey);
 
   return cacheKey;

--- a/packages/shared-internals/src/dep-validation.ts
+++ b/packages/shared-internals/src/dep-validation.ts
@@ -24,7 +24,9 @@ export function crawlDeps(startingPackage: Package): Map<Package, Package[][]> {
       seen.add(pkg);
       for (let dep of pkg.dependencies) {
         if (pkg.categorizeDependency(dep.name) !== 'peerDependencies') {
-          queue.push({ pkg: dep, path: [...path, pkg] });
+          let queuePath = path.slice();
+          queuePath.push(pkg);
+          queue.push({ pkg: dep, path: queuePath });
         }
       }
     }

--- a/packages/shared-internals/src/package.ts
+++ b/packages/shared-internals/src/package.ts
@@ -160,7 +160,7 @@ export default class Package {
       }
     }
     pkgs.delete(this);
-    return [...pkgs.values()];
+    return Array.from(pkgs.values());
   }
 
   get mayRebuild(): boolean {

--- a/packages/shared-internals/src/rewritten-package-cache.ts
+++ b/packages/shared-internals/src/rewritten-package-cache.ts
@@ -276,7 +276,7 @@ class WrappedPackage implements PackageTheGoodParts {
       }
     }
     pkgs.delete(castToPackage(this));
-    return [...pkgs.values()];
+    return Array.from(pkgs.values());
   }
 
   get mayRebuild() {

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -916,7 +916,7 @@ function applyEdits(source: string, edits: { start: number; end: number; replace
   let cursor = 0;
   let output: string[] = [];
   let previousDeletion = false;
-  edits = [...edits].sort((a, b) => a.start - b.start);
+  edits = edits.slice().sort((a, b) => a.start - b.start);
   for (let { start, end, replacement } of edits) {
     if (start > cursor) {
       let interEditContent = source.slice(cursor, start);

--- a/packages/vite/src/warn-root-url.ts
+++ b/packages/vite/src/warn-root-url.ts
@@ -25,13 +25,13 @@ export function warnRootUrl(): Plugin {
         );
 
         const matches = html.matchAll(ROOT_URL_TOKEN_REGEX);
-        const count = [...matches].length;
+        const count = Array.from(matches).length;
 
         const dom = new JSDOM(html, {
           includeNodeLocations: true,
         });
         const document = dom.window.document;
-        const nodes = [...document.querySelectorAll('*')].filter(node =>
+        const nodes = Array.from(document.querySelectorAll('*')).filter(node =>
           node.getAttributeNames().some(key => node.getAttribute(key)?.match(ROOT_URL_TOKEN_REGEX))
         );
 


### PR DESCRIPTION
While working on a v2 addon with v1 compat in its test app build I was hitting stack overflow errors from embroider/macros containing 68,900 copies of itself in its v1 addon tree all pointing at the same file on disk. This fixes that issue in 2 ways plus adds a lot more defensive coding to embroider overall around common array perf traps.

- Way it fixes it # 1: dedupe paths to avoid having 68,900 copies in the first place.
- Way it fixes it # 2: dont use array spread, which for even moderately sized arrays is very slow and leads to stack overflow errors.

Notes:

A: I'm not convinced we are deduping aggressively enough yet - I might still have follow up to take better advantage of the set in addPlugin.
B: There's clearly something going wrong higher in the the compat build system that leads us to have so many copies in the first place. I'm seeing the build take several minutes before even reaching the compatBuild for macros specifically, mostly in creating babel trees - thousands of them.
C: The project this is in has about 3k modules between library code and test code. It pulls in *maybe* another 100 files max from a few small v1-addons, and another 500 from 2 v2-addons. And yet, I am seeing logs that 10k files are transformed.

