### PR TITLE
Narrow maybeCaptureNewOptimizedDep

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -269,21 +269,23 @@ async function maybeCaptureNewOptimizedDep(
   }
   let newResult = await context.resolve(target, join(jumpRoot, 'package.json'));
   if (newResult) {
-    if (idFromResult(newResult) === foundFile) {
-      // This case is normal. For example, people could be using
-      // `optimizeDeps.exclude` or they might be working in a monorepo where an
-      // addon is not in node_modules. In both cases vite will decide not to
-      // optimize the file, even though we gave it a chance to.
-      //
-      // We cache that result so we don't keep trying.
-      debug('maybeCaptureNewOptimizedDep: %s did not become an optimized dep', foundFile);
-      notViteDeps.add(foundFile);
+    let newId = idFromResult(newResult);
+    if (newId && normalize(newId).startsWith(cacheDir)) {
+      // we captured an optimized dep
+      return newResult;
     }
-
-    return newResult;
-  } else {
-    return result;
   }
+
+  // We didn't capture an optimized dep. There are many legit reasons why
+  // the dep might not acutally be optimized. For example, people could be
+  // using `optimizeDeps.exclude` or they might be working in a monorepo
+  // where an addon is not in node_modules. In both cases vite will decide
+  // not to optimize the file, even though we gave it a chance to.
+  //
+  // We cache that result so we don't keep trying.
+  debug('maybeCaptureNewOptimizedDep: %s did not become an optimized dep', foundFile);
+  notViteDeps.add(foundFile);
+  return result;
 }
 
 function buildViteJump(pkg: Package) {


### PR DESCRIPTION
This changes the logic in maybeCaptureNewOptimizedDep so that it only overrides the result when it affirmatively detects something in .vite/deps. Before, it would use whatever new resolution it found as the result.

This narrower behavior is clearer and safer in general. But it's also motivated by a case I'm seeing where rolldown is giving me wrong answers on the re-resolve during `vite build`.