### PR TITLE
perf: use a faster hash function for cacheKey (and cache it where possible)

### DIFF
--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@embroider/shared-internals": "workspace:*",
+    "@node-rs/xxhash": "1.7.6",
     "assert-never": "^1.2.1",
     "babel-import-util": "^3.0.1",
     "ember-cli-babel": "^7.26.6 || ^8.3.1",

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -497,7 +497,7 @@ const NO_LOCK_FILE_FOUND = 'no-lockfile-found';
 let _LOCK_FILE_CONTENTS: string | Buffer | null = null;
 function getLockFile(appRoot: string): Buffer | string {
   if (!_LOCK_FILE_CONTENTS) {
-    let lockFilePath = findUp.sync(['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml'], { cwd: appRoot });
+    let lockFilePath = findUp.sync(['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock'], { cwd: appRoot });
 
     if (!lockFilePath) {
       lockFilePath = findUp.sync('package.json', { cwd: appRoot });

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import { join } from 'path';
-import crypto from 'crypto';
+import { xxh3 } from '@node-rs/xxhash';
 import findUp from 'find-up';
 import type { PluginItem } from '@babel/core';
-import { RewrittenPackageCache, getOrCreate } from '@embroider/shared-internals';
+import { AddonInstance, RewrittenPackageCache, getOrCreate } from '@embroider/shared-internals';
 import type { FirstTransformParams } from './glimmer/ast-transform';
 import { makeFirstTransform, makeSecondTransform } from './glimmer/ast-transform';
 import type State from './babel/state';
@@ -338,7 +338,7 @@ export default class MacrosConfig {
       },
       owningPackageRoot,
 
-      isDevelopingPackageRoots: [...this.isDevelopingPackageRoots],
+      isDevelopingPackageRoots: Array.from(this.isDevelopingPackageRoots),
 
       get appPackageRoot() {
         return self.appRoot;
@@ -355,31 +355,10 @@ export default class MacrosConfig {
       importSyncImplementation: this.importSyncImplementation,
     };
 
-    let lockFilePath = findUp.sync(['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml'], { cwd: self.appRoot });
-
-    if (!lockFilePath) {
-      lockFilePath = findUp.sync('package.json', { cwd: opts.appPackageRoot });
-    }
-
-    let lockFileBuffer = lockFilePath ? fs.readFileSync(lockFilePath) : 'no-cache-key';
-
-    // @embroider/macros provides a macro called dependencySatisfies which checks if a given
-    // package name satisfies a given semver version range. Due to the way babel caches this can
-    // cause a problem where the macro plugin does not run (because it has been cached) but the version
-    // of the dependency being checked for changes (due to installing a different version). This will lead to
-    // the old evaluated state being used which might be invalid. This cache busting plugin keeps track of a
-    // hash representing the lock file of the app and if it ever changes forces babel to rerun its plugins.
-    // more information in issue #906
-    let hash = crypto.createHash('sha256');
-    hash = hash.update(lockFileBuffer);
-    if (appOrAddonInstance) {
-      // ensure that the actual running addon names and versions are accounted
-      // for in the cache key; this ensures that we still invalidate the cache
-      // when linking another project (e.g. ember-source) which would normally
-      // not cause the lockfile to change;
-      hash = hash.update(gatherAddonCacheKey(appOrAddonInstance.project));
-    }
-    let cacheKey = hash.digest('hex');
+    const cacheKey = getAddonCacheKey({
+      appRoot: self.appRoot,
+      project: appOrAddonInstance ? appOrAddonInstance.project : null,
+    });
 
     return [
       [join(__dirname, 'babel', 'macros-babel-plugin.js'), opts],
@@ -503,4 +482,66 @@ function isScalar(val: any): boolean {
 
 function isPlainObject(obj: any): obj is Record<string, any> {
   return typeof obj === 'object' && obj.constructor === Object && obj.toString() === '[object Object]';
+}
+
+/**
+ * Caching the lockfile contents in memory *does* mean that if you change something in the lockfile
+ * you will need to restart your build for it to take effect. However, this is already the case today
+ * with embroider assets (and for many things using vite) so this feels like an acceptable tradeoff.
+ *
+ * If we determine that this is a problem in practice, we can still gain a perf boost by caching the
+ * path lookup, and comparing the full contents of the lockfile to the cached version to determine
+ * if we need to bust the cache, without needing to read the lockfile on every single babel transform.
+ */
+const NO_LOCK_FILE_FOUND = 'no-lockfile-found';
+let _LOCK_FILE_CONTENTS: string | Buffer | null = null;
+function getLockFile(appRoot: string): Buffer | string {
+  if (!_LOCK_FILE_CONTENTS) {
+    let lockFilePath = findUp.sync(['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml'], { cwd: appRoot });
+
+    if (!lockFilePath) {
+      lockFilePath = findUp.sync('package.json', { cwd: appRoot });
+    }
+
+    _LOCK_FILE_CONTENTS = lockFilePath ? fs.readFileSync(lockFilePath) : NO_LOCK_FILE_FOUND;
+  }
+
+  return _LOCK_FILE_CONTENTS;
+}
+
+// Cached so we only pay the cost of hashing the (potentially large) lockfile once.
+// Used as the seed for per-addon hashes so that both inputs affect the final key.
+let _lockFileHash: bigint | null = null;
+function getLockFileHash(appRoot: string): bigint {
+  if (_lockFileHash === null) {
+    _lockFileHash = xxh3.xxh64(getLockFile(appRoot));
+  }
+  return _lockFileHash;
+}
+
+/**
+ * Generates a two-part cache key for babel based on the contents of the app's lockfile and the
+ * addons in the project. This is used to bust babel's cache when either of those things change.
+ */
+function getAddonCacheKey(options: { appRoot: string; project: AddonInstance['project'] | null | undefined }): string {
+  // Part 1: lockfile hash, computed once and reused as the seed for part 2.
+  // @embroider/macros provides a macro called dependencySatisfies which checks if a given
+  // package name satisfies a given semver version range. Due to the way babel caches this can
+  // cause a problem where the macro plugin does not run (because it has been cached) but the version
+  // of the dependency being checked for changes (due to installing a different version). This will lead to
+  // the old evaluated state being used which might be invalid. This cache busting plugin keeps track of a
+  // hash representing the lock file of the app and if it ever changes forces babel to rerun its plugins.
+  // more information in issue #906
+  const lockHash = getLockFileHash(options.appRoot);
+
+  if (options.project) {
+    // Part 2: ensure that the actual running addon names and versions are accounted
+    // for in the cache key; this ensures that we still invalidate the cache
+    // when linking another project (e.g. ember-source) which would normally
+    // not cause the lockfile to change. The lockfile hash seeds this so both
+    // parts contribute to the final key.
+    return xxh3.xxh64(gatherAddonCacheKey(options.project), lockHash).toString(16);
+  }
+
+  return lockHash.toString(16);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,6 +591,9 @@ importers:
       '@embroider/shared-internals':
         specifier: workspace:*
         version: link:../shared-internals
+      '@node-rs/xxhash':
+        specifier: 1.7.6
+        version: 1.7.6
       assert-never:
         specifier: ^1.2.1
         version: 1.4.0
@@ -4957,6 +4960,9 @@ packages:
     resolution: {integrity: sha512-3lBouSuF7CqlseLB+FKES0K4FQ02JrbEoRtJhxnsyB1s5v4AP03gsoohN8jp7DcOImhaR9scYdztq3/sLfk/qQ==}
     engines: {node: '>=14.18.0'}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -4965,6 +4971,93 @@ packages:
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
+
+  '@node-rs/xxhash-android-arm-eabi@1.7.6':
+    resolution: {integrity: sha512-ptmfpFZ8SgTef58Us+0HsZ9BKhyX/gZYbhLkuzPt7qUoMqMSJK85NC7LEgzDgjUiG+S5GahEEQ9/tfh9BVvKhw==}
+    engines: {node: '>= 12'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/xxhash-android-arm64@1.7.6':
+    resolution: {integrity: sha512-n4MyZvqifuoARfBvrZ2IBqmsGzwlVI3kb2mB0gVvoHtMsPbl/q94zoDBZ7WgeP3t4Wtli+QS3zgeTCOWUbqqUQ==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/xxhash-darwin-arm64@1.7.6':
+    resolution: {integrity: sha512-6xGuE07CiCIry/KT3IiwQd/kykTOmjKzO/ZnHlE5ibGMx64NFE0qDuwJbxQ4rGyUzgJ0KuN9ZdOhUDJmepnpcw==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/xxhash-darwin-x64@1.7.6':
+    resolution: {integrity: sha512-Z4oNnhyznDvHhxv+s0ka+5KG8mdfLVucZMZMejj9BL+CPmamClygPiHIRiifRcPAoX9uPZykaCsULngIfLeF3Q==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/xxhash-freebsd-x64@1.7.6':
+    resolution: {integrity: sha512-arCDOf3xZ5NfBL5fk5J52sNPjXL2cVWN6nXNB3nrtRFFdPBLsr6YXtshAc6wMVxnIW4VGaEv/5K6IpTA8AFyWw==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/xxhash-linux-arm-gnueabihf@1.7.6':
+    resolution: {integrity: sha512-ndLLEW+MwLH3lFS0ahlHCcmkf2ykOv/pbP8OBBeAOlz/Xc3jKztg5IJ9HpkjKOkHk470yYxgHVaw1QMoMzU00A==}
+    engines: {node: '>= 12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/xxhash-linux-arm64-gnu@1.7.6':
+    resolution: {integrity: sha512-VX7VkTG87mAdrF2vw4aroiRpFIIN8Lj6NgtGHF+IUVbzQxPudl4kG+FPEjsNH8y04yQxRbPE7naQNgHcTKMrNw==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/xxhash-linux-arm64-musl@1.7.6':
+    resolution: {integrity: sha512-AB5m6crGYSllM9F/xZNOQSPImotR5lOa9e4arW99Bv82S+gcpphI8fGMDOVTTCXY/RLRhvvhwzLDxmLB2O8VDg==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/xxhash-linux-x64-gnu@1.7.6':
+    resolution: {integrity: sha512-a2A6M+5tc0PVlJlE/nl0XsLEzMpKkwg7Y1lR5urFUbW9uVQnKjJYQDrUojhlXk0Uv3VnYQPa6ThmwlacZA5mvQ==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/xxhash-linux-x64-musl@1.7.6':
+    resolution: {integrity: sha512-WioGJSC1GoxQpmdQrG5l/uddSBAS4XCWczHNwXe895J5xadGQzyvmr0r17BNfihvbBUDH1H9jwouNYzDDeA6+A==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/xxhash-wasm32-wasi@1.7.6':
+    resolution: {integrity: sha512-WDXXKMMFMrez+esm2DzMPHFNPFYf+wQUtaXrXwtxXeQMFEzleOLwEaqV0+bbXGJTwhPouL3zY1Qo2xmIH4kkTg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/xxhash-win32-arm64-msvc@1.7.6':
+    resolution: {integrity: sha512-qjDFUZJT/Zq0yFS+0TApkD86p0NBdPXlOoHur9yNeO9YX2/9/b1sC2P7N27PgOu13h61TUOvTUC00e/82jAZRQ==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/xxhash-win32-ia32-msvc@1.7.6':
+    resolution: {integrity: sha512-s7a+mQWOTnU4NiiypRq/vbNGot/il0HheXuy9oxJ0SW2q/e4BJ8j0pnP6UBlAjsk+005A76vOwsEj01qbQw8+A==}
+    engines: {node: '>= 12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/xxhash-win32-x64-msvc@1.7.6':
+    resolution: {integrity: sha512-zHOHm2UaIahRhgRPJll+4Xy4Z18aAT/7KNeQW+QJupGvFz+GzOFXMGs3R/3B1Ktob/F5ui3i1MrW9GEob3CWTg==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/xxhash@1.7.6':
+    resolution: {integrity: sha512-XMisO+aQHsVpxRp/85EszTtOQTOlhPbd149P/Xa9F55wafA6UM3h2UhOgOs7aAzItnHU/Aw1WQ1FVTEg7WB43Q==}
+    engines: {node: '>= 12'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -18619,6 +18712,13 @@ snapshots:
       jju: 1.4.0
       js-yaml: 4.1.1
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -18629,6 +18729,67 @@ snapshots:
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
       eslint-scope: 5.1.1
+
+  '@node-rs/xxhash-android-arm-eabi@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-android-arm64@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-darwin-arm64@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-darwin-x64@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-freebsd-x64@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-arm-gnueabihf@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-arm64-gnu@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-arm64-musl@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-x64-gnu@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-x64-musl@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-wasm32-wasi@1.7.6':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@node-rs/xxhash-win32-arm64-msvc@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-win32-ia32-msvc@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-win32-x64-msvc@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash@1.7.6':
+    optionalDependencies:
+      '@node-rs/xxhash-android-arm-eabi': 1.7.6
+      '@node-rs/xxhash-android-arm64': 1.7.6
+      '@node-rs/xxhash-darwin-arm64': 1.7.6
+      '@node-rs/xxhash-darwin-x64': 1.7.6
+      '@node-rs/xxhash-freebsd-x64': 1.7.6
+      '@node-rs/xxhash-linux-arm-gnueabihf': 1.7.6
+      '@node-rs/xxhash-linux-arm64-gnu': 1.7.6
+      '@node-rs/xxhash-linux-arm64-musl': 1.7.6
+      '@node-rs/xxhash-linux-x64-gnu': 1.7.6
+      '@node-rs/xxhash-linux-x64-musl': 1.7.6
+      '@node-rs/xxhash-wasm32-wasi': 1.7.6
+      '@node-rs/xxhash-win32-arm64-msvc': 1.7.6
+      '@node-rs/xxhash-win32-ia32-msvc': 1.7.6
+      '@node-rs/xxhash-win32-x64-msvc': 1.7.6
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
This is part of a series of optimizations I've found while working on diagnosing why the v1-compat portion of a v2 addon test build was crashing with a stack-overflow after 30min. This series of optimizations now has that same build completing start-to-finish (not just compat) in 45s. This particular optimization drops the time taken from 3min (after all other optimizations are appleid) to 45s. It overlaps partially with a potentially unsafe optimization (separate PR) that had reduced the time by 1min - so the total improvement here is a bit bigger if we don't accept the unsafe optimization PR.