### PR TITLE
fix: tolerate ENOTEMPTY on jumpRoot rename race in @embroider/vite resolver

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -258,9 +258,10 @@ async function maybeCaptureNewOptimizedDep(
     try {
       renameSync(tmp, jumpRoot);
     } catch (err) {
-      if (err.code === 'EEXIST') {
+      if (err.code === 'EEXIST' || err.code === 'ENOTEMPTY') {
         // somebody raced us and made it first. It's content-addressable so
-        // that's fine.
+        // that's fine. ENOTEMPTY happens on Linux when renaming onto a
+        // now-non-empty directory; same race, different errno.
       } else {
         throw err;
       }


### PR DESCRIPTION
## Summary

`maybeCaptureNewOptimizedDep` in `@embroider/vite`'s resolver already tolerates `EEXIST` from `renameSync(tmp, jumpRoot)` because the jump root is content-addressable — if another concurrent build won the race, its directory is equivalent to ours and we can safely continue.

On Linux, the same race surfaces as `ENOTEMPTY` instead of `EEXIST` (rename onto a now-non-empty directory). Today that errno escapes and aborts the build.

This widens the recovery to cover both errnos, treating them the same way.

```ts
} catch (err) {
-   if (err.code === 'EEXIST') {
+   if (err.code === 'EEXIST' || err.code === 'ENOTEMPTY') {
      // somebody raced us and made it first. It's content-addressable so
-     // that's fine.
+     // that's fine. ENOTEMPTY happens on Linux when renaming onto a
+     // now-non-empty directory; same race, different errno.
    } else {
      throw err;
    }
```

Refs #2603 — multiple users in that issue (including on `@embroider/vite@1.7.x`) hit `ENOTEMPTY` in parallel/CI builds with the same `embroider-vite-jump-tmp-* -> embroider-vite-jump-<hash>` stack trace.

## Verification

We've been running this patch in production via `pnpm patch` on `@embroider/vite@1.7.3` across our monorepo CI for parallel builds, and it cleanly resolves the intermittent `ENOTEMPTY` failures we were seeing on Linux runners while keeping behavior identical for the success and `EEXIST` paths.