### PR TITLE
`publicAssets` uses `closeBundle` instead of `generateBundle` so it can work with generated assets

### DIFF
--- a/packages/addon-dev/src/rollup-public-assets.ts
+++ b/packages/addon-dev/src/rollup-public-assets.ts
@@ -42,7 +42,7 @@ export default function publicAssets(
       this.addWatchFile(path);
     },
 
-    generateBundle() {
+    closeBundle() {
       let pkg = readJsonSync('package.json');
       const filenames = walkSync(path, {
         directories: false,


### PR DESCRIPTION
Makes it possible to work with assets that have been generated as part of the build process.
```js
publicAssets('dist/assets', {
  include: ['sprite-*.svg'],
  namespace: 'assets',
}),
```

Closes #2776 