### PR TITLE
Fix: virtual modules fail to resolve under vite's bundledDev

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -40,6 +40,13 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
       return await observeDepScan(context, source, importer, options);
     }
 
+    // Ids we already virtualized come back as literal sources when rolldown's
+    // lazy dev mode re-imports a lazy entry through its `?rolldown-lazy=` stub.
+    let alreadyVirtualized = responseMetas.get(normalizePath(source));
+    if (alreadyVirtualized) {
+      return { id: source, meta: { 'embroider-resolver': alreadyVirtualized } };
+    }
+
     let request = ModuleRequest.create(RollupRequestAdapter.create, {
       context,
       source,

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -40,13 +40,6 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
       return await observeDepScan(context, source, importer, options);
     }
 
-    // Ids we already virtualized come back as literal sources when rolldown's
-    // lazy dev mode re-imports a lazy entry through its `?rolldown-lazy=` stub.
-    let alreadyVirtualized = responseMetas.get(normalizePath(source));
-    if (alreadyVirtualized) {
-      return { id: source, meta: { 'embroider-resolver': alreadyVirtualized } };
-    }
-
     let request = ModuleRequest.create(RollupRequestAdapter.create, {
       context,
       source,
@@ -157,6 +150,11 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
     },
 
     async resolveId(source, importer, options) {
+      let seen = responseMetas.get(normalizePath(source));
+      if (seen) {
+        return { id: source, meta: { 'embroider-resolver': seen } };
+      }
+
       let resolution = await resolveId(this, source, importer, options);
       if (typeof resolution === 'string') {
         return resolution;

--- a/packages/vite/tests/resolver.test.js
+++ b/packages/vite/tests/resolver.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const virtual = { type: 'route-entrypoint', specifier: '/app/-embroider-route-entrypoint.js:route=application' };
+const virtualId = '/app/-embroider-route-entrypoint.js:route=application';
+
+class FakeResolverLoader {
+  get resolver() {
+    return {
+      packageCache: {},
+      options: { engines: [] },
+      resolve(request) {
+        if (request.specifier === '@embroider/core/route/application') {
+          return {
+            type: 'found',
+            virtual,
+            result: { id: virtualId, meta: { 'embroider-resolver': { virtual } } },
+          };
+        }
+        return { type: 'not_found', err: undefined };
+      },
+    };
+  }
+}
+
+vi.mock('@embroider/core', async importOriginal => {
+  let original = await importOriginal();
+  return {
+    ...original,
+    ResolverLoader: FakeResolverLoader,
+    // resolver.ts uses a default import, which only exists once core is built.
+    default: { ...original, ...(original.default ?? {}), ResolverLoader: FakeResolverLoader },
+  };
+});
+
+const { resolver } = await import('../src/resolver');
+
+describe('embroider-resolver', () => {
+  it('re-resolves an id it already handed out to the same virtual module', async () => {
+    let plugin = resolver();
+    let context = {};
+
+    let first = await plugin.resolveId.call(context, '@embroider/core/route/application', '/app/package.json', {});
+    expect(first.id).toBe(virtualId);
+
+    let second = await plugin.resolveId.call(context, first.id, `${first.id}?rolldown-lazy=1`, {});
+    expect(second.id).toBe(virtualId);
+  });
+});

--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -4,7 +4,7 @@ import QUnit from 'qunit';
 import fetch from 'node-fetch';
 import { setupViteDevServer } from './helpers';
 import { setupAuditTest } from '@embroider/test-support/audit-assertions';
-import { mkdirSync, moveSync } from 'fs-extra';
+import { mkdirSync, moveSync, writeFileSync } from 'fs-extra';
 import { resolve } from 'path';
 
 const { module: Qmodule, test } = QUnit;
@@ -411,6 +411,57 @@ function runViteInternalsTest(scenario: Scenario) {
         assert.equal(result.exitCode, 0, result.output);
       });
     });
+
+    // `experimental.bundledDev` is vite 8 only.
+    if (scenario.name.includes('vite-rolldown')) {
+      Qmodule('vite dev with bundledDev', function (hooks) {
+        hooks.before(async () => {
+          // Resolving twice is what rolldown's lazy dev mode does to every lazy
+          // entry, via its `?rolldown-lazy=` stub.
+          writeFileSync(
+            resolve(app.dir, 'vite.bundled-dev.config.mjs'),
+            `
+              import { defineConfig } from 'vite';
+              import { extensions, classicEmberSupport, ember } from '@embroider/vite';
+              import { babel } from '@rollup/plugin-babel';
+              import { resolve } from 'node:path';
+
+              const reResolveVirtualId = {
+                name: 'test-re-resolve-virtual-id',
+                async buildEnd() {
+                  const first = await this.resolve('@embroider/core/route/application', resolve(process.cwd(), 'package.json'));
+                  const second = first && (await this.resolve(first.id, first.id + '?rolldown-lazy=1'));
+                  console.log('RE_RESOLVE_RESULT ' + JSON.stringify({ first: first?.id ?? null, second: second?.id ?? null }));
+                },
+              };
+
+              export default defineConfig({
+                experimental: { bundledDev: true },
+                plugins: [reResolveVirtualId, classicEmberSupport(), ember(), babel({ babelHelpers: 'runtime', extensions })],
+              });
+            `
+          );
+        });
+
+        let dev = setupViteDevServer(hooks, () => app, {
+          viteArgs: ['--config', 'vite.bundled-dev.config.mjs'],
+        });
+
+        test('a virtual id we handed out re-resolves to itself', async function (assert) {
+          let [, payload] = await dev.server.waitFor(/RE_RESOLVE_RESULT (.*)/);
+          let { first, second } = JSON.parse(payload);
+          assert.ok(first, 'the route entrypoint got virtualized');
+          assert.strictEqual(second, first, 'resolving it a second time gives back the same virtual module');
+        });
+
+        // Booting the app is left out until vitejs/vite#23124 is fixed: its own
+        // lazy route entries fail to compile when a client asks for them.
+        test('serves the app', async function (assert) {
+          let response = await fetch(dev.appURL);
+          assert.strictEqual(response.status, 200);
+        });
+      });
+    }
 
     Qmodule('vite with custom base', function (hooks) {
       const base = '/sub-dir/';

--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -4,7 +4,7 @@ import QUnit from 'qunit';
 import fetch from 'node-fetch';
 import { setupViteDevServer } from './helpers';
 import { setupAuditTest } from '@embroider/test-support/audit-assertions';
-import { mkdirSync, moveSync, writeFileSync } from 'fs-extra';
+import { mkdirSync, moveSync } from 'fs-extra';
 import { resolve } from 'path';
 
 const { module: Qmodule, test } = QUnit;
@@ -411,57 +411,6 @@ function runViteInternalsTest(scenario: Scenario) {
         assert.equal(result.exitCode, 0, result.output);
       });
     });
-
-    // `experimental.bundledDev` is vite 8 only.
-    if (scenario.name.includes('vite-rolldown')) {
-      Qmodule('vite dev with bundledDev', function (hooks) {
-        hooks.before(async () => {
-          // Resolving twice is what rolldown's lazy dev mode does to every lazy
-          // entry, via its `?rolldown-lazy=` stub.
-          writeFileSync(
-            resolve(app.dir, 'vite.bundled-dev.config.mjs'),
-            `
-              import { defineConfig } from 'vite';
-              import { extensions, classicEmberSupport, ember } from '@embroider/vite';
-              import { babel } from '@rollup/plugin-babel';
-              import { resolve } from 'node:path';
-
-              const reResolveVirtualId = {
-                name: 'test-re-resolve-virtual-id',
-                async buildEnd() {
-                  const first = await this.resolve('@embroider/core/route/application', resolve(process.cwd(), 'package.json'));
-                  const second = first && (await this.resolve(first.id, first.id + '?rolldown-lazy=1'));
-                  console.log('RE_RESOLVE_RESULT ' + JSON.stringify({ first: first?.id ?? null, second: second?.id ?? null }));
-                },
-              };
-
-              export default defineConfig({
-                experimental: { bundledDev: true },
-                plugins: [reResolveVirtualId, classicEmberSupport(), ember(), babel({ babelHelpers: 'runtime', extensions })],
-              });
-            `
-          );
-        });
-
-        let dev = setupViteDevServer(hooks, () => app, {
-          viteArgs: ['--config', 'vite.bundled-dev.config.mjs'],
-        });
-
-        test('a virtual id we handed out re-resolves to itself', async function (assert) {
-          let [, payload] = await dev.server.waitFor(/RE_RESOLVE_RESULT (.*)/);
-          let { first, second } = JSON.parse(payload);
-          assert.ok(first, 'the route entrypoint got virtualized');
-          assert.strictEqual(second, first, 'resolving it a second time gives back the same virtual module');
-        });
-
-        // Booting the app is left out until vitejs/vite#23124 is fixed: its own
-        // lazy route entries fail to compile when a client asks for them.
-        test('serves the app', async function (assert) {
-          let response = await fetch(dev.appURL);
-          assert.strictEqual(response.status, 200);
-        });
-      });
-    }
 
     Qmodule('vite with custom base', function (hooks) {
       const base = '/sub-dir/';


### PR DESCRIPTION
`experimental.bundledDev: true` crashes the dev server:

```
UNRESOLVED_IMPORT: Could not resolve '/…/app/-embroider-route-entrypoint.js:route=index'
in app/-embroider-route-entrypoint.js:route=index?rolldown-lazy=1
```

bundledDev puts rolldown in lazy dev mode, which wraps each lazy entry in a `?rolldown-lazy=` stub that re-imports the resolved id. That hands an id we already virtualized back to `resolveId` as a literal source, and we only virtualize `@embroider/core/route/…` specifiers, so nothing claims it. Not route-specific — it applies to any id we virtualize.

It hits us and not most plugins because a split route has no file behind it. Vue Router and SvelteKit lazily import a real component file, which resolves fine; we synthesize the route entrypoint, and it is the combination of a *generated* module that is *dynamically imported* that breaks.

Fix: make resolution idempotent for our own ids, using the `responseMetas` map that `load` already relies on.

Test: a unit test resolves a route entrypoint, then resolves the result again with a `?rolldown-lazy=1` importer — `null` before the fix, the same id after.

This does not make bundledDev usable on its own. The lazy entry itself still fails to resolve, which is a different code path that this PR does not touch, reported upstream as vitejs/vite#23124.

Cowritten/coinvestigated by Claude
