### PR TITLE
Use parseSync in @embroider/macros for Babel 8 compatibility

### DIFF
--- a/packages/macros/src/babel/evaluate-json.ts
+++ b/packages/macros/src/babel/evaluate-json.ts
@@ -480,7 +480,7 @@ export function buildLiterals(
   if (typeof value === 'undefined') {
     return babelContext.types.identifier('undefined');
   }
-  let statement = babelContext.parse(`a(${JSON.stringify(value)})`, { configFile: false }) as t.File;
+  let statement = babelContext.parseSync(`a(${JSON.stringify(value)})`, { configFile: false }) as t.File;
   let expression = (statement.program.body[0] as t.ExpressionStatement).expression as t.CallExpression;
   return expression.arguments[0] as t.ObjectExpression;
 }


### PR DESCRIPTION
`buildLiterals` calls `babel.parse()` with no callback. In Babel 7 that runs synchronously via a backward-compat shim, which [the docs](https://babeljs.io/docs/babel-core/#parse) note "will be dropped in Babel 8". Babel 8 dropped it, so the call now throws under `@babel/core@8`:

> Starting from Babel 8.0.0, the 'parse' function expects a callback. If you need to call it synchronously, please use 'parseSync'.

`parseSync` (added in Babel 7.0, identical behaviour) is the documented replacement — a no-op on Babel 7, and the fix on Babel 8. It's the only such call in the repo source.

Refs: [babel-core API](https://babeljs.io/docs/babel-core/#parsesync) · [Babel 8 API migration](https://babeljs.io/docs/v8-migration-api/) ("functions … no longer support synchronous usage without a callback. Use *Sync variants instead").

Verified in a downstream Vite + Embroider 4 app: the full production build completes under `@babel/core@8.0.1` (previously threw here).
