### PR TITLE
Add more text to the invalid import error

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1163,7 +1163,7 @@ export class Resolver {
       !reliablyResolvable(pkg, packageName)
     ) {
       throw new Error(
-        `${pkg.name} is trying to import from ${packageName} but that is not one of its explicit dependencies`
+        `${pkg.name} is trying to import from ${packageName} but that is not one of its explicit dependencies. ${pkg.name} is a v2 addon, and v2 addons are only allowed to import from their dependencies (or peerDependencies).`
       );
     }
 


### PR DESCRIPTION
to import things that don't exist, folks should not use a v2 addon (and use a non-addon npm package)