### PR TITLE
Fix eager importSync pattern support

### DIFF
--- a/packages/macros/.gitignore
+++ b/packages/macros/.gitignore
@@ -5,6 +5,8 @@
 /tests/**/*.js
 /tests/**/*.d.ts
 /tests/**/*.map
+# test fixtures are checked in, they're not compiler output
+!/tests/**/fixtures/**
 !/src/vendor/*.js
 !/src/addon/*.js
 /tsconfig.tsbuildinfo

--- a/packages/macros/README.md
+++ b/packages/macros/README.md
@@ -159,6 +159,35 @@ let foo = importSync('foo');
 let foo = require('foo');
 ```
 
+#### dynamic paths
+
+`importSync` also accepts a template literal with interpolations, as long as the
+directory part of the path is a relative path that's known at build time:
+
+```js
+import { importSync } from '@embroider/macros';
+
+let mod = importSync(`./results/${type}-result`);
+```
+
+The macro reads that directory at build time and expands the call into a lookup
+over its contents, so the above compiles to something like:
+
+```js
+let mod = {
+  'fact-result': esc(_factResult),
+  'task-result': esc(_taskResult),
+}[`${type}-result`];
+```
+
+Only the entries that the pattern could actually select are included. A file
+extension on the pattern is optional and ignored — `./results/${type}-result.js`
+behaves identically to `./results/${type}-result`.
+
+The interpolations must stay within a single path segment. A pattern like
+`./results/${dir}/${type}` is a build error, because the directory to read isn't
+known until runtime.
+
 #### hint
 
 When using `importSync` on non ember-addon packages both the package being imported from *and* `ember-auto-import` *must* be in the `dependencies` of your addons `package.json`.

--- a/packages/macros/src/babel/import-sync-pattern.ts
+++ b/packages/macros/src/babel/import-sync-pattern.ts
@@ -1,0 +1,183 @@
+import type * as Babel from '@babel/core';
+import type { types as t } from '@babel/core';
+
+type Types = typeof Babel.types;
+
+/*
+  Support for `importSync` with a dynamic path, like:
+
+     importSync(`../components/results/${type}-result`)
+
+  In eager mode we can't do a truly dynamic import, so we expand the call into a
+  lookup table over the real contents of the directory. To do that correctly we
+  need to understand the *whole* pattern, not just the part before the first
+  interpolation.
+*/
+
+export type PatternPart = { type: 'static'; value: string } | { type: 'dynamic'; value: t.Expression };
+
+// A parsed `importSync` specifier: the statically-known directory that we will
+// read, plus the pattern that filenames within it must match.
+export interface ParsedSpecifier {
+  // always ends in "/", always starts with "." (we only support relative paths)
+  dir: string;
+  // the filename pattern, with the file extension (if any) already removed, so
+  // it lines up with the extension-less keys we put in the lookup table
+  pattern: PatternPart[];
+}
+
+// Turns a specifier expression into a flat list of static and dynamic parts.
+// Returns undefined if this isn't a shape we understand.
+export function patternParts(types: Types, specifier: t.Node): PatternPart[] | undefined {
+  if (specifier.type === 'TemplateLiteral') {
+    let parts: PatternPart[] = [];
+    for (let [index, quasi] of specifier.quasis.entries()) {
+      parts.push({ type: 'static', value: quasi.value.cooked! });
+      let expression = specifier.expressions[index];
+      if (expression) {
+        if (!types.isExpression(expression)) {
+          return undefined;
+        }
+        parts.push({ type: 'dynamic', value: expression });
+      }
+    }
+    return normalize(parts);
+  }
+
+  // babel might transform the template form `../my-path/${id}` into
+  // '../my-path/'.concat(id)
+  if (
+    specifier.type === 'CallExpression' &&
+    specifier.callee.type === 'MemberExpression' &&
+    specifier.callee.property.type === 'Identifier' &&
+    specifier.callee.property.name === 'concat' &&
+    specifier.callee.object.type === 'StringLiteral'
+  ) {
+    let parts: PatternPart[] = [{ type: 'static', value: specifier.callee.object.value }];
+    for (let arg of specifier.arguments) {
+      if (arg.type === 'StringLiteral') {
+        parts.push({ type: 'static', value: arg.value });
+      } else if (types.isExpression(arg)) {
+        parts.push({ type: 'dynamic', value: arg });
+      } else {
+        return undefined;
+      }
+    }
+    return normalize(parts);
+  }
+
+  return undefined;
+}
+
+// merges adjacent static parts and drops empty ones, so that the rest of the
+// code can assume statics are maximal and non-empty
+function normalize(parts: PatternPart[]): PatternPart[] {
+  let output: PatternPart[] = [];
+  for (let part of parts) {
+    if (part.type === 'static') {
+      if (part.value === '') {
+        continue;
+      }
+      let previous = output[output.length - 1];
+      if (previous?.type === 'static') {
+        output[output.length - 1] = { type: 'static', value: previous.value + part.value };
+        continue;
+      }
+    }
+    output.push(part);
+  }
+  return output;
+}
+
+// Splits the parts into the directory we're going to read and the pattern that
+// entries in it need to match. Returns undefined when the parts don't describe
+// a relative path with a statically-known directory.
+export function parseSpecifier(parts: PatternPart[]): ParsedSpecifier | undefined {
+  let first = parts[0];
+  if (first?.type !== 'static' || !first.value.startsWith('.')) {
+    return undefined;
+  }
+  let slash = first.value.lastIndexOf('/');
+  if (slash === -1) {
+    return undefined;
+  }
+  let dir = first.value.slice(0, slash + 1);
+  let head = first.value.slice(slash + 1);
+  let pattern = normalize([{ type: 'static', value: head }, ...parts.slice(1)]);
+
+  // The directory we read is only one level deep, so a "/" anywhere later in
+  // the pattern could never match one of its entries.
+  if (pattern.some(part => part.type === 'static' && part.value.includes('/'))) {
+    return undefined;
+  }
+
+  return { dir, pattern: withoutExtension(pattern) };
+}
+
+// The lookup table is keyed by extension-less filenames, because that's what we
+// hand to the resolver. So if the author wrote the extension (which is what
+// Vite's own dynamic import rules ask for) we drop it from the pattern too.
+function withoutExtension(pattern: PatternPart[]): PatternPart[] {
+  let last = pattern[pattern.length - 1];
+  if (last?.type !== 'static') {
+    return pattern;
+  }
+  let stripped = last.value.replace(/\.\w+$/, '');
+  if (stripped === last.value) {
+    return pattern;
+  }
+  return normalize([...pattern.slice(0, -1), { type: 'static', value: stripped }]);
+}
+
+// The key we use for a directory entry: its name minus the file extension.
+export function entryKey(entry: string): string {
+  let dot = entry.lastIndexOf('.');
+  return dot === -1 ? entry : entry.slice(0, dot);
+}
+
+// Which keys could this pattern actually select? Everything else in the
+// directory would be dead weight in the bundle.
+export function patternMatcher(pattern: PatternPart[]): (key: string) => boolean {
+  let source =
+    '^' + pattern.map(part => (part.type === 'static' ? escapeRegExp(part.value) : '[\\s\\S]*')).join('') + '$';
+  let regex = new RegExp(source);
+  return key => regex.test(key);
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Builds the expression we use to index into the lookup table. When the pattern
+// is a single interpolation (the only shape that used to work) this is just that
+// expression, so existing call sites compile to byte-identical output.
+export function lookupExpression(types: Types, pattern: PatternPart[]): t.Expression {
+  if (pattern.length === 1 && pattern[0].type === 'dynamic') {
+    return pattern[0].value;
+  }
+  let quasis: t.TemplateElement[] = [];
+  let expressions: t.Expression[] = [];
+  let pending = '';
+  for (let part of pattern) {
+    if (part.type === 'static') {
+      pending += part.value;
+    } else {
+      quasis.push(types.templateElement({ raw: escapeTemplate(pending), cooked: pending }));
+      pending = '';
+      expressions.push(part.value);
+    }
+  }
+  quasis.push(types.templateElement({ raw: escapeTemplate(pending), cooked: pending }, true));
+  return types.templateLiteral(quasis, expressions);
+}
+
+function escapeTemplate(str: string): string {
+  return str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+
+// path.join() will strip a leading "./", which would turn our relative path
+// into a bare package specifier.
+export function relativeSpecifier(path: string): string {
+  let normalized = path.replace(/\\/g, '/');
+  return normalized.startsWith('.') ? normalized : './' + normalized;
+}

--- a/packages/macros/src/babel/macros-babel-plugin.ts
+++ b/packages/macros/src/babel/macros-babel-plugin.ts
@@ -12,6 +12,14 @@ import failBuild from './fail-build';
 import { Evaluator, buildLiterals } from './evaluate-json';
 import type * as Babel from '@babel/core';
 import { existsSync, readdirSync } from 'fs';
+import {
+  entryKey,
+  lookupExpression,
+  parseSpecifier,
+  patternMatcher,
+  patternParts,
+  relativeSpecifier,
+} from './import-sync-pattern';
 import { resolve, dirname, join } from 'path';
 
 export default function main(context: typeof Babel): unknown {
@@ -166,57 +174,59 @@ export default function main(context: typeof Babel): unknown {
         if (callee.referencesImport('@embroider/macros', 'importSync')) {
           if (state.opts.importSyncImplementation === 'eager') {
             let specifier = path.node.arguments[0];
-            if (specifier?.type !== 'StringLiteral') {
-              let relativePath = '';
-              let property;
-              if (specifier.type === 'TemplateLiteral') {
-                relativePath = specifier.quasis[0].value.cooked!;
-                property = specifier.expressions[0] as t.Expression;
-              }
-              // babel might transform template form `../my-path/${id}` to '../my-path/'.concat(id)
-              if (
-                specifier.type === 'CallExpression' &&
-                specifier.callee.type === 'MemberExpression' &&
-                specifier.callee.property.type === 'Identifier' &&
-                specifier.callee.property.name === 'concat' &&
-                specifier.callee.object.type === 'StringLiteral'
-              ) {
-                relativePath = specifier.callee.object.value;
-                property = specifier.arguments[0] as t.Expression;
-              }
-              if (property && relativePath && relativePath.startsWith('.')) {
-                const resolvedPath = resolve(dirname((state as any).filename), relativePath);
+            let target: string | undefined;
+            if (specifier?.type === 'StringLiteral') {
+              target = specifier.value;
+            } else {
+              let parts = specifier ? patternParts(t, specifier) : undefined;
+              if (parts && parts.length > 0 && parts.every(part => part.type === 'static')) {
+                // a template literal that has no interpolations at all is just
+                // a string, so treat it like one
+                target = parts.map(part => (part.type === 'static' ? part.value : '')).join('');
+              } else {
+                let parsed = parts ? parseSpecifier(parts) : undefined;
+                if (!parsed) {
+                  throw new Error(
+                    `importSync eager mode only supports dynamic paths which are relative, must start with a '.', had ${specifier?.type}`
+                  );
+                }
+                const { dir, pattern } = parsed;
+                const resolvedPath = resolve(dirname((state as any).filename), dir);
                 let entries: string[] = [];
                 if (existsSync(resolvedPath)) {
                   entries = readdirSync(resolvedPath).filter(e => !e.startsWith('.'));
                 }
-                const obj = t.objectExpression(
-                  entries.map(e => {
-                    let key = e.split('.')[0];
-                    const rest = e.split('.').slice(1, -1);
-                    if (rest.length) {
-                      key += `.${rest}`;
-                    }
-                    const id = t.callExpression(
-                      state.importUtil.import(path, state.pathToOurAddon('es-compat2'), 'default', 'esc'),
-                      [state.importUtil.import(path, join(relativePath, key).replace(/\\/g, '/'), '*')]
-                    );
-                    return t.objectProperty(t.stringLiteral(key), id);
-                  })
+                const matches = patternMatcher(pattern);
+                const seen = new Set<string>();
+                const properties: t.ObjectProperty[] = [];
+                for (const entry of entries) {
+                  const key = entryKey(entry);
+                  // entries that the pattern could never select would just bloat
+                  // the bundle, and files that differ only by extension collapse
+                  // to the same key (and the same extension-less import)
+                  if (!matches(key) || seen.has(key)) {
+                    continue;
+                  }
+                  seen.add(key);
+                  const id = t.callExpression(
+                    state.importUtil.import(path, state.pathToOurAddon('es-compat2'), 'default', 'esc'),
+                    [state.importUtil.import(path, relativeSpecifier(join(dir, key)), '*')]
+                  );
+                  properties.push(t.objectProperty(t.stringLiteral(key), id));
+                }
+                const memberExpr = t.memberExpression(
+                  t.objectExpression(properties),
+                  lookupExpression(t, pattern),
+                  true
                 );
-                const memberExpr = t.memberExpression(obj, property, true);
                 path.replaceWith(memberExpr);
                 state.calledIdentifiers.add(callee.node);
                 return;
-              } else {
-                throw new Error(
-                  `importSync eager mode only supports dynamic paths which are relative, must start with a '.', had ${specifier.type}`
-                );
               }
             }
             path.replaceWith(
               t.callExpression(state.importUtil.import(path, state.pathToOurAddon('es-compat2'), 'default', 'esc'), [
-                state.importUtil.import(path, specifier.value, '*'),
+                state.importUtil.import(path, target, '*'),
               ])
             );
             state.calledIdentifiers.add(callee.node);

--- a/packages/macros/tests/babel/__snapshots__/import-sync.test.ts.snap
+++ b/packages/macros/tests/babel/__snapshots__/import-sync.test.ts.snap
@@ -1,55 +1,93 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`importSync > with presets > babel7 > importSync accepts template argument with dynamic part 1`] = `
-"function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
-function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
-function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
-function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
-import esc from "../../src/addon/es-compat2";
-import * as _importSync20 from "../../README";
-import * as _importSync40 from "../../node_modules";
-import * as _importSync60 from "../../package";
-import * as _importSync80 from "../../smoke-test";
-import * as _importSync00 from "../../src";
-import * as _importSync100 from "../../tests";
-import * as _importSync120 from "../../tsconfig";
-import * as _importSync140 from "../../tsconfig";
-import * as _importSync160 from "../../vitest.config";
+"import esc from "../../src/addon/es-compat2";
+import * as _importSync20 from "./fixtures/results/chart-result";
+import * as _importSync40 from "./fixtures/results/fact-result";
+import * as _importSync60 from "./fixtures/results/helper";
+import * as _importSync80 from "./fixtures/results/pre-alpha";
+import * as _importSync00 from "./fixtures/results/pre-beta";
+import * as _importSync100 from "./fixtures/results/task-result";
 function getFile(file) {
-  return _defineProperty(_defineProperty({
-    "README": esc(_importSync20),
-    "node_modules": esc(_importSync40),
-    "package": esc(_importSync60),
-    "smoke-test": esc(_importSync80),
-    "src": esc(_importSync00),
-    "tests": esc(_importSync100),
-    "tsconfig": esc(_importSync120)
-  }, "tsconfig", esc(_importSync140)), "vitest.config", esc(_importSync160))[file].default;
+  return {
+    "chart-result": esc(_importSync20),
+    "fact-result": esc(_importSync40),
+    "helper": esc(_importSync60),
+    "pre-alpha": esc(_importSync80),
+    "pre-beta": esc(_importSync00),
+    "task-result": esc(_importSync100)
+  }[file].default;
+}"
+`;
+
+exports[`importSync > with presets > babel7 > importSync template argument keeps static text after the interpolation 1`] = `
+"import esc from "../../src/addon/es-compat2";
+import * as _importSync20 from "./fixtures/results/chart-result";
+import * as _importSync40 from "./fixtures/results/fact-result";
+import * as _importSync60 from "./fixtures/results/task-result";
+function getResult(type) {
+  return {
+    "chart-result": esc(_importSync20),
+    "fact-result": esc(_importSync40),
+    "task-result": esc(_importSync60)
+  }["".concat(type, "-result")].default;
+}"
+`;
+
+exports[`importSync > with presets > babel7 > importSync template argument supports static text before the interpolation 1`] = `
+"import esc from "../../src/addon/es-compat2";
+import * as _importSync20 from "./fixtures/results/pre-alpha";
+import * as _importSync40 from "./fixtures/results/pre-beta";
+function getPre(name) {
+  return {
+    "pre-alpha": esc(_importSync20),
+    "pre-beta": esc(_importSync40)
+  }["pre-".concat(name)].default;
 }"
 `;
 
 exports[`importSync > without presets > babel7 > importSync accepts template argument with dynamic part 1`] = `
 "import esc from "../../src/addon/es-compat2";
-import * as _importSync20 from "../../README";
-import * as _importSync40 from "../../node_modules";
-import * as _importSync60 from "../../package";
-import * as _importSync80 from "../../smoke-test";
-import * as _importSync00 from "../../src";
-import * as _importSync100 from "../../tests";
-import * as _importSync120 from "../../tsconfig";
-import * as _importSync140 from "../../tsconfig";
-import * as _importSync160 from "../../vitest.config";
+import * as _importSync20 from "./fixtures/results/chart-result";
+import * as _importSync40 from "./fixtures/results/fact-result";
+import * as _importSync60 from "./fixtures/results/helper";
+import * as _importSync80 from "./fixtures/results/pre-alpha";
+import * as _importSync00 from "./fixtures/results/pre-beta";
+import * as _importSync100 from "./fixtures/results/task-result";
 function getFile(file) {
   return {
-    "README": esc(_importSync20),
-    "node_modules": esc(_importSync40),
-    "package": esc(_importSync60),
-    "smoke-test": esc(_importSync80),
-    "src": esc(_importSync00),
-    "tests": esc(_importSync100),
-    "tsconfig": esc(_importSync120),
-    "tsconfig": esc(_importSync140),
-    "vitest.config": esc(_importSync160)
+    "chart-result": esc(_importSync20),
+    "fact-result": esc(_importSync40),
+    "helper": esc(_importSync60),
+    "pre-alpha": esc(_importSync80),
+    "pre-beta": esc(_importSync00),
+    "task-result": esc(_importSync100)
   }[file].default;
+}"
+`;
+
+exports[`importSync > without presets > babel7 > importSync template argument keeps static text after the interpolation 1`] = `
+"import esc from "../../src/addon/es-compat2";
+import * as _importSync20 from "./fixtures/results/chart-result";
+import * as _importSync40 from "./fixtures/results/fact-result";
+import * as _importSync60 from "./fixtures/results/task-result";
+function getResult(type) {
+  return {
+    "chart-result": esc(_importSync20),
+    "fact-result": esc(_importSync40),
+    "task-result": esc(_importSync60)
+  }[\`\${type}-result\`].default;
+}"
+`;
+
+exports[`importSync > without presets > babel7 > importSync template argument supports static text before the interpolation 1`] = `
+"import esc from "../../src/addon/es-compat2";
+import * as _importSync20 from "./fixtures/results/pre-alpha";
+import * as _importSync40 from "./fixtures/results/pre-beta";
+function getPre(name) {
+  return {
+    "pre-alpha": esc(_importSync20),
+    "pre-beta": esc(_importSync40)
+  }[\`pre-\${name}\`].default;
 }"
 `;

--- a/packages/macros/tests/babel/fixtures/results/chart-result.hbs
+++ b/packages/macros/tests/babel/fixtures/results/chart-result.hbs
@@ -1,0 +1,1 @@
+{{! chart-result }}

--- a/packages/macros/tests/babel/fixtures/results/chart-result.js
+++ b/packages/macros/tests/babel/fixtures/results/chart-result.js
@@ -1,0 +1,1 @@
+export default 'chart-result';

--- a/packages/macros/tests/babel/fixtures/results/fact-result.js
+++ b/packages/macros/tests/babel/fixtures/results/fact-result.js
@@ -1,0 +1,1 @@
+export default 'fact-result';

--- a/packages/macros/tests/babel/fixtures/results/helper.js
+++ b/packages/macros/tests/babel/fixtures/results/helper.js
@@ -1,0 +1,1 @@
+export default 'helper';

--- a/packages/macros/tests/babel/fixtures/results/pre-alpha.js
+++ b/packages/macros/tests/babel/fixtures/results/pre-alpha.js
@@ -1,0 +1,1 @@
+export default 'pre-alpha';

--- a/packages/macros/tests/babel/fixtures/results/pre-beta.js
+++ b/packages/macros/tests/babel/fixtures/results/pre-beta.js
@@ -1,0 +1,1 @@
+export default 'pre-beta';

--- a/packages/macros/tests/babel/fixtures/results/task-result.js
+++ b/packages/macros/tests/babel/fixtures/results/task-result.js
@@ -1,0 +1,1 @@
+export default 'task-result';

--- a/packages/macros/tests/babel/import-sync.test.ts
+++ b/packages/macros/tests/babel/import-sync.test.ts
@@ -1,8 +1,14 @@
 import { allBabelVersions } from './helpers';
+import type { Transform } from '@embroider/test-support';
 import type { MacrosConfig } from '../../src/node';
 
+// the keys of the object literal that importSync's eager mode expands to
+function lookupKeys(code: string): string[] {
+  return [...code.matchAll(/"([^"]+)": esc\(/g)].map(m => m[1]);
+}
+
 describe('importSync', function () {
-  allBabelVersions(function createTests(transform: (code: string) => string, config: MacrosConfig) {
+  allBabelVersions(function createTests(transform: Transform, config: MacrosConfig) {
     config.setOwnConfig(__filename, { target: 'my-plugin' });
     config.importSyncImplementation = 'eager';
     config.finalize();
@@ -58,10 +64,106 @@ describe('importSync', function () {
       let code = transform(`
       import { importSync } from '@embroider/macros';
       function getFile(file) {
-        return importSync(\`../../\${file}\`).default;
+        return importSync(\`./fixtures/results/\${file}\`).default;
       }
       `);
+      expect(lookupKeys(code)).toEqual([
+        'chart-result',
+        'fact-result',
+        'helper',
+        'pre-alpha',
+        'pre-beta',
+        'task-result',
+      ]);
+      // a bare interpolation indexes with the expression itself, exactly as it
+      // did before we understood the rest of the pattern
+      expect(code).toMatch(/\}\[file\]\.default/);
       expect(code).toMatchSnapshot();
+    });
+    test('importSync template argument keeps static text after the interpolation', () => {
+      let code = transform(`
+      import { importSync } from '@embroider/macros';
+      function getResult(type) {
+        return importSync(\`./fixtures/results/\${type}-result\`).default;
+      }
+      `);
+      // only the entries the pattern can actually select
+      expect(lookupKeys(code)).toEqual(['chart-result', 'fact-result', 'task-result']);
+      expect(code).toMatchSnapshot();
+    });
+    test('importSync template argument tolerates a file extension', () => {
+      let withExtension = transform(`
+      import { importSync } from '@embroider/macros';
+      function getResult(type) {
+        return importSync(\`./fixtures/results/\${type}-result.js\`).default;
+      }
+      `);
+      let withoutExtension = transform(`
+      import { importSync } from '@embroider/macros';
+      function getResult(type) {
+        return importSync(\`./fixtures/results/\${type}-result\`).default;
+      }
+      `);
+      expect(withExtension).toEqual(withoutExtension);
+    });
+    test('importSync template argument supports static text before the interpolation', () => {
+      let code = transform(`
+      import { importSync } from '@embroider/macros';
+      function getPre(name) {
+        return importSync(\`./fixtures/results/pre-\${name}\`).default;
+      }
+      `);
+      expect(lookupKeys(code)).toEqual(['pre-alpha', 'pre-beta']);
+      expect(code).toMatchSnapshot();
+    });
+    test('importSync collapses entries that differ only by extension', () => {
+      let code = transform(`
+      import { importSync } from '@embroider/macros';
+      function getChart(name) {
+        return importSync(\`./fixtures/results/chart-\${name}\`).default;
+      }
+      `);
+      // chart-result.hbs and chart-result.js are colocated, and both resolve
+      // through the same extension-less import
+      expect(lookupKeys(code)).toEqual(['chart-result']);
+      expect(code).toMatch(/from "\.\/fixtures\/results\/chart-result"/);
+    });
+    test('importSync accepts a concat expression with trailing static text', () => {
+      let code = transform(`
+      import { importSync } from '@embroider/macros';
+      function getResult(type) {
+        return importSync("./fixtures/results/".concat(type, "-result")).default;
+      }
+      `);
+      expect(lookupKeys(code)).toEqual(['chart-result', 'fact-result', 'task-result']);
+    });
+    test('importSync accepts a template literal with no interpolations', () => {
+      let code = transform(`
+      import { importSync } from '@embroider/macros';
+      importSync(\`foo\`);
+      `);
+      expect(code).toMatch(/import \* as _importSync\d* from "foo"/);
+      expect(code).toMatch(/esc\(_importSync\d*\);/);
+    });
+    test('importSync rejects a directory that is not statically known', () => {
+      expect(() => {
+        transform(`
+        import { importSync } from '@embroider/macros';
+        function getResult(dir, type) {
+          return importSync(\`./fixtures/\${dir}/\${type}-result\`).default;
+        }
+        `);
+      }).toThrow(/importSync eager mode only supports dynamic paths which are relative/);
+    });
+    test('importSync rejects a non-relative dynamic path', () => {
+      expect(() => {
+        transform(`
+        import { importSync } from '@embroider/macros';
+        function getResult(type) {
+          return importSync(\`some-package/results/\${type}\`).default;
+        }
+        `);
+      }).toThrow(/importSync eager mode only supports dynamic paths which are relative/);
     });
   });
 });


### PR DESCRIPTION
Previously, importSync in eager mode only supported patterns that end with the first interpolation. It would only use quasis[0] and expressions[0], ignoring the rest. This was a gap because non-eager mode (supported under Embroider 3.x) supported more complex patterns correctly.

This PR brings eager mode up to full compatibility.