### PR TITLE
maybeBabel 2, electric downlevelaloo

### DIFF
--- a/packages/vite/index.ts
+++ b/packages/vite/index.ts
@@ -11,3 +11,4 @@ export * from './src/classic-ember-support.js';
 export * from './src/ember.js';
 export * from './src/build-once.js';
 export { configTargets } from './src/config-targets.js';
+export { maybeBabel } from './src/maybe-babel.js';

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -36,6 +36,8 @@
     "@babel/core": "^7.22.9",
     "@embroider/macros": "workspace:*",
     "@embroider/reverse-exports": "workspace:*",
+    "@rolldown/pluginutils": "^1.0.1",
+    "@rollup/plugin-babel": "^7.1.0",
     "assert-never": "^1.2.1",
     "browserslist": "*",
     "browserslist-to-esbuild": "^2.1.1",
@@ -51,7 +53,6 @@
   },
   "devDependencies": {
     "@embroider/core": "workspace:^",
-    "@rollup/plugin-babel": "^5.3.1",
     "@types/babel__core": "^7.20.1",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.12",

--- a/packages/vite/src/maybe-babel.ts
+++ b/packages/vite/src/maybe-babel.ts
@@ -109,6 +109,9 @@ export function maybeBabel(userOptions: Options = {}): Plugin {
         // is one of the babel-supported extensions
         id(extensionRegExp),
         or(
+          // always run gts and gjs through babel
+          id(/\.gts$/),
+          id(/\.gjs$/),
           // imports one of the modules above
           code(importsRegex),
           // (a common way to do translations)

--- a/packages/vite/src/maybe-babel.ts
+++ b/packages/vite/src/maybe-babel.ts
@@ -1,0 +1,136 @@
+import { babel } from '@rollup/plugin-babel';
+import type { RollupBabelInputPluginOptions } from '@rollup/plugin-babel';
+import { and, code, id, include, not, or } from '@rolldown/pluginutils';
+import type { Plugin } from 'vite';
+
+import { extensions } from './ember.js';
+
+/**
+ * If a file imports any of these, it needs babel (templates, macros, and a
+ * couple of addons that ship decorator-adjacent runtime code).
+ */
+const babelRequiredImports = [
+  // Templates
+  // (old non template() form)
+  '@ember/template-compiler',
+  '@ember/template-compilation',
+
+  // Legacy templates (hbs / loose mode)
+  'ember-cli-htmlbars',
+  'ember-cli-htmlbars-inline-precompile',
+  'htmlbars-inline-precompile',
+
+  // Build Macros
+  // (since import.meta.env is not available in all environments)
+  '@embroider/macros',
+  '@glimmer/env',
+  '@ember/debug',
+  '@ember/application/deprecations',
+];
+
+function escapeRegExp(s: string) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const decoratorRegex = /(?<![\w'"`])(?<!\*\s+)(?<!\/\/[^\n]*)(?<!\/\*[^\n]*)@\w+/;
+//                     └────┬─────┘└───┬───┘└──────┬──────┘└──────┬──────┘└┬─┘
+//                          │          │           │              │        │
+//                          │          │           │              │        └── the `@decorator`
+//                          │          │           │              └──────── not inside a single-line block comment (`/* @dec */`)
+//                          │          │           └─────────────────────── not on a `//` line comment
+//                          │          └─────────────────────────────────── not a JSDoc tag, even with multiple spaces (`*    @param`)
+//                          └────────────────────────────────────────────── not mid-identifier or inside a string
+
+const nodeModulesPattern = /\/node_modules\//;
+
+function escapeRegExpCharacters(str: string) {
+  return str.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}
+
+const extensionRegExp = new RegExp(
+  `(${extensions
+    .filter(ext => ext !== '.json')
+    .map(escapeRegExpCharacters)
+    .join('|')})(\\?.*)?(#.*)?$`
+);
+
+type Options = Omit<RollupBabelInputPluginOptions, 'filter'> & {
+  filter?: {
+    include: {
+      /**
+       * If any additional (custom) plugins are provided, a pattern
+       * should be provided that detects their usage
+       *
+       * for example, to also run babel on files that import from ember-concurrency
+       * ```js
+       * {
+       *   code: ['ember-concurrency'],
+       * }
+       * ```
+       */
+      imports: string[];
+      /**
+       * If any additional (custom) plugins are provided, a pattern
+       * should be provided that detects their usage
+       *
+       * for example, to also run babel on files that use polyfilled APIs,
+       * or use the "formatMessage" technique for translations
+       * ```js
+       * {
+       *   code: ['myPolyfilledAPICall(', /\bintl\.formatMessage\b/],
+       * }
+       * ```
+       */
+      code: (string | RegExp)[];
+    };
+  };
+};
+
+export function maybeBabel(userOptions: Options = {}): Plugin {
+  const { filter, ...options } = userOptions;
+
+  const plugin = babel({
+    babelHelpers: 'runtime',
+    extensions,
+    skipPreflightCheck: true,
+    ...options,
+  });
+
+  const importsRegex = new RegExp(
+    babelRequiredImports
+      .concat(filter?.include?.imports ?? [])
+      .map(escapeRegExp)
+      .join('|')
+  );
+
+  const maybeBabelFilter = [
+    include(
+      and(
+        // is one of the babel-supported extensions
+        id(extensionRegExp),
+        or(
+          // imports one of the modules above
+          code(importsRegex),
+          // (a common way to do translations)
+          // local app code using a decorator
+          // NOTE: maybeBabel requires that all libraries compile away their decorators
+          //
+          // TODO: what do we do when native decorators start shipping?
+          //     (ignore decorator transforming entirely?)
+          and(not(id(nodeModulesPattern)), code(decoratorRegex)),
+          // user provided additional opt-ins to the regex here
+          ...(filter?.include?.code?.map(x => code(x)) ?? [])
+        )
+      )
+    ),
+  ];
+
+  // types are incorrect
+  (plugin.transform as { filter: unknown }).filter = maybeBabelFilter;
+
+  return {
+    ...plugin,
+    enforce: 'pre',
+    name: 'embroider:maybe-babel',
+  } as Plugin;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -967,6 +967,12 @@ importers:
       '@embroider/reverse-exports':
         specifier: workspace:*
         version: link:../reverse-exports
+      '@rolldown/pluginutils':
+        specifier: ^1.0.1
+        version: 1.0.1
+      '@rollup/plugin-babel':
+        specifier: ^7.1.0
+        version: 7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4)
       assert-never:
         specifier: ^1.2.1
         version: 1.4.0
@@ -1007,9 +1013,6 @@ importers:
       '@embroider/core':
         specifier: workspace:^
         version: link:../core
-      '@rollup/plugin-babel':
-        specifier: ^5.3.1
-        version: 5.3.1(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4)
       '@types/babel__core':
         specifier: ^7.20.1
         version: 7.20.5
@@ -5374,6 +5377,19 @@ packages:
       rollup: ^1.20.0||^2.0.0
     peerDependenciesMeta:
       '@types/babel__core':
+        optional: true
+
+  '@rollup/plugin-babel@7.1.0':
+    resolution: {integrity: sha512-h9Y+xYha6p4wKO+FwdiPIkE+eIYCm8MzZPpX1iARIoFBnmKP9CnpT1p9dDf/DTFm6fyN8PmuLyRI5qZgchnitw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      '@types/babel__core': ^7.1.9
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      '@types/babel__core':
+        optional: true
+      rollup:
         optional: true
 
   '@rollup/plugin-typescript@11.1.6':
@@ -14268,6 +14284,9 @@ packages:
   workerpool@6.5.1:
     resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
 
+  workerpool@9.3.4:
+    resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -19126,6 +19145,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.24.7
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      workerpool: 9.3.4
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
+      rollup: 4.60.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@rollup/plugin-typescript@11.1.6(rollup@3.30.0)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@3.30.0)
@@ -19156,6 +19187,14 @@ snapshots:
       picomatch: 4.0.4
     optionalDependencies:
       rollup: 3.30.0
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.4)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.4
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
@@ -33307,6 +33346,8 @@ snapshots:
       - supports-color
 
   workerpool@6.5.1: {}
+
+  workerpool@9.3.4: {}
 
   wrap-ansi@6.2.0:
     dependencies:


### PR DESCRIPTION
a maybeBabel with simple options API

works on JS and TS

only passes regex to rust land, and doesn't manually re-parse.


lighter alternative to
- #2774

based on discourse's latest approach: 
- https://github.com/discourse/discourse/blob/5e8d72c85e611c95259131fc59f06d55c905ef0f/frontend/discourse/lib/maybe-babel.mjs#L1


todo: 
- [x] pr to #2774 to show a difference
  - https://github.com/embroider-build/embroider/pull/2784