### PR TITLE
perf: potentially-unsafe deduplication of addon instances

### DIFF
--- a/packages/compat/src/v1-addon.ts
+++ b/packages/compat/src/v1-addon.ts
@@ -315,10 +315,7 @@ export default class V1Addon {
 
   @Memoize()
   get root(): string {
-    // addonInstance.root gets modified by a customized "main" or
-    // "ember-addon.main" in package.json. We want the real package root here
-    // (the place where package.json lives).
-    return dirname(pkgUpSync({ cwd: this.addonInstance.root })!);
+    return v1AddonRoot(this.addonInstance);
   }
 
   @Memoize()
@@ -1063,6 +1060,15 @@ export default class V1Addon {
     this.buildPackageJSON(built);
     return built;
   }
+}
+
+/**
+ * addonInstance.root gets modified by a customized "main" or
+ * "ember-addon.main" in package.json. We want the real package root here
+ * (the place where package.json lives).
+ */
+export function v1AddonRoot(addonInstance: AddonInstance) {
+  return dirname(pkgUpSync({ cwd: addonInstance.root })!);
 }
 
 export interface V1AddonConstructor {

--- a/packages/compat/src/v1-instance-cache.ts
+++ b/packages/compat/src/v1-instance-cache.ts
@@ -3,7 +3,7 @@
 // between the new and old words.
 
 import type { V1AddonConstructor } from './v1-addon';
-import V1Addon from './v1-addon';
+import V1Addon, { v1AddonRoot } from './v1-addon';
 import { pathExistsSync } from 'fs-extra';
 import type { AddonInstance, PackageCache } from '@embroider/core';
 import { getOrCreate } from '@embroider/core';
@@ -13,7 +13,7 @@ export default class V1InstanceCache {
   // maps from package root directories to known V1 instances of that packages.
   // There can be many because a single copy of an addon may be consumed by many
   // other packages and each gets an instance.
-  private addons: Map<string, V1Addon[]> = new Map();
+  private addons: Map<string, V1Addon> = new Map();
   private orderIdx: number;
 
   constructor(private app: CompatApp, private packageCache: PackageCache) {
@@ -62,13 +62,17 @@ export default class V1InstanceCache {
     addonInstance.addons.forEach(a => this.addAddon(a));
 
     this.orderIdx += 1;
-    let Klass = this.adapterClass(addonInstance);
-    let v1Addon = new Klass(addonInstance, this.app.options, this.app, this.packageCache, this.orderIdx);
-    let pkgs = getOrCreate(this.addons, v1Addon.root, () => []);
-    pkgs.push(v1Addon);
+    const root = v1AddonRoot(addonInstance);
+
+    getOrCreate(this.addons, root, () => {
+      let Klass = this.adapterClass(addonInstance);
+      let v1Addon = new Klass(addonInstance, this.app.options, this.app, this.packageCache, this.orderIdx);
+      return v1Addon;
+    });
   }
 
   getAddons(root: string): V1Addon[] {
-    return this.addons.get(root) || [];
+    const addon = this.addons.get(root);
+    return addon ? [addon] : [];
   }
 }


### PR DESCRIPTION
This is part of a series of optimizations I've found while working on diagnosing why the v1-compat portion of a v2 addon test build was crashing with a stack-overflow after 30min. This series of optimizations now has that same build completing start-to-finish (not just compat) in 45s. This particular optimization drops the time taken from 4min (after array spread optimizations) to 3min. It overlaps partially with #2755 - so the total improvement here is a bit smaller once that PR's effects are taken into account.

I'm relatively sure this is not safe. Today (no-dedupe) is imo an over-eager attempt at maximal correctness. There is a completely correct solution somewhere between "just one instance" and "68,900 instances" of the same addon. This also does not fix a similar problem higher up the tree: it solves for these wrappers but we're still doing a ton of addon instance generation (and babel plugin creation to support such) before this on a similar over-eager number of instances.