### PR TITLE
Warn when index.html references the deprecated @embroider/virtual/app.css

### DIFF
--- a/packages/vite/src/ember.ts
+++ b/packages/vite/src/ember.ts
@@ -5,6 +5,7 @@ import type { ConfigEnv, Plugin } from 'vite';
 
 import { esBuildResolver } from './esbuild-resolver.js';
 import { warnRootUrl } from './warn-root-url.js';
+import { warnVirtualAppCss } from './warn-virtual-app-css.js';
 import type { ViteUserConfig as UserConfig, Vite8UserConfig } from './types.js';
 
 export let extensions = ['.mjs', '.gjs', '.js', '.mts', '.gts', '.ts', '.hbs', '.hbs.js', '.json'];
@@ -31,6 +32,7 @@ export function ember(params?: {
 }) {
   return [
     warnRootUrl(),
+    warnVirtualAppCss(),
     templateTag(),
     resolver(),
     {

--- a/packages/vite/src/warn-virtual-app-css.ts
+++ b/packages/vite/src/warn-virtual-app-css.ts
@@ -1,0 +1,39 @@
+import type { Plugin } from 'vite';
+import chalk from 'chalk';
+
+const VIRTUAL_APP_CSS = '@embroider/virtual/app.css';
+const DEPRECATION_GUIDE = 'https://deprecations.emberjs.com/id/broccoli-css-pipeline';
+
+export function warnVirtualAppCss(): Plugin {
+  return {
+    name: 'embroider-warn-virtual-app-css',
+    transformIndexHtml: {
+      order: 'pre',
+      handler(html, { filename }) {
+        if (process.env.EMBROIDER_WARN_VIRTUAL_APP_CSS === 'false') {
+          return html;
+        }
+
+        if (!html.includes(VIRTUAL_APP_CSS)) {
+          return html;
+        }
+
+        console.log(
+          `\n${chalk.bold.yellow('WARNING')}\n${chalk.yellow(
+            `Referencing ${chalk.blue(VIRTUAL_APP_CSS)} in ${filename} is deprecated.\n`
+          )}`
+        );
+
+        console.log(
+          `The Broccoli CSS pipeline is deprecated. Vite apps should let Vite process\n` +
+            `application CSS. Update the stylesheet link to ${chalk.blue('/app/styles/app.css')}.\n\n` +
+            `See ${DEPRECATION_GUIDE}`
+        );
+
+        console.log('\nTo disable this warning set environment variable "EMBROIDER_WARN_VIRTUAL_APP_CSS" to "false"\n');
+
+        return html;
+      },
+    },
+  };
+}

--- a/packages/vite/tests/warn-virtual-app-css.test.js
+++ b/packages/vite/tests/warn-virtual-app-css.test.js
@@ -1,0 +1,75 @@
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+import { it, expect, describe, vi, afterAll, afterEach } from 'vitest';
+import { warnVirtualAppCss } from '../src/warn-virtual-app-css';
+
+describe('Vite plugin warnVirtualAppCss', () => {
+  const instance = warnVirtualAppCss();
+  const transformHtml = instance.transformIndexHtml;
+
+  const run = (html, context) => {
+    if (transformHtml && typeof transformHtml === 'object' && 'handler' in transformHtml) {
+      return transformHtml.handler(html, context);
+    }
+    throw new Error('No handler found');
+  };
+
+  let out = '';
+  const consoleSpy = vi.spyOn(console, 'log').mockImplementation(message => (out += message + '\n'));
+
+  afterAll(() => {
+    consoleSpy.mockReset();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockClear();
+    out = '';
+  });
+
+  it('does not change the output when @embroider/virtual/app.css is not in index.html', () => {
+    const html = '<html><body><h1>Hello World</h1></body></html>';
+    const result = run(html, { filename: 'index.html', server: undefined });
+
+    expect(result).toBe(html);
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not change the output when @embroider/virtual/app.css is in index.html', () => {
+    const html =
+      '<html><head><link rel="stylesheet" href="/@embroider/virtual/app.css"></head><body></body></html>';
+    const result = run(html, { filename: 'index.html', server: undefined });
+
+    expect(result).toBe(html);
+  });
+
+  it('prints a deprecation warning when @embroider/virtual/app.css is found in index.html', () => {
+    run('<html><head><link rel="stylesheet" href="/@embroider/virtual/app.css"></head><body></body></html>', {
+      filename: 'path/to/index.html',
+      server: undefined,
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('WARNING'));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Referencing @embroider/virtual/app.css in path/to/index.html is deprecated.')
+    );
+    // recommends the Vite CSS pipeline replacement from RFC 1148
+    expect(out).toContain('/app/styles/app.css');
+    // links to the deprecation guide
+    expect(out).toContain('https://deprecations.emberjs.com/id/broccoli-css-pipeline');
+  });
+
+  it('does not warn if EMBROIDER_WARN_VIRTUAL_APP_CSS is set to "false"', () => {
+    let originalEnv = process.env.EMBROIDER_WARN_VIRTUAL_APP_CSS;
+
+    process.env.EMBROIDER_WARN_VIRTUAL_APP_CSS = 'false';
+
+    run('<html><head><link rel="stylesheet" href="/@embroider/virtual/app.css"></head><body></body></html>', {
+      filename: 'path/to/index.html',
+      server: undefined,
+    });
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(out).to.equal('');
+
+    process.env.EMBROIDER_WARN_VIRTUAL_APP_CSS = originalEnv;
+  });
+});


### PR DESCRIPTION
Implementing https://github.com/emberjs/rfcs/pull/1148

Adds a deprecation message if still using the vitual app.css

I have no idea what branch I should target, so if not main, tell me which one 😅 