### PR TITLE
fix(test-setup): stop embroiderSafe/Optimized mutating shared devDependencies (stable)

### DIFF
--- a/packages/test-setup/src/index.ts
+++ b/packages/test-setup/src/index.ts
@@ -88,7 +88,9 @@ export function embroiderOptimized(extension?: object) {
 function extendScenario(scenario: object, extension?: object) {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
   let mergeWith = require('lodash/mergeWith') as typeof import('lodash/mergeWith');
-  return mergeWith(scenario, extension, appendArrays);
+  // Merge into a fresh object: `scenario.npm.devDependencies` is the shared
+  // `embroiderDevDeps`, and mergeWith writes into its first argument.
+  return mergeWith({}, scenario, extension, appendArrays);
 }
 
 function appendArrays(objValue: any, srcValue: any) {


### PR DESCRIPTION
Backport of #2789 to `stable`, as requested in https://github.com/embroider-build/embroider/pull/2789#pullrequestreview-4907874990 (test-setup on `main` is private and not released from there).

Clean cherry-pick of d7a76e3 — the diff is identical to what merged on `main`.

## The bug

`embroiderDevDeps` is a module-level object, and both `embroiderSafe` and `embroiderOptimized` hand it straight to `extendScenario` as `npm.devDependencies`. `extendScenario` calls `mergeWith(scenario, extension, appendArrays)`, which mutates its first argument and merges into *existing* nested objects — so `scenario.npm.devDependencies` **is** `embroiderDevDeps`, and every call that passes an extension permanently writes into it.

## Repro

```js
const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');

embroiderSafe({ npm: { devDependencies: { 'ember-source': 'RELEASE' } } });
embroiderSafe({ npm: { devDependencies: { 'ember-source': 'CANARY' } } });

embroiderOptimized().npm.devDependencies;
// => { '@embroider/core': …, webpack: '^5.0.0', 'ember-source': 'CANARY' }
```

A scenario created with **no extension at all** comes back carrying another scenario's `ember-source`. It fails silently: ember-try prints the scenario name you asked for while installing a different `ember-source`, so a matrix of channel scenarios can test the same version several times and still report as if it covered the range.

## The fix

Merge into a fresh object — the same idiom `maybeEmbroider` already uses for `recommendedOptions`:

```ts
return mergeWith({}, scenario, extension, appendArrays);
```

Not a problem before 4.0.0 — the dev-deps object used to be an inline literal inside each function, so it was allocated fresh per call.
