### PR TITLE
Fix: split child route "parent.map" fails to load in vite dev

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -464,7 +464,9 @@ export class Resolver {
       browser: true,
       conditions: ['default', 'imports'],
     });
-    let target = matched ? `${matched}:route=${routeName}` : `-embroider-route-entrypoint.js:route=${routeName}`;
+    // Keep the id from ending in a route-controlled extension like `.map`,
+    // which Vite's dev sourcemap middleware would mis-serve. See #2670.
+    let target = matched ? `${matched}:route=${routeName}.js` : `-embroider-route-entrypoint.js:route=${routeName}.js`;
     let specifier = resolve(pkg.root, target);
 
     return logTransition(

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -464,9 +464,10 @@ export class Resolver {
       browser: true,
       conditions: ['default', 'imports'],
     });
-    // Keep the id from ending in a route-controlled extension like `.map`,
-    // which Vite's dev sourcemap middleware would mis-serve. See #2670.
-    let target = matched ? `${matched}:route=${routeName}.js` : `-embroider-route-entrypoint.js:route=${routeName}.js`;
+    // The trailing `.js` stops the id from ending in a route-controlled extension
+    // like `.map`, which Vite's dev sourcemap middleware hijacks. See #2670.
+    let entrypoint = matched ?? '-embroider-route-entrypoint.js';
+    let target = `${entrypoint}:route=${routeName}.js`;
     let specifier = resolve(pkg.root, target);
 
     return logTransition(

--- a/tests/scenarios/compat-route-split-test.ts
+++ b/tests/scenarios/compat-route-split-test.ts
@@ -395,7 +395,7 @@ splitScenarios
       });
 
       test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people\?import"\)/);
+        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has split controllers in route entrypoint', function () {
@@ -566,7 +566,7 @@ splitScenarios
       });
 
       test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people\?import"\)/);
+        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
       });
 
       test('has split controllers in route entrypoint', function () {

--- a/tests/scenarios/compat-route-split-test.ts
+++ b/tests/scenarios/compat-route-split-test.ts
@@ -224,7 +224,7 @@ splitScenarios
       });
 
       test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
+        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people.js/);
       });
 
       test('has split controllers in route entrypoint', function () {
@@ -395,7 +395,7 @@ splitScenarios
       });
 
       test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
+        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people.js/);
       });
 
       test('has split controllers in route entrypoint', function () {
@@ -566,7 +566,7 @@ splitScenarios
       });
 
       test('dynamically imports the route entrypoint from the main entrypoint', function () {
-        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people/);
+        inEntrypoint(/import\("\/app\/-embroider-route-entrypoint.js:route=people.js/);
       });
 
       test('has split controllers in route entrypoint', function () {

--- a/tests/scenarios/vite-app-test.ts
+++ b/tests/scenarios/vite-app-test.ts
@@ -95,6 +95,20 @@ wideAppScenarios
 
     project.addDevDependency(addon2);
     project.mergeFiles({
+      'ember-cli-build.js': `
+        'use strict';
+        const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+        const { compatBuild } = require('@embroider/compat');
+        module.exports = async function (defaults) {
+          const { buildOnce } = await import('@embroider/vite');
+          let app = new EmberApp(defaults, {});
+          // Split a route named "map" (its route entrypoint id ends in ".map")
+          // to cover the vite dev regression in #2670.
+          return compatBuild(app, buildOnce, {
+            splitAtRoutes: ['parent', 'parent.map'],
+          });
+        };
+      `,
       'testem-dev.js': `
           'use strict';
 
@@ -135,6 +149,11 @@ wideAppScenarios
             test('visiting /', async function (assert) {
               await visit('/');
               assert.dom().includesText('hey');
+            });
+
+            test('can load a code-split route named "map" at /parent/map', async function (assert) {
+              await visit('/parent/map');
+              assert.dom('[data-test-map]').exists('the split "map" route loaded');
             });
           });
           `,
@@ -240,6 +259,19 @@ wideAppScenarios
         },
       },
       app: {
+        'router.js': `
+          import EmberRouter from '@embroider/router';
+          import config from 'app-template/config/environment';
+          export default class Router extends EmberRouter {
+            location = config.locationType;
+            rootURL = config.rootURL;
+          }
+          Router.map(function () {
+            this.route('parent', function () {
+              this.route('map');
+            });
+          });
+        `,
         components: {
           old: {
             'component.js': `import Component from '@glimmer/component';
@@ -280,6 +312,9 @@ wideAppScenarios
           `,
         },
         routes: {
+          parent: {
+            'map.js': `import Route from '@ember/routing/route'; export default class MapRoute extends Route {}`,
+          },
           'application.js': `
             import Route from '@ember/routing/route';
             import * as emberService from '@ember/service';
@@ -300,6 +335,10 @@ wideAppScenarios
           <Old @message={{this.model.message}} />
 
           {{outlet}}`,
+          'parent.hbs': `{{outlet}}`,
+          parent: {
+            'map.hbs': `<div data-test-map>map route loaded</div>`,
+          },
         },
       },
       public: {

--- a/tests/scenarios/vite-app-test.ts
+++ b/tests/scenarios/vite-app-test.ts
@@ -102,8 +102,8 @@ wideAppScenarios
         module.exports = async function (defaults) {
           const { buildOnce } = await import('@embroider/vite');
           let app = new EmberApp(defaults, {});
-          // Split a route named "map" (its route entrypoint id ends in ".map")
-          // to cover the vite dev regression in #2670.
+          // Covers #2670. Both routes must be split: vite strips the ".map" off the
+          // child's id and only hijacks it if "route=parent" is a module it knows.
           return compatBuild(app, buildOnce, {
             splitAtRoutes: ['parent', 'parent.map'],
           });


### PR DESCRIPTION
Failing test + targeted fix for embroider-build/embroider#2670.

Repro: https://github.com/johanrd/embroider-repro-optimize-deps/tree/repro/map-route-name

Cowritten by claude.

## Problem

A code-split route whose name ends in the segment `map` (e.g. `authenticated.map`) cannot be loaded in `vite dev`. Production builds are unaffected.

```
TypeError: Failed to fetch dynamically imported module:
  .../app/-embroider-route-entrypoint.js:route=authenticated.map?import
```

## Root cause

`handleRouteEntrypoint` appends the raw route name, so a `map` route's id ends in `.map`. Vite's dev sourcemap middleware (same code in Vite 6, 7 and 8) strips that `.map`, looks up `…:route=<parent>` — a real module, because the parent is also split — and serves that module's sourcemap instead of the route's JavaScript.

## Fix

The route is carried in the resolver `meta` and nothing decodes the `:route=…` tail, so append a trailing `.js` to the id. Every id then ends in `.js` and every sourcemap URL ends in `.map`, so the collision becomes unrepresentable rather than merely avoided. A `\0` / `virtual-module:` prefix would be the more canonical Vite convention, but a much larger change for the same outcome.

## Test

The bug only reproduces through a real browser dynamic import; an HTTP/audit fetch against `vite dev` does **not** trigger it. So the check rides the existing `vite-app-test` scenario, which already boots a browser against `vite dev`: split `parent` / `parent.map`, add a `map` route, `visit('/parent/map')`. Fails before, passes after, no new CI job.

`compat-route-split-test`'s three route-entrypoint id assertions now assert `route=people.js`. Two of them dropped a `?import` tail, because Vite only adds that marker to ids it doesn't recognize as JS (`path.extname` of the old id was `.js:route=people`) and the id now ends in `.js`.
