### PR TITLE
perf: dedupe v2 addons by default

### DIFF
--- a/packages/addon-shim/src/index.ts
+++ b/packages/addon-shim/src/index.ts
@@ -116,6 +116,8 @@ export function addonV1Shim(directory: string, options: ShimOptions = {}) {
       this._super.included.apply(this, args);
     },
 
+    allowCachingPerBundle: true,
+
     treeForApp(this: AddonInstance) {
       if (disabled) {
         return undefined;


### PR DESCRIPTION
The compat shim doesn't set this flag for ember-cli, but should for v2 addons.