### PR TITLE
perf: dont use array spread

### DIFF
--- a/packages/compat/src/compat-adapters/ember-source.ts
+++ b/packages/compat/src/compat-adapters/ember-source.ts
@@ -542,7 +542,8 @@ function moveObjectSpecifiersToMetal() {
            * I need to use getAllPRevSiblings and getAllNextSiblings here because I need the siblings
            * to be paths and path.container only holds nodes (for some strange reason).
            */
-          const objectimport = [...path.getAllPrevSiblings(), ...path.getAllNextSiblings()].find(
+          const searchObjects = Array.from(path.getAllPrevSiblings()).concat(Array.from(path.getAllNextSiblings()));
+          const objectimport = searchObjects.find(
             p => p.node.type === 'ImportDeclaration' && p.node.source.value === '@ember/object'
           ) as NodePath<Babel.types.ImportDeclaration>;
 

--- a/packages/compat/src/module-visitor.ts
+++ b/packages/compat/src/module-visitor.ts
@@ -350,7 +350,7 @@ class ModuleVisitor {
       ...result,
       type: 'parsed',
       resolutions: fromPairs(
-        [...module.resolved].map(([source, target]) => [
+        Array.from(module.resolved).map(([source, target]) => [
           source,
           isResolutionFailure(target) ? null : explicitRelative(this.base, target),
         ])

--- a/packages/compat/src/standalone-addon-build.ts
+++ b/packages/compat/src/standalone-addon-build.ts
@@ -8,6 +8,7 @@ import broccoliMergeTrees from 'broccoli-merge-trees';
 import writeFile from 'broccoli-file-creator';
 import type { Node } from 'broccoli-node-api';
 import type CompatApp from './compat-app';
+import { join } from 'path';
 
 export function convertLegacyAddons(compatApp: CompatApp) {
   let packageCache = PackageCache.shared('embroider', compatApp.root);
@@ -44,7 +45,7 @@ ${summarizePeerDepViolations(violations)}
   let index = buildAddonIndex(appPackage, v1Addons);
 
   let interiorTrees: Node[] = [];
-  let exteriorTrees = Array.from(v1Addons).map(pkg => {
+  let exteriorTrees = [...v1Addons].map(pkg => {
     let interior = buildCompatAddon(pkg, instanceCache);
     interiorTrees.push(interior);
     return new Funnel(interior, { destDir: index.packages[pkg.root] });
@@ -56,10 +57,11 @@ ${summarizePeerDepViolations(violations)}
       segments.pop();
     }
     segments.push('moved-package-target.js');
-    return writeFile(segments.join('/'), '');
+    return writeFile(join(...segments), '');
   });
 
-  let additionalTrees = [
+  return broccoliMergeTrees([
+    ...exteriorTrees,
     new Funnel(compatApp.synthesizeStylesPackage(interiorTrees), {
       destDir: '@embroider/synthesized-styles',
     }),
@@ -67,11 +69,8 @@ ${summarizePeerDepViolations(violations)}
       destDir: '@embroider/synthesized-vendor',
     }),
     writeFile('index.json', JSON.stringify(index, null, 2)),
-  ];
-
-  let finalTrees = exteriorTrees.slice().concat(additionalTrees, fakeTargets);
-
-  return broccoliMergeTrees(finalTrees);
+    ...fakeTargets,
+  ]);
 }
 
 function buildAddonIndex(appPackage: Package, packages: Set<Package>): RewrittenPackageIndex {
@@ -84,13 +83,13 @@ function buildAddonIndex(appPackage: Package, packages: Set<Package>): Rewritten
     content.packages[oldPkg.root] = newRoot;
     let nonResolvableDeps = oldPkg.nonResolvableDeps;
     if (nonResolvableDeps) {
-      content.extraResolutions[newRoot] = Array.from(nonResolvableDeps.values()).map(v => v.root);
+      content.extraResolutions[newRoot] = [...nonResolvableDeps.values()].map(v => v.root);
     }
   }
 
   let nonResolvableDeps = appPackage.nonResolvableDeps;
   if (nonResolvableDeps) {
-    let extraRoots = Array.from(nonResolvableDeps.values()).map(v => v.root);
+    let extraRoots = [...nonResolvableDeps.values()].map(v => v.root);
     // the app gets extraResolutions registered against its *original*
     // location
     content.extraResolutions[appPackage.root] = extraRoots;

--- a/packages/compat/src/standalone-addon-build.ts
+++ b/packages/compat/src/standalone-addon-build.ts
@@ -8,7 +8,6 @@ import broccoliMergeTrees from 'broccoli-merge-trees';
 import writeFile from 'broccoli-file-creator';
 import type { Node } from 'broccoli-node-api';
 import type CompatApp from './compat-app';
-import { join } from 'path';
 
 export function convertLegacyAddons(compatApp: CompatApp) {
   let packageCache = PackageCache.shared('embroider', compatApp.root);
@@ -45,7 +44,7 @@ ${summarizePeerDepViolations(violations)}
   let index = buildAddonIndex(appPackage, v1Addons);
 
   let interiorTrees: Node[] = [];
-  let exteriorTrees = [...v1Addons].map(pkg => {
+  let exteriorTrees = Array.from(v1Addons).map(pkg => {
     let interior = buildCompatAddon(pkg, instanceCache);
     interiorTrees.push(interior);
     return new Funnel(interior, { destDir: index.packages[pkg.root] });
@@ -57,11 +56,10 @@ ${summarizePeerDepViolations(violations)}
       segments.pop();
     }
     segments.push('moved-package-target.js');
-    return writeFile(join(...segments), '');
+    return writeFile(segments.join('/'), '');
   });
 
-  return broccoliMergeTrees([
-    ...exteriorTrees,
+  let additionalTrees = [
     new Funnel(compatApp.synthesizeStylesPackage(interiorTrees), {
       destDir: '@embroider/synthesized-styles',
     }),
@@ -69,8 +67,11 @@ ${summarizePeerDepViolations(violations)}
       destDir: '@embroider/synthesized-vendor',
     }),
     writeFile('index.json', JSON.stringify(index, null, 2)),
-    ...fakeTargets,
-  ]);
+  ];
+
+  let finalTrees = exteriorTrees.slice().concat(additionalTrees, fakeTargets);
+
+  return broccoliMergeTrees(finalTrees);
 }
 
 function buildAddonIndex(appPackage: Package, packages: Set<Package>): RewrittenPackageIndex {
@@ -83,13 +84,13 @@ function buildAddonIndex(appPackage: Package, packages: Set<Package>): Rewritten
     content.packages[oldPkg.root] = newRoot;
     let nonResolvableDeps = oldPkg.nonResolvableDeps;
     if (nonResolvableDeps) {
-      content.extraResolutions[newRoot] = [...nonResolvableDeps.values()].map(v => v.root);
+      content.extraResolutions[newRoot] = Array.from(nonResolvableDeps.values()).map(v => v.root);
     }
   }
 
   let nonResolvableDeps = appPackage.nonResolvableDeps;
   if (nonResolvableDeps) {
-    let extraRoots = [...nonResolvableDeps.values()].map(v => v.root);
+    let extraRoots = Array.from(nonResolvableDeps.values()).map(v => v.root);
     // the app gets extraResolutions registered against its *original*
     // location
     content.extraResolutions[appPackage.root] = extraRoots;

--- a/packages/core/src/module-resolver-options.ts
+++ b/packages/core/src/module-resolver-options.ts
@@ -98,7 +98,7 @@ function partitionEngines(
     findActiveAddons(current.package, current, extraDeps);
     // ensure addons are applied in the correct order, if set (via @embroider/compat/v1-addon)
     current.addons = new Map(
-      [...current.addons].sort(([a], [b]) => {
+      Array.from(current.addons).sort(([a], [b]) => {
         return (a.meta['order-index'] || 0) - (b.meta['order-index'] || 0);
       })
     );

--- a/packages/core/src/virtual-entrypoint.ts
+++ b/packages/core/src/virtual-entrypoint.ts
@@ -298,7 +298,7 @@ export function splitRoute(
   }
 
   if (ownFiles.length > 0) {
-    addLazyBundle([...ownNames], ownFiles);
+    addLazyBundle(Array.from(ownNames), ownFiles);
   }
 }
 

--- a/packages/core/src/virtual-vendor-styles.ts
+++ b/packages/core/src/virtual-vendor-styles.ts
@@ -83,7 +83,9 @@ function impliedAddonVendorStyles(engine: Engine): string[] {
     let styles = getAddonImplicitStyles(addon);
 
     if (styles.length) {
-      result = [...styles, ...result];
+      const newResult = styles.slice().concat(result);
+
+      result = newResult;
     }
   }
   return result;

--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -64,7 +64,7 @@ function gatherAddonCacheKey(project: any): string {
     gatherAddonCacheKeyWorker(addon, memo);
   });
 
-  cacheKey = [...memo].join('|');
+  cacheKey = Array.from(memo).join('|');
   addonCacheKey.set(project, cacheKey);
 
   return cacheKey;

--- a/packages/shared-internals/src/dep-validation.ts
+++ b/packages/shared-internals/src/dep-validation.ts
@@ -24,7 +24,9 @@ export function crawlDeps(startingPackage: Package): Map<Package, Package[][]> {
       seen.add(pkg);
       for (let dep of pkg.dependencies) {
         if (pkg.categorizeDependency(dep.name) !== 'peerDependencies') {
-          queue.push({ pkg: dep, path: [...path, pkg] });
+          let queuePath = path.slice();
+          queuePath.push(pkg);
+          queue.push({ pkg: dep, path: queuePath });
         }
       }
     }

--- a/packages/shared-internals/src/dep-validation.ts
+++ b/packages/shared-internals/src/dep-validation.ts
@@ -24,8 +24,7 @@ export function crawlDeps(startingPackage: Package): Map<Package, Package[][]> {
       seen.add(pkg);
       for (let dep of pkg.dependencies) {
         if (pkg.categorizeDependency(dep.name) !== 'peerDependencies') {
-          let queuePath = path.slice();
-          queuePath.push(pkg);
+          let queuePath = path.concat(pkg);
           queue.push({ pkg: dep, path: queuePath });
         }
       }

--- a/packages/shared-internals/src/package.ts
+++ b/packages/shared-internals/src/package.ts
@@ -160,7 +160,7 @@ export default class Package {
       }
     }
     pkgs.delete(this);
-    return [...pkgs.values()];
+    return Array.from(pkgs.values());
   }
 
   get mayRebuild(): boolean {

--- a/packages/shared-internals/src/rewritten-package-cache.ts
+++ b/packages/shared-internals/src/rewritten-package-cache.ts
@@ -276,7 +276,7 @@ class WrappedPackage implements PackageTheGoodParts {
       }
     }
     pkgs.delete(castToPackage(this));
-    return [...pkgs.values()];
+    return Array.from(pkgs.values());
   }
 
   get mayRebuild() {

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -916,7 +916,7 @@ function applyEdits(source: string, edits: { start: number; end: number; replace
   let cursor = 0;
   let output: string[] = [];
   let previousDeletion = false;
-  edits = edits.slice().sort((a, b) => a.start - b.start);
+  edits = edits.toSorted((a, b) => a.start - b.start);
   for (let { start, end, replacement } of edits) {
     if (start > cursor) {
       let interEditContent = source.slice(cursor, start);

--- a/packages/template-tag-codemod/src/index.ts
+++ b/packages/template-tag-codemod/src/index.ts
@@ -916,7 +916,7 @@ function applyEdits(source: string, edits: { start: number; end: number; replace
   let cursor = 0;
   let output: string[] = [];
   let previousDeletion = false;
-  edits = [...edits].sort((a, b) => a.start - b.start);
+  edits = edits.slice().sort((a, b) => a.start - b.start);
   for (let { start, end, replacement } of edits) {
     if (start > cursor) {
       let interEditContent = source.slice(cursor, start);

--- a/packages/template-tag-codemod/tsconfig.json
+++ b/packages/template-tag-codemod/tsconfig.json
@@ -5,7 +5,7 @@
   "extends": "../../tsconfig-base.json",
   "compilerOptions": {
     "composite": true,
-    "target": "es2021",
+    "target": "es2024",
     "outDir": "dist"
   },
 }

--- a/packages/vite/src/warn-root-url.ts
+++ b/packages/vite/src/warn-root-url.ts
@@ -25,13 +25,13 @@ export function warnRootUrl(): Plugin {
         );
 
         const matches = html.matchAll(ROOT_URL_TOKEN_REGEX);
-        const count = [...matches].length;
+        const count = Array.from(matches).length;
 
         const dom = new JSDOM(html, {
           includeNodeLocations: true,
         });
         const document = dom.window.document;
-        const nodes = [...document.querySelectorAll('*')].filter(node =>
+        const nodes = Array.from(document.querySelectorAll('*')).filter(node =>
           node.getAttributeNames().some(key => node.getAttribute(key)?.match(ROOT_URL_TOKEN_REGEX))
         );
 


### PR DESCRIPTION
This is part of a series of optimizations I've found while working on diagnosing why the v1-compat portion of a v2 addon test build was crashing with a stack-overflow after 30min. This series of optimizations now has that same build completing start-to-finish (not just compat) in 45s.

These changes were a smaller contributor to this that de-risk additional codepaths from high memory/cpu/stack-overflow risks.

For other changes see #2755 #2758 and #2757 