### PR TITLE
Ensure rolldown wont mess with ts

### DIFF
--- a/packages/vite/src/ember.ts
+++ b/packages/vite/src/ember.ts
@@ -78,6 +78,17 @@ export function ember(params?: {
 
           config.optimizeDeps.rolldownOptions.resolve ||= {};
           config.optimizeDeps.rolldownOptions.resolve.extensions = extensions;
+
+          config.build.rolldownOptions ||= {};
+          config.build.rolldownOptions.moduleTypes ||= {};
+          if (!config.build.rolldownOptions.moduleTypes['.ts']) {
+            // tell rolldown to treat '.ts' files like '.js' files so that it
+            // doesn't apply its own (wrong) transformations to things like
+            // class field initialization. This is the `vite build` equivalent
+            // to `config.oxc = false` which we do to get the same effect in
+            // `vite dev`.
+            config.build.rolldownOptions.moduleTypes['.ts'] = 'js';
+          }
         } else {
           /**
            * Vite 7 and lower

--- a/tests/scenarios/vite-internals-test.ts
+++ b/tests/scenarios/vite-internals-test.ts
@@ -187,6 +187,33 @@ function buildViteInternalsTest(testNonColocatedTemplates: boolean, app: Project
             });
           });
         `,
+        'ts-field-test.ts': `
+          import { module, test } from "qunit";
+
+          module("Unit | ts field handling", function (hooks) {
+            test("ts class field initialzation uses expected semantics", async function (assert) {
+              class Base {
+                get thing() {
+                  return 1;
+                }
+                set thing(value) {
+                  throw new Error('setting not allowed');
+                }
+              }
+
+              class Child extends (Base as any) {
+                thing = 2;
+              }
+
+              // if our field initialzation gets implemented as Set instead of Define,
+              // this will throw. We want both vite dev and vite prod to agree that it's a
+              // Define.
+              new Child();
+              assert.ok(true);
+            });
+          });
+
+        `,
       },
       integration: {
         components: {


### PR DESCRIPTION
We don't use vite's built-in TS support because it does the wrong thing with decorators and class fields.

It was already disabled in `vite dev` via `oxc=false`, but it was still taking effect in `vite build`. This change remaps rolldowns `.ts` behavior to `js` behavior so that won't happen. (The types were already stripped, we were getting unnecessary double-typescript transpilation too.)

The test fails without this change by showing that `vite build` gets different semantics than `vite dev`.