### PR TITLE
Don't reload virtual modules on file content changes

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -117,7 +117,18 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
 
     configureServer(s) {
       server = s;
-      server.watcher.on('all', (_eventName, path) => {
+      server.watcher.on('all', (eventName, path) => {
+        // The virtual modules that register `watches` (the app/engine
+        // entrypoint and template-only-component shims) derive their contents
+        // purely from *which* files exist under the watched paths, never from
+        // those files' contents. So only add/unlink events can invalidate
+        // them. A plain 'change' event cannot, and reloading the virtual
+        // module for it forces a redundant full page reload -- most visibly on
+        // every stylesheet edit, where it pre-empts Vite's own CSS HMR. Let
+        // Vite's module graph handle content changes.
+        if (eventName === 'change') {
+          return;
+        }
         for (let [id, watches] of virtualDeps) {
           for (let watch of watches) {
             if (path.startsWith(watch)) {


### PR DESCRIPTION
## Problem

With `@embroider/vite` in dev, **every stylesheet edit triggers a full page reload** instead of a hot style update. In an app whose CSS is imported for side effects from `app/app.js` (e.g. `import './app.css'`, or a Sass entry via `vite.config` `css.preprocessorOptions`), that module is a self-accepting CSS module and Vite *does* emit a clean `hmr update` for it — but a full-reload lands on top of it every time:

```
file changed app/styles/_header.scss
[vite] (client) page reload /app/-embroider-entrypoint.js   <- unwanted
[vite] (client) hmr update /app/styles/app.css              <- what should happen alone
```

## Cause

`configureServer` in `packages/vite/src/resolver.ts` installs a watcher that reloads **every** virtual module whose `watches` paths contain the changed file, on **any** watcher event:

```ts
server.watcher.on('all', (_eventName, path) => {
  for (let [id, watches] of virtualDeps) {
    for (let watch of watches) {
      if (path.startsWith(watch)) {
        server.moduleGraph.onFileChange(id);
        let m = server.moduleGraph.getModuleById(id);
        if (m) server.reloadModule(m);
      }
    }
  }
});
```

The only virtual modules that register a non-empty `watches`:

- **the app / engine entrypoint** (`virtual-entrypoint.ts` → `watches: [fromDir]`) — its source is a list of `import`s produced by globbing `fromDir`
- **template-only-component shims** (`virtual-content.ts` → `watches: [specifier, hbs?]`) — its source is the constant `templateOnlyComponentSource()`

Both derive their output purely from **which files exist**, never from file *contents*. So only `add` / `unlink` events can invalidate them. A plain `change` event cannot change what they generate — but the watcher still calls `server.reloadModule` on the entrypoint, which has no HMR boundary, so it escalates to a full page reload.

Stylesheets are just the most visible victim (they live under the app dir, so they're inside the entrypoint's watch, and Vite otherwise HMRs them cleanly). Editing a component `.js`/`.hbs` hits the same redundant entrypoint reload — it's only less noticeable there because the end result is a full reload either way.

## Fix

Ignore `change` events in that watcher; keep reacting to `add` / `unlink` (and dir variants), which is what actually affects virtual-module output. Vite's own module graph already handles content changes — CSS HMR, JS reload, and template handling via the hbs plugin / `ember-vite-hmr`.

## Verification

Tested against a real app (Ember 6.8, Embroider core 4.6 / vite 1.7.10, Vite 8):

| edit | before | after |
|---|---|---|
| `app/styles/_header.scss` (content) | full page reload | `hmr update` only, no reload ✅ |
| `app/services/foo.js` (content) | full page reload | full page reload (unchanged) ✅ |
| add `app/components/probe.js` | entrypoint reload | entrypoint reload (still picked up) ✅ |
| delete `app/components/probe.js` | entrypoint reload | entrypoint reload (still picked up) ✅ |

Happy to add a scenario test if you can point me at the right harness — I didn't find existing coverage for the dev-server watcher / HMR behavior under `tests/scenarios/vite-*`.
