### PR TITLE
perf: fix stack overflow

### DIFF
--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -37,7 +37,9 @@ export default function buildCompatAddon(originalPackage: Package, v1Cache: V1In
   if (needsSmooshing) {
     let trees = oldPackages.map(pkg => pkg.v2Tree).reverse();
     let smoosher = new SmooshPackageJSON(trees, { annotation: originalPackage.name });
-    return broccoliMergeTrees([...trees, smoosher], { overwrite: true });
+    let finalTrees = trees.slice();
+    finalTrees.push(smoosher);
+    return broccoliMergeTrees(finalTrees, { overwrite: true });
   } else {
     return oldPackages[0].v2Tree;
   }

--- a/packages/compat/src/build-compat-addon.ts
+++ b/packages/compat/src/build-compat-addon.ts
@@ -37,8 +37,7 @@ export default function buildCompatAddon(originalPackage: Package, v1Cache: V1In
   if (needsSmooshing) {
     let trees = oldPackages.map(pkg => pkg.v2Tree).reverse();
     let smoosher = new SmooshPackageJSON(trees, { annotation: originalPackage.name });
-    let finalTrees = trees.slice();
-    finalTrees.push(smoosher);
+    let finalTrees = trees.concat(smoosher);
     return broccoliMergeTrees(finalTrees, { overwrite: true });
   } else {
     return oldPackages[0].v2Tree;

--- a/packages/compat/src/merges.ts
+++ b/packages/compat/src/merges.ts
@@ -1,12 +1,18 @@
 import mergeWith from 'lodash/mergeWith';
 import uniq from 'lodash/uniq';
 
-export function mergeWithAppend(dest: object, ...srcs: object[]) {
-  return mergeWith(dest, ...srcs, appendArrays);
+export function mergeWithAppend(dest: object, srcs: object[]) {
+  for (const src of srcs) {
+    mergeWith(dest, src, appendArrays);
+  }
+  return dest;
 }
 
-export function mergeWithUniq(dest: object, ...srcs: object[]) {
-  return mergeWith(dest, ...srcs, appendArraysUniq);
+export function mergeWithUniq(dest: object, srcs: object[]) {
+  for (const src of srcs) {
+    mergeWith(dest, src, appendArraysUniq);
+  }
+  return dest;
 }
 
 function appendArrays(objValue: any, srcValue: any) {

--- a/packages/compat/src/smoosh-package-json.ts
+++ b/packages/compat/src/smoosh-package-json.ts
@@ -20,7 +20,7 @@ export default class SmooshPackageJSON extends Plugin {
         return JSON.parse(readFileSync(pkgPath, 'utf8'));
       }
     });
-    let pkg = mergeWithUniq({}, ...pkgs);
+    let pkg = mergeWithUniq({}, pkgs);
     writeFileSync(join(this.outputPath, 'package.json'), JSON.stringify(pkg, null, 2), 'utf8');
   }
 }

--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -583,14 +583,17 @@ export default class V1Addon {
   // things to the package metadata.
   protected get packageMeta(): Partial<AddonMeta> {
     let built = this.build();
+    const metas = [built.staticMeta];
+    for (const dynamicMeta of built.dynamicMeta) {
+      metas.push(dynamicMeta());
+    }
     return mergeWithAppend(
       {
         version: 2,
         'auto-upgraded': true,
         type: 'addon',
       },
-      built.staticMeta,
-      ...built.dynamicMeta.map(d => d())
+      metas
     );
   }
 


### PR DESCRIPTION
This is part of a series of optimizations I've found while working on diagnosing why the v1-compat portion of a v2 addon test build was crashing with a stack-overflow after 30min. This series of optimizations now has that same build completing start-to-finish (not just compat) in 45s. This particular optimization fixes the stack overflow and accounts for most of the time drop from 30min-to-crash to 4min-to-build.

The underlying root cause was a reliance on array spread in code paths that receive unbounded array sizes. In this case the array was 68,900 items (various embroider macros instances). Why the array was so large is a tougher subject to address: I have one PR that I'll open for discussion that partially addresses that issue but is likely unsafe.