### PR TITLE
Don't reload virtual modules on file content changes

### DIFF
--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -117,7 +117,18 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
 
     configureServer(s) {
       server = s;
-      server.watcher.on('all', (_eventName, path) => {
+      server.watcher.on('all', (eventName, path) => {
+        // The virtual modules that register `watches` (the app/engine
+        // entrypoint and template-only-component shims) derive their contents
+        // purely from *which* files exist under the watched paths, never from
+        // those files' contents. So only add/unlink events can invalidate
+        // them. A plain 'change' event cannot, and reloading the virtual
+        // module for it forces a redundant full page reload -- most visibly on
+        // every stylesheet edit, where it pre-empts Vite's own CSS HMR. Let
+        // Vite's module graph handle content changes.
+        if (eventName === 'change') {
+          return;
+        }
         for (let [id, watches] of virtualDeps) {
           for (let watch of watches) {
             if (path.startsWith(watch)) {

--- a/packages/vite/src/resolver.ts
+++ b/packages/vite/src/resolver.ts
@@ -121,12 +121,19 @@ export function resolver(params?: { rolldown?: boolean }): Plugin {
         // The virtual modules that register `watches` (the app/engine
         // entrypoint and template-only-component shims) derive their contents
         // purely from *which* files exist under the watched paths, never from
-        // those files' contents. So only add/unlink events can invalidate
-        // them. A plain 'change' event cannot, and reloading the virtual
-        // module for it forces a redundant full page reload -- most visibly on
-        // every stylesheet edit, where it pre-empts Vite's own CSS HMR. Let
-        // Vite's module graph handle content changes.
-        if (eventName === 'change') {
+        // those files' contents. So a plain 'change' event can never invalidate
+        // them -- only 'add' and 'unlink' can.
+        //
+        // We still fall through to the reload below for a changed file that
+        // Vite's own module graph doesn't know about, because for those the
+        // entrypoint reload is the only thing that gets the change to the
+        // browser (for example the classic `app/styles/app.css`, which reaches
+        // the browser as a broccoli-built <link> rather than as a module). But
+        // when Vite is already tracking the file, reloading the entrypoint on
+        // top of Vite's own update is redundant, and worse than redundant for
+        // stylesheets: the full page reload pre-empts CSS hot replacement on
+        // every single edit.
+        if (eventName === 'change' && server.moduleGraph.getModulesByFile(path)?.size) {
           return;
         }
         for (let [id, watches] of virtualDeps) {

--- a/tests/scenarios/vite-hmr-test.ts
+++ b/tests/scenarios/vite-hmr-test.ts
@@ -1,0 +1,103 @@
+import { appScenarios } from './scenarios';
+import type { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+import merge from 'lodash/merge';
+import fetch from 'node-fetch';
+import { writeFileSync } from 'fs-extra';
+import { join } from 'path';
+import { setupViteDevServer } from './helpers';
+import { DEFAULT_TIMEOUT } from './helpers/command-watcher';
+
+const { module: Qmodule, test } = QUnit;
+
+// A stylesheet that is imported as a module, the way a vite-native app pulls in
+// its styles. Vite owns this file, so it can hot-replace it without reloading.
+const MODULE_STYLESHEET = 'app/hmr-styles.css';
+
+// The classic ember stylesheet, which broccoli builds and which reaches the
+// browser as a <link> to `@embroider/virtual/app.css`. Vite has no module for
+// this file, so a full page reload is the only way its changes get there.
+const CLASSIC_STYLESHEET = 'app/styles/app.css';
+
+let app = appScenarios.map('vite-hmr', project => {
+  merge(project.files, {
+    app: {
+      'hmr-styles.css': `.hmr-probe { color: rgb(1, 1, 1); }\n`,
+    },
+  });
+
+  let appFiles = project.files.app as Record<string, string>;
+  appFiles['app.js'] = `import './hmr-styles.css';\n${appFiles['app.js']}`;
+});
+
+app.forEachScenario(scenario => {
+  Qmodule(scenario.name, function (hooks) {
+    let app: PreparedApp;
+
+    hooks.before(async () => {
+      app = await scenario.prepare();
+    });
+
+    function write(relativePath: string, content: string): void {
+      writeFileSync(join(app.dir, ...relativePath.split('/')), content);
+    }
+
+    // Each case gets its own dev server, because one stylesheet edit can make
+    // vite say more than one thing and only the first of those matters here:
+    // the cases must not read each other's leftovers.
+    function setupCase(hooks: NestedHooks) {
+      let viteDev = setupViteDevServer(hooks, () => app);
+
+      return {
+        // Vite only reacts to a file once that file is in its module graph, and
+        // the graph is only populated by requests. Ask for the app's entrypoint
+        // so that it, and the stylesheet it imports, are being tracked.
+        async primeModuleGraph(): Promise<void> {
+          for (let url of ['/app/app.js', '/app/hmr-styles.css']) {
+            let response = await fetch(`${viteDev.appURL}${url}`);
+            if (!response.ok) {
+              throw new Error(`expected ${url} to be servable, got ${response.status}`);
+            }
+          }
+        },
+
+        // The two outcomes are mutually exclusive from the browser's point of
+        // view: whichever vite announces first is the one the user experiences,
+        // because a page reload discards any hot update that follows it.
+        async firstAnnouncement(): Promise<string> {
+          let [line] = await viteDev.server.waitFor(/(?:page reload|hmr update) .*/, DEFAULT_TIMEOUT);
+          return line;
+        },
+      };
+    }
+
+    Qmodule('a stylesheet vite owns', function (hooks) {
+      let testCase = setupCase(hooks);
+
+      test('is hot-updated rather than reloaded', async function (assert) {
+        await testCase.primeModuleGraph();
+
+        write(MODULE_STYLESHEET, `.hmr-probe { color: rgb(2, 2, 2); }\n`);
+
+        let announcement = await testCase.firstAnnouncement();
+        assert.ok(
+          /hmr update .*hmr-styles\.css/.test(announcement),
+          `expected vite to hot-update the stylesheet, got: ${announcement}`
+        );
+      });
+    });
+
+    Qmodule('a stylesheet vite does not own', function (hooks) {
+      let testCase = setupCase(hooks);
+
+      test('still reloads the page', async function (assert) {
+        await testCase.primeModuleGraph();
+
+        write(CLASSIC_STYLESHEET, `.classic-probe { color: rgb(3, 3, 3); }\n`);
+
+        let announcement = await testCase.firstAnnouncement();
+        assert.ok(/page reload/.test(announcement), `expected vite to reload the page, got: ${announcement}`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
@NullVoxPopuli  This is a new attempt, i closed the issue/PR https://github.com/embroider-build/embroider/pull/2803, due to new findings.

> is there a way I can test the before/after behavior? and better yet, is there a way to add an automated tests for that using our existing test setup?

Yes to both, and writing the test turned up something that changes the fix.

Again, i gave the task to Claud Code (Opus 5) and this is what it delivered.
So seemingly i have an 'ucommon' css setup in my app, i would say.
Not the Ember+Vite+ModernCSS Vanilla stack..

All freshly rebased onto current main.

** from here on: Claude's writing: **

**Reproducing it by hand** needs an app whose stylesheet is imported as a module (`import './global-styles.css'` from `app/app.js`). Run `vite dev`, edit the stylesheet, and watch the dev server output. On `main`:

```
[vite] (client) page reload /…/app/-embroider-entrypoint.js
[vite] (client) hmr update /app/global-styles.css
```

The reload lands first and discards the hot update, so every CSS edit becomes a full page refresh.

It turns out this reproduces on this repo's own `tests/app-template` with a two-line change — add a `.css` file and import it from `app.js` — so there was no need for the hollowed-out app I offered. That let me go straight to the second half of your question.

**The automated test** fits the existing scenario harness: `tests/scenarios/vite-hmr-test.ts`. It boots `vite` through `CommandWatcher` the way `vite-dep-optimizer-test.ts` already does, edits a stylesheet, and asserts on the first `page reload` / `hmr update` line the dev server prints — whichever comes first is what a browser actually experiences, since a reload discards any hot update that follows it. Each case runs against its own dev server so they can't read each other's leftovers.

**What the test caught:** my original blanket skip of `change` events *regressed* the classic `app/styles/app.css`. Broccoli builds that file and it reaches the page as a `<link>` to `@embroider/virtual/app.css`, so Vite has no module for it — meaning the entrypoint reload was the only thing propagating its changes. With the blanket skip, editing it produced no client update at all. That was a real bug in the PR as it stood, and I'd never have found it by hand.

So the fix is now narrower: on a `change` event, skip the virtual-module reload only for files that are already in Vite's module graph. Vite updates those itself; everything else falls through to the reload it has always had.

| edit | `main` | this PR |
| --- | --- | --- |
| stylesheet imported from `app.js` | `page reload` + `hmr update` → full reload | `hmr update` only |
| `app/styles/app.css` (classic broccoli) | `page reload` | `page reload` |
| `app/router.js` | `page reload` ×2 | `page reload` ×1 |

Rows one and two are the two tests. On `main` without the fix, the first fails with `page reload …/app/-embroider-entrypoint.js` and the second passes.

Two notes on the change itself:

- Sass partials are covered. They aren't modules in their own right, but Vite registers them as preprocessor dependencies, so `getModulesByFile` finds them and they still hot-update. I verified this on the real app this started from.
- It uses the deprecated `server.moduleGraph`, matching the `onFileChange` / `getModuleById` calls already in that same block. 

