### PR TITLE
Kill the compat prebuild watcher when a vite dev server closes

### DIFF
--- a/packages/vite/src/build.ts
+++ b/packages/vite/src/build.ts
@@ -1,11 +1,17 @@
 import { fork } from 'child_process';
+import type { ChildProcess } from 'child_process';
 import type { Plugin } from 'vite';
 import { createRequire } from 'node:module';
 import { join, dirname } from 'node:path';
 
 const require = createRequire(import.meta.url);
 
-export function emberBuild(command: string, mode: string, resolvableExtensions: string[] | undefined): Promise<void> {
+export function emberBuild(
+  command: string,
+  mode: string,
+  resolvableExtensions: string[] | undefined,
+  onWatcher?: (child: ChildProcess) => void
+): Promise<void> {
   let env: Record<string, string> = {
     ...process.env,
     EMBROIDER_PREBUILD: 'true',
@@ -38,6 +44,7 @@ export function emberBuild(command: string, mode: string, resolvableExtensions: 
         env,
       }
     );
+    onWatcher?.(child);
     child.on('exit', code => (code === 0 ? resolve() : reject(new Error('ember build --watch failed'))));
     child.on('spawn', () => {
       child.stderr?.on('data', data => {
@@ -58,6 +65,7 @@ export function compatPrebuild(): Plugin {
   let viteMode: string | undefined;
   let resolvableExtensions: string[] | undefined;
   let buildPromise: Promise<void> | undefined;
+  let watcher: ChildProcess | undefined;
 
   return {
     name: 'embroider-builder',
@@ -85,8 +93,16 @@ export function compatPrebuild(): Plugin {
         throw new Error(`bug: embroider compatPrebuild did not detect Vite's mode`);
       }
 
-      buildPromise = emberBuild(viteCommand, viteMode, resolvableExtensions);
+      buildPromise = emberBuild(viteCommand, viteMode, resolvableExtensions, child => {
+        watcher = child;
+      });
       await buildPromise;
+    },
+
+    closeBundle() {
+      watcher?.kill('SIGTERM');
+      watcher = undefined;
+      buildPromise = undefined;
     },
   };
 }

--- a/packages/vite/tests/compat-prebuild.test.js
+++ b/packages/vite/tests/compat-prebuild.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// `emberBuild` resolves ember-cli relative to cwd, which is not installed for this package,
+// and forks a real long running build. Both are stubbed so the test can drive the plugin's
+// lifecycle directly.
+vi.mock('child_process', () => ({ fork: vi.fn() }));
+
+vi.mock('node:module', async importOriginal => {
+  return {
+    ...(await importOriginal()),
+    createRequire: () => ({ resolve: () => '/fake/node_modules/ember-cli/lib/cli/index.js' }),
+  };
+});
+
+const { fork } = await import('child_process');
+const { compatPrebuild } = await import('../src/build');
+
+function fakeChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+}
+
+// The watch branch resolves once the forked build reports success on stdout.
+function reportBuildSuccessful(child) {
+  child.emit('spawn');
+  child.stdout.emit('data', 'Build successful (1234ms)');
+}
+
+async function startServer(plugin, child) {
+  plugin.config({}, { command: 'serve', mode: 'development' });
+  const started = plugin.options();
+  reportBuildSuccessful(child);
+  await started;
+}
+
+describe('compatPrebuild', () => {
+  beforeEach(() => {
+    fork.mockReset();
+  });
+
+  it('terminates the prebuild watcher when the dev server closes', async () => {
+    const child = fakeChild();
+    fork.mockReturnValue(child);
+    const plugin = compatPrebuild();
+
+    await startServer(plugin, child);
+    plugin.closeBundle();
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  // Vite discards the plugin instance and builds a new one on restart. Before this fix the
+  // old watcher was never referenced again, so every restart orphaned one.
+  it('does not leave the previous watcher running across a dev server restart', async () => {
+    const first = fakeChild();
+    fork.mockReturnValue(first);
+    const firstPlugin = compatPrebuild();
+    await startServer(firstPlugin, first);
+
+    firstPlugin.closeBundle();
+
+    const second = fakeChild();
+    fork.mockReturnValue(second);
+    const secondPlugin = compatPrebuild();
+    await startServer(secondPlugin, second);
+
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(second.kill).not.toHaveBeenCalled();
+  });
+
+  it('kills nothing after a production build, which forks no watcher', async () => {
+    const child = fakeChild();
+    fork.mockReturnValue(child);
+    const plugin = compatPrebuild();
+
+    plugin.config({}, { command: 'build', mode: 'production' });
+    const built = plugin.options();
+    child.emit('exit', 0);
+    await built;
+
+    plugin.closeBundle();
+
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`compatPrebuild` forks a long lived `ember build --watch` and keeps no reference to it, so it has nothing to terminate. Vite rebuilds plugin instances when it restarts a dev server, and the new instance forks another watcher (`buildPromise` is undefined in the fresh closure) while the previous one keeps running. Every restart orphans a watcher, and each one holds a whole broccoli build resident.

Measured in an Ember monorepo with 8 vite apps: roughly 560 MB per orphan. With a `server.watch.ignored` entry that stopped ignoring `node_modules/.embroider`, which is the prebuild's own output, the restart became self feeding and reached 76 orphaned processes holding 31 GB, exhausting a 123 GB machine. Even after removing that trigger, an ordinary boot of 9 apps restarts about 4 times and leaks roughly 2 GB per `vite` start.

This stores the forked watcher and kills it in `closeBundle`, which vite calls when it tears a server down, including on restart. `vite build` forks no watcher, so it does nothing there.

Why this belongs inside the plugin: an external plugin cannot do it. A stale watcher and a freshly forked one are both `ember` children of the same vite process, and vite interleaves the teardown of the old server with the startup of the new one. I measured a plugin that reaped `ember` children killing the live watcher instead, after which editing an app source file no longer triggered a rebuild. Only the plugin instance knows which child is its own.

Tests in `packages/vite/tests/compat-prebuild.test.js` cover the close, the restart sequence (the previous watcher is killed, the replacement is left alone) and the production build case. All three fail without this change. The full `packages/vite` suite passes, `tsc -b` is clean, and prettier and eslint are clean.

The same code is present in 1.7.9.
