### PR TITLE
move addon-dev to tsconfig project

### DIFF
--- a/packages/addon-dev/.gitignore
+++ b/packages/addon-dev/.gitignore
@@ -7,6 +7,7 @@
 /tests/**/*.js
 /tests/**/*.d.ts
 /tests/**/*.map
+/dist/
 
 # dependencies
 /node_modules/

--- a/packages/addon-dev/package.json
+++ b/packages/addon-dev/package.json
@@ -10,17 +10,15 @@
   "license": "MIT",
   "author": "Edward Faulkner <edward@eaf4.com>",
   "bin": {
-    "addon-dev": "./src/commands.js"
+    "addon-dev": "./dist/commands.js"
   },
   "exports": {
-    "./template-colocation-plugin": "./src/template-colocation-plugin.js",
-    "./rollup": "./src/rollup.js"
+    "./template-colocation-plugin": "./dist/template-colocation-plugin.js",
+    "./rollup": "./dist/rollup.js"
   },
   "files": [
     "sample-rollup.config.js",
-    "src/**/*.js",
-    "src/**/*.d.ts",
-    "src/**/*.js.map"
+    "dist"
   ],
   "scripts": {
     "test": "vitest"

--- a/packages/addon-dev/tsconfig.json
+++ b/packages/addon-dev/tsconfig.json
@@ -6,6 +6,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "packages/reverse-exports",
     "packages/addon-shim",
     "packages/macros",
+    "packages/addon-dev"
   ],
   "references": [
     { "path": "packages/reverse-exports" },
@@ -35,6 +36,7 @@
     { "path": "packages/legacy-inspector-support" },
     { "path": "packages/addon-shim" },
     { "path": "packages/macros" },
+    { "path": "packages/addon-dev" },
     { "path": "tests/scenarios" },
   ]
 }


### PR DESCRIPTION
This is part of a larger effort to simplify the build configuration 👍 (and to remove compiled JS files from the source directories 😂 ) 