### PR TITLE
[draft] add a maybe-babel implementation

### DIFF
--- a/packages/vite/index.ts
+++ b/packages/vite/index.ts
@@ -11,3 +11,4 @@ export * from './src/classic-ember-support.js';
 export * from './src/ember.js';
 export * from './src/build-once.js';
 export { configTargets } from './src/config-targets.js';
+export { maybeBabelFilter, maybeBabelRegexFilter } from './src/maybe-babel.js';

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -36,6 +36,7 @@
     "@babel/core": "^7.22.9",
     "@embroider/macros": "workspace:*",
     "@embroider/reverse-exports": "workspace:*",
+    "@rolldown/pluginutils": "^1.0.1",
     "assert-never": "^1.2.1",
     "browserslist": "*",
     "browserslist-to-esbuild": "^2.1.1",
@@ -45,9 +46,11 @@
     "fast-glob": "^3.3.2",
     "fs-extra": "^10.0.0",
     "jsdom": "^25.0.0",
+    "oxc-parser": "^0.137.0",
     "send": "^1.2.1",
     "source-map-url": "^0.4.1",
-    "terser": "^5.7.0"
+    "terser": "^5.7.0",
+    "zimmerframe": "^1.1.4"
   },
   "devDependencies": {
     "@embroider/core": "workspace:^",

--- a/packages/vite/src/maybe-babel.ts
+++ b/packages/vite/src/maybe-babel.ts
@@ -1,0 +1,89 @@
+/**
+ * Most of this code was taken from https://github.com/discourse/discourse/blob/7f591bc7c590eb4f9f970a5deb33a25bfee3575a/frontend/discourse/lib/maybe-babel.mjs
+ * and previous iterations of the same code. This is currently provided as an experiment for people to try out and report back their findings
+ */
+
+import { parse as oxcParse } from 'oxc-parser';
+import { walk } from 'zimmerframe';
+import { extensions } from './ember.js';
+import { and, code, id, include, not, or } from '@rolldown/pluginutils';
+
+const babelRequiredImports = [
+  // Templates
+  '@ember/template-compiler',
+  '@ember/template-compilation',
+  'ember-cli-htmlbars',
+  'ember-cli-htmlbars-inline-precompile',
+  'htmlbars-inline-precompile',
+
+  // Macros
+  '@embroider/macros',
+  '@glimmer/env',
+  '@ember/debug',
+  '@ember/application/deprecations',
+];
+
+export async function maybeBabelFilter(id: string, code: string) {
+  const estree = await oxcParse(id, code);
+
+  let hasDecorators = false;
+  let hasBabelRequiredImport = false;
+
+  walk(
+    estree.program,
+    /* state */ {},
+    {
+      // @ts-expect-error
+      Decorator(_node: unknown, { stop }: { stop: () => void }) {
+        hasDecorators = true;
+        stop();
+      },
+      ImportDeclaration(node: any, { stop }: { stop: () => void }) {
+        if (babelRequiredImports.includes(node.source.value)) {
+          hasBabelRequiredImport = true;
+          stop();
+        }
+      },
+    }
+  );
+
+  return hasDecorators || hasBabelRequiredImport;
+}
+
+function escapeRegExp(s: string) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const importsRegex = new RegExp(babelRequiredImports.map(escapeRegExp).join('|'));
+
+const decoratorRegex = /(?<![\w'"`])(?<!\*\s)(?<!\/\/[^\n]*)@\w+/;
+//                      └────┬─────┘└───┬───┘└──────┬──────┘└┬─┘
+//                           │          │           │         │
+//                           │          │           │         └── the `@decorator`
+//                           │          │           └── not on a `//` line comment
+//                           │          └── not a JSDoc tag (`* @param`)
+//                           └── not mid-identifier or inside a string
+
+const nodeModulesPattern = /\/node_modules\//;
+
+const regExpCharactersRegExp = /[\\^$.*+?()[\]{}|]/g;
+const escapeRegExpCharacters = (str: string) => str.replace(regExpCharactersRegExp, '\\$&');
+
+const extensionRegExp = new RegExp(
+  `(${extensions
+    .filter(ext => ext !== '.json')
+    .map(escapeRegExpCharacters)
+    .join('|')})(\\?.*)?(#.*)?$`
+);
+
+export const maybeBabelRegexFilter = [
+  include(
+    and(
+      id(extensionRegExp), // Is one of the babel-supported extensions
+      or(
+        code(importsRegex), // Imports one of our listed modules
+        and(not(id(nodeModulesPattern)), code(decoratorRegex)) // Is local app code which uses a decorator
+      )
+    )
+  ),
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         version: 1.5.2(typescript@5.9.3)
       '@glint/ember-tsc':
         specifier: ^1.0.8
-        version: 1.7.5(ember-source@7.0.0(@glimmer/component@2.1.1))(typescript@5.9.3)
+        version: 1.7.5(ember-source@7.1.0(@glimmer/component@2.1.1))(typescript@5.9.3)
       '@glint/environment-ember-loose':
         specifier: ^1.5.0
         version: 1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7))
@@ -111,7 +111,7 @@ importers:
         version: 1.7.7
       '@glint/tsserver-plugin':
         specifier: ^2.0.8
-        version: 2.5.5(ember-source@7.0.0(@glimmer/component@2.1.1))
+        version: 2.5.5(ember-source@7.1.0(@glimmer/component@2.1.1))
       '@types/fs-extra':
         specifier: ^9.0.12
         version: 9.0.13
@@ -967,6 +967,9 @@ importers:
       '@embroider/reverse-exports':
         specifier: workspace:*
         version: link:../reverse-exports
+      '@rolldown/pluginutils':
+        specifier: ^1.0.1
+        version: 1.0.1
       assert-never:
         specifier: ^1.2.1
         version: 1.4.0
@@ -994,6 +997,9 @@ importers:
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1(supports-color@8.1.1)
+      oxc-parser:
+        specifier: ^0.137.0
+        version: 0.137.0
       send:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1003,6 +1009,9 @@ importers:
       terser:
         specifier: ^5.7.0
         version: 5.48.0
+      zimmerframe:
+        specifier: ^1.1.4
+        version: 1.1.4
     devDependencies:
       '@embroider/core':
         specifier: workspace:^
@@ -1811,7 +1820,7 @@ importers:
         version: 7.29.7
       '@ember/legacy-built-in-components':
         specifier: ^0.4.1
-        version: 0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+        version: 0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/string':
         specifier: ^3.0.0
         version: 3.1.1
@@ -1883,7 +1892,7 @@ importers:
         version: 3.0.0
       ember-bootstrap:
         specifier: ^6.0.0
-        version: 6.7.0(@babel/core@7.29.7)(@glimmer/component@2.1.1)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-modifier@4.3.0(@babel/core@7.29.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+        version: 6.7.0(@babel/core@7.29.7)(@glimmer/component@2.1.1)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-modifier@4.3.0(@babel/core@7.29.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-cli-3.28:
         specifier: npm:ember-cli@~3.28.0
         version: ember-cli@3.28.6(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.9)(underscore@1.13.8)
@@ -1907,37 +1916,37 @@ importers:
         version: ember-cli-babel@8.3.1(@babel/core@7.29.7)
       ember-cli-beta:
         specifier: npm:ember-cli@beta
-        version: ember-cli@7.1.0-beta.1(@babel/core@7.29.7)(@types/node@22.19.19)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: ember-cli@7.1.0-beta.2(@babel/core@7.29.7)(@types/node@22.19.19)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
       ember-cli-fastboot:
         specifier: ^4.1.1
-        version: 4.1.5(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+        version: 4.1.5(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-cli-htmlbars-7:
         specifier: npm:ember-cli-htmlbars@^7.0.0
-        version: ember-cli-htmlbars@7.0.1(@babel/core@7.29.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+        version: ember-cli-htmlbars@7.0.1(@babel/core@7.29.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-cli-latest:
         specifier: npm:ember-cli@latest
         version: ember-cli@7.0.1(@babel/core@7.29.7)(@types/node@22.19.19)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
       ember-data:
         specifier: ~3.28.0
-        version: 3.28.13(@babel/core@7.29.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+        version: 3.28.13(@babel/core@7.29.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-data-4.12:
         specifier: npm:ember-data@~4.12.0
-        version: ember-data@4.12.8(@babel/core@7.29.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+        version: ember-data@4.12.8(@babel/core@7.29.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-data-4.4:
         specifier: npm:ember-data@~4.4.0
-        version: ember-data@4.4.3(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+        version: ember-data@4.4.3(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-data-4.8:
         specifier: npm:ember-data@~4.8.0
-        version: ember-data@4.8.8(@babel/core@7.29.7)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+        version: ember-data@4.8.8(@babel/core@7.29.7)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-data-5.3:
         specifier: npm:ember-data@~5.3.13
-        version: ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(qunit@2.25.0)
+        version: ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(qunit@2.25.0)
       ember-data-latest:
         specifier: npm:ember-data@~5.5.0
-        version: ember-data@5.5.0(@ember/string@3.1.1)(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(qunit@2.25.0)
+        version: ember-data@5.5.0(@ember/string@3.1.1)(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(qunit@2.25.0)
       ember-engines:
         specifier: ^0.8.23
-        version: 0.8.23(@ember/legacy-built-in-components@0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+        version: 0.8.23(@ember/legacy-built-in-components@0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-inline-svg:
         specifier: ^0.2.1
         version: 0.2.1(@babel/core@7.29.7)
@@ -1946,13 +1955,13 @@ importers:
         version: 4.3.0(@babel/core@7.29.7)
       ember-page-title:
         specifier: ^8.2.3
-        version: 8.2.4(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+        version: 8.2.4(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-page-title-9:
         specifier: npm:ember-page-title@^9.0.0
         version: ember-page-title@9.0.3
       ember-qunit-6:
         specifier: npm:ember-qunit@^6.0.0
-        version: ember-qunit@6.2.0(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(qunit@2.25.0)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+        version: ember-qunit@6.2.0(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(qunit@2.25.0)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-qunit-9:
         specifier: npm:ember-qunit@^9.0.0
         version: ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0)
@@ -1982,22 +1991,22 @@ importers:
         version: ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
       ember-source-beta:
         specifier: npm:ember-source@beta
-        version: ember-source@7.1.0-beta.1(@glimmer/component@2.1.1)
+        version: ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)
       ember-source-canary:
         specifier: npm:ember-source@alpha
-        version: ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)
+        version: ember-source@7.2.0-alpha.4(@glimmer/component@2.1.1)
       ember-source-latest:
         specifier: npm:ember-source@latest
-        version: ember-source@7.0.0(@glimmer/component@2.1.1)
+        version: ember-source@7.1.0(@glimmer/component@2.1.1)
       ember-template-imports:
         specifier: ^4.1.2
         version: 4.4.0
       ember-test-helpers-2:
         specifier: npm:@ember/test-helpers@^2.0.0
-        version: '@ember/test-helpers@2.9.6(@babel/core@7.29.7)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))'
+        version: '@ember/test-helpers@2.9.6(@babel/core@7.29.7)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))'
       ember-test-helpers-4:
         specifier: npm:@ember/test-helpers@^4.0.0
-        version: '@ember/test-helpers@4.0.5(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))'
+        version: '@ember/test-helpers@4.0.5(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))'
       ember-test-helpers-5:
         specifier: npm:@ember/test-helpers@^5.0.0
         version: '@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7)'
@@ -3810,11 +3819,20 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -4963,6 +4981,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
@@ -5056,8 +5080,130 @@ packages:
   '@octokit/types@14.1.0':
     resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
 
+  '@oxc-parser/binding-android-arm-eabi@0.137.0':
+    resolution: {integrity: sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.137.0':
+    resolution: {integrity: sha512-WhALNzfy3x/RfC6bsqX+csavuUY0yHHE7XfgPE5M542uhoBZUUoGTPG+nkMbGoG4+gcfss5s7urMyn5QBHu0sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.137.0':
+    resolution: {integrity: sha512-bFPr5hgmNMOMoyPTGtdsK4Ug21RovIPojRMgDDhSp1LtCnc/DkLwGONKjgRjszg677RlGnkYSviQ8hHaUPOVYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.137.0':
+    resolution: {integrity: sha512-CL5dMm1asqXIDZHg14FLxj3Mc36w8PI7xCWh1uA4is6z8g2XrIILoTcQYOxDbwzuk34RDPX5IAGUxZr6LA9KAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.137.0':
+    resolution: {integrity: sha512-79h8rYGnSlKPGWo7mHr2ixO6ea7aW8B0CT965SZ8SLbNnCOH5aOYBTeVXUY6eMvEaiLyWr8Skuiugr5pDYgLGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.137.0':
+    resolution: {integrity: sha512-ASgmlSimhGyr0lksgVIo6hibz1obnDq4qJbiMX/AzltfgPnanRrzG1Q+23g8ljOHOjv6dsznkUuCYL3gg0sY1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.137.0':
+    resolution: {integrity: sha512-AU2J9aa22Sx32wRGnDjybOU9TQXXQUud5sdUi+ZB0XxwM8aToWLweV+yA0wlQm0yIUVqljquqoHCYEq9II8gJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.137.0':
+    resolution: {integrity: sha512-GdEtiG89yMr7XkUGxifgodXEEm2f+xW2f9CpDjlgAnBOwhTmrpQMvhOGobLVKUyzf/qHBXW16smk5zbF3nZU6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.137.0':
+    resolution: {integrity: sha512-EGJ+Bs8iXx8KBH8DQ5BLoEm5lnHaYjlh4/8j8vFhrr/6z4tqONy5BZDzLpKmmNWlN6Hlc5r8YOuBVHqZ9vRFEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
+    resolution: {integrity: sha512-vzFUQENy/fnbSe5DZWovq6tIBc1uhuMztanSW6rz1e9WdQE4gHwYuD7ZII6JnrJifd1R3RSoqiZbgRFlVL2tYQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.137.0':
+    resolution: {integrity: sha512-SfVI14HBQs9gtLcUD5hTt5hsNbdrqSUNg9S8muN+LhVQ5nf1WwH3hAoK6B9NKgdYgWAQSXFXGiiBedQ4r/BKuw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
+    resolution: {integrity: sha512-e7Ppy4FCIFNQxT/ikSeIWFoQ0l+N9vgtRBtLcyZXeolTzApyVoPqEXsYPrcdM/9i0Bwk8knvYd37vaEMxHyi6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
+    resolution: {integrity: sha512-Bho5qFwdhqsIFR7gipYEUlqvi3SRrY8sugxXig380MIaakBB1PyU9+7dBiBVScfImTNWhijUxdBwqrprGdq5WA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.137.0':
+    resolution: {integrity: sha512-36mGWtg7PyFzjJwGDkH6/F4o2nIDEoKXLPr/X/lwqklkomQwJJt1I5GJVmGhovUEmgPK5WAeAZMqlFCehwiy9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.137.0':
+    resolution: {integrity: sha512-/Jqx6+N7A44n2BdvUr7pXhVr2vFjs6WGH3unZRczwrfiH0H1zY0QwKQMG/dtRiTlKGDKGukznPT8lx84/oEsZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-openharmony-arm64@0.137.0':
+    resolution: {integrity: sha512-9Uj0qHNNl+OgT1UTGwF7ixIXU6T1u2SbMidmgPy/h1h/fl2gRS6YpAxxY1gwHofcWjoTwkoMFd8xs5Vuj6GOFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.137.0':
+    resolution: {integrity: sha512-gW2vfkytNGgMVADiuzdvOfw0mWG9za20F/1fCJsif5aBMAvWJTSbpIXbIe0XkOe0VENk+PadpQ7cZgUy2sUJcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.137.0':
+    resolution: {integrity: sha512-x+pFANF0yL5uK/6T7lu6SlR5qid6sp//eZXKLq5iNsIE+EQg6EaS8/wsW7E91nXXjpnPhSoMOHXShSVhGRdn8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.137.0':
+    resolution: {integrity: sha512-sQUqym80PFi6McRsIqfJrSu2JrSClEZIXXD+/FjAFoULEKzOPsldIdFBG96xdX8aVMzCNQ9792FPx3MfkEIrFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.137.0':
+    resolution: {integrity: sha512-2AsevxlvNN4WKxpEn3RtqD5zbqMaXF+T7JXblsP4gVuY+vC9dXS4ED/PwfRCliFqoeisYS3Iro4DHzxr0TEvVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
+  '@oxc-project/types@0.137.0':
+    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5611,6 +5757,9 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/babel-types@7.0.16':
     resolution: {integrity: sha512-5QXs9GBFTNTmilLlWBhnsprqpjfrotyrnzUdwDrywEL/DA4LuCWQT300BTOXA3Y9ngT9F2uvmCoIxI6z8DlJEA==}
@@ -8339,8 +8488,8 @@ packages:
     engines: {node: '>= 20.19.0'}
     hasBin: true
 
-  ember-cli@7.1.0-beta.1:
-    resolution: {integrity: sha512-cHKpEKISZvhiGPDFlrDe4BlwAry9gipUbH1aWGlZFlRCUSWr4n3iSm6Hf/rFENVSW5CpUrbu7rP5AWt/mh0jRg==}
+  ember-cli@7.1.0-beta.2:
+    resolution: {integrity: sha512-wuDvXjToKS9DgQlOrylss6pqaVAv1OfCfyMliOhT1JYDUQowHwBQBhE0+9kbCJQl40g6LBFo+9fthluUavGVlA==}
     engines: {node: '>= 20.19.0'}
     hasBin: true
 
@@ -8629,20 +8778,20 @@ packages:
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
 
-  ember-source@7.0.0:
-    resolution: {integrity: sha512-30dv3f4jMKAFhUmyjbb5V8B+hhkhwn2Y+GbwIxbb4SuEXtJf0uPr1Ppp1g5s6LzrxU5zPlCXh2bfN3LCwqqGog==}
+  ember-source@7.1.0:
+    resolution: {integrity: sha512-qOHhTiVMeYcNp2UQKuAqsf33LKgNtzqvw46dQX5AqutTfXXPn4KYR0+aiGQdJaCuzs81nFvvTDJuHzELOZ5UBg==}
     engines: {node: '>= 20.19'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
 
-  ember-source@7.1.0-beta.1:
-    resolution: {integrity: sha512-G4fEzISgB8rK9fqvmSbm0PNwrEsC/KQduC/DKC9Lhl7+kNqv9ldCeZM5soe5rUXvlCK2mvCQHVqbYcq1j2peZg==}
+  ember-source@7.2.0-alpha.4:
+    resolution: {integrity: sha512-WGkWGIsWCnqGbhRAUL63ARs9mqnjxSgdT/jbR3I2vyOhultudpI7LW+qKUh1GP9IINUjfNUV7Na7eZyaUvSnrg==}
     engines: {node: '>= 20.19'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
 
-  ember-source@7.2.0-alpha.1:
-    resolution: {integrity: sha512-oJ2yJqxPkYP7gH3s/iwNtRinRg107g3tvgdwjNPHI2z2hGk4WbvKkxKTJXwgyRzqrvVrWuK0h6Y05bsAMMbzRw==}
+  ember-source@7.2.0-beta.1:
+    resolution: {integrity: sha512-WtFN4K4h7ahNjfTK1vNOE7USfiP1kuv8fL8zn/mKvxjIpLodQ80HryFLsSeAPBB4rUMHLrrSW5kMRwe4jWL19w==}
     engines: {node: '>= 20.19'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
@@ -11659,6 +11808,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxc-parser@0.137.0:
+    resolution: {integrity: sha512-yFImD+WLElJpLKy8llG1qe4DCmMsL18peRp8XP1JKfig/gISbJkglnpDtX2aTmAn10kZF7164HbN2H8QPsXxGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   p-cancelable@0.4.1:
     resolution: {integrity: sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==}
     engines: {node: '>=4'}
@@ -14406,6 +14559,9 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
 snapshots:
 
   '@asamuzakjp/css-color@3.2.0':
@@ -15906,15 +16062,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/adapter@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))':
+  '@ember-data/adapter@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -15935,27 +16091,27 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/adapter@4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
+  '@ember-data/adapter@4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
     dependencies:
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  '@ember-data/adapter@5.3.13(c7cc75dccd8610f2fbef6fe9ba15af17)':
+  '@ember-data/adapter@5.3.13(bba1dc98161fc9a910c2d58a89731cde)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.13(883afd83fd6be47b2ced534fa6817bbc)
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/legacy-compat': 5.3.13(c2b690b8b6ed883b9d8cc1905f7e766d)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
@@ -15963,16 +16119,16 @@ snapshots:
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/adapter@5.5.0(1671f1abb1977c67c8e553be91fe34c9)':
+  '@ember-data/adapter@5.5.0(717565551974b9d10d2a716dd7b3fe65)':
     dependencies:
-      '@ember-data/legacy-compat': 5.5.0(7d2fc24dd54058c686f3cc313e26a39f)
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/legacy-compat': 5.5.0(898799fc64f97874879366744981ec45)
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
@@ -15980,7 +16136,7 @@ snapshots:
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16022,7 +16178,7 @@ snapshots:
   '@ember-data/debug@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
@@ -16061,30 +16217,30 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/debug@5.3.13(f5946a023f90421636f893382a534ff6)':
+  '@ember-data/debug@5.3.13(f8c7ba311e198e7529af5f23ca22313c)':
     dependencies:
-      '@ember-data/model': 5.3.13(4c9d3f38d3c2163c7d04fbe1495848dd)
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/model': 5.3.13(6a9b29b54fdb1680d0ab61748ef50753)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/debug@5.5.0(53228376cb5f3b4d8404ae6778204080)':
+  '@ember-data/debug@5.5.0(14c954512686c73ea4afbe6566947cf4)':
     dependencies:
-      '@ember-data/model': 5.5.0(b704708eb7b49f65dcf7acbba2155fec)
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/model': 5.5.0(1f01221aaa8e3d107289bcb8c6e18665)
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16092,7 +16248,7 @@ snapshots:
   '@ember-data/graph@4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-cli-babel: 7.26.11
@@ -16100,20 +16256,20 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember-data/graph@5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))':
+  '@ember-data/graph@5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))':
     dependencies:
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
@@ -16125,7 +16281,7 @@ snapshots:
     dependencies:
       '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-cli-babel: 7.26.11
@@ -16133,11 +16289,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@5.3.13(4333a2d6d8e1ec7a65fd7c888a6fa263)':
+  '@ember-data/json-api@5.3.13(1d74d0090632e0cbfe71fd514209b16c)':
     dependencies:
-      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
@@ -16147,11 +16303,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@5.5.0(7651bf037c97f8da4f2d1edf415ebd90)':
+  '@ember-data/json-api@5.5.0(b9fb7d1ed6218abbe28f26b5f018b9d1)':
     dependencies:
-      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
@@ -16174,36 +16330,36 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@5.3.13(883afd83fd6be47b2ced534fa6817bbc)':
+  '@ember-data/legacy-compat@5.3.13(c2b690b8b6ed883b9d8cc1905f7e766d)':
     dependencies:
       '@ember-data/request': 5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     optionalDependencies:
-      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/json-api': 5.3.13(4333a2d6d8e1ec7a65fd7c888a6fa263)
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/json-api': 5.3.13(1d74d0090632e0cbfe71fd514209b16c)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@5.5.0(7d2fc24dd54058c686f3cc313e26a39f)':
+  '@ember-data/legacy-compat@5.5.0(898799fc64f97874879366744981ec45)':
     dependencies:
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     optionalDependencies:
-      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
-      '@ember-data/json-api': 5.5.0(7651bf037c97f8da4f2d1edf415ebd90)
+      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
+      '@ember-data/json-api': 5.5.0(b9fb7d1ed6218abbe28f26b5f018b9d1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16226,20 +16382,20 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/model@4.12.8(@babel/core@7.29.7)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember-data/model@4.12.8(@babel/core@7.29.7)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember-data/tracking': 4.12.8(@glint/template@1.7.7)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       inflection: 2.0.1
     optionalDependencies:
       '@ember-data/debug': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
@@ -16272,22 +16428,22 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/model@4.8.8(@babel/core@7.29.7)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
+  '@ember-data/model@4.8.8(@babel/core@7.29.7)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
     dependencies:
       '@ember-data/canary-features': 4.8.8(@glint/template@1.7.7)
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember-data/tracking': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
       ember-compatibility-helpers: 1.2.7(@babel/core@7.29.7)
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       inflection: 1.13.4
     optionalDependencies:
       '@ember-data/record-data': 4.8.8(@ember-data/store@4.8.8)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
@@ -16298,43 +16454,43 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/model@5.3.13(4c9d3f38d3c2163c7d04fbe1495848dd)':
+  '@ember-data/model@5.3.13(6a9b29b54fdb1680d0ab61748ef50753)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.13(883afd83fd6be47b2ced534fa6817bbc)
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/tracking': 5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/legacy-compat': 5.3.13(c2b690b8b6ed883b9d8cc1905f7e766d)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/tracking': 5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
       inflection: 3.0.2
     optionalDependencies:
-      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/json-api': 5.3.13(4333a2d6d8e1ec7a65fd7c888a6fa263)
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/json-api': 5.3.13(1d74d0090632e0cbfe71fd514209b16c)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@5.5.0(b704708eb7b49f65dcf7acbba2155fec)':
+  '@ember-data/model@5.5.0(1f01221aaa8e3d107289bcb8c6e18665)':
     dependencies:
-      '@ember-data/legacy-compat': 5.5.0(7d2fc24dd54058c686f3cc313e26a39f)
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/legacy-compat': 5.5.0(898799fc64f97874879366744981ec45)
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
       inflection: 3.0.2
     optionalDependencies:
-      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
-      '@ember-data/json-api': 5.5.0(7651bf037c97f8da4f2d1edf415ebd90)
+      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
+      '@ember-data/json-api': 5.5.0(b9fb7d1ed6218abbe28f26b5f018b9d1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16501,7 +16657,7 @@ snapshots:
     dependencies:
       '@ember-data/canary-features': 4.8.8(@glint/template@1.7.7)
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
@@ -16511,20 +16667,20 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     optionalDependencies:
       '@ember/string': 3.1.1
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))':
+  '@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))':
     dependencies:
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
@@ -16532,7 +16688,7 @@ snapshots:
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
     optionalDependencies:
       '@ember/string': 3.1.1
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16580,15 +16736,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/serializer@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))':
+  '@ember-data/serializer@4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16607,26 +16763,26 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/serializer@4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
+  '@ember-data/serializer@4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
     dependencies:
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  '@ember-data/serializer@5.3.13(c7cc75dccd8610f2fbef6fe9ba15af17)':
+  '@ember-data/serializer@5.3.13(bba1dc98161fc9a910c2d58a89731cde)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.13(883afd83fd6be47b2ced534fa6817bbc)
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/legacy-compat': 5.3.13(c2b690b8b6ed883b9d8cc1905f7e766d)
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
@@ -16634,16 +16790,16 @@ snapshots:
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/serializer@5.5.0(1671f1abb1977c67c8e553be91fe34c9)':
+  '@ember-data/serializer@5.5.0(717565551974b9d10d2a716dd7b3fe65)':
     dependencies:
-      '@ember-data/legacy-compat': 5.5.0(7d2fc24dd54058c686f3cc313e26a39f)
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/legacy-compat': 5.5.0(898799fc64f97874879366744981ec45)
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
@@ -16651,7 +16807,7 @@ snapshots:
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16670,20 +16826,20 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/store@4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember-data/store@4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
       '@ember-data/tracking': 4.12.8(@glint/template@1.7.7)
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@glimmer/tracking': 1.1.2
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-cli-babel: 7.26.11
     optionalDependencies:
       '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)
-      '@ember-data/model': 4.12.8(@babel/core@7.29.7)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/model': 4.12.8(@babel/core@7.29.7)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -16707,7 +16863,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/store@4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
+  '@ember-data/store@4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
     dependencies:
       '@ember-data/canary-features': 4.8.8(@glint/template@1.7.7)
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.7.7)
@@ -16716,10 +16872,10 @@ snapshots:
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-cli-babel: 7.26.11
     optionalDependencies:
-      '@ember-data/model': 4.8.8(@babel/core@7.29.7)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/model': 4.8.8(@babel/core@7.29.7)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember-data/record-data': 4.8.8(@ember-data/store@4.8.8)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
     transitivePeerDependencies:
       - '@babel/core'
@@ -16728,29 +16884,29 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@ember-data/request': 5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/tracking': 5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/tracking': 5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
     optionalDependencies:
-      '@ember-data/tracking': 5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      '@ember-data/tracking': 5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16771,22 +16927,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16931,13 +17087,13 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember/legacy-built-in-components@0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember/legacy-built-in-components@0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-typescript: 4.2.1
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -16966,13 +17122,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/render-modifiers@3.0.0(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember/render-modifiers@3.0.0(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@babel/core': 7.29.7
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.29.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     optionalDependencies:
       '@glint/template': 1.7.7
     transitivePeerDependencies:
@@ -16984,17 +17140,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/test-helpers@2.9.6(@babel/core@7.29.7)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember/test-helpers@2.9.6(@babel/core@7.29.7)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
-      '@embroider/util': 1.13.5(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@embroider/util': 1.13.5(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-destroyable-polyfill: 2.0.3(@babel/core@7.29.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/environment-ember-loose'
@@ -17065,7 +17221,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember/test-helpers@4.0.5(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@ember/test-helpers@4.0.5(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': link:packages/addon-shim
@@ -17073,7 +17229,7 @@ snapshots:
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.2(@babel/core@7.29.7)
       dom-element-descriptors: 0.5.1
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -17196,12 +17352,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/util@1.13.5(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))':
+  '@embroider/util@1.13.5(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))':
     dependencies:
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     optionalDependencies:
       '@glint/environment-ember-loose': 1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7))
       '@glint/template': 1.7.7
@@ -17214,12 +17370,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -18161,7 +18333,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@glint/ember-tsc@1.7.5(ember-source@7.0.0(@glimmer/component@2.1.1))(typescript@5.9.3)':
+  '@glint/ember-tsc@1.7.5(ember-source@7.1.0(@glimmer/component@2.1.1))(typescript@5.9.3)':
     dependencies:
       '@glimmer/syntax': 0.95.0
       '@glint/template': 1.7.7
@@ -18181,7 +18353,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      ember-source: 7.0.0(@glimmer/component@2.1.1)
+      ember-source: 7.1.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18209,9 +18381,9 @@ snapshots:
 
   '@glint/template@1.7.7': {}
 
-  '@glint/tsserver-plugin@2.5.5(ember-source@7.0.0(@glimmer/component@2.1.1))':
+  '@glint/tsserver-plugin@2.5.5(ember-source@7.1.0(@glimmer/component@2.1.1))':
     dependencies:
-      '@glint/ember-tsc': 1.7.5(ember-source@7.0.0(@glimmer/component@2.1.1))(typescript@5.9.3)
+      '@glint/ember-tsc': 1.7.5(ember-source@7.1.0(@glimmer/component@2.1.1))(typescript@5.9.3)
       '@volar/language-core': 2.4.28
       '@volar/typescript': 2.4.28
       jiti: 2.6.1
@@ -18626,6 +18798,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
       eslint-scope: 5.1.1
@@ -18745,7 +18924,73 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 25.1.0
 
+  '@oxc-parser/binding-android-arm-eabi@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.137.0':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.137.0':
+    optional: true
+
   '@oxc-project/types@0.132.0': {}
+
+  '@oxc-project/types@0.137.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -19293,6 +19538,11 @@ snapshots:
   '@tsconfig/node16@1.0.4': {}
 
   '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -19894,16 +20144,16 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/ember@5.5.0(0222ee837524024e74a775c6a753cfad)':
+  '@warp-drive/ember@5.5.0(9c0926fb1ede337f8d1b884ce785e695)':
     dependencies:
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -22828,11 +23078,11 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-bootstrap@6.7.0(@babel/core@7.29.7)(@glimmer/component@2.1.1)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-modifier@4.3.0(@babel/core@7.29.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
+  ember-bootstrap@6.7.0(@babel/core@7.29.7)(@glimmer/component@2.1.1)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-modifier@4.3.0(@babel/core@7.29.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
     dependencies:
-      '@ember/render-modifiers': 3.0.0(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember/render-modifiers': 3.0.0(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
-      '@embroider/util': 1.13.5(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@embroider/util': 1.13.5(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.3.0(@babel/core@7.29.7)))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@glimmer/component': 2.1.1
       '@glimmer/tracking': 1.1.2
       broccoli-debug: 0.6.5
@@ -22842,17 +23092,17 @@ snapshots:
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       ember-cli-build-config-editor: 0.5.1
-      ember-cli-htmlbars: 7.0.1(@babel/core@7.29.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-cli-htmlbars: 7.0.1(@babel/core@7.29.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       ember-cli-version-checker: 5.1.2
       ember-concurrency: 4.0.6(@babel/core@7.29.7)(@glint/template@1.7.7)
       ember-element-helper: 0.8.8
       ember-focus-trap: 1.2.0(@babel/core@7.29.7)
       ember-modifier: 4.3.0(@babel/core@7.29.7)
       ember-on-helper: 0.1.0
-      ember-popper-modifier: 4.1.1(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      ember-popper-modifier: 4.1.1(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-ref-bucket: 5.0.8(@babel/core@7.29.7)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-render-helpers: 2.0.0(@babel/core@7.29.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
       ember-style-modifier: 4.6.0(@babel/core@7.29.7)
       findup-sync: 5.0.0
       resolve: 1.22.12
@@ -22885,7 +23135,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)):
+  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)):
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@glimmer/tracking': 1.1.2
@@ -22893,7 +23143,7 @@ snapshots:
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.29.7)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -23068,7 +23318,7 @@ snapshots:
       resolve: 1.22.12
       semver: 5.7.2
 
-  ember-cli-fastboot@4.1.5(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)):
+  ember-cli-fastboot@4.1.5(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)):
     dependencies:
       broccoli-concat: 4.2.7
       broccoli-file-creator: 2.1.1
@@ -23080,7 +23330,7 @@ snapshots:
       ember-cli-lodash-subset: 2.0.1
       ember-cli-preprocess-registry: 3.3.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
       fastboot: 4.1.5
       fastboot-express-middleware: 4.1.2
       fastboot-transform: 0.1.3
@@ -23154,7 +23404,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-htmlbars@7.0.1(@babel/core@7.29.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)):
+  ember-cli-htmlbars@7.0.1(@babel/core@7.29.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)):
     dependencies:
       '@babel/core': 7.29.7
       '@ember/edition-utils': 1.2.0
@@ -23162,7 +23412,7 @@ snapshots:
       broccoli-debug: 0.6.5
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
       fs-tree-diff: 2.0.1
       heimdalljs-logger: 0.1.10
       js-string-escape: 1.0.1
@@ -24750,7 +25000,7 @@ snapshots:
       - walrus
       - whiskers
 
-  ember-cli@7.1.0-beta.1(@babel/core@7.29.7)(@types/node@22.19.19)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8):
+  ember-cli@7.1.0-beta.2(@babel/core@7.29.7)(@types/node@22.19.19)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8):
     dependencies:
       '@ember-tooling/blueprint-blueprint': 0.3.0
       '@ember-tooling/blueprint-model': 0.6.3
@@ -24914,7 +25164,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-data@3.28.13(@babel/core@7.29.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)):
+  ember-data@3.28.13(@babel/core@7.29.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)):
     dependencies:
       '@ember-data/adapter': 3.28.13(@babel/core@7.29.7)
       '@ember-data/debug': 3.28.13(@babel/core@7.29.7)
@@ -24929,24 +25179,24 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 4.2.1
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - ember-source
       - supports-color
 
-  ember-data@4.12.8(@babel/core@7.29.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
+  ember-data@4.12.8(@babel/core@7.29.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
     dependencies:
-      '@ember-data/adapter': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
+      '@ember-data/adapter': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
       '@ember-data/debug': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember-data/graph': 4.12.8(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/json-api': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/legacy-compat': 4.12.8(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)
-      '@ember-data/model': 4.12.8(@babel/core@7.29.7)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/model': 4.12.8(@babel/core@7.29.7)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
       '@ember-data/request': 4.12.8(@glint/template@1.7.7)
-      '@ember-data/serializer': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/serializer': 4.12.8(@ember-data/store@4.12.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/store': 4.12.8(@babel/core@7.29.7)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@glint/template@1.7.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember-data/tracking': 4.12.8(@glint/template@1.7.7)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
@@ -24955,7 +25205,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-cli-babel: 7.26.11
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/tracking'
@@ -24964,7 +25214,7 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-data@4.4.3(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
+  ember-data@4.4.3(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
     dependencies:
       '@ember-data/adapter': 4.4.3(@babel/core@7.29.7)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember-data/debug': 4.4.3(@babel/core@7.29.7)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
@@ -24980,7 +25230,7 @@ snapshots:
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.3.0
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -24988,15 +25238,15 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-data@4.8.8(@babel/core@7.29.7)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
+  ember-data@4.8.8(@babel/core@7.29.7)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
     dependencies:
-      '@ember-data/adapter': 4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/adapter': 4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember-data/debug': 4.8.8(@ember/string@3.1.1)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
-      '@ember-data/model': 4.8.8(@babel/core@7.29.7)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/model': 4.8.8(@babel/core@7.29.7)(@ember-data/record-data@4.8.8)(@ember-data/store@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember-data/private-build-infra': 4.8.8(@glint/template@1.7.7)
       '@ember-data/record-data': 4.8.8(@ember-data/store@4.8.8)(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
-      '@ember-data/serializer': 4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
-      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/serializer': 4.8.8(@ember-data/store@4.8.8)(@ember/string@3.1.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      '@ember-data/store': 4.8.8(@babel/core@7.29.7)(@ember-data/model@4.8.8)(@ember-data/record-data@4.8.8)(@ember-data/tracking@4.8.8)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@ember-data/tracking': 4.8.8
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
@@ -25005,7 +25255,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-cli-babel: 7.26.11
-      ember-inflector: 4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      ember-inflector: 4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/tracking'
@@ -25014,24 +25264,24 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(qunit@2.25.0):
+  ember-data@5.3.13(@ember/string@3.1.1)(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(qunit@2.25.0):
     dependencies:
-      '@ember-data/adapter': 5.3.13(c7cc75dccd8610f2fbef6fe9ba15af17)
-      '@ember-data/debug': 5.3.13(f5946a023f90421636f893382a534ff6)
-      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/json-api': 5.3.13(4333a2d6d8e1ec7a65fd7c888a6fa263)
-      '@ember-data/legacy-compat': 5.3.13(883afd83fd6be47b2ced534fa6817bbc)
-      '@ember-data/model': 5.3.13(4c9d3f38d3c2163c7d04fbe1495848dd)
+      '@ember-data/adapter': 5.3.13(bba1dc98161fc9a910c2d58a89731cde)
+      '@ember-data/debug': 5.3.13(f8c7ba311e198e7529af5f23ca22313c)
+      '@ember-data/graph': 5.3.13(@ember-data/store@5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/json-api': 5.3.13(1d74d0090632e0cbfe71fd514209b16c)
+      '@ember-data/legacy-compat': 5.3.13(c2b690b8b6ed883b9d8cc1905f7e766d)
+      '@ember-data/model': 5.3.13(6a9b29b54fdb1680d0ab61748ef50753)
       '@ember-data/request': 5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))
-      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/serializer': 5.3.13(c7cc75dccd8610f2fbef6fe9ba15af17)
-      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/tracking': 5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/request-utils': 5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/serializer': 5.3.13(bba1dc98161fc9a910c2d58a89731cde)
+      '@ember-data/store': 5.3.13(@ember-data/request-utils@5.3.13(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@ember-data/request@5.3.13(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7)))(@ember-data/tracking@5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/tracking': 5.3.13(@glint/template@1.7.7)(@warp-drive/core-types@0.0.3(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 0.0.3(@glint/template@1.7.7)
       '@warp-drive/core-types': 0.0.3(@glint/template@1.7.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     optionalDependencies:
       '@ember/test-helpers': 5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7)
       '@ember/test-waiters': 3.1.0
@@ -25042,25 +25292,25 @@ snapshots:
       - ember-inflector
       - supports-color
 
-  ember-data@5.5.0(@ember/string@3.1.1)(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(qunit@2.25.0):
+  ember-data@5.5.0(@ember/string@3.1.1)(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(qunit@2.25.0):
     dependencies:
-      '@ember-data/adapter': 5.5.0(1671f1abb1977c67c8e553be91fe34c9)
-      '@ember-data/debug': 5.5.0(53228376cb5f3b4d8404ae6778204080)
-      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
-      '@ember-data/json-api': 5.5.0(7651bf037c97f8da4f2d1edf415ebd90)
-      '@ember-data/legacy-compat': 5.5.0(7d2fc24dd54058c686f3cc313e26a39f)
-      '@ember-data/model': 5.5.0(b704708eb7b49f65dcf7acbba2155fec)
+      '@ember-data/adapter': 5.5.0(717565551974b9d10d2a716dd7b3fe65)
+      '@ember-data/debug': 5.5.0(14c954512686c73ea4afbe6566947cf4)
+      '@ember-data/graph': 5.5.0(@ember-data/store@5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
+      '@ember-data/json-api': 5.5.0(b9fb7d1ed6218abbe28f26b5f018b9d1)
+      '@ember-data/legacy-compat': 5.5.0(898799fc64f97874879366744981ec45)
+      '@ember-data/model': 5.5.0(1f01221aaa8e3d107289bcb8c6e18665)
       '@ember-data/request': 5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))
-      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))
-      '@ember-data/serializer': 5.5.0(1671f1abb1977c67c8e553be91fe34c9)
-      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
-      '@ember-data/tracking': 5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember-data/request-utils': 5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))
+      '@ember-data/serializer': 5.5.0(717565551974b9d10d2a716dd7b3fe65)
+      '@ember-data/store': 5.5.0(@ember-data/request-utils@5.5.0(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember/string@3.1.1)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))))(@ember-data/request@5.5.0(@ember/test-waiters@3.1.0)(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7)))(@ember-data/tracking@5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
+      '@ember-data/tracking': 5.5.0(@glint/template@1.7.7)(@warp-drive/core-types@5.5.0(@glint/template@1.7.7))(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       '@warp-drive/build-config': 5.5.0(@glint/template@1.7.7)
       '@warp-drive/core-types': 5.5.0(@glint/template@1.7.7)
-      '@warp-drive/ember': 5.5.0(0222ee837524024e74a775c6a753cfad)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      '@warp-drive/ember': 5.5.0(9c0926fb1ede337f8d1b884ce785e695)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     optionalDependencies:
       '@ember/test-helpers': 5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7)
       '@ember/test-waiters': 3.1.0
@@ -25113,9 +25363,9 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)):
+  ember-engines@0.8.23(@ember/legacy-built-in-components@0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)):
     dependencies:
-      '@ember/legacy-built-in-components': 0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))
+      '@ember/legacy-built-in-components': 0.4.2(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))
       '@embroider/macros': 1.20.2(@glint/template@1.7.7)
       amd-name-resolver: 1.3.1
       babel-plugin-compact-reexports: 1.1.0
@@ -25133,7 +25383,7 @@ snapshots:
       ember-cli-preprocess-registry: 3.3.0
       ember-cli-string-utils: 1.1.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
       lodash: 4.18.1
     transitivePeerDependencies:
       - '@glint/template'
@@ -25166,10 +25416,10 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  ember-inflector@4.0.3(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)):
+  ember-inflector@4.0.3(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)):
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -25260,18 +25510,18 @@ snapshots:
       '@simple-dom/document': 1.4.0
       ember-source: 6.3.0-alpha.3(@glimmer/component@2.1.1)(@glint/template@1.7.7)(rsvp@4.8.5)
 
-  ember-page-title@8.2.4(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1)):
+  ember-page-title@8.2.4(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1)):
     dependencies:
       '@embroider/addon-shim': link:packages/addon-shim
       '@simple-dom/document': 1.4.0
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
 
   ember-page-title@9.0.3:
     dependencies:
       '@embroider/addon-shim': link:packages/addon-shim
       '@simple-dom/document': 1.4.0
 
-  ember-popper-modifier@4.1.1(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
+  ember-popper-modifier@4.1.1(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@popperjs/core': 2.11.8
@@ -25279,7 +25529,7 @@ snapshots:
       ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       ember-cli-htmlbars: 6.3.0
       ember-modifier: 4.3.0(@babel/core@7.29.7)
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -25304,7 +25554,7 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-qunit@6.2.0(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1))(qunit@2.25.0)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
+  ember-qunit@6.2.0(@ember/test-helpers@5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-source@7.2.0-beta.1(@glimmer/component@2.1.1))(qunit@2.25.0)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
     dependencies:
       '@ember/test-helpers': 5.4.2(@babel/core@7.29.7)(@glint/template@1.7.7)
       broccoli-funnel: 3.0.8
@@ -25313,7 +25563,7 @@ snapshots:
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.1.0
-      ember-source: 7.2.0-alpha.1(@glimmer/component@2.1.1)
+      ember-source: 7.2.0-beta.1(@glimmer/component@2.1.1)
       qunit: 2.25.0
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -26041,7 +26291,7 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-source@7.0.0(@glimmer/component@2.1.1):
+  ember-source@7.1.0(@glimmer/component@2.1.1):
     dependencies:
       '@babel/core': 7.29.7
       '@embroider/addon-shim': link:packages/addon-shim
@@ -26065,7 +26315,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-source@7.1.0-beta.1(@glimmer/component@2.1.1):
+  ember-source@7.2.0-alpha.4(@glimmer/component@2.1.1):
     dependencies:
       '@babel/core': 7.29.7
       '@embroider/addon-shim': link:packages/addon-shim
@@ -26089,7 +26339,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-source@7.2.0-alpha.1(@glimmer/component@2.1.1):
+  ember-source@7.2.0-beta.1(@glimmer/component@2.1.1):
     dependencies:
       '@babel/core': 7.29.7
       '@embroider/addon-shim': link:packages/addon-shim
@@ -30229,6 +30479,31 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxc-parser@0.137.0:
+    dependencies:
+      '@oxc-project/types': 0.137.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.137.0
+      '@oxc-parser/binding-android-arm64': 0.137.0
+      '@oxc-parser/binding-darwin-arm64': 0.137.0
+      '@oxc-parser/binding-darwin-x64': 0.137.0
+      '@oxc-parser/binding-freebsd-x64': 0.137.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.137.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.137.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.137.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.137.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.137.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.137.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.137.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.137.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.137.0
+      '@oxc-parser/binding-linux-x64-musl': 0.137.0
+      '@oxc-parser/binding-openharmony-arm64': 0.137.0
+      '@oxc-parser/binding-wasm32-wasi': 0.137.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.137.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.137.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.137.0
+
   p-cancelable@0.4.1: {}
 
   p-cancelable@1.1.0: {}
@@ -33416,3 +33691,5 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zimmerframe@1.1.4: {}


### PR DESCRIPTION
This is a basic implementation of 2 different options for maybeBabel that people could use for themselves. These functions have no effect unless imported and passed as the `filter` option to the `@rollup/plugin-babel` plugin: 

```js
import { defineConfig } from 'vite';
import { extensions, classicEmberSupport, ember } from '@embroider/vite';
import { babel } from '@rollup/plugin-babel';

// importing both so you can swap between them and test each one
import { maybeBabelFilter, maybeBabelRegexFilter } from '@embroider/vite';

export default defineConfig({
  plugins: [
    classicEmberSupport(),
    ember(),
    // extra plugins here
    babel({
      babelHelpers: 'runtime',
      extensions: extensions.filter(ext => ext !== '.json'),
      filter: maybeBabelFilter,
    }),
  ],
});
```