### PR TITLE
perf: faster path generation, safer tree building

### DIFF
--- a/packages/compat/src/standalone-addon-build.ts
+++ b/packages/compat/src/standalone-addon-build.ts
@@ -69,7 +69,7 @@ ${summarizePeerDepViolations(violations)}
     writeFile('index.json', JSON.stringify(index, null, 2)),
   ];
 
-  let finalTrees = exteriorTrees.slice().concat(additionalTrees, fakeTargets);
+  let finalTrees = exteriorTrees.concat(additionalTrees, fakeTargets);
 
   return broccoliMergeTrees(finalTrees);
 }

--- a/packages/compat/src/standalone-addon-build.ts
+++ b/packages/compat/src/standalone-addon-build.ts
@@ -8,7 +8,6 @@ import broccoliMergeTrees from 'broccoli-merge-trees';
 import writeFile from 'broccoli-file-creator';
 import type { Node } from 'broccoli-node-api';
 import type CompatApp from './compat-app';
-import { join } from 'path';
 
 export function convertLegacyAddons(compatApp: CompatApp) {
   let packageCache = PackageCache.shared('embroider', compatApp.root);
@@ -45,7 +44,7 @@ ${summarizePeerDepViolations(violations)}
   let index = buildAddonIndex(appPackage, v1Addons);
 
   let interiorTrees: Node[] = [];
-  let exteriorTrees = [...v1Addons].map(pkg => {
+  let exteriorTrees = Array.from(v1Addons).map(pkg => {
     let interior = buildCompatAddon(pkg, instanceCache);
     interiorTrees.push(interior);
     return new Funnel(interior, { destDir: index.packages[pkg.root] });
@@ -57,11 +56,10 @@ ${summarizePeerDepViolations(violations)}
       segments.pop();
     }
     segments.push('moved-package-target.js');
-    return writeFile(join(...segments), '');
+    return writeFile(segments.join('/'), '');
   });
 
-  return broccoliMergeTrees([
-    ...exteriorTrees,
+  let additionalTrees = [
     new Funnel(compatApp.synthesizeStylesPackage(interiorTrees), {
       destDir: '@embroider/synthesized-styles',
     }),
@@ -69,8 +67,11 @@ ${summarizePeerDepViolations(violations)}
       destDir: '@embroider/synthesized-vendor',
     }),
     writeFile('index.json', JSON.stringify(index, null, 2)),
-    ...fakeTargets,
-  ]);
+  ];
+
+  let finalTrees = exteriorTrees.slice().concat(additionalTrees, fakeTargets);
+
+  return broccoliMergeTrees(finalTrees);
 }
 
 function buildAddonIndex(appPackage: Package, packages: Set<Package>): RewrittenPackageIndex {
@@ -83,13 +84,13 @@ function buildAddonIndex(appPackage: Package, packages: Set<Package>): Rewritten
     content.packages[oldPkg.root] = newRoot;
     let nonResolvableDeps = oldPkg.nonResolvableDeps;
     if (nonResolvableDeps) {
-      content.extraResolutions[newRoot] = [...nonResolvableDeps.values()].map(v => v.root);
+      content.extraResolutions[newRoot] = Array.from(nonResolvableDeps.values()).map(v => v.root);
     }
   }
 
   let nonResolvableDeps = appPackage.nonResolvableDeps;
   if (nonResolvableDeps) {
-    let extraRoots = [...nonResolvableDeps.values()].map(v => v.root);
+    let extraRoots = Array.from(nonResolvableDeps.values()).map(v => v.root);
     // the app gets extraResolutions registered against its *original*
     // location
     content.extraResolutions[appPackage.root] = extraRoots;


### PR DESCRIPTION
This is part of a series of optimizations I've found while working on diagnosing why the v1-compat portion of a v2 addon test build was crashing with a stack-overflow after 30min. This series of optimizations now has that same build completing start-to-finish (not just compat) in 45s. This particular optimization was a smaller (but distinct) part of dropping the time from 30min-to-crash to 4min-to-build, most of which was achieved with #2757 