### PR TITLE
macroCondition: support && / || logical expression position

### DIFF
--- a/packages/macros/src/babel/macro-condition.ts
+++ b/packages/macros/src/babel/macro-condition.ts
@@ -1,20 +1,32 @@
 import type { NodePath } from '@babel/traverse';
 import { Evaluator } from './evaluate-json';
 import type { types as t } from '@babel/core';
+import type * as Babel from '@babel/core';
 import error from './error';
 import type State from './state';
 
 export interface MacroCondition {
   parity: boolean;
-  conditional: NodePath<t.IfStatement | t.ConditionalExpression>;
+  conditional: NodePath<t.IfStatement | t.ConditionalExpression | t.LogicalExpression>;
   callExpression: NodePath<t.CallExpression>;
 }
 
 export function identifyMacroConditionPath(
-  path: NodePath<t.IfStatement | t.ConditionalExpression>
+  path: NodePath<t.IfStatement | t.ConditionalExpression | t.LogicalExpression>
 ): MacroCondition | false {
   let parity = true;
-  let test = path.get('test');
+  let test: NodePath<t.Node>;
+
+  if (path.isLogicalExpression()) {
+    // `??` has no equivalent branch semantics for a boolean predicate, so we
+    // leave it alone (and the ReferencedIdentifier check will flag it).
+    if (path.node.operator !== '&&' && path.node.operator !== '||') {
+      return false;
+    }
+    test = path.get('left');
+  } else {
+    test = (path as NodePath<t.IfStatement | t.ConditionalExpression>).get('test');
+  }
 
   if (test.isUnaryExpression() && test.node.operator === '!') {
     parity = false;
@@ -30,7 +42,7 @@ export function identifyMacroConditionPath(
   return false;
 }
 
-export default function macroCondition(macro: MacroCondition, state: State) {
+export default function macroCondition(macro: MacroCondition, state: State, context: typeof Babel) {
   let args = macro.callExpression.get('arguments');
   if (args.length !== 1) {
     throw error(macro.conditional, `macroCondition accepts exactly one argument, you passed ${args.length}`);
@@ -42,22 +54,43 @@ export default function macroCondition(macro: MacroCondition, state: State) {
     throw error(args[0], `the first argument to macroCondition must be statically known`);
   }
 
-  let consequent = macro.conditional.get('consequent');
-  let alternate = macro.conditional.get('alternate');
-
   if (state.opts.mode === 'run-time' && predicate.hasRuntimeImplementation !== false) {
     let callee = macro.callExpression.get('callee');
     callee.replaceWith(state.importUtil.import(callee, state.pathToOurAddon('runtime'), 'macroCondition'));
-  } else {
-    let [kept, removed] =
-      predicate.value === macro.parity ? [consequent.node, alternate.node] : [alternate.node, consequent.node];
-    if (kept) {
-      macro.conditional.replaceWith(kept);
+    return;
+  }
+
+  if (macro.conditional.isLogicalExpression()) {
+    // Bundlers and minifiers routinely collapse
+    // `macroCondition(x) ? expr : {};` statements into
+    // `macroCondition(x) && expr;`, so published code can legitimately reach
+    // us in this shape even though authors write the ternary/if form.
+    let effectivePredicate = predicate.value === macro.parity;
+    let right = macro.conditional.get('right');
+    // `true && right` / `false || right` evaluate to the right operand;
+    // otherwise the expression short-circuits to the predicate's value.
+    let keptRight = (macro.conditional.node.operator === '&&') === effectivePredicate;
+    if (keptRight) {
+      macro.conditional.replaceWith(right.node);
     } else {
-      macro.conditional.remove();
+      state.removed.add(right.node);
+      macro.conditional.replaceWith(context.types.booleanLiteral(effectivePredicate));
     }
-    if (removed) {
-      state.removed.add(removed);
-    }
+    return;
+  }
+
+  let conditional = macro.conditional as NodePath<t.IfStatement | t.ConditionalExpression>;
+  let consequent = conditional.get('consequent');
+  let alternate = conditional.get('alternate');
+
+  let [kept, removed] =
+    predicate.value === macro.parity ? [consequent.node, alternate.node] : [alternate.node, consequent.node];
+  if (kept) {
+    conditional.replaceWith(kept);
+  } else {
+    conditional.remove();
+  }
+  if (removed) {
+    state.removed.add(removed);
   }
 }

--- a/packages/macros/src/babel/macro-condition.ts
+++ b/packages/macros/src/babel/macro-condition.ts
@@ -18,8 +18,6 @@ export function identifyMacroConditionPath(
   let test: NodePath<t.Node>;
 
   if (path.isLogicalExpression()) {
-    // `??` has no equivalent branch semantics for a boolean predicate, so we
-    // leave it alone (and the ReferencedIdentifier check will flag it).
     if (path.node.operator !== '&&' && path.node.operator !== '||') {
       return false;
     }
@@ -61,14 +59,8 @@ export default function macroCondition(macro: MacroCondition, state: State, cont
   }
 
   if (macro.conditional.isLogicalExpression()) {
-    // Bundlers and minifiers routinely collapse
-    // `macroCondition(x) ? expr : {};` statements into
-    // `macroCondition(x) && expr;`, so published code can legitimately reach
-    // us in this shape even though authors write the ternary/if form.
     let effectivePredicate = predicate.value === macro.parity;
     let right = macro.conditional.get('right');
-    // `true && right` / `false || right` evaluate to the right operand;
-    // otherwise the expression short-circuits to the predicate's value.
     let keptRight = (macro.conditional.node.operator === '&&') === effectivePredicate;
     if (keptRight) {
       macro.conditional.replaceWith(right.node);

--- a/packages/macros/src/babel/macros-babel-plugin.ts
+++ b/packages/macros/src/babel/macros-babel-plugin.ts
@@ -29,12 +29,12 @@ export default function main(context: typeof Babel): unknown {
         }
       },
     },
-    'IfStatement|ConditionalExpression': {
-      enter(path: NodePath<t.IfStatement | t.ConditionalExpression>, state: State) {
+    'IfStatement|ConditionalExpression|LogicalExpression': {
+      enter(path: NodePath<t.IfStatement | t.ConditionalExpression | t.LogicalExpression>, state: State) {
         let found = identifyMacroConditionPath(path);
         if (found) {
           state.calledIdentifiers.add(found.callExpression.get('callee').node);
-          macroCondition(found, state);
+          macroCondition(found, state, context);
         }
       },
     },
@@ -257,7 +257,10 @@ export default function main(context: typeof Babel): unknown {
       }
 
       if (path.referencesImport('@embroider/macros', 'macroCondition') && !state.calledIdentifiers.has(path.node)) {
-        throw error(path, `macroCondition can only be used as the predicate of an if statement or ternary expression`);
+        throw error(
+          path,
+          `macroCondition can only be used as the predicate of an if statement, ternary expression, or && / || logical expression`
+        );
       }
 
       if (path.referencesImport('@embroider/macros', 'each') && !state.calledIdentifiers.has(path.node)) {

--- a/packages/macros/tests/babel/macro-condition.test.ts
+++ b/packages/macros/tests/babel/macro-condition.test.ts
@@ -160,6 +160,107 @@ describe('macroCondition', function () {
         expect(code).not.toMatch(/\/runtime/);
       });
 
+      test('logical && with true predicate keeps right operand', () => {
+        let code = transform(`
+      import { macroCondition } from '@embroider/macros';
+      export default function() {
+        return macroCondition(true) && 'alpha';
+      }
+      `);
+        expect(run(code, { filename })).toBe('alpha');
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/&&/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+        expect(code).not.toMatch(/\/runtime/);
+      });
+
+      test('logical && with false predicate drops right operand', () => {
+        let code = transform(`
+      import { macroCondition } from '@embroider/macros';
+      export default function() {
+        return macroCondition(false) && 'alpha';
+      }
+      `);
+        expect(run(code, { filename })).toBe(false);
+        expect(code).not.toMatch(/alpha/);
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/&&/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+        expect(code).not.toMatch(/\/runtime/);
+      });
+
+      test('logical || with true predicate drops right operand', () => {
+        let code = transform(`
+      import { macroCondition } from '@embroider/macros';
+      export default function() {
+        return macroCondition(true) || 'alpha';
+      }
+      `);
+        expect(run(code, { filename })).toBe(true);
+        expect(code).not.toMatch(/alpha/);
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/\|\|/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+        expect(code).not.toMatch(/\/runtime/);
+      });
+
+      test('logical || with false predicate keeps right operand', () => {
+        let code = transform(`
+      import { macroCondition } from '@embroider/macros';
+      export default function() {
+        return macroCondition(false) || 'alpha';
+      }
+      `);
+        expect(run(code, { filename })).toBe('alpha');
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/\|\|/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+        expect(code).not.toMatch(/\/runtime/);
+      });
+
+      test('negated logical && keeps right operand', () => {
+        let code = transform(`
+      import { macroCondition } from '@embroider/macros';
+      export default function() {
+        return !macroCondition(false) && 'alpha';
+      }
+      `);
+        expect(run(code, { filename })).toBe('alpha');
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/&&/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+        expect(code).not.toMatch(/\/runtime/);
+      });
+
+      test('logical && statement (minifier output shape) keeps side effect', () => {
+        let code = transform(`
+      import { macroCondition } from '@embroider/macros';
+      export default function() {
+        let result = 'beta';
+        macroCondition(true) && (result = 'alpha');
+        return result;
+      }
+      `);
+        expect(run(code, { filename })).toBe('alpha');
+        expect(code).not.toMatch(/macroCondition/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+        expect(code).not.toMatch(/\/runtime/);
+      });
+
+      runTimeTest('given runtime implementation, logical && keeps runtime predicate', () => {
+        let code = transform(`
+      import { isTesting, macroCondition } from '@embroider/macros';
+      export default function() {
+        return macroCondition(isTesting()) && 'alpha';
+      }
+      `);
+        expect(run(code, { filename })).toBe('alpha');
+        expect(code).toMatch(/macroCondition/);
+        expect(code).toMatch(/&&/);
+        expect(code).not.toMatch(/@embroider\/macros/);
+        expect(code).toMatch(/\/runtime/);
+      });
+
       test('if selects consequent, no alternate', () => {
         let code = transform(`
       import { macroCondition } from '@embroider/macros';
@@ -303,7 +404,9 @@ describe('macroCondition', function () {
           return macroCondition(true);
         }
         `);
-        }).toThrow(/macroCondition can only be used as the predicate of an if statement or ternary expression/);
+        }).toThrow(
+          /macroCondition can only be used as the predicate of an if statement, ternary expression, or && \/ \|\| logical expression/
+        );
       });
 
       test('composes with other macros using ternary', () => {


### PR DESCRIPTION
> [!NOTE]
> This PR was made with Claude (AI) under my direction — apologies in advance if anything here misses existing conventions or context; happy to rework it however you'd prefer.

## Problem

Bundlers and minifiers routinely collapse statement-position ternaries into logical expressions:

```js
// what library authors (or their tooling) write / emit:
macroCondition(getGlobalConfig().WarpDrive.env.DEBUG) ? doAssert(test) : {};

// what the bundler publishes:
macroCondition(getGlobalConfig().WarpDrive.env.DEBUG) && doAssert(test);
```

Rolldown performs this `cond ? expr : {}` → `cond && expr` rewrite **by default, even with minification disabled**, and terser/esbuild do it as a standard compression. So a prebuilt (v2 addon) library that legally ships `macroCondition` in ternary form can end up publishing the logical-expression form, and the consuming app's build then fails with:

```
MacroError: macroCondition can only be used as the predicate of an if statement or ternary expression
```

Concrete real-world case: `@warp-drive/build-config`'s `assert()` babel macro emits exactly the ternary-statement shape above; building a library that uses it with tsdown/rolldown produces the `&&` form in dist, which apps then cannot compile.

## Solution

Teach the babel plugin to accept `macroCondition` as the left operand of `&&` and `||` (including the negated `!macroCondition(x)` form, mirroring the existing if/ternary handling):

- **build-time**: `macroCondition(true) && expr` → `expr`; `macroCondition(false) && expr` → `false`, with the right operand recorded in `state.removed` so dead-branch handling (e.g. `importSync` pruning) works the same as for dropped ternary branches. `||` is symmetric.
- **run-time**: the callee is rewritten to the runtime `macroCondition` implementation and the logical expression is left in place — same treatment as if/ternary.

`??` is intentionally not supported: a boolean predicate is never nullish, so there's no meaningful branch to select (it still hits the "can only be used as…" error, whose message now mentions logical expressions).

## Testing

Added build-time tests for all four `&&`/`||` × true/false combinations, the negated form, the minifier-output statement shape (`macroCondition(true) && (result = 'alpha');`), and a run-time mode test asserting the expression survives with the runtime import. All existing tests pass (one assertion updated for the expanded error message).