### PR TITLE
addon-dev: read externals from ember-source's renamed-modules

### DIFF
--- a/packages/addon-dev/src/rollup-addon-dependencies.ts
+++ b/packages/addon-dev/src/rollup-addon-dependencies.ts
@@ -1,5 +1,7 @@
 import type { Plugin } from 'rollup';
 import { readJsonSync } from 'fs-extra';
+import { createRequire } from 'module';
+import { join } from 'path';
 import {
   emberVirtualPackages,
   emberVirtualPeerDeps,
@@ -27,8 +29,37 @@ function resolvableDependencies(): Set<string> {
   return deps;
 }
 
+// ember-source declares the modules it provides in ember-addon.renamed-modules,
+// so reading it stays in sync with modules added in newer ember-source releases
+// that the static emberVirtualPackages list doesn't know about yet.
+function emberSourceProvidedPackages(): {
+  packages: Set<string>;
+  packageJsonPath: string | undefined;
+} {
+  let packages = new Set<string>();
+  let packageJsonPath: string | undefined;
+  try {
+    let require = createRequire(join(process.cwd(), 'package.json'));
+    packageJsonPath = require.resolve('ember-source/package.json');
+  } catch (err) {
+    // ember-source is always external, so it's not guaranteed to be installed
+    // where an addon builds. The static lists still cover that case.
+    return { packages, packageJsonPath };
+  }
+  let renamedModules =
+    readJsonSync(packageJsonPath)['ember-addon']?.['renamed-modules'] ?? {};
+  for (let moduleName of Object.keys(renamedModules)) {
+    let name = packageName(moduleName);
+    if (name) {
+      packages.add(name);
+    }
+  }
+  return { packages, packageJsonPath };
+}
+
 export default function emberExternals(): Plugin {
   let deps: Set<string>;
+  let emberProvided: Set<string>;
 
   return {
     name: 'ember-externals',
@@ -36,6 +67,11 @@ export default function emberExternals(): Plugin {
     buildStart() {
       this.addWatchFile('package.json');
       deps = resolvableDependencies();
+      let emberSource = emberSourceProvidedPackages();
+      emberProvided = emberSource.packages;
+      if (emberSource.packageJsonPath) {
+        this.addWatchFile(emberSource.packageJsonPath);
+      }
     },
 
     async resolveId(source) {
@@ -48,6 +84,7 @@ export default function emberExternals(): Plugin {
 
       if (
         deps.has(pkgName) ||
+        emberProvided.has(pkgName) ||
         emberVirtualPeerDeps.has(pkgName) ||
         emberVirtualPackages.has(pkgName) ||
         compilationModules.has(pkgName)

--- a/packages/addon-dev/tests/dependencies.test.ts
+++ b/packages/addon-dev/tests/dependencies.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, afterEach, expect } from 'vitest';
+
+import dependencies from '../src/rollup-addon-dependencies';
+import { Project } from 'scenario-tester';
+import { rollup } from 'rollup';
+import { readFile } from 'fs-extra';
+import { join } from 'path';
+
+function emberSourceWithRenamedModules(): Project {
+  let emberSource = new Project('ember-source', '7.3.0');
+  emberSource.pkg['ember-addon'] = {
+    version: 2,
+    type: 'addon',
+    'renamed-modules': {
+      '@ember/reactive/index.js': 'ember-source/@ember/reactive/index.js',
+      '@ember/reactive/collections.js':
+        'ember-source/@ember/reactive/collections.js',
+    },
+  };
+  return emberSource;
+}
+
+async function generateProject(src: {}): Promise<Project> {
+  const project = new Project('my-addon', {
+    files: {
+      src,
+    },
+  });
+
+  return project;
+}
+
+async function runRollup(dir: string, rollupOptions = {}) {
+  const currentDir = process.cwd();
+  process.chdir(dir);
+
+  try {
+    const bundle = await rollup({
+      input: './src/index.js',
+      plugins: [dependencies()],
+      ...rollupOptions,
+      onLog(level, log, defaultLog) {
+        if (['warn'].includes(level)) {
+          expect(log).toBe("we don't want warnings");
+        }
+
+        defaultLog(level, log);
+      },
+    });
+
+    await bundle.write({ format: 'esm', dir: 'dist' });
+  } finally {
+    process.chdir(currentDir);
+  }
+}
+
+describe('dependencies', function () {
+  let project: Project | null;
+
+  afterEach(() => {
+    project?.dispose();
+    project = null;
+  });
+
+  test('it works without imports', async function () {
+    project = await generateProject({
+      'index.js': 'export default 123',
+    });
+    await project.write();
+
+    await runRollup(project.baseDir);
+
+    expect(
+      await readFile(join(project.baseDir, 'dist/index.js'), {
+        encoding: 'utf8',
+      })
+    ).toContain('default');
+  });
+
+  test('modules from ember-source renamed-modules stay external', async function () {
+    project = await generateProject({
+      'index.js': `
+        import { trackedObject } from '@ember/reactive/collections';
+
+        export const state = trackedObject();
+      `,
+    });
+    project.addDevDependency(emberSourceWithRenamedModules());
+    await project.write();
+
+    await runRollup(project.baseDir);
+
+    const output = await readFile(join(project.baseDir, 'dist/index.js'), {
+      encoding: 'utf8',
+    });
+
+    expect(output).toContain(`from '@ember/reactive/collections'`);
+  });
+
+  test('static virtual packages stay external without ember-source', async function () {
+    project = await generateProject({
+      'index.js': `
+        import { getOwner } from '@ember/owner';
+
+        export const owner = getOwner({});
+      `,
+    });
+    await project.write();
+
+    await runRollup(project.baseDir);
+
+    const output = await readFile(join(project.baseDir, 'dist/index.js'), {
+      encoding: 'utf8',
+    });
+
+    expect(output).toContain(`from '@ember/owner'`);
+  });
+});


### PR DESCRIPTION
`addon.dependencies()` now marks a package as external when ember-source lists it in `ember-addon.renamed-modules`. The static `emberVirtualPackages` list stays as the fallback, so nothing changes for addons that build without ember-source installed.

This removes the rollup warning for modules newer than the static list:

```
(!) Unresolved dependencies
@ember/reactive/collections (imported by "src/services/known-modules.ts")
@ember/reactive (imported by "src/services/known-modules.ts")
```

## How it works

At `buildStart`, the plugin resolves `ember-source/package.json` from the addon's working directory. If found, every package name derived from the `renamed-modules` keys joins the external check, and the file joins rollup's watch list. If ember-source is not resolvable, the plugin behaves exactly as before.

## Context

#2655 and #2704 added `@ember/reactive` to the static list. #2704's description already named this approach as the original goal, with the concern that ember-source may be absent at addon build time. The opportunistic resolve plus static fallback answers that concern, and no list update is needed for future ember-source modules.

This change does not touch `ember-standard-modules.ts`, so classic-build behavior is unaffected (the failure mode that stopped #2655).

## Testing

- New unit tests in `packages/addon-dev/tests/dependencies.test.ts`: a fake ember-source with `renamed-modules` gets its modules externalized with zero rollup warnings, and the static list still applies when ember-source is absent.
- Verified against a real addon (`ember-repl` in NullVoxPopuli/limber, ember-source 7.x alpha): the warning disappears and the `@ember/reactive` imports stay intact in `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
