### PR TITLE
fix(test-setup): stop embroiderSafe/Optimized mutating shared devDependencies

### DIFF
--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -104,7 +104,9 @@ export function embroiderOptimized(extension?: object) {
 function extendScenario(scenario: object, extension?: object) {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
   let mergeWith = require('lodash/mergeWith') as typeof import('lodash/mergeWith');
-  return mergeWith(scenario, extension, appendArrays);
+  // Merge into a fresh object: `scenario.npm.devDependencies` is the shared
+  // `embroiderDevDeps`, and mergeWith writes into its first argument.
+  return mergeWith({}, scenario, extension, appendArrays);
 }
 
 function appendArrays(objValue: any, srcValue: any) {


### PR DESCRIPTION
## The bug

`embroiderDevDeps` is a module-level object, and both `embroiderSafe` and `embroiderOptimized` hand it straight to `extendScenario` as `npm.devDependencies`:

```ts
const embroiderDevDeps = { '@embroider/core': …, '@embroider/webpack': …, … };

export function embroiderSafe(extension?: object) {
  return extendScenario({
    name: 'embroider-safe',
    npm: { devDependencies: embroiderDevDeps },   // shared reference
    env: { EMBROIDER_TEST_SETUP_OPTIONS: 'safe' },
  }, extension);
}

function extendScenario(scenario: object, extension?: object) {
  return mergeWith(scenario, extension, appendArrays);   // writes into arg 1
}
```

`mergeWith` mutates its first argument, and merges into *existing* nested objects rather than replacing them — so `scenario.npm.devDependencies` **is** `embroiderDevDeps`, and every call that passes an extension permanently writes into it.

## Repro

```js
const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');

embroiderSafe({ npm: { devDependencies: { 'ember-source': 'RELEASE' } } });
embroiderSafe({ npm: { devDependencies: { 'ember-source': 'CANARY' } } });

embroiderOptimized().npm.devDependencies;
// => { '@embroider/core': …, webpack: '^5.0.0', 'ember-source': 'CANARY' }
```

A scenario created with **no extension at all** comes back carrying another scenario's `ember-source`.

## Why it matters

It fails silently. `ember-try` prints the scenario name you asked for while installing a different `ember-source`, so a matrix of channel scenarios can test the same version several times and still report as if it covered the range. I hit this building an ember-try config with four channel scenarios — all six embroider scenarios ended up pinned to canary, and nothing in the output said so.

## The fix

Merge into a fresh object. This is the same idiom `maybeEmbroider` already uses a few lines above for `recommendedOptions`:

```ts
opts = mergeWith({}, scenario, opts, appendArrays);
```

Fixing it in `extendScenario` covers both helpers and any future caller, rather than spreading at each construction site. Verified against lodash: merging into `{}` does not alias the source's nested objects, so `embroiderDevDeps` is left untouched and each scenario gets its own copy.

## Regression range

Not a problem before 4.0.0 — the dev-deps object used to be an inline literal inside each function, so it was allocated fresh per call. Hoisting it to module scope introduced the sharing.

Cowritten/coinvestigated by Claude