### PR TITLE
Abstract vite dev utility (for qunit) for visiting /tests

### DIFF
--- a/tests/scenarios/helpers/index.ts
+++ b/tests/scenarios/helpers/index.ts
@@ -2,3 +2,4 @@ export * from './fastboot';
 export * from './fixtures';
 export * from './v2-addon';
 export * from './filesystem';
+export * from './vite-dev';

--- a/tests/scenarios/helpers/vite-dev.ts
+++ b/tests/scenarios/helpers/vite-dev.ts
@@ -1,0 +1,59 @@
+import { readFileSync, writeFileSync } from 'fs-extra';
+import { resolve } from 'path';
+import type { PreparedApp } from 'scenario-tester';
+import CommandWatcher from './command-watcher';
+
+export function setupViteDevServer(
+  hooks: NestedHooks,
+  getApp: () => PreparedApp,
+  options: {
+    viteArgs?: string[];
+    rewriteProxy?: {
+      testemFile?: string;
+      base?: string;
+    };
+  } = {}
+): {
+  readonly appURL: string;
+  readonly server: CommandWatcher;
+} {
+  let server: CommandWatcher;
+  let appURL: string;
+
+  hooks.before(async () => {
+    let app = getApp();
+    server = CommandWatcher.launch('vite', ['--clearScreen', 'false', ...(options.viteArgs ?? [])], { cwd: app.dir });
+    [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
+
+    let rewrite = options.rewriteProxy;
+    if (rewrite) {
+      let testemFile = rewrite.testemFile ?? 'testem-dev.cjs';
+      let base = rewrite.base ?? '/';
+      let url = appURL.replace(new RegExp(`^${base}`), '/').replace('//', '/');
+
+      let testem = readFileSync(resolve(app.dir, testemFile)).toString();
+
+      testem = testem.replace(`test_page: '/tests?hidepassed',`, `test_page: '${base}tests?hidepassed',`);
+      testem = testem.replace(`.testemProxy('http://localhost:4200', '/')`, `.testemProxy('${url}', '${base}')`);
+
+      writeFileSync(resolve(app.dir, testemFile), testem);
+
+      let environment = readFileSync(resolve(app.dir, 'config', 'environment.js')).toString();
+      environment = environment.replace(`rootURL: '/',`, `rootURL: '${base}',`);
+      writeFileSync(resolve(app.dir, 'config', 'environment.js'), environment);
+    }
+  });
+
+  hooks.after(async () => {
+    await server?.shutdown();
+  });
+
+  return {
+    get appURL() {
+      return appURL;
+    },
+    get server() {
+      return server;
+    },
+  };
+}

--- a/tests/scenarios/helpers/vite-dev.ts
+++ b/tests/scenarios/helpers/vite-dev.ts
@@ -29,7 +29,9 @@ export function setupViteDevServer(
     if (rewrite) {
       let testemFile = rewrite.testemFile ?? 'testem-dev.cjs';
       let base = rewrite.base ?? '/';
-      let url = appURL.replace(new RegExp(`^${base}`), '/').replace('//', '/');
+      // The dev server URL includes the base path (e.g. `http://localhost:5173/sub-dir`); the
+      // proxy just needs the bare origin, since the base is passed separately below.
+      let url = new URL(appURL).origin;
 
       let testem = readFileSync(resolve(app.dir, testemFile)).toString();
 

--- a/tests/scenarios/legacy-inspector-support-test.ts
+++ b/tests/scenarios/legacy-inspector-support-test.ts
@@ -1,9 +1,9 @@
 import { wideAppScenarios } from './scenarios';
 import type { PreparedApp, Project, Scenario } from 'scenario-tester';
 import QUnit from 'qunit';
-import { readdirSync, readFileSync, writeFileSync } from 'fs-extra';
-import { join, resolve } from 'path';
-import CommandWatcher from './helpers/command-watcher';
+import { readdirSync } from 'fs-extra';
+import { join } from 'path';
+import { setupViteDevServer } from './helpers';
 
 const { module: Qmodule, test } = QUnit;
 
@@ -155,20 +155,7 @@ function runTests(scenario: Scenario) {
     });
 
     Qmodule('vite dev', function (hooks) {
-      let server: CommandWatcher;
-
-      hooks.before(async () => {
-        server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
-        const [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
-
-        let testem = readFileSync(resolve(app.dir, 'testem-dev.js')).toString();
-        testem = testem.replace(`.testemProxy('http://localhost:4200', '/')`, `.testemProxy('${appURL}', '/')`);
-        writeFileSync(resolve(app.dir, 'testem-dev.js'), testem);
-      });
-
-      hooks.after(async () => {
-        await server?.shutdown();
-      });
+      setupViteDevServer(hooks, () => app, { rewriteProxy: { testemFile: 'testem-dev.js' } });
 
       test('run test suite against vite dev', async function (assert) {
         let result = await app.execute('pnpm testem --file testem-dev.js ci');

--- a/tests/scenarios/minimal-app-test.ts
+++ b/tests/scenarios/minimal-app-test.ts
@@ -2,7 +2,7 @@ import { minimalAppScenarios } from './scenarios';
 import type { PreparedApp } from 'scenario-tester';
 import QUnit from 'qunit';
 import fetch from 'node-fetch';
-import CommandWatcher from './helpers/command-watcher';
+import { setupViteDevServer } from './helpers';
 import { setupAuditTest } from '@embroider/test-support/audit-assertions';
 
 const { module: Qmodule, test } = QUnit;
@@ -181,28 +181,19 @@ export function start() {
   .forEachScenario(scenario => {
     Qmodule(scenario.name, function (hooks) {
       let app: PreparedApp;
-      let server: CommandWatcher;
-      let appURL: string;
 
       hooks.before(async () => {
         app = await scenario.prepare();
       });
 
       Qmodule('vite dev', function (hooks) {
-        hooks.before(async () => {
-          server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
-          [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
-        });
+        let dev = setupViteDevServer(hooks, () => app);
 
         let expectAudit = setupAuditTest(hooks, () => ({
-          appURL,
+          appURL: dev.appURL,
           startingFrom: ['index.html'],
           fetch: fetch as unknown as typeof globalThis.fetch,
         }));
-
-        hooks.after(async () => {
-          await server?.shutdown();
-        });
 
         test(`dep optimization of a v2 addon`, async function (assert) {
           expectAudit

--- a/tests/scenarios/vite-app-test.ts
+++ b/tests/scenarios/vite-app-test.ts
@@ -1,9 +1,9 @@
 import { baseAddon, wideAppScenarios } from './scenarios';
 import type { PreparedApp } from 'scenario-tester';
 import QUnit from 'qunit';
-import { readdirSync, readFileSync, writeFileSync } from 'fs-extra';
-import { join, resolve } from 'path';
-import CommandWatcher from './helpers/command-watcher';
+import { readdirSync } from 'fs-extra';
+import { join } from 'path';
+import { setupViteDevServer } from './helpers';
 
 const { module: Qmodule, test } = QUnit;
 
@@ -353,20 +353,7 @@ wideAppScenarios
       });
 
       Qmodule('vite dev', function (hooks) {
-        let server: CommandWatcher;
-
-        hooks.before(async () => {
-          server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
-          const [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
-
-          let testem = readFileSync(resolve(app.dir, 'testem-dev.js')).toString();
-          testem = testem.replace(`.testemProxy('http://localhost:4200', '/')`, `.testemProxy('${appURL}', '/')`);
-          writeFileSync(resolve(app.dir, 'testem-dev.js'), testem);
-        });
-
-        hooks.after(async () => {
-          await server?.shutdown();
-        });
+        setupViteDevServer(hooks, () => app, { rewriteProxy: { testemFile: 'testem-dev.js' } });
 
         test('run test suite against vite dev', async function (assert) {
           let result = await app.execute('pnpm testem --file testem-dev.js ci');

--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -2,9 +2,9 @@ import { baseAddon, tsAppScenarios } from './scenarios';
 import type { PreparedApp, Project, Scenario, Scenarios } from 'scenario-tester';
 import QUnit from 'qunit';
 import fetch from 'node-fetch';
-import CommandWatcher from './helpers/command-watcher';
+import { setupViteDevServer } from './helpers';
 import { setupAuditTest } from '@embroider/test-support/audit-assertions';
-import { mkdirSync, moveSync, readFileSync, writeFileSync } from 'fs-extra';
+import { mkdirSync, moveSync } from 'fs-extra';
 import { resolve } from 'path';
 
 const { module: Qmodule, test } = QUnit;
@@ -349,28 +349,19 @@ function editBabelConfig(src: string): string {
 function runViteInternalsTest(scenario: Scenario) {
   Qmodule(scenario.name, function (hooks) {
     let app: PreparedApp;
-    let server: CommandWatcher;
-    let appURL: string;
 
     hooks.before(async () => {
       app = await scenario.prepare();
     });
 
     Qmodule('vite dev', function (hooks) {
-      hooks.before(async () => {
-        server = CommandWatcher.launch('vite', ['--clearScreen', 'false'], { cwd: app.dir });
-        [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
-      });
+      let dev = setupViteDevServer(hooks, () => app);
 
       let expectAudit = setupAuditTest(hooks, () => ({
-        appURL,
+        appURL: dev.appURL,
         startingFrom: ['index.html'],
         fetch: fetch as unknown as typeof globalThis.fetch,
       }));
-
-      hooks.after(async () => {
-        await server?.shutdown();
-      });
 
       test(`dep optimization of a v2 addon`, async function (assert) {
         expectAudit
@@ -428,22 +419,12 @@ function runViteInternalsTest(scenario: Scenario) {
       });
 
       Qmodule('vite dev', function (hooks) {
-        hooks.before(async () => {
-          server = CommandWatcher.launch('vite', ['--clearScreen', 'false', '--base', base], { cwd: app.dir });
-          const [, appURL] = await server.waitFor(/Local:\s+(https?:\/\/.*)\//g);
-          let testem = readFileSync(resolve(app.dir, 'testem-dev.js')).toString();
-          let environment = readFileSync(resolve(app.dir, 'config', 'environment.js')).toString();
-          const url = appURL.replace('/sub-dir', '');
-          testem = testem
-            .replace(`test_page: '/tests?hidepassed',`, `test_page: '${base}tests?hidepassed',`)
-            .replace(`.testemProxy('http://localhost:4200', '/')`, `.testemProxy('${url}', '${base}')`);
-          environment = environment.replace(`rootURL: '/',`, `rootURL: '${base}',`);
-          writeFileSync(resolve(app.dir, 'testem-dev.js'), testem);
-          writeFileSync(resolve(app.dir, 'config', 'environment.js'), environment);
-        });
-
-        hooks.after(async () => {
-          await server?.shutdown();
+        setupViteDevServer(hooks, () => app, {
+          viteArgs: ['--base', base],
+          rewriteProxy: {
+            testemFile: 'testem-dev.js',
+            base,
+          },
         });
 
         test('run test suite against vite dev', async function (assert) {


### PR DESCRIPTION
our vite dev stuff has been duplicated across 4 scenarios

since I want to use vite dev + testem-proxy in https://github.com/embroider-build/embroider/pull/2779 , I decided to pivot to this refactor