### PR TITLE
Macros: v2 addon

### DIFF
--- a/packages/macros/package.json
+++ b/packages/macros/package.json
@@ -73,6 +73,8 @@
     "node": "12.* || 14.* || >= 16"
   },
   "ember-addon": {
+    "version": 2,
+    "type": "addon",
     "main": "src/ember-addon-main.js"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2022,6 +2022,9 @@ importers:
       popper.js:
         specifier: ^1.16.1
         version: 1.16.1
+      puppeteer-core:
+        specifier: ^23.0.0
+        version: 23.11.1
       strip-ansi:
         specifier: ^6.0.0
         version: 6.0.1
@@ -5273,6 +5276,11 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@puppeteer/browsers@2.6.1':
+    resolution: {integrity: sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5589,6 +5597,9 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@tsconfig/ember@1.0.1':
     resolution: {integrity: sha512-aPzLw5BfQxsFPrh5fNDOK4SbSkp2q5fMlrKVeniVjMz1lAcyOh2eH5THkKKcBi1YN1/fbMdAWN/dKGW6lg2+8g==}
     deprecated: Please use @ember/app-tsconfig or @ember/library-tsconfig instead. These live at https://github.com/ember-cli/tsconfigs
@@ -5849,6 +5860,9 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@5.62.0':
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -6384,6 +6398,10 @@ packages:
     resolution: {integrity: sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==}
     engines: {node: '>=4'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -6426,6 +6444,14 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-code-frame@6.26.0:
     resolution: {integrity: sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==}
@@ -6761,6 +6787,43 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.4:
+    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.5:
+    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -6780,6 +6843,10 @@ packages:
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
 
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
@@ -7071,6 +7138,9 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -7226,6 +7296,11 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  chromium-bidi@0.11.0:
+    resolution: {integrity: sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==}
+    peerDependencies:
+      devtools-protocol: '*'
 
   ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
@@ -7840,6 +7915,10 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
@@ -7967,6 +8046,10 @@ packages:
     resolution: {integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==}
     engines: {node: '>=0.10.0'}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -8010,6 +8093,9 @@ packages:
   detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  devtools-protocol@0.0.1367902:
+    resolution: {integrity: sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -9078,6 +9164,9 @@ packages:
     resolution: {integrity: sha512-f/qE2gImHRa4Cp2y1stEOSgw8wTFyUdVJX7G//bMwbaV9JqISFxg99NbmVQeP7YLnDUZ2un851jlaDrlpmGehQ==}
     engines: {node: '>=12'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -9157,6 +9246,11 @@ packages:
     resolution: {integrity: sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==}
     engines: {node: '>=8'}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
 
@@ -9165,6 +9259,9 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -9226,6 +9323,9 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -9587,6 +9687,10 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -11302,6 +11406,9 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
@@ -11403,6 +11510,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -11759,6 +11870,14 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -11914,6 +12033,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -12146,6 +12268,13 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
@@ -12159,6 +12288,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  puppeteer-core@23.11.1:
+    resolution: {integrity: sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==}
+    engines: {node: '>=18'}
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -12868,6 +13001,10 @@ packages:
     resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
     engines: {node: '>= 10'}
 
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -13018,6 +13155,9 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
   strict-uri-encode@1.1.0:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
@@ -13261,10 +13401,19 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
@@ -13331,6 +13480,9 @@ packages:
     resolution: {integrity: sha512-SSFfJQK/SGruISFjoKG2jCYwK596wWNPJFj2Wo77GzeIUxZ8ZjuwpyF01uekTLu4ITL6i9R4m1sWaKPK/HsunA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     hasBin: true
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -13591,6 +13743,9 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
+
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
@@ -13622,6 +13777,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  unbzip2-stream@1.4.3:
+    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
   underscore.string@3.3.6:
     resolution: {integrity: sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==}
@@ -14386,6 +14544,9 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -14405,6 +14566,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -19053,6 +19217,22 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@puppeteer/browsers@2.6.1':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.1
+      tar-fs: 3.1.3
+      unbzip2-stream: 1.4.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@rolldown/binding-android-arm64@1.0.2':
     optional: true
 
@@ -19279,6 +19459,8 @@ snapshots:
   '@tootallnate/once@1.1.2': {}
 
   '@tootallnate/once@2.0.1': {}
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@tsconfig/ember@1.0.1': {}
 
@@ -19577,6 +19759,11 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.19
+    optional: true
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)':
     dependencies:
@@ -20274,6 +20461,10 @@ snapshots:
 
   ast-types@0.13.3: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   astral-regex@2.0.0: {}
 
   async-disk-cache@1.3.5:
@@ -20329,6 +20520,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  b4a@1.8.1: {}
 
   babel-code-frame@6.26.0:
     dependencies:
@@ -21024,6 +21217,35 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.4:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.5
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.5:
+    dependencies:
+      bare-path: 3.1.1
+
   base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
@@ -21043,6 +21265,8 @@ snapshots:
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
+
+  basic-ftp@5.3.1: {}
 
   before-after-hook@3.0.2: {}
 
@@ -21746,6 +21970,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  buffer-crc32@0.2.13: {}
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -21938,6 +22164,12 @@ snapshots:
   chownr@2.0.0: {}
 
   chrome-trace-event@1.0.4: {}
+
+  chromium-bidi@0.11.0(devtools-protocol@0.0.1367902):
+    dependencies:
+      devtools-protocol: 0.0.1367902
+      mitt: 3.0.1
+      zod: 3.23.8
 
   ci-info@2.0.0: {}
 
@@ -22457,6 +22689,8 @@ snapshots:
 
   data-uri-to-buffer@2.0.2: {}
 
+  data-uri-to-buffer@6.0.2: {}
+
   data-urls@3.0.2:
     dependencies:
       abab: 2.0.6
@@ -22576,6 +22810,12 @@ snapshots:
       is-descriptor: 1.0.4
       isobject: 3.0.1
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   delayed-stream@1.0.0: {}
 
   depd@1.1.2: {}
@@ -22599,6 +22839,8 @@ snapshots:
   detect-newline@3.1.0: {}
 
   detect-newline@4.0.1: {}
+
+  devtools-protocol@0.0.1367902: {}
 
   diff-sequences@29.6.3: {}
 
@@ -26930,6 +27172,12 @@ snapshots:
 
   events-to-array@2.0.3: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   exec-sh@0.3.6: {}
@@ -27128,11 +27376,23 @@ snapshots:
 
   extract-stack@2.0.0: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-content-type-parse@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -27236,6 +27496,10 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -27710,6 +27974,14 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   get-value@2.0.6: {}
 
@@ -29815,6 +30087,8 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  mitt@3.0.1: {}
+
   mixin-deep@1.3.2:
     dependencies:
       for-in: 1.0.2
@@ -29913,6 +30187,8 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  netmask@2.1.1: {}
 
   nice-try@1.0.5: {}
 
@@ -30305,6 +30581,24 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
   package-json-from-dist@1.0.1: {}
 
   package-json@10.0.1:
@@ -30434,6 +30728,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
@@ -30620,6 +30916,21 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -30632,6 +30943,22 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  puppeteer-core@23.11.1:
+    dependencies:
+      '@puppeteer/browsers': 2.6.1
+      chromium-bidi: 0.11.0(devtools-protocol@0.0.1367902)
+      debug: 4.4.3(supports-color@8.1.1)
+      devtools-protocol: 0.0.1367902
+      typed-query-selector: 2.12.2
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   pure-rand@6.1.0: {}
 
@@ -31542,6 +31869,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
   socks@2.8.9:
     dependencies:
       ip-address: 10.2.0
@@ -31699,6 +32034,15 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   strict-uri-encode@1.1.0: {}
 
@@ -32026,6 +32370,29 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.7.4
+      bare-path: 3.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.4
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -32034,6 +32401,13 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   temp@0.9.4:
     dependencies:
@@ -32176,6 +32550,12 @@ snapshots:
       - velocityjs
       - walrus
       - whiskers
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 
@@ -32466,6 +32846,8 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typed-query-selector@2.12.2: {}
+
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
@@ -32493,6 +32875,11 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  unbzip2-stream@1.4.3:
+    dependencies:
+      buffer: 5.7.1
+      through: 2.3.8
 
   underscore.string@3.3.6:
     dependencies:
@@ -33407,6 +33794,11 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
@@ -33416,3 +33808,5 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zod@3.23.8: {}

--- a/tests/app-template-minimal/.env.development
+++ b/tests/app-template-minimal/.env.development
@@ -1,0 +1,8 @@
+# This file is committed to git and should not contain any secrets.
+#
+# Vite recommends using .env.local or .env.[mode].local if you need to manage secrets
+# SEE: https://vite.dev/guide/env-and-mode.html#env-files for more information.
+
+
+# Default NODE_ENV with vite build --mode=test is production
+NODE_ENV=development

--- a/tests/app-template-minimal/package.json
+++ b/tests/app-template-minimal/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "build:test": "NODE_ENV=development vite build --mode development",
+    "build:test": "vite build --mode development",
     "start": "vite",
     "test": "pnpm test:ember",
     "test:ember": "pnpm build:test && pnpm dist:ember:test",

--- a/tests/scenarios/helpers/browser.ts
+++ b/tests/scenarios/helpers/browser.ts
@@ -1,0 +1,47 @@
+import puppeteer, { type Browser } from 'puppeteer-core';
+import { existsSync } from 'fs';
+
+/**
+ * We use puppeteer-core (rather than full puppeteer) so we don't download a
+ * bundled Chromium. Instead we drive whatever Chrome/Chromium is already on the
+ * machine — the same browser testem uses in CI. Honor the usual env overrides
+ * first, then fall back to the well-known install locations per platform.
+ */
+export function findChrome(): string {
+  let fromEnv = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.CHROME_BIN;
+  if (fromEnv && existsSync(fromEnv)) {
+    return fromEnv;
+  }
+
+  let candidates = [
+    // macOS
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    // Linux
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    // Windows
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+  ];
+  for (let candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    'Could not find a Chrome/Chromium executable to drive. ' +
+      'Set PUPPETEER_EXECUTABLE_PATH (or CHROME_BIN) to its path.'
+  );
+}
+
+export async function launchBrowser(): Promise<Browser> {
+  return puppeteer.launch({
+    executablePath: findChrome(),
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--mute-audio'],
+  });
+}

--- a/tests/scenarios/macro-deep-v2-addon-compat-test.ts
+++ b/tests/scenarios/macro-deep-v2-addon-compat-test.ts
@@ -1,0 +1,100 @@
+import { appScenarios, baseV2Addon } from './scenarios';
+import type { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+import merge from 'lodash/merge';
+
+const { module: Qmodule, test } = QUnit;
+
+appScenarios
+  .only('canary')
+  .map('macro-deep-v2-addon-compat-istesting', project => {
+    let addon = baseV2Addon();
+    addon.pkg.name = 'macros-consumer-addon';
+    // an app-js initializer that re-exports a module which imports undeclared macros
+    (addon.pkg as any)['ember-addon']['app-js']['./initializers/macros-consumer.js'] =
+      './app/initializers/macros-consumer.js';
+    merge(addon.files, {
+      app: {
+        initializers: {
+          'macros-consumer.js': `export { default } from 'macros-consumer-addon/macros-init';`,
+        },
+      },
+      'macros-init.js': `
+        import { isTesting } from '@embroider/macros';
+
+        export const isTestingAtModuleLoad = isTesting();
+
+        export default {
+          name: 'macros-consumer',
+          initialize() {},
+        };
+      `,
+    });
+
+    let deep = baseV2Addon();
+    deep.pkg.name = 'deep-macros-addon';
+    merge(deep.files, {
+      'is-testing-at-load.js': `
+        import { isTesting } from '@embroider/macros';
+
+        export const isTestingAtModuleLoad = isTesting();
+      `,
+    });
+
+    let intermediate = baseV2Addon();
+    intermediate.pkg.name = 'intermediate-addon';
+    intermediate.addDependency(deep);
+    merge(intermediate.files, {
+      're-export.js': `
+        export { isTestingAtModuleLoad } from 'deep-macros-addon/is-testing-at-load';
+      `,
+    });
+
+    project.addDevDependency(addon);
+    project.addDevDependency(intermediate);
+    project.linkDevDependency('@embroider/macros', { baseDir: __dirname });
+
+    merge(project.files, {
+      tests: {
+        unit: {
+          'deep-v2-addon-istesting-test.js': `
+            import { module, test } from 'qunit';
+            import { isTestingAtModuleLoad } from 'intermediate-addon/re-export';
+
+            module('Unit | deep v2 addon | isTesting at module load (compat)', function () {
+              test('a second-level v2 addon sees isTesting() === true when evaluated at module load', function (assert) {
+                assert.true(
+                  isTestingAtModuleLoad,
+                  'macros test-support set isTesting before the deep v2 addon module was evaluated'
+                );
+              });
+            });
+          `,
+          'virtual-peer-istesting-test.js': `
+            import { module, test } from 'qunit';
+            import { isTestingAtModuleLoad } from 'macros-consumer-addon/macros-init';
+
+            module('Unit | v2 addon app-js | macros virtual peer dep', function () {
+              test('an undeclared @embroider/macros import from a v2 addon app-tree resolves and isTesting() is true', function (assert) {
+                assert.true(isTestingAtModuleLoad, 'macros rehomed to the app copy + test-support enabled isTesting');
+              });
+            });
+          `,
+        },
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test('pnpm test', async function (assert) {
+        let result = await app.execute('pnpm test');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
+  });

--- a/tests/scenarios/macro-deep-v2-addon-dev-mode-test.ts
+++ b/tests/scenarios/macro-deep-v2-addon-dev-mode-test.ts
@@ -1,0 +1,259 @@
+import { minimalAppScenarios, baseV2Addon } from './scenarios';
+import type { PreparedApp } from 'scenario-tester';
+import type { Browser } from 'puppeteer-core';
+import QUnit from 'qunit';
+import merge from 'lodash/merge';
+import { setupViteDevServer } from './helpers';
+import { launchBrowser } from './helpers/browser';
+
+const { module: Qmodule, test } = QUnit;
+
+minimalAppScenarios
+  .only('canary')
+  .map('macro-deep-v2-addon-dev-mode', project => {
+    let deep = baseV2Addon();
+    deep.pkg.name = 'deep-macros-addon';
+    merge(deep.files, {
+      'is-testing-at-load.js': `
+        import { isTesting } from '@embroider/macros';
+
+        // captured once, when this module is first evaluated
+        export const isTestingAtModuleLoad = isTesting();
+
+        // a live reading, evaluated whenever it is called
+        export function isTestingNow() {
+          return isTesting();
+        }
+      `,
+    });
+
+    let intermediate = baseV2Addon();
+    intermediate.pkg.name = 'intermediate-addon';
+    intermediate.addDependency(deep);
+    merge(intermediate.files, {
+      're-export.js': `
+        export { isTestingAtModuleLoad, isTestingNow } from 'deep-macros-addon/is-testing-at-load';
+      `,
+    });
+
+    project.addDevDependency(intermediate);
+    project.linkDevDependency('@embroider/macros', { baseDir: __dirname });
+    project.linkDevDependency('testem', { baseDir: __dirname });
+    project.linkDevDependency('@embroider/test-support', { baseDir: __dirname });
+    project.linkDevDependency('@ember/test-waiters', { baseDir: __dirname, resolveName: '@ember/test-waiters-4' });
+
+    merge(project.files, {
+      'testem-dev.cjs': `
+        'use strict';
+
+        module.exports = {
+          test_page: 'tests?hidepassed',
+          disable_watching: true,
+          launch_in_ci: ['Chrome'],
+          launch_in_dev: ['Chrome'],
+          browser_start_timeout: 120,
+          browser_args: {
+            Chrome: {
+              ci: [
+                // --no-sandbox is needed when running Chrome inside a container
+                process.env.CI ? '--no-sandbox' : null,
+                '--headless',
+                '--disable-dev-shm-usage',
+                '--disable-software-rasterizer',
+                '--mute-audio',
+                '--remote-debugging-port=0',
+                '--window-size=1440,900',
+              ].filter(Boolean),
+            },
+          },
+          middleware: [
+            require('@embroider/test-support/testem-proxy').testemProxy('http://localhost:4200')
+          ],
+        };
+      `,
+      'vite.config.mjs': `
+        import { defineConfig } from 'vite';
+        import { extensions, ember, hbs } from '@embroider/vite';
+        import { babel } from '@rollup/plugin-babel';
+
+        export default defineConfig({
+          optimizeDeps: {
+            exclude: ['@embroider/macros'],
+          },
+          plugins: [
+            hbs(),
+            ember(),
+            babel({
+              babelHelpers: 'runtime',
+              extensions,
+            }),
+          ],
+        });
+      `,
+      src: {
+        templates: {
+          // Rendered when the app boots normally at '/'. Because the app is not
+          // running as tests, isTesting() is false here.
+          'application.gjs': `
+            import { isTestingAtModuleLoad, isTestingNow } from 'intermediate-addon/re-export';
+
+            const liveIsTesting = () => (isTestingNow() ? 'true' : 'false');
+            const atModuleLoad = isTestingAtModuleLoad ? 'true' : 'false';
+
+            <template>
+              <div data-test-mode>
+                <span data-is-testing>{{liveIsTesting}}</span>
+                <span data-is-testing-at-load>{{atModuleLoad}}</span>
+              </div>
+            </template>
+          `,
+        },
+      },
+      tests: {
+        'test-helper.js': `
+          import Application from '#/app';
+          import config, { enterTestMode } from '#config';
+
+          import * as QUnit from 'qunit';
+          import { setApplication } from '@ember/test-helpers';
+          import { setup } from 'qunit-dom';
+          import { start as qunitStart, setupEmberOnerrorValidation } from 'ember-qunit';
+
+          QUnit.config.autostart = false;
+
+          export async function start(loadModules) {
+            enterTestMode();
+            await loadModules();
+            setApplication(Application.create(config.APP));
+            setup(QUnit.assert);
+            setupEmberOnerrorValidation();
+            qunitStart({ loadTests: false });
+          }
+        `,
+        'babel.config.cjs': `
+          const { buildMacros } = require('@embroider/macros/babel');
+
+          const macros = buildMacros({
+            configure(config) {
+              config.enableRuntimeMode();
+            },
+          });
+
+          module.exports = {
+            plugins: [
+              [
+                'babel-plugin-ember-template-compilation',
+                {
+                  enableLegacyModules: ['ember-cli-htmlbars'],
+                  transforms: [...macros.templateMacros],
+                },
+              ],
+              [
+                'module:decorator-transforms',
+                {
+                  runtime: {
+                    import: require.resolve('decorator-transforms/runtime-esm'),
+                  },
+                },
+              ],
+              [
+                '@babel/plugin-transform-runtime',
+                {
+                  absoluteRuntime: __dirname,
+                  useESModules: true,
+                  regenerator: false,
+                },
+              ],
+              ...macros.babelMacros,
+            ],
+
+            generatorOpts: {
+              compact: false,
+            },
+          };
+        `,
+        'index.html': `
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8" />
+              <title>AppTemplate Tests</title>
+            </head>
+            <body>
+              <div id="qunit"></div>
+              <div id="qunit-fixture">
+                <div id="ember-testing-container">
+                  <div id="ember-testing"></div>
+                </div>
+              </div>
+
+              <script src="/testem.js" integrity="" data-embroider-ignore></script>
+              <script type="module">
+                import "ember-testing";
+              </script>
+
+              <script type="module">
+                import { start } from "./test-helper";
+
+                start(() =>
+                  Promise.all(
+                    Object.values(import.meta.glob("./**/*.{js,gjs,gts}")).map((m) => m())
+                  )
+                );
+              </script>
+            </body>
+          </html>
+        `,
+        unit: {
+          'deep-v2-addon-istesting-test.js': `
+            import { module, test } from 'qunit';
+            import { isTestingNow } from 'intermediate-addon/re-export';
+
+            module('Unit | deep v2 addon | isTesting in test mode', function () {
+              test('a second-level v2 addon sees isTesting() === true when running as tests', function (assert) {
+                assert.true(isTestingNow(), 'the deep v2 addon resolves the app copy of macros and reads test mode');
+              });
+            });
+          `,
+        },
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      let browser: Browser;
+
+      hooks.before(async () => {
+        app = await scenario.prepare();
+        browser = await launchBrowser();
+      });
+
+      hooks.after(async () => {
+        await browser?.close();
+      });
+
+      let dev = setupViteDevServer(hooks, () => app);
+
+      test('the tests page runs under test mode (isTesting() === true)', async function (assert) {
+        let result = await app.execute('pnpm testem --file testem-dev.cjs ci');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+
+      test('the app page boots without test mode (isTesting() === false)', async function (assert) {
+        let page = await browser.newPage();
+        try {
+          await page.goto(`${dev.appURL}/`, { waitUntil: 'networkidle0' });
+          await page.waitForSelector('[data-test-mode] [data-is-testing]', { timeout: 30_000 });
+          let info = await page.$eval('[data-test-mode]', el => ({
+            isTesting: el.querySelector('[data-is-testing]')?.textContent?.trim(),
+            atModuleLoad: el.querySelector('[data-is-testing-at-load]')?.textContent?.trim(),
+          }));
+          assert.equal(info.isTesting, 'false', 'live isTesting() is false in the running app');
+          assert.equal(info.atModuleLoad, 'false', 'isTesting() at module load was false in the running app');
+        } finally {
+          await page.close();
+        }
+      });
+    });
+  });

--- a/tests/scenarios/macro-deep-v2-addon-test.ts
+++ b/tests/scenarios/macro-deep-v2-addon-test.ts
@@ -1,0 +1,179 @@
+import { minimalAppScenarios, baseV2Addon } from './scenarios';
+import type { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+import merge from 'lodash/merge';
+
+const { module: Qmodule, test } = QUnit;
+
+minimalAppScenarios
+  .only('canary')
+  .map('macro-deep-v2-addon-runtime-mode-istesting', project => {
+    let deep = baseV2Addon();
+    deep.pkg.name = 'deep-macros-addon';
+    merge(deep.files, {
+      'is-testing-at-load.js': `
+        import { isTesting } from '@embroider/macros';
+
+        export const isTestingAtModuleLoad = isTesting();
+      `,
+    });
+
+    let intermediate = baseV2Addon();
+    intermediate.pkg.name = 'intermediate-addon';
+    intermediate.addDependency(deep);
+    merge(intermediate.files, {
+      're-export.js': `
+        export { isTestingAtModuleLoad } from 'deep-macros-addon/is-testing-at-load';
+      `,
+    });
+
+    project.addDevDependency(intermediate);
+    project.linkDevDependency('@embroider/macros', { baseDir: __dirname });
+
+    merge(project.files, {
+      'vite.config.mjs': `
+        import { defineConfig } from 'vite';
+        import { extensions, ember, hbs } from '@embroider/vite';
+        import { babel } from '@rollup/plugin-babel';
+
+        export default defineConfig({
+          optimizeDeps: {
+            exclude: ['@embroider/macros'],
+          },
+          plugins: [
+            hbs(),
+            ember(),
+            babel({
+              babelHelpers: 'runtime',
+              extensions,
+            }),
+          ],
+        });
+      `,
+      tests: {
+        'test-helper.js': `
+          import Application from '#/app';
+          import config, { enterTestMode } from '#config';
+
+          import * as QUnit from 'qunit';
+          import { setApplication } from '@ember/test-helpers';
+          import { setup } from 'qunit-dom';
+          import { start as qunitStart, setupEmberOnerrorValidation } from 'ember-qunit';
+
+          QUnit.config.autostart = false;
+
+          export async function start(loadModules) {
+            enterTestMode();
+            await loadModules();
+            setApplication(Application.create(config.APP));
+            setup(QUnit.assert);
+            setupEmberOnerrorValidation();
+            qunitStart({ loadTests: false });
+          }
+        `,
+        'babel.config.cjs': `
+          const { buildMacros } = require('@embroider/macros/babel');
+
+          const macros = buildMacros({
+            configure(config) {
+              config.enableRuntimeMode();
+            },
+          });
+
+          module.exports = {
+            plugins: [
+              [
+                'babel-plugin-ember-template-compilation',
+                {
+                  enableLegacyModules: ['ember-cli-htmlbars'],
+                  transforms: [...macros.templateMacros],
+                },
+              ],
+              [
+                'module:decorator-transforms',
+                {
+                  runtime: {
+                    import: require.resolve('decorator-transforms/runtime-esm'),
+                  },
+                },
+              ],
+              [
+                '@babel/plugin-transform-runtime',
+                {
+                  absoluteRuntime: __dirname,
+                  useESModules: true,
+                  regenerator: false,
+                },
+              ],
+              ...macros.babelMacros,
+            ],
+
+            generatorOpts: {
+              compact: false,
+            },
+          };
+        `,
+        'index.html': `
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8" />
+              <title>AppTemplate Tests</title>
+            </head>
+            <body>
+              <div id="qunit"></div>
+              <div id="qunit-fixture">
+                <div id="ember-testing-container">
+                  <div id="ember-testing"></div>
+                </div>
+              </div>
+
+              <script src="/testem.js" integrity="" data-embroider-ignore></script>
+              <script type="module">
+                import "ember-testing";
+              </script>
+
+              <script type="module">
+                import { start } from "./test-helper";
+
+                start(() =>
+                  Promise.all(
+                    Object.values(import.meta.glob("./**/*.{js,gjs,gts}")).map((m) => m())
+                  )
+                );
+              </script>
+            </body>
+          </html>
+        `,
+        unit: {
+          'deep-v2-addon-istesting-test.js': `
+            import { module, test } from 'qunit';
+            import { isTestingAtModuleLoad } from 'intermediate-addon/re-export';
+
+            module('Unit | deep v2 addon | isTesting at module load', function () {
+              test('a second-level v2 addon sees isTesting() === true when evaluated at module load', function (assert) {
+                assert.true(
+                  isTestingAtModuleLoad,
+                  'macros test-support set isTesting before the deep v2 addon module was evaluated'
+                );
+              });
+            });
+          `,
+        },
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test('pnpm test', async function (assert) {
+        let result = await app.execute('pnpm test');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
+  });

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -115,6 +115,7 @@
     "node-fetch": "2.7.0",
     "pkg-up": "^3.1.0",
     "popper.js": "^1.16.1",
+    "puppeteer-core": "^23.0.0",
     "strip-ansi": "^6.0.0",
     "testem": "^3.10.1",
     "tslib": "^2.6.0",


### PR DESCRIPTION
For compatless apps, this is needed so that the embroiderResolver can resolve the runtime module in runtime mode correctly

todo:
- [x] define a test that has a v2 addon deep in dependencies that checks the isTesting() value (e.g.: v2.0.0 of ember-window-mock)
- [x] define a test susing runtime mode in compat to see if things still work
- [x] try on ember-auto-import with a patch that sets v2 addon
  - [x] https://github.com/embroider-build/ember-auto-import/pull/719
    - looks like it's working
- [x] create repro/app for old ember
  is this relevant?: https://github.com/emberjs/ember.js/blob/295185931a184306b083af1bb1a3fc408ae85174/lib/index.cjs#L12
  - [x] ember-auto-import v1
  - [x] no ember-auto-import (3.8? lol)