### PR TITLE
Enable declarationMap in our base tsconfig

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -4,6 +4,7 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
+    "declarationMap": true,
     "typeRoots": ["types", "node_modules/@types"],
     "esModuleInterop": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
This makes jump-to-definition work across packages correctly again, now that their have separate builds.